### PR TITLE
Generate type for enums in Go

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -79,8 +79,13 @@ static void BeginClass(const StructDef &struct_def, std::string *code_ptr) {
 }
 
 // Begin enum code with a class declaration.
-static void BeginEnum(std::string *code_ptr) {
+static void BeginEnum(const EnumDef &enum_def, std::string *code_ptr) {
   std::string &code = *code_ptr;
+  code += "type ";
+  code += enum_def.name;
+  code += " ";
+  code += GenTypeBasic(enum_def.underlying_type);
+  code += "\n\n";
   code += "const (\n";
 }
 
@@ -89,8 +94,9 @@ static void EnumMember(const EnumDef &enum_def, const EnumVal ev,
                        std::string *code_ptr) {
   std::string &code = *code_ptr;
   code += "\t";
-  code += enum_def.name;
   code += ev.name;
+  code += " ";
+  code += enum_def.name;
   code += " = ";
   code += NumToString(ev.value) + "\n";
 }
@@ -559,7 +565,7 @@ static void GenEnum(const EnumDef &enum_def, std::string *code_ptr) {
   if (enum_def.generated) return;
 
   GenComment(enum_def.doc_comment, code_ptr, nullptr);
-  BeginEnum(code_ptr);
+  BeginEnum(enum_def, code_ptr);
   for (auto it = enum_def.vals.vec.begin();
        it != enum_def.vals.vec.end();
        ++it) {


### PR DESCRIPTION
**Unfinished** pull request for #197.

This _almost_ generates the code discussed in the issue:

```go
type Color int8

const (
    Red Color = 1
    Green = 2
    Blue = 3
)
```

What's left:

- [ ] Type is not identical (e.g. `int8` instead of `byte`)
- [ ] Figure out how to test this (`go_test.go` does not deal with enums directly)
- [ ] Can enums have anything else than simple types (vectors, structs)?