### PR TITLE
Fix pointer underrun when allocating large vectors

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -367,7 +367,7 @@ class vector_downward {
   }
 
   uint8_t *make_space(size_t len) {
-    if (buf_ > cur_ - len) {
+    if (len > size_t( cur_ ) || buf_ > cur_ - len) {
       auto old_size = size();
       reserved_ += std::max(len, growth_policy(reserved_));
       auto new_buf = allocator_.allocate(reserved_);


### PR DESCRIPTION
If len is bigger then cur_, cur_ - len had an underflow and was bigger
then buf_, causing a segfault.