### PR TITLE
Union accessors in C# should use generic type for the table

### DIFF
--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -66,7 +66,7 @@ namespace FlatBuffers
         }
 
         // Initialize any Table-derived type to point to the union at the given offset.
-        protected Table __union(Table t, int offset)
+        protected TTable __union<TTable>(TTable t, int offset) where TTable : Table
         {
             offset += bb_pos;
             t.bb_pos = offset + bb.GetInt(offset);

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -20,7 +20,7 @@ public sealed class Monster : Table {
   public int InventoryLength { get { int o = __offset(14); return o != 0 ? __vector_len(o) : 0; } }
   public Color Color { get { int o = __offset(16); return o != 0 ? (Color)bb.GetSbyte(o + bb_pos) : (Color)8; } }
   public Any TestType { get { int o = __offset(18); return o != 0 ? (Any)bb.Get(o + bb_pos) : (Any)0; } }
-  public Table GetTest(Table obj) { int o = __offset(20); return o != 0 ? __union(obj, o) : null; }
+  public TTable GetTest<TTable>(TTable obj) where TTable : Table { int o = __offset(20); return o != 0 ? __union(obj, o) : null; }
   public Test GetTest4(int j) { return GetTest4(new Test(), j); }
   public Test GetTest4(Test obj, int j) { int o = __offset(22); return o != 0 ? obj.__init(__vector(o) + j * 4, bb) : null; }
   public int Test4Length { get { int o = __offset(22); return o != 0 ? __vector_len(o) : 0; } }


### PR DESCRIPTION
When accessing a union field, we should return the same object type as was given to the method, i.e. the parameter should have a generic type for any Table-derived type. This way, we do not need to make superfluous casts (which also reduce type safety) like

`var myUnionType = (MyUnionType)buff.GetUnionField(new MyUnionType());`

when we can do just
`var myUnionType = buff.GetUnionField(new MyUnionType());`