### PR TITLE
Fixed endianness Vector's begin() and end()

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -286,8 +286,8 @@ public:
   iterator begin() { return iterator(Data(), 0); }
   const_iterator begin() const { return const_iterator(Data(), 0); }
 
-  iterator end() { return iterator(Data(), length_); }
-  const_iterator end() const { return const_iterator(Data(), length_); }
+  iterator end() { return iterator(Data(), EndianScalar(length_)); }
+  const_iterator end() const { return const_iterator(Data(), EndianScalar(length_)); }
 
   // Change elements if you have a non-const pointer to this object.
   void Mutate(uoffset_t i, T val) {


### PR DESCRIPTION
for( auto it=...begin(); it!=end(); ++it ) {}
iterated by far to many times on my PowerPC 750 (ppc603). After applying this patch, it worked as expected.

Note that there are other accesses to that member without any endianness handling. Probably there are more bugs like this - but I haven't reviewed those.