### PR TITLE
Java: added reuse for root objects

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -304,13 +304,18 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
   if (!struct_def.fixed) {
     // Generate a special accessor for the table that when used as the root
     // of a FlatBuffer
-    code += "  public static " + struct_def.name + " ";
-    code += FunctionStart(lang, 'G') + "etRootAs" + struct_def.name;
-    code += "(ByteBuffer _bb) { ";
+    std::string method_name = FunctionStart(lang, 'G') + "etRootAs" + struct_def.name;
+    std::string method_signature = "  public static " + struct_def.name + " " + method_name;
+      
+    // create convenience method that doesn't require an existing object
+    code += method_signature + "(ByteBuffer _bb) ";
+    code += "{ return " + method_name + "(_bb, new " + struct_def.name+ "()); }\n";
+      
+    // create method that allows object reuse
+    code += method_signature + "(ByteBuffer _bb, " + struct_def.name + " obj) { ";
     code += lang.set_bb_byteorder;
-    code += "return (new " + struct_def.name;
-    code += "()).__init(_bb." + FunctionStart(lang, 'G');
-    code += "etInt(_bb.position()) + _bb.position(), _bb); }\n";
+    code += "return (obj.__init(_bb." + FunctionStart(lang, 'G');
+    code += "etInt(_bb.position()) + _bb.position(), _bb)); }\n";
     if (parser.root_struct_def == &struct_def) {
       if (parser.file_identifier_.length()) {
         // Check if a buffer has the identifier.

--- a/tests/MyGame/Example/Monster.java
+++ b/tests/MyGame/Example/Monster.java
@@ -8,7 +8,8 @@ import java.util.*;
 import com.google.flatbuffers.*;
 
 public class Monster extends Table {
-  public static Monster getRootAsMonster(ByteBuffer _bb) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (new Monster()).__init(_bb.getInt(_bb.position()) + _bb.position(), _bb); }
+  public static Monster getRootAsMonster(ByteBuffer _bb) { return getRootAsMonster(_bb, new Monster()); }
+  public static Monster getRootAsMonster(ByteBuffer _bb, Monster obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__init(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public static boolean MonsterBufferHasIdentifier(ByteBuffer _bb) { return __has_identifier(_bb, "MONS"); }
   public Monster __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
 

--- a/tests/MyGame/Example/Stat.java
+++ b/tests/MyGame/Example/Stat.java
@@ -8,7 +8,8 @@ import java.util.*;
 import com.google.flatbuffers.*;
 
 public class Stat extends Table {
-  public static Stat getRootAsStat(ByteBuffer _bb) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (new Stat()).__init(_bb.getInt(_bb.position()) + _bb.position(), _bb); }
+  public static Stat getRootAsStat(ByteBuffer _bb) { return getRootAsStat(_bb, new Stat()); }
+  public static Stat getRootAsStat(ByteBuffer _bb, Stat obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__init(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public Stat __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
 
   public String id() { int o = __offset(4); return o != 0 ? __string(o + bb_pos) : null; }


### PR DESCRIPTION
I split the current getRootAs method into two, a convenience method with the current signature, and one that allows object reuse