### PR TITLE
Fix out of bound access in FlatBufferBuilder::EndTable()

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -527,7 +527,10 @@ class FlatBufferBuilder {
     // See if we already have generated a vtable with this exact same
     // layout before. If so, make it point to the old one, remove this one.
     for (auto it = vtables_.begin(); it != vtables_.end(); ++it) {
-      if (memcmp(buf_.data_at(*it), vt1, vt1_size)) continue;
+      auto vt_cur = buf_.data_at(*it);
+      auto vt_cur_size = *vt_cur;
+      if (vt_cur_size == vt1_size ||
+          memcmp(vt_cur+1, vt1+1, vt_cur_size-1)) continue;
       vt_use = *it;
       buf_.pop(GetSize() - vtableoffsetloc);
       break;


### PR DESCRIPTION
Detected with Clang+ASAN

Note: the rational is that `buf_buf_.data_at(0)` is the end of the buffer, so memcmp should not got beyond. In the case where `*it` is closer to 0 than `vt1_size`, and the comparison succeeded for the `*it` first elements, the code was accessing out of bound.
