### PR TITLE
Fix for #218 - Check empty namespace in general generator

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -876,8 +876,8 @@ static bool SaveClass(const LanguageParameters &lang, const Parser &parser,
 
   std::string code = "// automatically generated, do not modify\n\n";
   if (!namespace_general.empty()) {
-	  code += lang.namespace_ident + namespace_general + lang.namespace_begin;
-	  code += "\n\n";
+	code += lang.namespace_ident + namespace_general + lang.namespace_begin;
+	code += "\n\n";
   }
   if (needs_includes) code += lang.includes;
   code += classcode;

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -875,11 +875,13 @@ static bool SaveClass(const LanguageParameters &lang, const Parser &parser,
   EnsureDirExists(namespace_dir);
 
   std::string code = "// automatically generated, do not modify\n\n";
-  code += lang.namespace_ident + namespace_general + lang.namespace_begin;
-  code += "\n\n";
+  if (!namespace_general.empty()) {
+	  code += lang.namespace_ident + namespace_general + lang.namespace_begin;
+	  code += "\n\n";
+  }
   if (needs_includes) code += lang.includes;
   code += classcode;
-  code += lang.namespace_end;
+  if (!namespace_general.empty()) code += lang.namespace_end;
   auto filename = namespace_dir + def.name + lang.file_extension;
   return SaveFile(filename.c_str(), code, false);
 }


### PR DESCRIPTION
If you have a schema with no namespace, the resulting C#/Java won't have
an erroneous empty namespace keyword.