### PR TITLE
fix for parameter name clash in generated structs

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -481,7 +481,7 @@ static void GenStructBody(const LanguageParameters &lang,
     }
     if (IsStruct(field.value.type)) {
       GenStructBody(lang, *field.value.type.struct_def, code_ptr,
-                    (field.value.type.struct_def->name + "_").c_str());
+                    (nameprefix + (field.name + "_")).c_str());
     } else {
       code += "    builder." + FunctionStart(lang, 'P') + "ut";
       code += GenMethod(lang, field.value.type) + "(";

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -448,7 +448,7 @@ static void GenStructArgs(const LanguageParameters &lang,
     if (IsStruct(field.value.type)) {
       // Generate arguments for a struct inside a struct. To ensure names
       // don't clash, and to make it obvious these arguments are constructing
-      // a nested struct, prefix the name with the struct name.
+      // a nested struct, prefix the name with the field name.
       GenStructArgs(lang, *field.value.type.struct_def, code_ptr,
                     (nameprefix + (field.name + "_")).c_str());
     } else {

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -450,7 +450,7 @@ static void GenStructArgs(const LanguageParameters &lang,
       // don't clash, and to make it obvious these arguments are constructing
       // a nested struct, prefix the name with the struct name.
       GenStructArgs(lang, *field.value.type.struct_def, code_ptr,
-                    (field.value.type.struct_def->name + "_").c_str());
+                    (nameprefix + (field.name + "_")).c_str());
     } else {
       code += ", ";
       code += GenTypeForUser(lang,

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -332,7 +332,7 @@ static void StructBuilderArgs(const StructDef &struct_def,
       // don't clash, and to make it obvious these arguments are constructing
       // a nested struct, prefix the name with the struct name.
       StructBuilderArgs(*field.value.type.struct_def,
-                        (field.value.type.struct_def->name + "_").c_str(),
+                        (nameprefix + (field.name + "_")).c_str(),
                         code_ptr);
     } else {
       std::string &code = *code_ptr;
@@ -365,7 +365,7 @@ static void StructBuilderBody(const StructDef &struct_def,
       code += "    builder.Pad(" + NumToString(field.padding) + ")\n";
     if (IsStruct(field.value.type)) {
       StructBuilderBody(*field.value.type.struct_def,
-                        (field.value.type.struct_def->name + "_").c_str(),
+                        (nameprefix + (field.name + "_")).c_str(),
                         code_ptr);
     } else {
       code += "    builder.Prepend" + GenMethod(field) + "(";

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -330,7 +330,7 @@ static void StructBuilderArgs(const StructDef &struct_def,
     if (IsStruct(field.value.type)) {
       // Generate arguments for a struct inside a struct. To ensure names
       // don't clash, and to make it obvious these arguments are constructing
-      // a nested struct, prefix the name with the struct name.
+      // a nested struct, prefix the name with the field name.
       StructBuilderArgs(*field.value.type.struct_def,
                         (nameprefix + (field.name + "_")).c_str(),
                         code_ptr);

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -307,9 +307,9 @@ static void StructBuilderArgs(const StructDef &struct_def,
     if (IsStruct(field.value.type)) {
       // Generate arguments for a struct inside a struct. To ensure names
       // don't clash, and to make it obvious these arguments are constructing
-      // a nested struct, prefix the name with the struct name.
+      // a nested struct, prefix the name with the field name.
       StructBuilderArgs(*field.value.type.struct_def,
-                        (field.value.type.struct_def->name + "_").c_str(),
+                        (nameprefix + (field.name + "_")).c_str(),
                         code_ptr);
     } else {
       std::string &code = *code_ptr;
@@ -341,7 +341,7 @@ static void StructBuilderBody(const StructDef &struct_def,
       code += "    builder.Pad(" + NumToString(field.padding) + ")\n";
     if (IsStruct(field.value.type)) {
       StructBuilderBody(*field.value.type.struct_def,
-                        (field.value.type.struct_def->name + "_").c_str(),
+                        (nameprefix + (field.name + "_")).c_str(),
                         code_ptr);
     } else {
       code += "    builder.Prepend" + GenMethod(field) + "(";

--- a/tests/MyGame/Example/Vec3.cs
+++ b/tests/MyGame/Example/Vec3.cs
@@ -16,13 +16,13 @@ public sealed class Vec3 : Struct {
   public Test Test3 { get { return GetTest3(new Test()); } }
   public Test GetTest3(Test obj) { return obj.__init(bb_pos + 26, bb); }
 
-  public static int CreateVec3(FlatBufferBuilder builder, float X, float Y, float Z, double Test1, Color Test2, short Test_A, sbyte Test_B) {
+  public static int CreateVec3(FlatBufferBuilder builder, float X, float Y, float Z, double Test1, Color Test2, short test3_A, sbyte test3_B) {
     builder.Prep(16, 32);
     builder.Pad(2);
     builder.Prep(2, 4);
     builder.Pad(1);
-    builder.PutSbyte(Test_B);
-    builder.PutShort(Test_A);
+    builder.PutSbyte(test3_B);
+    builder.PutShort(test3_A);
     builder.Pad(1);
     builder.PutSbyte((sbyte)(Test2));
     builder.PutDouble(Test1);

--- a/tests/MyGame/Example/Vec3.go
+++ b/tests/MyGame/Example/Vec3.go
@@ -27,13 +27,13 @@ func (rcv *Vec3) Test3(obj *Test) *Test {
 	return obj
 }
 
-func CreateVec3(builder *flatbuffers.Builder, x float32, y float32, z float32, test1 float64, test2 int8, Test_a int16, Test_b int8) flatbuffers.UOffsetT {
+func CreateVec3(builder *flatbuffers.Builder, x float32, y float32, z float32, test1 float64, test2 int8, test3_a int16, test3_b int8) flatbuffers.UOffsetT {
     builder.Prep(16, 32)
     builder.Pad(2)
     builder.Prep(2, 4)
     builder.Pad(1)
-    builder.PrependInt8(Test_b)
-    builder.PrependInt16(Test_a)
+    builder.PrependInt8(test3_b)
+    builder.PrependInt16(test3_a)
     builder.Pad(1)
     builder.PrependInt8(test2)
     builder.PrependFloat64(test1)

--- a/tests/MyGame/Example/Vec3.java
+++ b/tests/MyGame/Example/Vec3.java
@@ -18,13 +18,13 @@ public final class Vec3 extends Struct {
   public Test test3() { return test3(new Test()); }
   public Test test3(Test obj) { return obj.__init(bb_pos + 26, bb); }
 
-  public static int createVec3(FlatBufferBuilder builder, float x, float y, float z, double test1, byte test2, short Test_a, byte Test_b) {
+  public static int createVec3(FlatBufferBuilder builder, float x, float y, float z, double test1, byte test2, short test3_a, byte test3_b) {
     builder.prep(16, 32);
     builder.pad(2);
     builder.prep(2, 4);
     builder.pad(1);
-    builder.putByte(Test_b);
-    builder.putShort(Test_a);
+    builder.putByte(test3_b);
+    builder.putShort(test3_a);
     builder.pad(1);
     builder.putByte(test2);
     builder.putDouble(test1);

--- a/tests/MyGame/Example/Vec3.py
+++ b/tests/MyGame/Example/Vec3.py
@@ -27,13 +27,13 @@ class Vec3(object):
         return obj
 
 
-def CreateVec3(builder, x, y, z, test1, test2, Test_a, Test_b):
+def CreateVec3(builder, x, y, z, test1, test2, test3_a, test3_b):
     builder.Prep(16, 32)
     builder.Pad(2)
     builder.Prep(2, 4)
     builder.Pad(1)
-    builder.PrependInt8(Test_b)
-    builder.PrependInt16(Test_a)
+    builder.PrependInt8(test3_b)
+    builder.PrependInt16(test3_a)
     builder.Pad(1)
     builder.PrependInt8(test2)
     builder.PrependFloat64(test1)

--- a/tests/generate_code.sh
+++ b/tests/generate_code.sh
@@ -1,2 +1,2 @@
-../flatc -c -j -n -g -b --gen-mutable --no-includes monster_test.fbs monsterdata_test.json
+../flatc -c -j -n -g -b -p --gen-mutable --no-includes monster_test.fbs monsterdata_test.json
 ../flatc -b --schema monster_test.fbs


### PR DESCRIPTION
This should fix #232.
I couldn't find out how you were testing generated code so I didn't add any for this PR.
Let me know if that is an issue and I'll find a way to include them.