### PR TITLE
Update idl_gen_general.cpp

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -506,18 +506,18 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
         code += field.name;
         // Java doesn't have defaults, which means this method must always
         // supply all arguments, and thus won't compile when fields are added.
-		    if (lang.language != GeneratorOptions::kJava)
-		    {
-		      //CSharp must use 'false' or 'true' not '0' or '1'
-		    	if (lang.language == GeneratorOptions::kCSharp)
-		    	{
-			    	code += field.value.type.base_type == BASE_TYPE_BOOL
-			    		? (field.value.constant == "0" ? " = false" : " = true")
-			    		: " = " + field.value.constant;
-			    }
-		    	else
-			    	code += " = " + field.value.constant;
-	    	}
+          if (lang.language != GeneratorOptions::kJava)
+	  {
+	    //CSharp must use 'false' or 'true' not '0' or '1'
+	    if (lang.language == GeneratorOptions::kCSharp)
+	    {
+	      code += field.value.type.base_type == BASE_TYPE_BOOL
+	              ? (field.value.constant == "0" ? " = false" : " = true")
+	              : " = " + field.value.constant;
+	    }
+	    else
+	      code += " = " + field.value.constant;
+           }
       }
       code += ") {\n    builder.";
       code += FunctionStart(lang, 'S') + "tartObject(";

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -506,8 +506,18 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
         code += field.name;
         // Java doesn't have defaults, which means this method must always
         // supply all arguments, and thus won't compile when fields are added.
-        if (lang.language != GeneratorOptions::kJava)
-          code += " = " + field.value.constant;
+		    if (lang.language != GeneratorOptions::kJava)
+		    {
+		      //CSharp must use 'false' or 'true' not '0' or '1'
+		    	if (lang.language == GeneratorOptions::kCSharp)
+		    	{
+			    	code += field.value.type.base_type == BASE_TYPE_BOOL
+			    		? (field.value.constant == "0" ? " = false" : " = true")
+			    		: " = " + field.value.constant;
+			    }
+		    	else
+			    	code += " = " + field.value.constant;
+	    	}
       }
       code += ") {\n    builder.";
       code += FunctionStart(lang, 'S') + "tartObject(";


### PR DESCRIPTION
There is a bug in creating a C# table when it includes a field of type 'BOOL'. The problem is that the generate C# code is as follows:
  "bool SampleValue = 0;"
This will fail to compile, because in C# this fails, it needs to be generated as:
 "bool SampleValue = false;"

The error is in line ~510