### PR TITLE
builder: Added PrependVector and ConvertBool (#244)

### DIFF
--- a/go/builder.go
+++ b/go/builder.go
@@ -277,6 +277,16 @@ func (b *Builder) StartVector(elemSize, numElems, alignment int) UOffsetT {
 	return b.Offset()
 }
 
+// PrependVector prepends a slice of bytes to the Builder buffer.
+// It should only be used after starting the vector. Internally it
+// calls EndVector and returns the offset.
+func (b *Builder) PrependVector(buf []byte) UOffsetT {
+	for i := len(buf) - 1; i >= 0; i-- {
+		b.PrependByte(buf[i])
+	}
+	return b.EndVector(len(buf))
+}
+
 // EndVector writes data necessary to finish vector construction.
 func (b *Builder) EndVector(vectorNumElems int) UOffsetT {
 	// we already made space for this, so write without PrependUint32
@@ -519,6 +529,14 @@ func vtableEqual(a []UOffsetT, objectStart UOffsetT, b []byte) bool {
 		}
 	}
 	return true
+}
+
+// ConvertBool simply converts a boolean to a byte.
+func ConvertBool(b bool) byte {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // PrependBool prepends a bool to the Builder buffer.

--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -98,6 +98,9 @@ func TestAll(t *testing.T) {
 	// some sanity checks:
 	CheckDocExample(generated, off, t.Fatalf)
 
+	// Make sure PrependVector works properly.
+	CheckPrependVector(t.Fatalf)
+
 	// Check Builder.CreateByteVector
 	CheckCreateByteVector(t.Fatalf)
 
@@ -1218,6 +1221,28 @@ func CheckCreateByteVector(fail func(string, ...interface{})) {
 		}
 		b1.EndVector(size)
 		b2.CreateByteVector(raw[:size])
+		CheckByteEquality(b1.Bytes, b2.Bytes, fail)
+	}
+}
+
+func CheckPrependVector(fail func(string, ...interface{})) {
+	raw := [30]byte{}
+	for i := 0; i < len(raw); i++ {
+		raw[i] = byte(i)
+	}
+
+	for size := 0; size < len(raw); size++ {
+		b1 := flatbuffers.NewBuilder(0)
+		b1.StartVector(1, size, 1)
+		for i := size - 1; i >= 0; i-- {
+			b1.PrependByte(raw[i])
+		}
+		b1.EndVector(size)
+
+		b2 := flatbuffers.NewBuilder(0)
+		b2.StartVector(1, size, 1)
+		b2.PrependVector(raw[:size])
+
 		CheckByteEquality(b1.Bytes, b2.Bytes, fail)
 	}
 }

--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -101,6 +101,9 @@ func TestAll(t *testing.T) {
 	// Make sure PrependVector works properly.
 	CheckPrependVector(t.Fatalf)
 
+	// Check for cosmic ray bit flips and stuff.
+	CheckConvertBool(t.Fail.f)
+
 	// Check Builder.CreateByteVector
 	CheckCreateByteVector(t.Fatalf)
 
@@ -1244,6 +1247,18 @@ func CheckPrependVector(fail func(string, ...interface{})) {
 		b2.PrependVector(raw[:size])
 
 		CheckByteEquality(b1.Bytes, b2.Bytes, fail)
+	}
+}
+
+func CheckConvertBool(fail func(string, ...interface{})) {
+	b := true
+	if ConvertBool(b) != 1 {
+		fail("ConvertBool(true) returned something other than 1")
+	}
+
+	f := false
+	if ConvertBool(f) != 0 {
+		fail("ConvertBool(false) returned something other than 0")
 	}
 }
 


### PR DESCRIPTION
PrependVector works like CreateByteVector except for it's designed to
work with code generated by flatc.

As per #244, a generated function similar to:

TypeStartMethodnameVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
    return builder.StartVector(1, numElems, 1)
}

will require the programmer to use a for-loop to prepend each byte of
buf to the Type and then call builder.EndVector(len(buf)).

PrependVector abstracts this into a function so the programmer can be
lazy and call

TypeStartMethodnameVector(builder, len(buf))
off := builder.PrependVector(buf)

ConvertBool simply converts a bool to a byte because the generated
functions ask for a byte instead of a bool. If you're marshalling
a structure that has multiple booleans, doing this by hand becomes
tiring.