### PR TITLE
Shell script for JavaTest

### DIFF
--- a/tests/JavaTest.sh
+++ b/tests/JavaTest.sh
@@ -1,21 +1,19 @@
 #!/bin/sh
-cat <<-LICENSE
-Copyright 2014 Google Inc. All rights reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+# Copyright 2014 Google Inc. All rights reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-LICENSE
-
-echo
 echo Compile then run the Java test.
 
 testdir=$(readlink -fn `dirname $0`)


### PR DESCRIPTION
JavaTest.bat does not run on unix. This commit fixes that by porting JavaTest.bat to shell.
