### PR TITLE
fix compile error for test.cpp in TEST_EQ

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -137,7 +137,7 @@ void AccessFlatBufferTest(const std::string &flatbuf) {
   TEST_EQ(pos->test3().b(), 20);
 
   auto inventory = monster->inventory();
-  TEST_EQ(VectorLength(inventory), 10);  // Works even if inventory is null.
+  TEST_EQ(VectorLength(inventory), (size_t)10);  // Works even if inventory is null.
   TEST_NOTNULL(inventory);
   unsigned char inv_data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   for (auto it = inventory->begin(); it != inventory->end(); ++it)


### PR DESCRIPTION
VectorLength returns size_t type
```c
template<typename T> static inline size_t VectorLength(const Vector<T> *v) {
  return v ? v->Length() : 0;
}
```

so, compiling test.cpp failed because of -Werror,-Wsign-compare

```c
/Users/charsyam/works/flatbuffers/tests/test.cpp:40:14: error: comparison of
      integers of different signs: 'unsigned long' and 'int'
      [-Werror,-Wsign-compare]
  if (expval != val) {
      ~~~~~~ ^  ~~~
/Users/charsyam/works/flatbuffers/tests/test.cpp:140:3: note: in instantiation
      of function template specialization 'TestEq<unsigned long, int>' requested
      here
  TEST_EQ(VectorLength(inventory), 10);  // Works even if inventory is null.
  ^
/Users/charsyam/works/flatbuffers/tests/test.cpp:50:27: note: expanded from
      macro 'TEST_EQ'
#define TEST_EQ(exp, val) TestEq(exp,         val,   #exp, __FILE__, __LINE__)
                          ^
1 error generated.
make[2]: *** [CMakeFiles/flattests.dir/tests/test.cpp.o] Error 1
make[1]: *** [CMakeFiles/flattests.dir/all] Error 2
make: *** [all] Error 2
```

So. I think it is better to explicit its type.
I tested this in MAC and Ubuntu 14.04 