### PR TITLE
Base type safety in C#. Clear FlatBufferBuilder in C#.

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -50,8 +50,8 @@ namespace flatbuffers {
   TD(FLOAT,  "float",  float,    float,  float32, float,  float32) /* begin float */ \
   TD(DOUBLE, "double", double,   double, float64, double, float64) /* end float/scalar */
 #define FLATBUFFERS_GEN_TYPES_POINTER(TD) \
-  TD(STRING, "string", Offset<void>, int, int, int, int) \
-  TD(VECTOR, "",       Offset<void>, int, int, int, int) \
+  TD(STRING, "string", Offset<void>, int, int, StringOffset, int) \
+  TD(VECTOR, "",       Offset<void>, int, int, VectorOffset, int) \
   TD(STRUCT, "",       Offset<void>, int, int, int, int) \
   TD(UNION,  "",       Offset<void>, int, int, int, int)
 

--- a/net/FlatBuffers/ByteBuffer.cs
+++ b/net/FlatBuffers/ByteBuffer.cs
@@ -41,6 +41,11 @@ namespace FlatBuffers
             _pos = 0;
         }
 
+        public void Reset()
+        {
+            _pos = 0;
+        }
+
         public int Position { get { return _pos; } }
 
         // Pre-allocated helper arrays for convertion.

--- a/net/FlatBuffers/FlatBufferBuilder.cs
+++ b/net/FlatBuffers/FlatBufferBuilder.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2014 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,6 +49,17 @@ namespace FlatBuffers
             _bb = new ByteBuffer(new byte[initialSize]);
         }
 
+        public void Clear()
+        {
+            _space = _bb.Length;
+            _bb.Reset();
+            _minAlign = 1;
+            _vtable = null;
+            _objectStart = 0;
+            _vtables = new int[16];
+            _numVtables = 0;
+            _vectorNumElems = 0;
+        }
 
         public int Offset { get { return _bb.Length - _space; } }
 
@@ -196,10 +207,10 @@ namespace FlatBuffers
             Prep(alignment, elemSize * count); // Just in case alignment > int.
         }
 
-        public int EndVector()
+        public VectorOffset EndVector()
         {
             PutInt(_vectorNumElems);
-            return Offset;
+            return new VectorOffset(Offset);
         }
 
         public void Nested(int obj)
@@ -250,7 +261,7 @@ namespace FlatBuffers
         public void AddDouble(int o, double x, double d) { if (x != d) { AddDouble(x); Slot(o); } }
         public void AddOffset(int o, int x, int d) { if (x != d) { AddOffset(x); Slot(o); } }
 
-        public int CreateString(string s)
+        public StringOffset CreateString(string s)
         {
             NotNested();
             byte[] utf8 = Encoding.UTF8.GetBytes(s);
@@ -258,7 +269,7 @@ namespace FlatBuffers
             StartVector(1, utf8.Length, 1);
             Buffer.BlockCopy(utf8, 0, _bb.Data, _space -= utf8.Length,
                              utf8.Length);
-            return EndVector();
+            return new StringOffset(EndVector().Value);
         }
 
         // Structs are stored inline, so nothing additional is being added.

--- a/net/FlatBuffers/FlatBuffers.csproj
+++ b/net/FlatBuffers/FlatBuffers.csproj
@@ -37,6 +37,7 @@
     <Compile Include="ByteBuffer.cs" />
     <Compile Include="FlatBufferBuilder.cs" />
     <Compile Include="FlatBufferConstants.cs" />
+    <Compile Include="Offset.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Struct.cs" />
     <Compile Include="Table.cs" />

