### PR TITLE
Fix for #214 - vector_downward::make_space

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -409,7 +409,7 @@ class vector_downward {
   uint8_t *make_space(size_t len) {
     if (len > static_cast<size_t>(cur_ - buf_)) {
       auto old_size = size();
-      reserved_ += std::max(len, growth_policy(reserved_));
+      reserved_ += (std::max)(len, growth_policy(reserved_));
       auto new_buf = allocator_.allocate(reserved_);
       auto new_cur = new_buf + reserved_ - old_size;
       memcpy(new_cur, cur_, old_size);


### PR DESCRIPTION
Hello,

this trivial pull request fixes https://github.com/google/flatbuffers/issues/214.

Without this fix std::max is considered for macro expansion when using Windows headers somewhere.