### PR TITLE
Tolerate DOS-style EOL in IDL line comments

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -186,7 +186,7 @@ void Parser::Next() {
       case '/':
         if (*cursor_ == '/') {
           const char *start = ++cursor_;
-          while (*cursor_ && *cursor_ != '\n') cursor_++;
+          while (*cursor_ && *cursor_ != '\n' && *cursor_ != '\r') cursor_++;
           if (*start == '/') {  // documentation comment
             if (cursor_ != source_ && !seen_newline)
               Error("a documentation comment should be on a line on its own");


### PR DESCRIPTION
If an IDL file uses DOS-style EOLs (CR+LF), line comments need to ignore the second linebreak character, otherwise, as is currently the case, the parsed documentation comment includes a trailing `\r` character, which is then output verbatim into the output source code by flatc.