--- a/net/FlatBuffers/Offset.cs
+++ b/net/FlatBuffers/Offset.cs
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace FlatBuffers
+{
+    /// <summary>
+    /// Offset class for typesafe assignments.
+    /// </summary>
+    public struct Offset<T> where T : class
+    {
+        public int Value;
+        public Offset(int value)
+        {
+            Value = value;
+        }
+    }
+
+    public struct StringOffset
+    {
+        public int Value;
+        public StringOffset(int value)
+        {
+            Value = value;
+        }
+    }
+
+    public struct VectorOffset
+    {
+        public int Value;
+        public VectorOffset(int value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -272,19 +272,6 @@ static std::string GenOffsetType(const LanguageParameters &lang, const StructDef
 }
 
 static std::string GenOffsetConstruct(const LanguageParameters &lang,
-                                      const Type &type,
-                                      const std::string &variable_name)
-{
-  if(lang.language == GeneratorOptions::kCSharp) {
-    switch(type.base_type) {
-      case BASE_TYPE_VECTOR: return "new VectorOffset(" + variable_name + ")";
-      case BASE_TYPE_STRING: return "new StringOffset(" + variable_name + ")";
-    }
-  }
-  return variable_name;
-}
-
-static std::string GenOffsetConstruct(const LanguageParameters &lang,
                                       const StructDef &struct_def,
                                       const std::string &variable_name)
 {

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -370,6 +370,8 @@ static std::string GenDefaultValue(const LanguageParameters &lang, const Value &
         return "default(Offset<" + value.type.struct_def->name + ">)";
       case BASE_TYPE_VECTOR:
         return "default(VectorOffset)";
+      default:
+        break;
     }
   }
 

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -19,6 +19,7 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
+#include <algorithm>
 
 namespace flatbuffers {
 
@@ -202,6 +203,10 @@ static std::string GenTypeBasic(const LanguageParameters &lang,
     #undef FLATBUFFERS_TD
   };
 
+  if(lang.language == GeneratorOptions::kCSharp && type.base_type == BASE_TYPE_STRUCT) {
+    return "Offset<" + type.struct_def->name + ">";
+  }
+
   return gtypename[type.base_type * GeneratorOptions::kMAX + lang.language];
 }
 
@@ -255,6 +260,45 @@ static Type DestinationType(const LanguageParameters &lang, const Type &type,
         return DestinationType(lang, type.VectorType(), vectorelem);
       // else fall thru:
     default: return type;
+  }
+}
+
+static std::string GenOffsetType(const LanguageParameters &lang, const StructDef &struct_def) {
+  if(lang.language == GeneratorOptions::kCSharp) {
+    return "Offset<" + struct_def.name + ">";
+  } else {
+    return "int";
+  }
+}
+
+static std::string GenOffsetConstruct(const LanguageParameters &lang,
+                                      const Type &type,
+                                      const std::string &variable_name)
+{
+  if(lang.language == GeneratorOptions::kCSharp) {
+    switch(type.base_type) {
+      case BASE_TYPE_VECTOR: return "new VectorOffset(" + variable_name + ")";
+      case BASE_TYPE_STRING: return "new StringOffset(" + variable_name + ")";
+    }
+  }
+  return variable_name;
+}
+
+static std::string GenOffsetConstruct(const LanguageParameters &lang,
+                                      const StructDef &struct_def,
+                                      const std::string &variable_name)
+{
+  if(lang.language == GeneratorOptions::kCSharp) {
+    return "new Offset<" + struct_def.name + ">(" + variable_name + ")";
+  }
+  return variable_name;
+}
+
+static std::string GenVectorOffsetType(const LanguageParameters &lang) {
+  if(lang.language == GeneratorOptions::kCSharp) {
+    return "VectorOffset";
+  } else {
+    return "int";
   }
 }
 
@@ -330,7 +374,18 @@ static std::string DestinationValue(const LanguageParameters &lang,
   }
 }
 
-static std::string GenDefaultValue(const Value &value) {
+static std::string GenDefaultValue(const LanguageParameters &lang, const Value &value, bool for_buffer) {
+  if(lang.language == GeneratorOptions::kCSharp && !for_buffer) {
+    switch(value.type.base_type) {
+      case BASE_TYPE_STRING:
+        return "default(StringOffset)";
+      case BASE_TYPE_STRUCT:
+        return "default(Offset<" + value.type.struct_def->name + ">)";
+      case BASE_TYPE_VECTOR:
+        return "default(VectorOffset)";
+    }
+  }
+
   return value.type.base_type == BASE_TYPE_BOOL
            ? (value.constant == "0" ? "false" : "true")
            : value.constant;
@@ -617,7 +672,7 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
       } else {
         code += offset_prefix + getter;
         code += "(o + bb_pos)" + dest_mask + " : " + default_cast;
-        code += GenDefaultValue(field.value);
+        code += GenDefaultValue(lang, field.value, false);
       }
     } else {
       switch (field.value.type.base_type) {
@@ -702,13 +757,14 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
   code += "\n";
   if (struct_def.fixed) {
     // create a struct constructor function
-    code += "  public static int " + FunctionStart(lang, 'C') + "reate";
+    code += "  public static " + GenOffsetType(lang, struct_def) + " ";
+    code += FunctionStart(lang, 'C') + "reate";
     code += struct_def.name + "(FlatBufferBuilder builder";
     GenStructArgs(lang, struct_def, code_ptr, "");
     code += ") {\n";
     GenStructBody(lang, struct_def, code_ptr, "");
-    code += "    return builder.";
-    code += lang.get_fbb_offset;
+    code += "    return ";
+    code += GenOffsetConstruct(lang, struct_def, "builder." + std::string(lang.get_fbb_offset));
     code += ";\n  }\n";
   } else {
     // Generate a method that creates a table in one go. This is only possible
@@ -728,9 +784,9 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
     }
     if (has_no_struct_fields && num_fields) {
       // Generate a table constructor of the form:
-      // public static void createName(FlatBufferBuilder builder, args...)
-      code += "  public static int " + FunctionStart(lang, 'C') + "reate";
-      code += struct_def.name;
+      // public static int createName(FlatBufferBuilder builder, args...)
+      code += "  public static " + GenOffsetType(lang, struct_def) + " ";
+      code += FunctionStart(lang, 'C') + "reate" + struct_def.name;
       code += "(FlatBufferBuilder builder";
       for (auto it = struct_def.fields.vec.begin();
            it != struct_def.fields.vec.end(); ++it) {
@@ -744,7 +800,7 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
         // Java doesn't have defaults, which means this method must always
         // supply all arguments, and thus won't compile when fields are added.
         if (lang.language != GeneratorOptions::kJava) {
-          code += " = " + GenDefaultValue(field.value);
+          code += " = " + GenDefaultValue(lang, field.value, false);
         }
       }
       code += ") {\n    builder.";
@@ -794,7 +850,10 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
       code += GenMethod(lang, field.value.type) + "(";
       code += NumToString(it - struct_def.fields.vec.begin()) + ", ";
       code += DestinationValue(lang, argname, field.value.type);
-      code += ", " + GenDefaultValue(field.value);
+      if(!IsScalar(field.value.type.base_type) && field.value.type.base_type != BASE_TYPE_UNION && lang.language == GeneratorOptions::kCSharp) {
+        code += ".Value";
+      }
+      code += ", " + GenDefaultValue(lang, field.value, true);
       code += "); }\n";
       if (field.value.type.base_type == BASE_TYPE_VECTOR) {
         auto vector_type = field.value.type.VectorType();
@@ -802,7 +861,7 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
         auto elem_size = InlineSize(vector_type);
         if (!IsStruct(vector_type)) {
           // Generate a method to create a vector from a Java array.
-          code += "  public static int " + FunctionStart(lang, 'C') + "reate";
+          code += "  public static " + GenVectorOffsetType(lang) + " " + FunctionStart(lang, 'C') + "reate";
           code += MakeCamel(field.name);
           code += "Vector(FlatBufferBuilder builder, ";
           code += GenTypeBasic(lang, vector_type) + "[] data) ";
@@ -814,8 +873,12 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
           code += FunctionStart(lang, 'L') + "ength - 1; i >= 0; i--) builder.";
           code += FunctionStart(lang, 'A') + "dd";
           code += GenMethod(lang, vector_type);
-          code += "(data[i]); return builder.";
-          code += FunctionStart(lang, 'E') + "ndVector(); }\n";
+          code += "(data[i]";
+          if(lang.language == GeneratorOptions::kCSharp &&
+              (vector_type.base_type == BASE_TYPE_STRUCT || vector_type.base_type == BASE_TYPE_STRING))
+              code += ".Value";
+          code += "); return ";
+          code += "builder." + FunctionStart(lang, 'E') + "ndVector(); }\n";
         }
         // Generate a method to start a vector, data to be added manually after.
         code += "  public static void " + FunctionStart(lang, 'S') + "tart";
@@ -827,7 +890,7 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
         code += "); }\n";
       }
     }
-    code += "  public static int ";
+    code += "  public static " + GenOffsetType(lang, struct_def) + " ";
     code += FunctionStart(lang, 'E') + "nd" + struct_def.name;
     code += "(FlatBufferBuilder builder) {\n    int o = builder.";
     code += FunctionStart(lang, 'E') + "ndObject();\n";
@@ -841,12 +904,16 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
         code += ");  // " + field.name + "\n";
       }
     }
-    code += "    return o;\n  }\n";
+    code += "    return " + GenOffsetConstruct(lang, struct_def, "o") + ";\n  }\n";
     if (parser.root_struct_def_ == &struct_def) {
       code += "  public static void ";
       code += FunctionStart(lang, 'F') + "inish" + struct_def.name;
-      code += "Buffer(FlatBufferBuilder builder, int offset) { ";
-      code += "builder." + FunctionStart(lang, 'F') + "inish(offset";
+      code += "Buffer(FlatBufferBuilder builder, " + GenOffsetType(lang, struct_def) + " offset) {";
+      code += " builder." + FunctionStart(lang, 'F') + "inish(offset";
+      if (lang.language == GeneratorOptions::kCSharp) {
+        code += ".Value";
+      }
+
       if (parser.file_identifier_.length())
         code += ", \"" + parser.file_identifier_ + "\"";
       code += "); }\n";

--- a/tests/FlatBuffers.Test/FlatBuffers.Test.csproj
+++ b/tests/FlatBuffers.Test/FlatBuffers.Test.csproj
@@ -41,6 +41,9 @@
     <Compile Include="..\..\net\FlatBuffers\ByteBuffer.cs">
       <Link>FlatBuffers\ByteBuffer.cs</Link>
     </Compile>
+	<Compile Include="..\..\net\FlatBuffers\Offset.cs">
+	  <Link>FlatBuffers\Offset.cs</Link>
+	</Compile>
     <Compile Include="..\..\net\FlatBuffers\FlatBufferBuilder.cs">
       <Link>FlatBuffers\FlatBufferBuilder.cs</Link>
     </Compile>

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -61,8 +61,8 @@ namespace FlatBuffers.Test
             var test4 = fbb.EndVector();
 
             Monster.StartTestarrayofstringVector(fbb, 2);
-            fbb.AddOffset(test2);
-            fbb.AddOffset(test1);
+            fbb.AddOffset(test2.Value);
+            fbb.AddOffset(test1.Value);
             var testArrayOfString = fbb.EndVector();
 
 
@@ -73,13 +73,13 @@ namespace FlatBuffers.Test
             Monster.AddName(fbb, str);
             Monster.AddInventory(fbb, inv);
             Monster.AddTestType(fbb, Any.Monster);
-            Monster.AddTest(fbb, mon2);
+            Monster.AddTest(fbb, mon2.Value);
             Monster.AddTest4(fbb, test4);
             Monster.AddTestarrayofstring(fbb, testArrayOfString);
             Monster.AddTestbool(fbb, false);
             var mon = Monster.EndMonster(fbb);
 
-            fbb.Finish(mon);
+            fbb.Finish(mon.Value);
 
             // Dump to output directory so we can inspect later, if needed
             using (var ms = new MemoryStream(fbb.DataBuffer.Data, fbb.DataBuffer.Position, fbb.Offset))

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -48,29 +48,29 @@ public sealed class Monster : Table {
   public ulong Testhashu64Fnv1a { get { int o = __offset(50); return o != 0 ? bb.GetUlong(o + bb_pos) : (ulong)0; } }
 
   public static void StartMonster(FlatBufferBuilder builder) { builder.StartObject(24); }
-  public static void AddPos(FlatBufferBuilder builder, int posOffset) { builder.AddStruct(0, posOffset, 0); }
+  public static void AddPos(FlatBufferBuilder builder, Offset<Vec3> posOffset) { builder.AddStruct(0, posOffset.Value, 0); }
   public static void AddMana(FlatBufferBuilder builder, short mana) { builder.AddShort(1, mana, 150); }
   public static void AddHp(FlatBufferBuilder builder, short hp) { builder.AddShort(2, hp, 100); }
-  public static void AddName(FlatBufferBuilder builder, int nameOffset) { builder.AddOffset(3, nameOffset, 0); }
-  public static void AddInventory(FlatBufferBuilder builder, int inventoryOffset) { builder.AddOffset(5, inventoryOffset, 0); }
-  public static int CreateInventoryVector(FlatBufferBuilder builder, byte[] data) { builder.StartVector(1, data.Length, 1); for (int i = data.Length - 1; i >= 0; i--) builder.AddByte(data[i]); return builder.EndVector(); }
+  public static void AddName(FlatBufferBuilder builder, StringOffset nameOffset) { builder.AddOffset(3, nameOffset.Value, 0); }
+  public static void AddInventory(FlatBufferBuilder builder, VectorOffset inventoryOffset) { builder.AddOffset(5, inventoryOffset.Value, 0); }
+  public static VectorOffset CreateInventoryVector(FlatBufferBuilder builder, byte[] data) { builder.StartVector(1, data.Length, 1); for (int i = data.Length - 1; i >= 0; i--) builder.AddByte(data[i]); return builder.EndVector(); }
   public static void StartInventoryVector(FlatBufferBuilder builder, int numElems) { builder.StartVector(1, numElems, 1); }
   public static void AddColor(FlatBufferBuilder builder, Color color) { builder.AddSbyte(6, (sbyte)(color), 8); }
   public static void AddTestType(FlatBufferBuilder builder, Any testType) { builder.AddByte(7, (byte)(testType), 0); }
   public static void AddTest(FlatBufferBuilder builder, int testOffset) { builder.AddOffset(8, testOffset, 0); }
-  public static void AddTest4(FlatBufferBuilder builder, int test4Offset) { builder.AddOffset(9, test4Offset, 0); }
+  public static void AddTest4(FlatBufferBuilder builder, VectorOffset test4Offset) { builder.AddOffset(9, test4Offset.Value, 0); }
   public static void StartTest4Vector(FlatBufferBuilder builder, int numElems) { builder.StartVector(4, numElems, 2); }
-  public static void AddTestarrayofstring(FlatBufferBuilder builder, int testarrayofstringOffset) { builder.AddOffset(10, testarrayofstringOffset, 0); }
-  public static int CreateTestarrayofstringVector(FlatBufferBuilder builder, int[] data) { builder.StartVector(4, data.Length, 4); for (int i = data.Length - 1; i >= 0; i--) builder.AddOffset(data[i]); return builder.EndVector(); }
+  public static void AddTestarrayofstring(FlatBufferBuilder builder, VectorOffset testarrayofstringOffset) { builder.AddOffset(10, testarrayofstringOffset.Value, 0); }
+  public static VectorOffset CreateTestarrayofstringVector(FlatBufferBuilder builder, StringOffset[] data) { builder.StartVector(4, data.Length, 4); for (int i = data.Length - 1; i >= 0; i--) builder.AddOffset(data[i].Value); return builder.EndVector(); }
   public static void StartTestarrayofstringVector(FlatBufferBuilder builder, int numElems) { builder.StartVector(4, numElems, 4); }
-  public static void AddTestarrayoftables(FlatBufferBuilder builder, int testarrayoftablesOffset) { builder.AddOffset(11, testarrayoftablesOffset, 0); }
-  public static int CreateTestarrayoftablesVector(FlatBufferBuilder builder, int[] data) { builder.StartVector(4, data.Length, 4); for (int i = data.Length - 1; i >= 0; i--) builder.AddOffset(data[i]); return builder.EndVector(); }
+  public static void AddTestarrayoftables(FlatBufferBuilder builder, VectorOffset testarrayoftablesOffset) { builder.AddOffset(11, testarrayoftablesOffset.Value, 0); }
+  public static VectorOffset CreateTestarrayoftablesVector(FlatBufferBuilder builder, Offset<Monster>[] data) { builder.StartVector(4, data.Length, 4); for (int i = data.Length - 1; i >= 0; i--) builder.AddOffset(data[i].Value); return builder.EndVector(); }
   public static void StartTestarrayoftablesVector(FlatBufferBuilder builder, int numElems) { builder.StartVector(4, numElems, 4); }
-  public static void AddEnemy(FlatBufferBuilder builder, int enemyOffset) { builder.AddOffset(12, enemyOffset, 0); }
-  public static void AddTestnestedflatbuffer(FlatBufferBuilder builder, int testnestedflatbufferOffset) { builder.AddOffset(13, testnestedflatbufferOffset, 0); }
-  public static int CreateTestnestedflatbufferVector(FlatBufferBuilder builder, byte[] data) { builder.StartVector(1, data.Length, 1); for (int i = data.Length - 1; i >= 0; i--) builder.AddByte(data[i]); return builder.EndVector(); }
+  public static void AddEnemy(FlatBufferBuilder builder, Offset<Monster> enemyOffset) { builder.AddOffset(12, enemyOffset.Value, 0); }
+  public static void AddTestnestedflatbuffer(FlatBufferBuilder builder, VectorOffset testnestedflatbufferOffset) { builder.AddOffset(13, testnestedflatbufferOffset.Value, 0); }
+  public static VectorOffset CreateTestnestedflatbufferVector(FlatBufferBuilder builder, byte[] data) { builder.StartVector(1, data.Length, 1); for (int i = data.Length - 1; i >= 0; i--) builder.AddByte(data[i]); return builder.EndVector(); }
   public static void StartTestnestedflatbufferVector(FlatBufferBuilder builder, int numElems) { builder.StartVector(1, numElems, 1); }
-  public static void AddTestempty(FlatBufferBuilder builder, int testemptyOffset) { builder.AddOffset(14, testemptyOffset, 0); }
+  public static void AddTestempty(FlatBufferBuilder builder, Offset<Stat> testemptyOffset) { builder.AddOffset(14, testemptyOffset.Value, 0); }
   public static void AddTestbool(FlatBufferBuilder builder, bool testbool) { builder.AddBool(15, testbool, false); }
   public static void AddTesthashs32Fnv1(FlatBufferBuilder builder, int testhashs32Fnv1) { builder.AddInt(16, testhashs32Fnv1, 0); }
   public static void AddTesthashu32Fnv1(FlatBufferBuilder builder, uint testhashu32Fnv1) { builder.AddUint(17, testhashu32Fnv1, 0); }
@@ -80,12 +80,12 @@ public sealed class Monster : Table {
   public static void AddTesthashu32Fnv1a(FlatBufferBuilder builder, uint testhashu32Fnv1a) { builder.AddUint(21, testhashu32Fnv1a, 0); }
   public static void AddTesthashs64Fnv1a(FlatBufferBuilder builder, long testhashs64Fnv1a) { builder.AddLong(22, testhashs64Fnv1a, 0); }
   public static void AddTesthashu64Fnv1a(FlatBufferBuilder builder, ulong testhashu64Fnv1a) { builder.AddUlong(23, testhashu64Fnv1a, 0); }
-  public static int EndMonster(FlatBufferBuilder builder) {
+  public static Offset<Monster> EndMonster(FlatBufferBuilder builder) {
     int o = builder.EndObject();
     builder.Required(o, 10);  // name
-    return o;
+    return new Offset<Monster>(o);
   }
-  public static void FinishMonsterBuffer(FlatBufferBuilder builder, int offset) { builder.Finish(offset, "MONS"); }
+  public static void FinishMonsterBuffer(FlatBufferBuilder builder, Offset<Monster> offset) { builder.Finish(offset.Value, "MONS"); }
 };
 
 

--- a/tests/MyGame/Example/Stat.cs
+++ b/tests/MyGame/Example/Stat.cs
@@ -14,8 +14,8 @@ public sealed class Stat : Table {
   public long Val { get { int o = __offset(6); return o != 0 ? bb.GetLong(o + bb_pos) : (long)0; } }
   public ushort Count { get { int o = __offset(8); return o != 0 ? bb.GetUshort(o + bb_pos) : (ushort)0; } }
 
-  public static int CreateStat(FlatBufferBuilder builder,
-      int id = 0,
+  public static Offset<Stat> CreateStat(FlatBufferBuilder builder,
+      StringOffset id = default(StringOffset),
       long val = 0,
       ushort count = 0) {
     builder.StartObject(3);
@@ -26,12 +26,12 @@ public sealed class Stat : Table {
   }
 
   public static void StartStat(FlatBufferBuilder builder) { builder.StartObject(3); }
-  public static void AddId(FlatBufferBuilder builder, int idOffset) { builder.AddOffset(0, idOffset, 0); }
+  public static void AddId(FlatBufferBuilder builder, StringOffset idOffset) { builder.AddOffset(0, idOffset.Value, 0); }
   public static void AddVal(FlatBufferBuilder builder, long val) { builder.AddLong(1, val, 0); }
   public static void AddCount(FlatBufferBuilder builder, ushort count) { builder.AddUshort(2, count, 0); }
-  public static int EndStat(FlatBufferBuilder builder) {
+  public static Offset<Stat> EndStat(FlatBufferBuilder builder) {
     int o = builder.EndObject();
-    return o;
+    return new Offset<Stat>(o);
   }
 };
 

--- a/tests/MyGame/Example/Test.cs
+++ b/tests/MyGame/Example/Test.cs
@@ -11,12 +11,12 @@ public sealed class Test : Struct {
   public short A { get { return bb.GetShort(bb_pos + 0); } }
   public sbyte B { get { return bb.GetSbyte(bb_pos + 2); } }
 
-  public static int CreateTest(FlatBufferBuilder builder, short A, sbyte B) {
+  public static Offset<Test> CreateTest(FlatBufferBuilder builder, short A, sbyte B) {
     builder.Prep(2, 4);
     builder.Pad(1);
     builder.PutSbyte(B);
     builder.PutShort(A);
-    return builder.Offset;
+    return new Offset<Test>(builder.Offset);
   }
 };
 

--- a/tests/MyGame/Example/Vec3.cs
+++ b/tests/MyGame/Example/Vec3.cs
@@ -16,7 +16,7 @@ public sealed class Vec3 : Struct {
   public Test Test3 { get { return GetTest3(new Test()); } }
   public Test GetTest3(Test obj) { return obj.__init(bb_pos + 26, bb); }
 
-  public static int CreateVec3(FlatBufferBuilder builder, float X, float Y, float Z, double Test1, Color Test2, short test3_A, sbyte test3_B) {
+  public static Offset<Vec3> CreateVec3(FlatBufferBuilder builder, float X, float Y, float Z, double Test1, Color Test2, short test3_A, sbyte test3_B) {
     builder.Prep(16, 32);
     builder.Pad(2);
     builder.Prep(2, 4);
@@ -30,7 +30,7 @@ public sealed class Vec3 : Struct {
     builder.PutFloat(Z);
     builder.PutFloat(Y);
     builder.PutFloat(X);
-    return builder.Offset;
+    return new Offset<Vec3>(builder.Offset);
   }
 };
 


### PR DESCRIPTION
Hi! I added basic offset safety in C# binding. And method that allows reset FlatBufferBuilder state.
int offsets replaced by `Offset<T>` for structs and tables, `StringOffset` for strings and `VectorOffset` for vectors.