### PR TITLE
Field accessors should use property getters in C#

### DIFF
--- a/docs/source/JavaUsage.md
+++ b/docs/source/JavaUsage.md
@@ -5,8 +5,8 @@ Generate code for Java with the `-j` option to `flatc`, or for C# with `-n`
 (think .Net).
 
 Note that this document is from the perspective of Java. Code for both languages
-is generated in the same way, with only very subtle differences, for example
-any `camelCase` Java call will be `CamelCase` in C#.
+is generated in the same way, with only minor differences. These differences
+are [explained in a section below](#differences-in-c-sharp).
 
 See `javaTest.java` for an example. Essentially, you read a FlatBuffer binary
 file into a `byte[]`, which you then turn into a `ByteBuffer`, which you pass to
@@ -151,7 +151,27 @@ not start from offset 0 in this buffer, but from `fbb.dataBuffer().position()`
 It ends at `fbb.capacity()`.
 
 
-## Text Parsing
+## Differences in C-sharp
+
+C# code works almost identically to Java, with only a few minor differences.
+You can see an example of C# code in `tests/FlatBuffers.Test/FlatBuffersExampleTests.cs`.
+
+First of all, naming follows standard C# style with `PascalCasing` identifiers,
+e.g. `GetRootAsMyRootType`. Also, values (except vectors and unions) are available
+as properties instead of parameterless accessor methods as in Java. The
+performance-enhancing methods to which you can pass an already created object
+are prefixed with `Get`, e.g.:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cs}
+    // property
+    var pos = monster.Pos;
+    // method filling a preconstructed object
+    var preconstructedPos = new Vec3();
+    monster.GetPos(preconstructedPos);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+## Text parsing
 
 There currently is no support for parsing text (Schema's and JSON) directly
 from Java, though you could use the C++ parser through JNI. Please see the

--- a/net/FlatBuffers/ByteBuffer.cs
+++ b/net/FlatBuffers/ByteBuffer.cs
@@ -17,7 +17,6 @@
 //#define UNSAFE_BYTEBUFFER  // uncomment this line to use faster ByteBuffer
 
 using System;
-using System.Linq;
 
 namespace FlatBuffers
 {
@@ -42,7 +41,7 @@ namespace FlatBuffers
             _pos = 0;
         }
 
-        public int position() { return _pos; }
+        public int Position { get { return _pos; } }
 
         // Pre-allocated helper arrays for convertion.
         private float[] floathelper = new[] { 0.0f };

--- a/net/FlatBuffers/FlatBufferBuilder.cs
+++ b/net/FlatBuffers/FlatBufferBuilder.cs
@@ -50,7 +50,7 @@ namespace FlatBuffers
         }
 
 
-        public int Offset() { return _bb.Length - _space; }
+        public int Offset { get { return _bb.Length - _space; } }
 
         public void Pad(int size)
         {
@@ -181,10 +181,10 @@ namespace FlatBuffers
         public void AddOffset(int off)
         {
             Prep(sizeof(int), 0);  // Ensure alignment is already done.
-            if (off > Offset())
+            if (off > Offset)
                 throw new ArgumentException();
 
-            off = Offset() - off + sizeof(int);
+            off = Offset - off + sizeof(int);
             PutInt(off);
         }
 
@@ -199,7 +199,7 @@ namespace FlatBuffers
         public int EndVector()
         {
             PutInt(_vectorNumElems);
-            return Offset();
+            return Offset;
         }
 
         public void Nested(int obj)
@@ -207,7 +207,7 @@ namespace FlatBuffers
             // Structs are always stored inline, so need to be created right
             // where they are used. You'll get this assert if you created it
             // elsewhere.
-            if (obj != Offset())
+            if (obj != Offset)
                 throw new Exception(
                     "FlatBuffers: struct must be serialized inline.");
         }
@@ -225,7 +225,7 @@ namespace FlatBuffers
         {
             NotNested();
             _vtable = new int[numfields];
-            _objectStart = Offset();
+            _objectStart = Offset;
         }
 
 
