### PR TITLE
C#: Allow ByteBuffer to use faster unsafe mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+Contributing    {#contributing}
+============
+
+Want to contribute? Great! First, read this page (including the small print at
+the end).
+
+# Before you contribute
+Before we can use your code, you must sign the
+[Google Individual Contributor License Agreement](https://developers.google.com/open-source/cla/individual?csw=1)
+(CLA), which you can do online. The CLA is necessary mainly because you own the
+copyright to your changes, even after your contribution becomes part of our
+codebase, so we need your permission to use and distribute your code. We also
+need to be sure of various other things—for instance that you'll tell us if you
+know that your code infringes on other people's patents. You don't have to sign
+the CLA until after you've submitted your code for review and a member has
+approved it, but you must do it before we can put your code into our codebase.
+Before you start working on a larger contribution, you should get in touch with
+us first through the issue tracker with your idea so that we can help out and
+possibly guide you. Coordinating up front makes it much easier to avoid
+frustration later on.
+
+# Code reviews
+All submissions, including submissions by project members, require review. We
+use Github pull requests for this purpose.
+
+# The small print
+Contributions made by corporations are covered by a different agreement than
+the one above, the Software Grant and Corporate Contributor License Agreement.

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -53,7 +53,7 @@ $(document).ready(function(){initNavTree('index.html','');});
 <div class="title">FlatBuffers Documentation</div>  </div>
 </div><!--header-->
 <div class="contents">
-<div class="textblock"><p>FlatBuffers is an efficient cross platform serialization library for C++, with support for Java and Go. It was created at Google specifically for game development and other performance-critical applications.</p>
+<div class="textblock"><p>FlatBuffers is an efficient cross platform serialization library for C++, with support for Java, C# and Go. It was created at Google specifically for game development and other performance-critical applications.</p>
 <p>It is available as open source under the Apache license, v2 (see LICENSE.txt).</p>
 <h2>Why use FlatBuffers?</h2>
 <ul>
@@ -65,7 +65,7 @@ $(document).ready(function(){initNavTree('index.html','');});
 <li><p class="startli"><b>Convenient to use</b> - Generated C++ code allows for terse access &amp; construction code. Then there's optional functionality for parsing schemas and JSON-like text representations at runtime efficiently if needed (faster and more memory efficient than other JSON parsers).</p>
 <p class="startli">Java and Go code supports object-reuse.</p>
 </li>
-<li><b>Cross platform C++11/Java/Go code with no dependencies</b> - will work with any recent gcc/clang and VS2010. Comes with build files for the tests &amp; samples (Android .mk files, and cmake for all other platforms).</li>
+<li><b>Cross platform C++11/Java/C#/Go code with no dependencies</b> - will work with any recent gcc/clang and VS2010. Comes with build files for the tests &amp; samples (Android .mk files, and cmake for all other platforms).</li>
 </ul>
 <h3>Why not use Protocol Buffers, or .. ?</h3>
 <p>Protocol Buffers is indeed relatively similar to FlatBuffers, with the primary difference being that FlatBuffers does not need a parsing/ unpacking step to a secondary representation before you can access data, often coupled with per-object memory allocation. The code is an order of magnitude bigger, too. Protocol Buffers has neither optional text import/export nor schema language features like unions.</p>
@@ -76,7 +76,7 @@ $(document).ready(function(){initNavTree('index.html','');});
 <p>This section is a quick rundown of how to use this system. Subsequent sections provide a more in-depth usage guide.</p>
 <ul>
 <li>Write a schema file that allows you to define the data structures you may want to serialize. Fields can have a scalar type (ints/floats of all sizes), or they can be a: string; array of any type; reference to yet another object; or, a set of possible objects (unions). Fields are optional and have defaults, so they don't need to be present for every object instance.</li>
-<li>Use <code>flatc</code> (the FlatBuffer compiler) to generate a C++ header (or Java/Go classes) with helper classes to access and construct serialized data. This header (say <code>mydata_generated.h</code>) only depends on <code>flatbuffers.h</code>, which defines the core functionality.</li>
+<li>Use <code>flatc</code> (the FlatBuffer compiler) to generate a C++ header (or Java/C#/Go classes) with helper classes to access and construct serialized data. This header (say <code>mydata_generated.h</code>) only depends on <code>flatbuffers.h</code>, which defines the core functionality.</li>
 <li>Use the <code>FlatBufferBuilder</code> class to construct a flat binary buffer. The generated functions allow you to add objects to this buffer recursively, often as simply as making a single function call.</li>
 <li>Store or send your buffer somewhere!</li>
 <li>When reading it back, you can obtain the pointer to the root object from the binary buffer, and from there traverse it conveniently in-place with <code>object-&gt;field()</code>.</li>
@@ -87,7 +87,7 @@ $(document).ready(function(){initNavTree('index.html','');});
 <li>How to <a href="md__compiler.html">use the compiler</a>.</li>
 <li>How to <a href="md__schemas.html">write a schema</a>.</li>
 <li>How to <a href="md__cpp_usage.html">use the generated C++ code</a> in your own programs.</li>
-<li>How to <a href="md__java_usage.html">use the generated Java code</a> in your own programs.</li>
+<li>How to <a href="md__java_usage.html">use the generated Java/C# code</a> in your own programs.</li>
 <li>How to <a href="md__go_usage.html">use the generated Go code</a> in your own programs.</li>
 <li>Some <a href="md__benchmarks.html">benchmarks</a> showing the advantage of using FlatBuffers.</li>
 <li>A <a href="md__white_paper.html">white paper</a> explaining the "why" of FlatBuffers.</li>

--- a/docs/html/md__cpp_usage.html
+++ b/docs/html/md__cpp_usage.html
@@ -86,7 +86,7 @@ $(document).ready(function(){initNavTree('md__cpp_usage.html','');});
 <h3>Reading in C++</h3>
 <p>If you've received a buffer from somewhere (disk, network, etc.) you can directly start traversing it using:</p>
 <div class="fragment"><div class="line"><span class="keyword">auto</span> monster = GetMonster(buffer_pointer);</div>
-</div><!-- fragment --><p><code>monster</code> is of type <code>Monster *</code>, and points to somewhere inside your buffer. If you look in your generated header, you'll see it has convenient accessors for all fields, e.g.</p>
+</div><!-- fragment --><p><code>monster</code> is of type <code>Monster *</code>, and points to somewhere <em>inside</em> your buffer (root object pointers are not the same as <code>buffer_pointer</code> !). If you look in your generated header, you'll see it has convenient accessors for all fields, e.g.</p>
 <div class="fragment"><div class="line">assert(monster-&gt;hp() == 80);</div>
 <div class="line">assert(monster-&gt;mana() == 150);  <span class="comment">// default</span></div>
 <div class="line">assert(strcmp(monster-&gt;name()-&gt;c_str(), <span class="stringliteral">&quot;MyMonster&quot;</span>) == 0);</div>

--- a/docs/html/md__java_usage.html
+++ b/docs/html/md__java_usage.html
@@ -4,7 +4,7 @@
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>
 <meta name="generator" content="Doxygen 1.8.7"/>
-<title>FlatBuffers: Use in Java</title>
+<title>FlatBuffers: Use in Java/C</title>
 <link href="tabs.css" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="jquery.js"></script>
 <script type="text/javascript" src="dynsections.js"></script>
@@ -50,10 +50,11 @@ $(document).ready(function(){initNavTree('md__java_usage.html','');});
 <div id="doc-content">
 <div class="header">
   <div class="headertitle">
-<div class="title">Use in Java </div>  </div>
+<div class="title">Use in Java/C </div>  </div>
 </div><!--header-->
 <div class="contents">
-<div class="textblock"><p>FlatBuffers supports reading and writing binary FlatBuffers in Java. Generate code for Java with the <code>-j</code> option to <code>flatc</code>.</p>
+<div class="textblock"><p>FlatBuffers supports reading and writing binary FlatBuffers in Java and C#. Generate code for Java with the <code>-j</code> option to <code>flatc</code>, or for C# with <code>-n</code> (think .Net).</p>
+<p>Note that this document is from the perspective of Java. Code for both languages is generated in the same way, with only very subtle differences, for example any <code>camelCase</code> Java call will be <code>CamelCase</code> in C#.</p>
 <p>See <code>javaTest.java</code> for an example. Essentially, you read a FlatBuffer binary file into a <code>byte[]</code>, which you then turn into a <code>ByteBuffer</code>, which you pass to the <code>getRootAsMyRootType</code> function:</p>
 <div class="fragment"><div class="line">ByteBuffer bb = ByteBuffer.wrap(data);</div>
 <div class="line">Monster monster = Monster.getRootAsMonster(bb);</div>

--- a/docs/html/md__schemas.html
+++ b/docs/html/md__schemas.html
@@ -93,12 +93,15 @@ root_type Monster;
 <h3>Structs</h3>
 <p>Similar to a table, only now none of the fields are optional (so no defaults either), and fields may not be added or be deprecated. Structs may only contain scalars or other structs. Use this for simple objects where you are very sure no changes will ever be made (as quite clear in the example <code>Vec3</code>). Structs use less memory than tables and are even faster to access (they are always stored in-line in their parent object, and use no virtual table).</p>
 <h3>Types</h3>
-<p>Builtin scalar types are:</p>
+<p>Built-in scalar types are:</p>
 <ul>
 <li>8 bit: <code>byte ubyte bool</code></li>
 <li>16 bit: <code>short ushort</code></li>
 <li>32 bit: <code>int uint float</code></li>
 <li>64 bit: <code>long ulong double</code></li>
+</ul>
+<p>Built-in non-scalar types:</p>
+<ul>
 <li>Vector of any other type (denoted with <code>[type]</code>). Nesting vectors is not supported, instead you can wrap the inner vector in a table.</li>
 <li><code>string</code>, which may only hold UTF-8 or 7-bit ASCII. For other text encodings or general binary data use vectors (<code>[byte]</code> or <code>[ubyte]</code>) instead.</li>
 <li>References to other tables or structs, enums or unions (see below).</li>
@@ -111,6 +114,8 @@ root_type Monster;
 <p>Define a sequence of named constants, each with a given value, or increasing by one from the previous one. The default first value is <code>0</code>. As you can see in the enum declaration, you specify the underlying integral type of the enum with <code>:</code> (in this case <code>byte</code>), which then determines the type of any fields declared with this enum type.</p>
 <h3>Unions</h3>
 <p>Unions share a lot of properties with enums, but instead of new names for constants, you use names of tables. You can then declare a union field which can hold a reference to any of those types, and additionally a hidden field with the suffix <code>_type</code> is generated that holds the corresponding enum value, allowing you to know which type to cast to at runtime.</p>
+<p>Unions are a good way to be able to send multiple message types as a FlatBuffer. Note that because a union field is really two fields, it must always be part of a table, it cannot be the root of a FlatBuffer by itself.</p>
+<p>If you have a need to distinguish between different FlatBuffers in a more open-ended way, for example for use as files, see the file identification feature below.</p>
 <h3>Namespaces</h3>
 <p>These will generate the corresponding namespace in C++ for all helper code, and packages in Java. You can use <code>.</code> to specify nested namespaces / packages.</p>
 <h3>Includes</h3>
@@ -126,6 +131,7 @@ root_type Monster;
 </pre><p>Identifiers must always be exactly 4 characters long. These 4 characters will end up as bytes at offsets 4-7 (inclusive) in the buffer.</p>
 <p>For any schema that has such an identifier, <code>flatc</code> will automatically add the identifier to any binaries it generates (with <code>-b</code>), and generated calls like <code>FinishMonsterBuffer</code> also add the identifier. If you have specified an identifier and wish to generate a buffer without one, you can always still do so by calling <code>FlatBufferBuilder::Finish</code> explicitly.</p>
 <p>After loading a buffer, you can use a call like <code>MonsterBufferHasIdentifier</code> to check if the identifier is present.</p>
+<p>Note that this is best for open-ended uses such as files. If you simply wanted to send one of a set of possible messages over a network for example, you'd be better off with a union.</p>
 <p>Additionally, by default <code>flatc</code> will output binary files as <code>.bin</code>. This declaration in the schema will change that to whatever you want: </p><pre class="fragment">file_extension "ext";
 </pre><h3>Comments &amp; documentation</h3>
 <p>May be written as in most C-based languages. Additionally, a triple comment (<code>///</code>) on a line by itself signals that a comment is documentation for whatever is declared on the line after it (table/struct/field/enum/union/element), and the comment is output in the corresponding C++ code. Multiple such lines per item are allowed.</p>

--- a/docs/html/navtree.js
+++ b/docs/html/navtree.js
@@ -6,7 +6,7 @@ var NAVTREE =
     [ "Writing a schema", "md__schemas.html", null ],
     [ "Use in C++", "md__cpp_usage.html", null ],
     [ "Use in Go", "md__go_usage.html", null ],
-    [ "Use in Java", "md__java_usage.html", null ],
+    [ "Use in Java/C", "md__java_usage.html", null ],
     [ "Benchmarks", "md__benchmarks.html", null ],
     [ "FlatBuffers white paper", "md__white_paper.html", null ],
     [ "FlatBuffer Internals", "md__internals.html", null ],

--- a/docs/html/pages.html
+++ b/docs/html/pages.html
@@ -60,7 +60,7 @@ $(document).ready(function(){initNavTree('pages.html','');});
 <tr id="row_2_" class="even"><td class="entry"><span style="width:16px;display:inline-block;">&#160;</span><a class="el" href="md__schemas.html" target="_self">Writing a schema</a></td><td class="desc"></td></tr>
 <tr id="row_3_"><td class="entry"><span style="width:16px;display:inline-block;">&#160;</span><a class="el" href="md__cpp_usage.html" target="_self">Use in C++</a></td><td class="desc"></td></tr>
 <tr id="row_4_" class="even"><td class="entry"><span style="width:16px;display:inline-block;">&#160;</span><a class="el" href="md__go_usage.html" target="_self">Use in Go</a></td><td class="desc"></td></tr>
-<tr id="row_5_"><td class="entry"><span style="width:16px;display:inline-block;">&#160;</span><a class="el" href="md__java_usage.html" target="_self">Use in Java</a></td><td class="desc"></td></tr>
+<tr id="row_5_"><td class="entry"><span style="width:16px;display:inline-block;">&#160;</span><a class="el" href="md__java_usage.html" target="_self">Use in Java/C</a></td><td class="desc"></td></tr>
 <tr id="row_6_" class="even"><td class="entry"><span style="width:16px;display:inline-block;">&#160;</span><a class="el" href="md__benchmarks.html" target="_self">Benchmarks</a></td><td class="desc"></td></tr>
 <tr id="row_7_"><td class="entry"><span style="width:16px;display:inline-block;">&#160;</span><a class="el" href="md__white_paper.html" target="_self">FlatBuffers white paper</a></td><td class="desc"></td></tr>
 <tr id="row_8_" class="even"><td class="entry"><span style="width:16px;display:inline-block;">&#160;</span><a class="el" href="md__internals.html" target="_self">FlatBuffer Internals</a></td><td class="desc"></td></tr>

--- a/docs/source/CppUsage.md
+++ b/docs/source/CppUsage.md
@@ -119,8 +119,9 @@ directly start traversing it using:
     auto monster = GetMonster(buffer_pointer);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`monster` is of type `Monster *`, and points to somewhere inside your
-buffer. If you look in your generated header, you'll see it has
+`monster` is of type `Monster *`, and points to somewhere *inside* your
+buffer (root object pointers are not the same as `buffer_pointer` !).
+If you look in your generated header, you'll see it has
 convenient accessors for all fields, e.g.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}

--- a/docs/source/FlatBuffers.md
+++ b/docs/source/FlatBuffers.md
@@ -1,7 +1,7 @@
 # FlatBuffers
 
 FlatBuffers is an efficient cross platform serialization library for C++,
-with support for Java and Go. It was created at Google specifically for game
+with support for Java, C# and Go. It was created at Google specifically for game
 development and other performance-critical applications.
 
 It is available as open source under the Apache license, v2 (see LICENSE.txt).
@@ -48,8 +48,8 @@ It is available as open source under the Apache license, v2 (see LICENSE.txt).
 
     Java and Go code supports object-reuse.
 
--   **Cross platform C++11/Java/Go code with no dependencies** - will work with
-    any recent gcc/clang and VS2010. Comes with build files for the tests &
+-   **Cross platform C++11/Java/C#/Go code with no dependencies** - will work
+    with any recent gcc/clang and VS2010. Comes with build files for the tests &
     samples (Android .mk files, and cmake for all other platforms).
 
 ### Why not use Protocol Buffers, or .. ?
@@ -87,10 +87,10 @@ sections provide a more in-depth usage guide.
     Fields are optional and have defaults, so they don't need to be
     present for every object instance.
 
--   Use `flatc` (the FlatBuffer compiler) to generate a C++ header (or Java/Go
-    classes) with helper classes to access and construct serialized data. This
-    header (say `mydata_generated.h`) only depends on `flatbuffers.h`, which
-    defines the core functionality.
+-   Use `flatc` (the FlatBuffer compiler) to generate a C++ header (or
+    Java/C#/Go classes) with helper classes to access and construct serialized
+    data. This header (say `mydata_generated.h`) only depends on
+    `flatbuffers.h`, which defines the core functionality.
 
 -   Use the `FlatBufferBuilder` class to construct a flat binary buffer.
     The generated functions allow you to add objects to this
@@ -110,7 +110,7 @@ sections provide a more in-depth usage guide.
 -   How to [write a schema](md__schemas.html).
 -   How to [use the generated C++ code](md__cpp_usage.html) in your own
     programs.
--   How to [use the generated Java code](md__java_usage.html) in your own
+-   How to [use the generated Java/C# code](md__java_usage.html) in your own
     programs.
 -   How to [use the generated Go code](md__go_usage.html) in your own
     programs.

--- a/docs/source/JavaUsage.md
+++ b/docs/source/JavaUsage.md
@@ -1,7 +1,12 @@
-# Use in Java
+# Use in Java/C#
 
-FlatBuffers supports reading and writing binary FlatBuffers in Java. Generate
-code for Java with the `-j` option to `flatc`.
+FlatBuffers supports reading and writing binary FlatBuffers in Java and C#.
+Generate code for Java with the `-j` option to `flatc`, or for C# with `-n`
+(think .Net).
+
+Note that this document is from the perspective of Java. Code for both languages
+is generated in the same way, with only very subtle differences, for example
+any `camelCase` Java call will be `CamelCase` in C#.
 
 See `javaTest.java` for an example. Essentially, you read a FlatBuffer binary
 file into a `byte[]`, which you then turn into a `ByteBuffer`, which you pass to

--- a/docs/source/Schemas.md
+++ b/docs/source/Schemas.md
@@ -82,7 +82,7 @@ parent object, and use no virtual table).
 
 ### Types
 
-Builtin scalar types are:
+Built-in scalar types are:
 
 -   8 bit: `byte ubyte bool`
 
@@ -91,6 +91,8 @@ Builtin scalar types are:
 -   32 bit: `int uint float`
 
 -   64 bit: `long ulong double`
+
+Built-in non-scalar types:
 
 -   Vector of any other type (denoted with `[type]`). Nesting vectors
     is not supported, instead you can wrap the inner vector in a table.
@@ -136,6 +138,14 @@ a union field which can hold a reference to any of those types, and
 additionally a hidden field with the suffix `_type` is generated that
 holds the corresponding enum value, allowing you to know which type to
 cast to at runtime.
+
+Unions are a good way to be able to send multiple message types as a FlatBuffer.
+Note that because a union field is really two fields, it must always be
+part of a table, it cannot be the root of a FlatBuffer by itself.
+
+If you have a need to distinguish between different FlatBuffers in a more
+open-ended way, for example for use as files, see the file identification
+feature below.
 
 ### Namespaces
 
@@ -194,6 +204,10 @@ without one, you can always still do so by calling
 
 After loading a buffer, you can use a call like
 `MonsterBufferHasIdentifier` to check if the identifier is present.
+
+Note that this is best for open-ended uses such as files. If you simply wanted
+to send one of a set of possible messages over a network for example, you'd
+be better off with a union.
 
 Additionally, by default `flatc` will output binary files as `.bin`.
 This declaration in the schema will change that to whatever you want:

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -304,6 +304,7 @@ struct String : public Vector<char> {
 // with custom allocation (see the FlatBufferBuilder constructor).
 class simple_allocator {
  public:
+  virtual ~simple_allocator() {}
   virtual uint8_t *allocate(size_t size) const { return new uint8_t[size]; }
   virtual void deallocate(uint8_t *p) const { delete[] p; }
 };

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -296,6 +296,12 @@ protected:
   uoffset_t length_;
 };
 
+// Convenient helper function to get the length of any vector, regardless
+// of wether it is null or not (the field is not set).
+template<typename T> static inline size_t VectorLength(const Vector<T> *v) {
+  return v ? v->Length() : 0;
+}
+
 struct String : public Vector<char> {
   const char *c_str() const { return reinterpret_cast<const char *>(Data()); }
 };

--- a/net/FlatBuffers/ByteBuffer.cs
+++ b/net/FlatBuffers/ByteBuffer.cs
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
+//#define UNSAFE_BYTEBUFFER  // uncomment this line to use faster ByteBuffer
+
 using System;
 using System.Linq;
 
 namespace FlatBuffers
 {
     /// <summary>
-    /// Class to mimick Java's ByteBuffer which is used heavily in Flatbuffers
+    /// Class to mimic Java's ByteBuffer which is used heavily in Flatbuffers.
+    /// If your execution environment allows unsafe code, you should enable 
+    /// unsafe code in your project and #define UNSAFE_BYTEBUFFER to use a 
+    /// MUCH faster version of ByteBuffer.
     /// </summary>
     public class ByteBuffer
     {
@@ -39,11 +44,13 @@ namespace FlatBuffers
 
         public int position() { return _pos; }
 
+#if !UNSAFE_BYTEBUFFER
+        // Helper functions for the safe (but slower) version.
         protected void WriteLittleEndian(int offset, byte[] data)
         {
             if (!BitConverter.IsLittleEndian)
             {
-                data = data.Reverse().ToArray();
+                Array.Reverse(data, 0, data.Length);
             }
             Buffer.BlockCopy(data, 0, _buffer, offset, data.Length);
             _pos = offset;
@@ -58,6 +65,7 @@ namespace FlatBuffers
               ? tmp
               : tmp.Reverse().ToArray();
         }
+#endif // UNSAFE_BYTEBUFFER
 
         private void AssertOffsetAndLength(int offset, int length)
         {
@@ -81,6 +89,157 @@ namespace FlatBuffers
             _pos = offset;
         }
 
+#if UNSAFE_BYTEBUFFER
+        // Unsafe but more efficient versions of Put*.
+        public unsafe void PutShort(int offset, short value)
+        {
+            AssertOffsetAndLength(offset, sizeof(short));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    *(short*)(ptr + offset) = value;
+                }
+                else
+                {
+                    ushort uvalue = (ushort)(value);
+                    *(ushort*)(ptr + offset) = (ushort)(((uvalue & 0x0FU) << 8) | ((uvalue & 0xF0U) << 0));
+                }
+            }
+            _pos = offset;
+        }
+
+        public unsafe void PutUshort(int offset, ushort value)
+        {
+            AssertOffsetAndLength(offset, sizeof(ushort));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    *(ushort*)(ptr + offset) = value;
+                }
+                else
+                {
+                    *(ushort*)(ptr + offset) = (ushort)(((value & 0x0FU) << 8) | ((value & 0xF0U) << 0));
+                }
+            }
+            _pos = offset;
+        }
+
+        public unsafe void PutInt(int offset, int value)
+        {
+            AssertOffsetAndLength(offset, sizeof(int));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    *(int*)(ptr + offset) = value;
+                }
+                else
+                {
+                    uint uvalue = (uint)(value);
+                    *(uint*)(ptr + offset) = ((uvalue & 0x000FU) << 24) | ((uvalue & 0x00F0U) << 16) | ((uvalue & 0x0F00U) << 8) | ((uvalue & 0xF000U) << 0);
+                }
+            }
+            _pos = offset;
+        }
+
+        public unsafe void PutUint(int offset, uint value)
+        {
+            AssertOffsetAndLength(offset, sizeof(uint));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    *(uint*)(ptr + offset) = value;
+                }
+                else
+                {
+                    *(uint*)(ptr + offset) = ((value & 0x000FU) << 24) | ((value & 0x00F0U) << 16) | ((value & 0x0F00U) << 8) | ((value & 0xF000U) << 0);
+                }
+            }
+            _pos = offset;
+        }
+
+        public unsafe void PutLong(int offset, long value)
+        {
+            AssertOffsetAndLength(offset, sizeof(long));
+            
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    *(long*)(ptr + offset) = value;
+                }
+                else
+                {
+                    ulong uvalue = (ulong)(value);
+                    *(ulong*)(ptr + offset) = (((uvalue & 0x0000000FUL) << 56) | ((uvalue & 0x000000F0UL) << 48) | ((uvalue & 0x00000F00UL) << 40) | ((uvalue & 0x0000F000UL) << 32) |
+                                               ((uvalue & 0x000F0000UL) << 24) | ((uvalue & 0x00F00000UL) << 16) | ((uvalue & 0x0F000000UL) << 8) | ((uvalue & 0xF0000000UL) << 0));
+                }
+            }
+            _pos = offset;
+        }
+
+        public unsafe void PutUlong(int offset, ulong value)
+        {
+            AssertOffsetAndLength(offset, sizeof(ulong));
+
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    *(ulong*)(ptr + offset) = value;
+                }
+                else
+                {
+                    *(ulong*)(ptr + offset) = (((value & 0x0000000FUL) << 56) | ((value & 0x000000F0UL) << 48) | ((value & 0x00000F00UL) << 40) | ((value & 0x0000F000UL) << 32) |
+                                               ((value & 0x000F0000UL) << 24) | ((value & 0x00F00000UL) << 16) | ((value & 0x0F000000UL) << 8) | ((value & 0xF0000000UL) << 0));
+                }
+            }
+            _pos = offset;
+        }
+
+
+        public unsafe void PutFloat(int offset, float value)
+        {
+            AssertOffsetAndLength(offset, sizeof(float));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    *(float*)(ptr + offset) = value;
+                }
+                else
+                {
+                    uint uvalue = *(uint*)(&value);
+                    *(uint*)(ptr + offset) = ((uvalue & 0x000FU) << 24) | ((uvalue & 0x00F0U) << 16) | ((uvalue & 0x0F00U) << 8) | ((uvalue & 0xF000U) << 0);
+                }
+            }
+            _pos = offset;
+        }
+
+        public unsafe void PutDouble(int offset, double value)
+        {
+            AssertOffsetAndLength(offset, sizeof(double));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    *(double*)(ptr + offset) = value;
+
+                }
+                else
+                {
+                    ulong uvalue = *(ulong*)(ptr + offset);
+                    *(ulong*)(ptr + offset) = ((uvalue & 0x0000000FUL) << 56) | ((uvalue & 0x000000F0UL) << 48) | ((uvalue & 0x00000F00UL) << 40) | ((uvalue & 0x0000F000UL) << 32) |
+                                              ((uvalue & 0x000F0000UL) << 24) | ((uvalue & 0x00F00000UL) << 16) | ((uvalue & 0x0F000000UL) << 8) | ((uvalue & 0xF0000000UL) << 0);
+                }
+            }
+            _pos = offset;
+        }
+#else // !UNSAFE_BYTEBUFFER
+        // Slower versions of Put* for when unsafe code is not allowed.
         public void PutShort(int offset, short value)
         {
             AssertOffsetAndLength(offset, sizeof(short));
@@ -129,6 +288,8 @@ namespace FlatBuffers
             WriteLittleEndian(offset, BitConverter.GetBytes(value));
         }
 
