### PR TITLE
Fixed compile warning in VS2013

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -108,7 +108,7 @@ static std::string TokenToString(int t) {
   };
   if (t < 256) {  // A single ascii char token.
     std::string s;
-    s.append(1, t);
+    s.append(1, (char)t);
     return s;
   } else {       // Other tokens.
     return tokens[t - 256];


### PR DESCRIPTION
This pull request fixes a minor warning in VS2013, which caused the build/VS2010/flatc.vcxproj project to fail building (warnings treated as errors).

The warning message was: 

> Warning    2   warning C4244: 'argument' : conversion from 'int' to 'char', possible loss of data   src\idl_parser.cpp 111 1   flatc