@@ -233,7 +233,7 @@ namespace FlatBuffers
         // buffer.
         public void Slot(int voffset)
         {
-            _vtable[voffset] = Offset();
+            _vtable[voffset] = Offset;
         }
 
         // Add a scalar to a table at `o` into its vtable, with value `x` and default `d`
@@ -280,7 +280,7 @@ namespace FlatBuffers
                   "Flatbuffers: calling endObject without a startObject");
 
             AddInt((int)0);
-            var vtableloc = Offset();
+            var vtableloc = Offset;
             // Write out the current vtable.
             for (int i = _vtable.Length - 1; i >= 0 ; i--) {
                 // Offset relative to the start of the table.
@@ -333,9 +333,9 @@ namespace FlatBuffers
 
                     _vtables = newvtables;
                 };
-                _vtables[_numVtables++] = Offset();
+                _vtables[_numVtables++] = Offset;
                 // Point table to current vtable.
-                _bb.PutInt(_bb.Length - vtableloc, Offset() - vtableloc);
+                _bb.PutInt(_bb.Length - vtableloc, Offset - vtableloc);
             }
 
             _vtable = null;
@@ -361,14 +361,14 @@ namespace FlatBuffers
             AddOffset(rootTable);
         }
 
-        public ByteBuffer DataBuffer() { return _bb; }
+        public ByteBuffer DataBuffer { get { return _bb; } }
 
         // Utility function for copying a byte array that starts at 0.
         public byte[] SizedByteArray()
         {
-            var newArray = new byte[_bb.Data.Length - _bb.position()];
-            Buffer.BlockCopy(_bb.Data, _bb.position(), newArray, 0,
-                             _bb.Data.Length - _bb.position());
+            var newArray = new byte[_bb.Data.Length - _bb.Position];
+            Buffer.BlockCopy(_bb.Data, _bb.Position, newArray, 0,
+                             _bb.Data.Length - _bb.Position);
             return newArray;
         }
 

--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -81,7 +81,7 @@ namespace FlatBuffers
 
             for (var i = 0; i < FlatBufferConstants.FileIdentifierLength; i++)
             {
-                if (ident[i] != (char)bb.Get(bb.position() + sizeof(int) + i)) return false;
+                if (ident[i] != (char)bb.Get(bb.Position + sizeof(int) + i)) return false;
             }
 
             return true;

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -82,61 +82,61 @@ namespace FlatBuffers.Test
             fbb.Finish(mon);
 
             // Dump to output directory so we can inspect later, if needed
-            using (var ms = new MemoryStream(fbb.DataBuffer().Data, fbb.DataBuffer().position(), fbb.Offset()))
+            using (var ms = new MemoryStream(fbb.DataBuffer.Data, fbb.DataBuffer.Position, fbb.Offset))
             {
                 var data = ms.ToArray();
                 File.WriteAllBytes(@"Resources/monsterdata_cstest.mon",data);
             }
 
             // Now assert the buffer
