### PR TITLE
Rename a few variables to fix the build in VS 2015. Make FuzzTest2 fuzzier.

### DIFF
--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -112,18 +112,18 @@ int main(int argc, const char *argv[]) {
   std::vector<std::string> filenames;
   std::vector<const char *> include_directories;
   size_t binary_files_from = std::numeric_limits<size_t>::max();
-  for (int i = 1; i < argc; i++) {
-    const char *arg = argv[i];
+  for (int argi = 1; argi < argc; argi++) {
+    const char *arg = argv[argi];
     if (arg[0] == '-') {
       if (filenames.size() && arg[1] != '-')
         Error("invalid option location", arg, true);
       std::string opt = arg;
       if (opt == "-o") {
-        if (++i >= argc) Error("missing path following", arg, true);
-        output_path = flatbuffers::ConCatPathFileName(argv[i], "");
+        if (++argi >= argc) Error("missing path following", arg, true);
+        output_path = flatbuffers::ConCatPathFileName(argv[argi], "");
       } else if(opt == "-I") {
-        if (++i >= argc) Error("missing path following", arg, true);
-        include_directories.push_back(argv[i]);
+        if (++argi >= argc) Error("missing path following", arg, true);
+        include_directories.push_back(argv[argi]);
       } else if(opt == "--strict-json") {
         opts.strict_json = true;
       } else if(opt == "--no-prefix") {
@@ -149,7 +149,7 @@ int main(int argc, const char *argv[]) {
         found:;
       }
     } else {
-      filenames.push_back(argv[i]);
+      filenames.push_back(argv[argi]);
     }
   }
 

--- a/src/idl_gen_fbs.cpp
+++ b/src/idl_gen_fbs.cpp
@@ -58,9 +58,9 @@ std::string GenerateFBS(const Parser &parser, const std::string &file_name,
   }
   schema += ";\n\n";
   // Generate code for all the enum declarations.
-  for (auto it = parser.enums_.vec.begin();
-           it != parser.enums_.vec.end(); ++it) {
-    EnumDef &enum_def = **it;
+  for (auto enum_def_it = parser.enums_.vec.begin();
+           enum_def_it != parser.enums_.vec.end(); ++enum_def_it) {
+    EnumDef &enum_def = **enum_def_it;
     schema += "enum " + enum_def.name + " : ";
     schema += GenType(enum_def.underlying_type) + " {\n";
     for (auto it = enum_def.vals.vec.begin();
@@ -75,9 +75,9 @@ std::string GenerateFBS(const Parser &parser, const std::string &file_name,
            it != parser.structs_.vec.end(); ++it) {
     StructDef &struct_def = **it;
     schema += "table " + struct_def.name + " {\n";
-    for (auto it = struct_def.fields.vec.begin();
-             it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+    for (auto field_it = struct_def.fields.vec.begin();
+             field_it != struct_def.fields.vec.end(); ++field_it) {
+      auto &field = **field_it;
       schema += "  " + field.name + ":" + GenType(field.value.type);
       if (field.value.constant != "0") schema += " = " + field.value.constant;
       if (field.required) schema += " (required)";

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -787,17 +787,17 @@ StructDef *Parser::LookupCreateStruct(const std::string &name) {
 }
 
 void Parser::ParseEnum(bool is_union) {
-  std::vector<std::string> dc = doc_comment_;
+  std::vector<std::string> enum_comment = doc_comment_;
   Next();
-  std::string name = attribute_;
+  std::string enum_name = attribute_;
   Expect(kTokenIdentifier);
   auto &enum_def = *new EnumDef();
-  enum_def.name = name;
+  enum_def.name = enum_name;
   if (!files_being_parsed_.empty()) enum_def.file = files_being_parsed_.top();
-  enum_def.doc_comment = dc;
+  enum_def.doc_comment = enum_comment;
   enum_def.is_union = is_union;
   enum_def.defined_namespace = namespaces_.back();
-  if (enums_.Add(name, &enum_def)) Error("enum already exists: " + name);
+  if (enums_.Add(enum_name, &enum_def)) Error("enum already exists: " + enum_name);
   if (is_union) {
     enum_def.underlying_type.base_type = BASE_TYPE_UTYPE;
     enum_def.underlying_type.enum_def = &enum_def;
@@ -821,19 +821,19 @@ void Parser::ParseEnum(bool is_union) {
   Expect('{');
   if (is_union) enum_def.vals.Add("NONE", new EnumVal("NONE", 0));
   do {
-    std::string name = attribute_;
-    std::vector<std::string> dc = doc_comment_;
+    std::string value_name = attribute_;
+    std::vector<std::string> value_comment = doc_comment_;
     Expect(kTokenIdentifier);
     auto prevsize = enum_def.vals.vec.size();
     auto value = enum_def.vals.vec.size()
       ? enum_def.vals.vec.back()->value + 1
       : 0;
-    auto &ev = *new EnumVal(name, value);
-    if (enum_def.vals.Add(name, &ev))
-      Error("enum value already exists: " + name);
-    ev.doc_comment = dc;
+    auto &ev = *new EnumVal(value_name, value);
+    if (enum_def.vals.Add(value_name, &ev))
+      Error("enum value already exists: " + value_name);
+    ev.doc_comment = value_comment;
     if (is_union) {
-      ev.struct_def = LookupCreateStruct(name);
+      ev.struct_def = LookupCreateStruct(value_name);
     }
     if (IsNext('=')) {
       ev.value = atoi(attribute_.c_str());
@@ -1198,10 +1198,10 @@ bool Parser::Parse(const char *source, const char **include_paths,
     for (auto it = enums_.vec.begin(); it != enums_.vec.end(); ++it) {
       auto &enum_def = **it;
       if (enum_def.is_union) {
-        for (auto it = enum_def.vals.vec.begin();
-             it != enum_def.vals.vec.end();
-             ++it) {
-          auto &val = **it;
+        for (auto val_it = enum_def.vals.vec.begin();
+             val_it != enum_def.vals.vec.end();
+             ++val_it) {
+          auto &val = **val_it;
           if (val.struct_def && val.struct_def->fixed)
             Error("only tables can be union elements: " + val.name);
         }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -365,6 +365,7 @@ void FuzzTest2() {
   const int num_struct_definitions = 5;  // Subset of num_definitions.
   const int fields_per_definition = 15;
   const int instances_per_definition = 5;
+  const int deprecation_rate = 10;        // 1 in deprecation_rate fields will be deprecated.
 
   std::string schema = "namespace test;\n\n";
 
@@ -403,24 +404,37 @@ void FuzzTest2() {
       "{\n");
 
     for (int field = 0; field < fields_per_definition; field++) {
+      const bool is_last_field = field == fields_per_definition - 1;
+
+      // Deprecate 1 in deprecation_rate fields. Only table fields can be deprecated.
+      // Don't deprecate the last field to avoid dangling commas in JSON.
+      const bool deprecated = !is_struct && !is_last_field && (lcg_rand() % deprecation_rate == 0);
+
       std::string field_name = "f" + flatbuffers::NumToString(field);
       AddToSchemaAndInstances(("  " + field_name + ":").c_str(),
-                              (field_name + ": ").c_str());
+                              deprecated ? "" : (field_name + ": ").c_str());
       // Pick random type:
       int base_type = lcg_rand() % (flatbuffers::BASE_TYPE_UNION + 1);
       switch (base_type) {
         case flatbuffers::BASE_TYPE_STRING:
           if (is_struct) {
-            Dummy();  // No strings in structs,
+            Dummy();  // No strings in structs.
           } else {
-            AddToSchemaAndInstances("string", "\"hi\"");
+            AddToSchemaAndInstances("string", deprecated ? "" : "\"hi\"");
+          }
+          break;
+        case flatbuffers::BASE_TYPE_VECTOR:
+          if (is_struct) {
+            Dummy();  // No vectors in structs.
+          }
+          else {
+            AddToSchemaAndInstances("[ubyte]", deprecated ? "" : "[\n0,\n1,\n255\n]");
           }
           break;
         case flatbuffers::BASE_TYPE_NONE:
         case flatbuffers::BASE_TYPE_UTYPE:
         case flatbuffers::BASE_TYPE_STRUCT:
         case flatbuffers::BASE_TYPE_UNION:
-        case flatbuffers::BASE_TYPE_VECTOR:
           if (definition) {
             // Pick a random previous definition and random data instance of
             // that definition.
@@ -428,7 +442,7 @@ void FuzzTest2() {
             int instance = lcg_rand() % instances_per_definition;
             AddToSchemaAndInstances(
               ("D" + flatbuffers::NumToString(defref)).c_str(),
-              definitions[defref].instances[instance].c_str());
+              deprecated ? "" : definitions[defref].instances[instance].c_str());
           } else {
             // If this is the first definition, we have no definition we can
             // refer to.
@@ -437,13 +451,18 @@ void FuzzTest2() {
           break;
         default:
           // All the scalar types.
-          AddToSchemaAndInstances(
-            flatbuffers::kTypeNames[base_type],
-            flatbuffers::NumToString(lcg_rand() % 128).c_str());
+          schema += flatbuffers::kTypeNames[base_type];
+
+          if (!deprecated) {
+            // We want each instance to use its own random value.
+            for (int inst = 0; inst < instances_per_definition; inst++)
+              definitions[definition].instances[inst] +=
+              flatbuffers::NumToString(lcg_rand() % 128).c_str();
+          }
       }
       AddToSchemaAndInstances(
-        ";\n",
-        field == fields_per_definition - 1 ? "\n" : ",\n");
+        deprecated ? "(deprecated);\n" : ";\n",
+        deprecated ? "" : is_last_field ? "\n" : ",\n");
     }
     AddToSchemaAndInstances("}\n\n", "}");
   }


### PR DESCRIPTION
VS 2015 new warnings: http://blogs.msdn.com/b/vcblog/archive/2014/11/12/improvements-to-warnings-in-the-c-compiler.aspx