### PR TITLE
Mono compatibility for C# version

### DIFF
--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -32,7 +32,7 @@ namespace FlatBuffers
         protected int __offset(int vtableOffset)
         {
             int vtable = bb_pos - bb.GetInt(bb_pos);
-            return vtableOffset < bb.GetShort(vtable) ? bb.GetShort(vtable + vtableOffset) : (short)0;
+            return vtableOffset < bb.GetShort(vtable) ? (int)bb.GetShort(vtable + vtableOffset) : 0;
         }
 
         // Retrieve the relative offset stored at "offset"

--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -32,7 +32,7 @@ namespace FlatBuffers
         protected int __offset(int vtableOffset)
         {
             int vtable = bb_pos - bb.GetInt(bb_pos);
-            return vtableOffset < bb.GetShort(vtable) ? bb.GetShort(vtable + vtableOffset) : 0;
+            return vtableOffset < bb.GetShort(vtable) ? bb.GetShort(vtable + vtableOffset) : (short)0;
         }
 
         // Retrieve the relative offset stored at "offset"


### PR DESCRIPTION
On my first attempt to build with mono on linux, I ran into [CS0172](https://msdn.microsoft.com/en-us/library/1yaky37f%28v=vs.90%29.aspx).

I'm not a C# expert, but the following single change appears to do the trick.