### PR TITLE
Fixed argument value to correct type

### DIFF
--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -176,7 +176,7 @@ int main(int argc, const char *argv[]) {
     }
   }
 
-  if (!filenames.size()) Error("missing input files", nullptr, true);
+  if (!filenames.size()) Error("missing input files", false, true);
 
   if (!any_generator)
     Error("no options: specify one of -c -g -j -t -b etc.", true);


### PR DESCRIPTION
GCC 5 on Fedora 22 fails to build because of this.