+#endif // UNSAFE_BYTEBUFFER
+
         public sbyte GetSbyte(int index)
         {
             AssertOffsetAndLength(index, sizeof(sbyte));
@@ -141,6 +302,150 @@ namespace FlatBuffers
             return _buffer[index];
         }
 
+#if UNSAFE_BYTEBUFFER
+        // Unsafe but more efficient versions of Get*.
+        public unsafe short GetShort(int offset)
+        {
+            AssertOffsetAndLength(offset, sizeof(short));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return *(short*)(ptr + offset);
+                }
+                else
+                {
+                    ushort uvalue = *(ushort*)(ptr + offset);
+                    return (short)(((uvalue & 0x0FU) << 8) | ((uvalue & 0xF0U) << 0));
+                }
+            }
+        }
+
+        public unsafe ushort GetUshort(int offset)
+        {
+            AssertOffsetAndLength(offset, sizeof(ushort));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return *(ushort*)(ptr + offset);
+                }
+                else
+                {
+                    ushort uvalue = *(ushort*)(ptr + offset);
+                    return (ushort)(((uvalue & 0x0FU) << 8) | ((uvalue & 0xF0U) << 0));
+                }
+            }
+        }
+
+        public unsafe int GetInt(int offset)
+        {
+            AssertOffsetAndLength(offset, sizeof(int));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian) { 
+                    return *(int*)(ptr + offset);
+                }
+                else
+                {
+                    uint uvalue = *(uint*)(ptr + offset);
+                    return (int)(((uvalue & 0x000FU) << 24) | ((uvalue & 0x00F0U) << 16) | ((uvalue & 0x0F00U) << 8) | ((uvalue & 0xF000U) << 0));
+                }
+            }
+        }
+
+        public unsafe uint GetUint(int offset)
+        {
+            AssertOffsetAndLength(offset, sizeof(uint));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return *(uint*)(ptr + offset);
+                }
+                else
+                {
+                    uint uvalue = *(uint*)(ptr + offset);
+                    return ((uvalue & 0x000FU) << 24) | ((uvalue & 0x00F0U) << 16) | ((uvalue & 0x0F00U) << 8) | ((uvalue & 0xF000U) << 0);
+                }
+            }
+        }
+
+        public unsafe long GetLong(int offset)
+        {
+            AssertOffsetAndLength(offset, sizeof(long));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return *(long*)(ptr + offset);
+                }
+                else
+                {
+                    ulong uvalue = (ulong)(ptr + offset);
+                    return (long)(((uvalue & 0x0000000FUL) << 56) | ((uvalue & 0x000000F0UL) << 48) | ((uvalue & 0x00000F00UL) << 40) | ((uvalue & 0x0000F000UL) << 32) |
+                                  ((uvalue & 0x000F0000UL) << 24) | ((uvalue & 0x00F00000UL) << 16) | ((uvalue & 0x0F000000UL) << 8) | ((uvalue & 0xF0000000UL) << 0));
+
+                }
+            }
+        }
+
+        public unsafe ulong GetUlong(int offset)
+        {
+            AssertOffsetAndLength(offset, sizeof(ulong));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return *(ulong*)(ptr + offset);
+                }
+                else
+                {
+                    ulong uvalue = (ulong)(ptr + offset);
+                    return ((uvalue & 0x0000000FUL) << 56) | ((uvalue & 0x000000F0UL) << 48) | ((uvalue & 0x00000F00UL) << 40) | ((uvalue & 0x0000F000UL) << 32) |
+                           ((uvalue & 0x000F0000UL) << 24) | ((uvalue & 0x00F00000UL) << 16) | ((uvalue & 0x0F000000UL) << 8) | ((uvalue & 0xF0000000UL) << 0);
+                }
+            }
+        }
+
+        public unsafe float GetFloat(int offset)
+        {
+            AssertOffsetAndLength(offset, sizeof(float));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return *(float*)(ptr + offset);
+                }
+                else
+                {
+                    uint uvalue = *(uint*)(ptr + offset);
+                    uvalue = ((uvalue & 0x000FU) << 24) | ((uvalue & 0x00F0U) << 16) | ((uvalue & 0x0F00U) << 8) | ((uvalue & 0xF000U) << 0);
+                    return *(float*)(&uvalue);
+                }
+            }
+        }
+
+        public unsafe double GetDouble(int offset)
+        {
+            AssertOffsetAndLength(offset, sizeof(double));
+            fixed (byte* ptr = _buffer)
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return *(double*)(ptr + offset);
+                }
+                else
+                {
+                    ulong uvalue = *(ulong*)(ptr + offset);
+                    uvalue = ((uvalue & 0x0000000FUL) << 56) | ((uvalue & 0x000000F0UL) << 48) | ((uvalue & 0x00000F00UL) << 40) | ((uvalue & 0x0000F000UL) << 32) |
+                             ((uvalue & 0x000F0000UL) << 24) | ((uvalue & 0x00F00000UL) << 16) | ((uvalue & 0x0F000000UL) << 8) | ((uvalue & 0xF0000000UL) << 0);
+                    return *(double*)(&uvalue);
+                }
+            }
+        }
+#else // !UNSAFE_BYTEBUFFER
+        // Slower versions of Get* for when unsafe code is not allowed.
         public short GetShort(int index)
         {
             var tmp = ReadLittleEndian(index, sizeof(short));
@@ -196,5 +501,6 @@ namespace FlatBuffers
             var value = BitConverter.ToDouble(tmp, 0);
             return value;
         }
