### PR TITLE
Add generated C++ function for returning file_identifier

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -638,21 +638,27 @@ std::string GenerateCPP(const Parser &parser,
               "return verifier.VerifyBuffer<";
       code += parser.root_struct_def->name + ">(); }\n\n";
 
+      if (parser.file_identifier_.length()) {
+        // Return the identifier
+        code += "inline const char *" + parser.root_struct_def->name;
+        code += "Identifier() { return \"" + parser.file_identifier_;
+        code += "\"; }\n\n";
+
+        // Check if a buffer has the identifier.
+        code += "inline bool " + parser.root_struct_def->name;
+        code += "BufferHasIdentifier(const void *buf) { return flatbuffers::";
+        code += "BufferHasIdentifier(buf, ";
+        code += parser.root_struct_def->name + "Identifier()); }\n\n";
+      }
+
       // Finish a buffer with a given root object:
       code += "inline void Finish" + parser.root_struct_def->name;
       code += "Buffer(flatbuffers::FlatBufferBuilder &fbb, flatbuffers::Offset<";
       code += parser.root_struct_def->name + "> root) { fbb.Finish(root";
       if (parser.file_identifier_.length())
-        code += ", \"" + parser.file_identifier_ + "\"";
+        code += ", " + parser.root_struct_def->name + "Identifier()";
       code += "); }\n\n";
 
-      if (parser.file_identifier_.length()) {
-        // Check if a buffer has the identifier.
-        code += "inline bool " + parser.root_struct_def->name;
-        code += "BufferHasIdentifier(const void *buf) { return flatbuffers::";
-        code += "BufferHasIdentifier(buf, \"" + parser.file_identifier_;
-        code += "\"); }\n\n";
-      }
     }
 
     CloseNestedNameSpaces(name_space, &code);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -117,6 +117,7 @@ void AccessFlatBufferTest(const std::string &flatbuf) {
     flatbuf.length());
   TEST_EQ(VerifyMonsterBuffer(verifier), true);
 
+  TEST_EQ(strcmp(MonsterIdentifier(), "MONS"), 0);
   TEST_EQ(MonsterBufferHasIdentifier(flatbuf.c_str()), true);
 
   // Access the buffer from the root.


### PR DESCRIPTION
The code adds a function for accessing the file identifier of a "root table". I send packages over the network and use the flatbuffer file_identifier for figuring out the type of packet instead of adding some kind of external identifier. With this function one avoids having to repeat the identifier string both in the .fbs file and in the code.

The generated code looks like this:

```
inline const char *MonsterIdentifier() { return "MONS"; }
```