-            TestBuffer(fbb.DataBuffer());
+            TestBuffer(fbb.DataBuffer);
         }
 
         private void TestBuffer(ByteBuffer bb)
         {
             var monster = Monster.GetRootAsMonster(bb);
 
-            Assert.AreEqual(80, monster.Hp());
-            Assert.AreEqual(150, monster.Mana());
-            Assert.AreEqual("MyMonster", monster.Name());
+            Assert.AreEqual(80, monster.Hp);
+            Assert.AreEqual(150, monster.Mana);
+            Assert.AreEqual("MyMonster", monster.Name);
 
-            var pos = monster.Pos();
-            Assert.AreEqual(1.0f, pos.X());
-            Assert.AreEqual(2.0f, pos.Y());
-            Assert.AreEqual(3.0f, pos.Z());
+            var pos = monster.Pos;
+            Assert.AreEqual(1.0f, pos.X);
+            Assert.AreEqual(2.0f, pos.Y);
+            Assert.AreEqual(3.0f, pos.Z);
 
-            Assert.AreEqual(3.0f, pos.Test1());
-            Assert.AreEqual(Color.Green, pos.Test2());
-            var t = pos.Test3();
-            Assert.AreEqual((short)5, t.A());
-            Assert.AreEqual((sbyte)6, t.B());
+            Assert.AreEqual(3.0f, pos.Test1);
+            Assert.AreEqual(Color.Green, pos.Test2);
+            var t = pos.Test3;
+            Assert.AreEqual((short)5, t.A);
+            Assert.AreEqual((sbyte)6, t.B);
 
-            Assert.AreEqual(Any.Monster, monster.TestType());
+            Assert.AreEqual(Any.Monster, monster.TestType);
 
             var monster2 = new Monster();
-            Assert.IsTrue(monster.Test(monster2) != null);
-            Assert.AreEqual("Fred", monster2.Name());
+            Assert.IsTrue(monster.GetTest(monster2) != null);
+            Assert.AreEqual("Fred", monster2.Name);
 
 
-            Assert.AreEqual(5, monster.InventoryLength());
+            Assert.AreEqual(5, monster.InventoryLength);
             var invsum = 0;
-            for (var i = 0; i < monster.InventoryLength(); i++)
+            for (var i = 0; i < monster.InventoryLength; i++)
             {
-                invsum += monster.Inventory(i);
+                invsum += monster.GetInventory(i);
             }
             Assert.AreEqual(10, invsum);
 
-            var test0 = monster.Test4(0);
-            var test1 = monster.Test4(1);
-            Assert.AreEqual(2, monster.Test4Length());
+            var test0 = monster.GetTest4(0);
+            var test1 = monster.GetTest4(1);
+            Assert.AreEqual(2, monster.Test4Length);
 
-            Assert.AreEqual(100, test0.A() + test0.B() + test1.A() + test1.B());
+            Assert.AreEqual(100, test0.A + test0.B + test1.A + test1.B);
 
-            Assert.AreEqual(2, monster.TestarrayofstringLength());
-            Assert.AreEqual("test1", monster.Testarrayofstring(0));
-            Assert.AreEqual("test2", monster.Testarrayofstring(1));
+            Assert.AreEqual(2, monster.TestarrayofstringLength);
+            Assert.AreEqual("test1", monster.GetTestarrayofstring(0));
+            Assert.AreEqual("test2", monster.GetTestarrayofstring(1));
 
-            Assert.AreEqual(false, monster.Testbool());
+            Assert.AreEqual(false, monster.Testbool);
         }
 
         public void CanReadCppGeneratedWireFile()

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -7,45 +7,45 @@ using FlatBuffers;
 
 public sealed class Monster : Table {
   public static Monster GetRootAsMonster(ByteBuffer _bb) { return GetRootAsMonster(_bb, new Monster()); }
-  public static Monster GetRootAsMonster(ByteBuffer _bb, Monster obj) { return (obj.__init(_bb.GetInt(_bb.position()) + _bb.position(), _bb)); }
+  public static Monster GetRootAsMonster(ByteBuffer _bb, Monster obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
   public static bool MonsterBufferHasIdentifier(ByteBuffer _bb) { return __has_identifier(_bb, "MONS"); }
   public Monster __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
 
-  public Vec3 Pos() { return Pos(new Vec3()); }
-  public Vec3 Pos(Vec3 obj) { int o = __offset(4); return o != 0 ? obj.__init(o + bb_pos, bb) : null; }
-  public short Mana() { int o = __offset(6); return o != 0 ? bb.GetShort(o + bb_pos) : (short)150; }
-  public short Hp() { int o = __offset(8); return o != 0 ? bb.GetShort(o + bb_pos) : (short)100; }
-  public string Name() { int o = __offset(10); return o != 0 ? __string(o + bb_pos) : null; }
-  public byte Inventory(int j) { int o = __offset(14); return o != 0 ? bb.Get(__vector(o) + j * 1) : (byte)0; }
-  public int InventoryLength() { int o = __offset(14); return o != 0 ? __vector_len(o) : 0; }
-  public Color Color() { int o = __offset(16); return o != 0 ? (Color)bb.GetSbyte(o + bb_pos) : (Color)8; }
-  public Any TestType() { int o = __offset(18); return o != 0 ? (Any)bb.Get(o + bb_pos) : (Any)0; }
-  public Table Test(Table obj) { int o = __offset(20); return o != 0 ? __union(obj, o) : null; }
-  public Test Test4(int j) { return Test4(new Test(), j); }
-  public Test Test4(Test obj, int j) { int o = __offset(22); return o != 0 ? obj.__init(__vector(o) + j * 4, bb) : null; }
-  public int Test4Length() { int o = __offset(22); return o != 0 ? __vector_len(o) : 0; }
-  public string Testarrayofstring(int j) { int o = __offset(24); return o != 0 ? __string(__vector(o) + j * 4) : null; }
-  public int TestarrayofstringLength() { int o = __offset(24); return o != 0 ? __vector_len(o) : 0; }
+  public Vec3 Pos { get { return GetPos(new Vec3()); } }
+  public Vec3 GetPos(Vec3 obj) { int o = __offset(4); return o != 0 ? obj.__init(o + bb_pos, bb) : null; }
+  public short Mana { get { int o = __offset(6); return o != 0 ? bb.GetShort(o + bb_pos) : (short)150; } }
+  public short Hp { get { int o = __offset(8); return o != 0 ? bb.GetShort(o + bb_pos) : (short)100; } }
+  public string Name { get { int o = __offset(10); return o != 0 ? __string(o + bb_pos) : null; } }
+  public byte GetInventory(int j) { int o = __offset(14); return o != 0 ? bb.Get(__vector(o) + j * 1) : (byte)0; }
+  public int InventoryLength { get { int o = __offset(14); return o != 0 ? __vector_len(o) : 0; } }
+  public Color Color { get { int o = __offset(16); return o != 0 ? (Color)bb.GetSbyte(o + bb_pos) : (Color)8; } }
+  public Any TestType { get { int o = __offset(18); return o != 0 ? (Any)bb.Get(o + bb_pos) : (Any)0; } }
+  public Table GetTest(Table obj) { int o = __offset(20); return o != 0 ? __union(obj, o) : null; }
+  public Test GetTest4(int j) { return GetTest4(new Test(), j); }
+  public Test GetTest4(Test obj, int j) { int o = __offset(22); return o != 0 ? obj.__init(__vector(o) + j * 4, bb) : null; }
+  public int Test4Length { get { int o = __offset(22); return o != 0 ? __vector_len(o) : 0; } }
+  public string GetTestarrayofstring(int j) { int o = __offset(24); return o != 0 ? __string(__vector(o) + j * 4) : null; }
+  public int TestarrayofstringLength { get { int o = __offset(24); return o != 0 ? __vector_len(o) : 0; } }
   /// an example documentation comment: this will end up in the generated code
   /// multiline too
-  public Monster Testarrayoftables(int j) { return Testarrayoftables(new Monster(), j); }
-  public Monster Testarrayoftables(Monster obj, int j) { int o = __offset(26); return o != 0 ? obj.__init(__indirect(__vector(o) + j * 4), bb) : null; }
-  public int TestarrayoftablesLength() { int o = __offset(26); return o != 0 ? __vector_len(o) : 0; }
-  public Monster Enemy() { return Enemy(new Monster()); }
-  public Monster Enemy(Monster obj) { int o = __offset(28); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
-  public byte Testnestedflatbuffer(int j) { int o = __offset(30); return o != 0 ? bb.Get(__vector(o) + j * 1) : (byte)0; }
-  public int TestnestedflatbufferLength() { int o = __offset(30); return o != 0 ? __vector_len(o) : 0; }
-  public Stat Testempty() { return Testempty(new Stat()); }
-  public Stat Testempty(Stat obj) { int o = __offset(32); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
-  public bool Testbool() { int o = __offset(34); return o != 0 ? 0!=bb.Get(o + bb_pos) : (bool)false; }
-  public int Testhashs32Fnv1() { int o = __offset(36); return o != 0 ? bb.GetInt(o + bb_pos) : (int)0; }
-  public uint Testhashu32Fnv1() { int o = __offset(38); return o != 0 ? bb.GetUint(o + bb_pos) : (uint)0; }
-  public long Testhashs64Fnv1() { int o = __offset(40); return o != 0 ? bb.GetLong(o + bb_pos) : (long)0; }
-  public ulong Testhashu64Fnv1() { int o = __offset(42); return o != 0 ? bb.GetUlong(o + bb_pos) : (ulong)0; }
-  public int Testhashs32Fnv1a() { int o = __offset(44); return o != 0 ? bb.GetInt(o + bb_pos) : (int)0; }
-  public uint Testhashu32Fnv1a() { int o = __offset(46); return o != 0 ? bb.GetUint(o + bb_pos) : (uint)0; }
-  public long Testhashs64Fnv1a() { int o = __offset(48); return o != 0 ? bb.GetLong(o + bb_pos) : (long)0; }
-  public ulong Testhashu64Fnv1a() { int o = __offset(50); return o != 0 ? bb.GetUlong(o + bb_pos) : (ulong)0; }
+  public Monster GetTestarrayoftables(int j) { return GetTestarrayoftables(new Monster(), j); }
+  public Monster GetTestarrayoftables(Monster obj, int j) { int o = __offset(26); return o != 0 ? obj.__init(__indirect(__vector(o) + j * 4), bb) : null; }
+  public int TestarrayoftablesLength { get { int o = __offset(26); return o != 0 ? __vector_len(o) : 0; } }
+  public Monster Enemy { get { return GetEnemy(new Monster()); } }
+  public Monster GetEnemy(Monster obj) { int o = __offset(28); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
+  public byte GetTestnestedflatbuffer(int j) { int o = __offset(30); return o != 0 ? bb.Get(__vector(o) + j * 1) : (byte)0; }
+  public int TestnestedflatbufferLength { get { int o = __offset(30); return o != 0 ? __vector_len(o) : 0; } }
+  public Stat Testempty { get { return GetTestempty(new Stat()); } }
+  public Stat GetTestempty(Stat obj) { int o = __offset(32); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
+  public bool Testbool { get { int o = __offset(34); return o != 0 ? 0!=bb.Get(o + bb_pos) : (bool)false; } }
+  public int Testhashs32Fnv1 { get { int o = __offset(36); return o != 0 ? bb.GetInt(o + bb_pos) : (int)0; } }
+  public uint Testhashu32Fnv1 { get { int o = __offset(38); return o != 0 ? bb.GetUint(o + bb_pos) : (uint)0; } }
+  public long Testhashs64Fnv1 { get { int o = __offset(40); return o != 0 ? bb.GetLong(o + bb_pos) : (long)0; } }
+  public ulong Testhashu64Fnv1 { get { int o = __offset(42); return o != 0 ? bb.GetUlong(o + bb_pos) : (ulong)0; } }
+  public int Testhashs32Fnv1a { get { int o = __offset(44); return o != 0 ? bb.GetInt(o + bb_pos) : (int)0; } }
+  public uint Testhashu32Fnv1a { get { int o = __offset(46); return o != 0 ? bb.GetUint(o + bb_pos) : (uint)0; } }
+  public long Testhashs64Fnv1a { get { int o = __offset(48); return o != 0 ? bb.GetLong(o + bb_pos) : (long)0; } }
+  public ulong Testhashu64Fnv1a { get { int o = __offset(50); return o != 0 ? bb.GetUlong(o + bb_pos) : (ulong)0; } }
 
   public static void StartMonster(FlatBufferBuilder builder) { builder.StartObject(24); }
   public static void AddPos(FlatBufferBuilder builder, int posOffset) { builder.AddStruct(0, posOffset, 0); }

--- a/tests/MyGame/Example/Stat.cs
+++ b/tests/MyGame/Example/Stat.cs
@@ -7,12 +7,12 @@ using FlatBuffers;
 
 public sealed class Stat : Table {
   public static Stat GetRootAsStat(ByteBuffer _bb) { return GetRootAsStat(_bb, new Stat()); }
-  public static Stat GetRootAsStat(ByteBuffer _bb, Stat obj) { return (obj.__init(_bb.GetInt(_bb.position()) + _bb.position(), _bb)); }
+  public static Stat GetRootAsStat(ByteBuffer _bb, Stat obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
   public Stat __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
 
-  public string Id() { int o = __offset(4); return o != 0 ? __string(o + bb_pos) : null; }
-  public long Val() { int o = __offset(6); return o != 0 ? bb.GetLong(o + bb_pos) : (long)0; }
-  public ushort Count() { int o = __offset(8); return o != 0 ? bb.GetUshort(o + bb_pos) : (ushort)0; }
+  public string Id { get { int o = __offset(4); return o != 0 ? __string(o + bb_pos) : null; } }
+  public long Val { get { int o = __offset(6); return o != 0 ? bb.GetLong(o + bb_pos) : (long)0; } }
+  public ushort Count { get { int o = __offset(8); return o != 0 ? bb.GetUshort(o + bb_pos) : (ushort)0; } }
 
   public static int CreateStat(FlatBufferBuilder builder,
       int id = 0,

--- a/tests/MyGame/Example/Test.cs
+++ b/tests/MyGame/Example/Test.cs
@@ -8,15 +8,15 @@ using FlatBuffers;
 public sealed class Test : Struct {
   public Test __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
 
-  public short A() { return bb.GetShort(bb_pos + 0); }
-  public sbyte B() { return bb.GetSbyte(bb_pos + 2); }
+  public short A { get { return bb.GetShort(bb_pos + 0); } }
+  public sbyte B { get { return bb.GetSbyte(bb_pos + 2); } }
 
   public static int CreateTest(FlatBufferBuilder builder, short A, sbyte B) {
     builder.Prep(2, 4);
     builder.Pad(1);
     builder.PutSbyte(B);
     builder.PutShort(A);
-    return builder.Offset();
+    return builder.Offset;
   }
 };
 

--- a/tests/MyGame/Example/Vec3.cs
+++ b/tests/MyGame/Example/Vec3.cs
@@ -8,13 +8,13 @@ using FlatBuffers;
 public sealed class Vec3 : Struct {
   public Vec3 __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
 
-  public float X() { return bb.GetFloat(bb_pos + 0); }
-  public float Y() { return bb.GetFloat(bb_pos + 4); }
-  public float Z() { return bb.GetFloat(bb_pos + 8); }
-  public double Test1() { return bb.GetDouble(bb_pos + 16); }
-  public Color Test2() { return (Color)bb.GetSbyte(bb_pos + 24); }
-  public Test Test3() { return Test3(new Test()); }
-  public Test Test3(Test obj) { return obj.__init(bb_pos + 26, bb); }
+  public float X { get { return bb.GetFloat(bb_pos + 0); } }
+  public float Y { get { return bb.GetFloat(bb_pos + 4); } }
+  public float Z { get { return bb.GetFloat(bb_pos + 8); } }
+  public double Test1 { get { return bb.GetDouble(bb_pos + 16); } }
+  public Color Test2 { get { return (Color)bb.GetSbyte(bb_pos + 24); } }
+  public Test Test3 { get { return GetTest3(new Test()); } }
+  public Test GetTest3(Test obj) { return obj.__init(bb_pos + 26, bb); }
 
   public static int CreateVec3(FlatBufferBuilder builder, float X, float Y, float Z, double Test1, Color Test2, short Test_A, sbyte Test_B) {
     builder.Prep(16, 32);
@@ -30,7 +30,7 @@ public sealed class Vec3 : Struct {
     builder.PutFloat(Z);
     builder.PutFloat(Y);
     builder.PutFloat(X);
-    return builder.Offset();
+    return builder.Offset;
   }
 };
 


### PR DESCRIPTION
In C#, plain field accessors should not be nonparametric methods but should be standard property getters.

The accessor methods with parameters were renamed to `GetXxx` because a method cannot be named identically to a property.

Also, `ByteBuffer.Position`, `FlatBufferBuilder.Offset` and `FlatBufferBuilder.DataBuffer` are now properties instead of nonparametric accessor methods, for more idiomatic C# style.

This is a breaking change, all client C# code accessing these fields needs to be changed (i.e. remove those `()` or add the `Get` prefix).

Issue: #77