+#endif // UNSAFE_BYTEBUFFER
     }
 }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -638,21 +638,27 @@ std::string GenerateCPP(const Parser &parser,
               "return verifier.VerifyBuffer<";
       code += parser.root_struct_def->name + ">(); }\n\n";
 
+      if (parser.file_identifier_.length()) {
+        // Return the identifier
+        code += "inline const char *" + parser.root_struct_def->name;
+        code += "Identifier() { return \"" + parser.file_identifier_;
+        code += "\"; }\n\n";
+
+        // Check if a buffer has the identifier.
+        code += "inline bool " + parser.root_struct_def->name;
+        code += "BufferHasIdentifier(const void *buf) { return flatbuffers::";
+        code += "BufferHasIdentifier(buf, ";
+        code += parser.root_struct_def->name + "Identifier()); }\n\n";
+      }
+
       // Finish a buffer with a given root object:
       code += "inline void Finish" + parser.root_struct_def->name;
       code += "Buffer(flatbuffers::FlatBufferBuilder &fbb, flatbuffers::Offset<";
       code += parser.root_struct_def->name + "> root) { fbb.Finish(root";
       if (parser.file_identifier_.length())
-        code += ", \"" + parser.file_identifier_ + "\"";
+        code += ", " + parser.root_struct_def->name + "Identifier()";
       code += "); }\n\n";
 
-      if (parser.file_identifier_.length()) {
-        // Check if a buffer has the identifier.
-        code += "inline bool " + parser.root_struct_def->name;
-        code += "BufferHasIdentifier(const void *buf) { return flatbuffers::";
-        code += "BufferHasIdentifier(buf, \"" + parser.file_identifier_;
-        code += "\"); }\n\n";
-      }
     }
 
     CloseNestedNameSpaces(name_space, &code);

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -422,7 +422,9 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
       code += "Length(" + offset_prefix;
       code += "__vector_len(o) : 0; }\n";
     }
