### PR TITLE
Added support for direct buffers by removing the use of bb.array()

### DIFF
--- a/java/flatbuffers/Table.java
+++ b/java/flatbuffers/Table.java
@@ -16,12 +16,13 @@
 
 package flatbuffers;
 
+import static flatbuffers.Constants.*;
 import java.lang.String;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 // All tables in the generated code derive from this class, and add their own accessors.
-public class Table extends Constants {
+public class Table {
   protected int bb_pos;
   protected ByteBuffer bb;
 


### PR DESCRIPTION
I made some Java changes to support direct buffer that do not have an array, i removed all references to bb.array().length and replaced it by bb.capacity() and also removed the use of bb.array() and replaced it but ByteBuffer put and get operations.
