### PR TITLE
Eagerly allocate space to handle vector assumptions

### DIFF
--- a/go/builder.go
+++ b/go/builder.go
@@ -198,7 +198,7 @@ func (b *Builder) Prep(size, additionalBytes int) {
 	alignSize &= (size - 1)
 
 	// Reallocate the buffer if needed:
-	for int(b.head) < alignSize+size+additionalBytes {
+	for int(b.head) <= alignSize+size+additionalBytes {
 		oldBufSize := len(b.Bytes)
 		b.growByteBuffer()
 		b.head += UOffsetT(len(b.Bytes) - oldBufSize)

--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -21,12 +21,13 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	flatbuffers "github.com/google/flatbuffers/go"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
 	"testing"
+
+	flatbuffers "github.com/google/flatbuffers/go"
 )
 
 var (
@@ -478,6 +479,20 @@ func CheckByteLayout(fail func(string, ...interface{})) {
 	check([]byte{2, 1, 0, 0})
 	b.EndVector(2)
 	check([]byte{2, 0, 0, 0, 2, 1, 0, 0}) // padding
+
+	// test 3b: 11xbyte vector matches builder size
+
+	b = flatbuffers.NewBuilder(12)
+	b.StartVector(flatbuffers.SizeByte, 8, 1)
+	start := []byte{}
+	check(start)
+	for i := 1; i < 12; i++ {
+		b.PrependByte(byte(i))
+		start = append([]byte{byte(i)}, start...)
+		check(start)
+	}
+	b.EndVector(8)
+	check(append([]byte{8, 0, 0, 0}, start...))
 
 	// test 4: 1xuint16 vector
 


### PR DESCRIPTION
With the test added in this PR, the current `master` branch will panic, since no space is available for the vector end marker. Based on the assumptions in [this comment](https://github.com/google/flatbuffers/blob/ca5c9e7496c79deb4d1e80258d3293e46397f4d8/go/builder.go#L243), I assumed more eagerly allocating would be the proper solution.

Another approach may be adding the requisite space to `StartVector` and similar helpers; this was just the most straight-forward fix.