-    if ((field.value.type.base_type == BASE_TYPE_VECTOR ||
+    // Generate a ByteBuffer accessor for strings & vectors of scalars.
+    if (((field.value.type.base_type == BASE_TYPE_VECTOR &&
+          IsScalar(field.value.type.VectorType().base_type)) ||
          field.value.type.base_type == BASE_TYPE_STRING) &&
         lang.language == GeneratorOptions::kJava) {
       code += "  public ByteBuffer ";

--- a/tests/MyGame/Example/Monster.java
+++ b/tests/MyGame/Example/Monster.java
@@ -27,16 +27,13 @@ public class Monster extends Table {
   public Test test4(int j) { return test4(new Test(), j); }
   public Test test4(Test obj, int j) { int o = __offset(22); return o != 0 ? obj.__init(__vector(o) + j * 4, bb) : null; }
   public int test4Length() { int o = __offset(22); return o != 0 ? __vector_len(o) : 0; }
-  public ByteBuffer test4AsByteBuffer() { return __vector_as_bytebuffer(22, 4); }
   public String testarrayofstring(int j) { int o = __offset(24); return o != 0 ? __string(__vector(o) + j * 4) : null; }
   public int testarrayofstringLength() { int o = __offset(24); return o != 0 ? __vector_len(o) : 0; }
-  public ByteBuffer testarrayofstringAsByteBuffer() { return __vector_as_bytebuffer(24, 4); }
   /// an example documentation comment: this will end up in the generated code
   /// multiline too
   public Monster testarrayoftables(int j) { return testarrayoftables(new Monster(), j); }
   public Monster testarrayoftables(Monster obj, int j) { int o = __offset(26); return o != 0 ? obj.__init(__indirect(__vector(o) + j * 4), bb) : null; }
   public int testarrayoftablesLength() { int o = __offset(26); return o != 0 ? __vector_len(o) : 0; }
-  public ByteBuffer testarrayoftablesAsByteBuffer() { return __vector_as_bytebuffer(26, 4); }
   public Monster enemy() { return enemy(new Monster()); }
   public Monster enemy(Monster obj) { int o = __offset(28); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
   public byte testnestedflatbuffer(int j) { int o = __offset(30); return o != 0 ? bb.get(__vector(o) + j * 1) : 0; }

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -240,9 +240,11 @@ inline const Monster *GetMonster(const void *buf) { return flatbuffers::GetRoot<
 
 inline bool VerifyMonsterBuffer(flatbuffers::Verifier &verifier) { return verifier.VerifyBuffer<Monster>(); }
 
-inline void FinishMonsterBuffer(flatbuffers::FlatBufferBuilder &fbb, flatbuffers::Offset<Monster> root) { fbb.Finish(root, "MONS"); }
+inline const char *MonsterIdentifier() { return "MONS"; }
 
-inline bool MonsterBufferHasIdentifier(const void *buf) { return flatbuffers::BufferHasIdentifier(buf, "MONS"); }
+inline bool MonsterBufferHasIdentifier(const void *buf) { return flatbuffers::BufferHasIdentifier(buf, MonsterIdentifier()); }
+
+inline void FinishMonsterBuffer(flatbuffers::FlatBufferBuilder &fbb, flatbuffers::Offset<Monster> root) { fbb.Finish(root, MonsterIdentifier()); }
 
 }  // namespace Example
 }  // namespace MyGame

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -137,6 +137,7 @@ void AccessFlatBufferTest(const std::string &flatbuf) {
   TEST_EQ(pos->test3().b(), 20);
 
   auto inventory = monster->inventory();
+  TEST_EQ(VectorLength(inventory), 10);  // Works even if inventory is null.
   TEST_NOTNULL(inventory);
   unsigned char inv_data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   for (auto it = inventory->begin(); it != inventory->end(); ++it)

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -117,6 +117,7 @@ void AccessFlatBufferTest(const std::string &flatbuf) {
     flatbuf.length());
   TEST_EQ(VerifyMonsterBuffer(verifier), true);
 
+  TEST_EQ(strcmp(MonsterIdentifier(), "MONS"), 0);
   TEST_EQ(MonsterBufferHasIdentifier(flatbuf.c_str()), true);
 
   // Access the buffer from the root.


### PR DESCRIPTION
Added an "unsafe" mode to the ByteBuffer class in C#.

If your C# runtime environment supports unsafe code, you can use
the #define UNSAFE_BYTEBUFFER setting and build the FlatBuffers assembly
in unsafe mode for greatly increased performance.