### PR TITLE
[Issue 252] Add type cast for default enum values in C#

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -789,7 +789,15 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
         // Java doesn't have defaults, which means this method must always
         // supply all arguments, and thus won't compile when fields are added.
         if (lang.language != GeneratorOptions::kJava) {
-          code += " = " + GenDefaultValue(lang, field.value, false);
+          code += " = ";
+          // in C#, enum values have their own type, so we need to cast the
+          // numeric value to the proper type
+          if (lang.language == GeneratorOptions::kCSharp &&
+            field.value.type.enum_def != nullptr &&
+            field.value.type.base_type != BASE_TYPE_UNION) {
+            code += "(" + field.value.type.enum_def->name + ")";
+          }
+          code += GenDefaultValue(lang, field.value, false);
         }
       }
       code += ") {\n    builder.";

--- a/tests/FlatBuffers.Test/FlatBuffers.Test.csproj
+++ b/tests/FlatBuffers.Test/FlatBuffers.Test.csproj
@@ -71,6 +71,9 @@
     <Compile Include="..\MyGame\Example\Test.cs">
       <Link>MyGame\Example\Test.cs</Link>
     </Compile>
+    <Compile Include="..\MyGame\Example\TestSimpleTableWithEnum.cs">
+      <Link>MyGame\Example\TestSimpleTableWithEnum.cs</Link>
+    </Compile>
     <Compile Include="..\MyGame\Example\Vec3.cs">
       <Link>MyGame\Example\Vec3.cs</Link>
     </Compile>

--- a/tests/MyGame/Example/Any.cs
+++ b/tests/MyGame/Example/Any.cs
@@ -7,6 +7,7 @@ public enum Any : byte
 {
  NONE = 0,
  Monster = 1,
+ TestSimpleTableWithEnum = 2,
 };
 
 

--- a/tests/MyGame/Example/Any.go
+++ b/tests/MyGame/Example/Any.go
@@ -5,4 +5,5 @@ package Example
 const (
 	AnyNONE = 0
 	AnyMonster = 1
+	AnyTestSimpleTableWithEnum = 2
 )

--- a/tests/MyGame/Example/Any.java
+++ b/tests/MyGame/Example/Any.java
@@ -6,8 +6,9 @@ public final class Any {
   private Any() { }
   public static final byte NONE = 0;
   public static final byte Monster = 1;
+  public static final byte TestSimpleTableWithEnum = 2;
 
-  private static final String[] names = { "NONE", "Monster", };
+  private static final String[] names = { "NONE", "Monster", "TestSimpleTableWithEnum", };
 
   public static String name(int e) { return names[e]; }
 };

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.cs
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.cs
@@ -1,0 +1,31 @@
+// automatically generated, do not modify
+
+namespace MyGame.Example
+{
+
+using FlatBuffers;
+
+public sealed class TestSimpleTableWithEnum : Table {
+  public static TestSimpleTableWithEnum GetRootAsTestSimpleTableWithEnum(ByteBuffer _bb) { return GetRootAsTestSimpleTableWithEnum(_bb, new TestSimpleTableWithEnum()); }
+  public static TestSimpleTableWithEnum GetRootAsTestSimpleTableWithEnum(ByteBuffer _bb, TestSimpleTableWithEnum obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
+  public TestSimpleTableWithEnum __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+
+  public Color Color { get { int o = __offset(4); return o != 0 ? (Color)bb.GetSbyte(o + bb_pos) : (Color)2; } }
+
+  public static Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnum(FlatBufferBuilder builder,
+      Color color = (Color)2) {
+    builder.StartObject(1);
+    TestSimpleTableWithEnum.AddColor(builder, color);
+    return TestSimpleTableWithEnum.EndTestSimpleTableWithEnum(builder);
+  }
+
+  public static void StartTestSimpleTableWithEnum(FlatBufferBuilder builder) { builder.StartObject(1); }
+  public static void AddColor(FlatBufferBuilder builder, Color color) { builder.AddSbyte(0, (sbyte)(color), 2); }
+  public static Offset<TestSimpleTableWithEnum> EndTestSimpleTableWithEnum(FlatBufferBuilder builder) {
+    int o = builder.EndObject();
+    return new Offset<TestSimpleTableWithEnum>(o);
+  }
+};
+
+
+}

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.go
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.go
@@ -1,0 +1,27 @@
+// automatically generated, do not modify
+
+package Example
+
+import (
+	flatbuffers "github.com/google/flatbuffers/go"
+)
+type TestSimpleTableWithEnum struct {
+	_tab flatbuffers.Table
+}
+
+func (rcv *TestSimpleTableWithEnum) Init(buf []byte, i flatbuffers.UOffsetT) {
+	rcv._tab.Bytes = buf
+	rcv._tab.Pos = i
+}
+
+func (rcv *TestSimpleTableWithEnum) Color() int8 {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
+	if o != 0 {
+		return rcv._tab.GetInt8(o + rcv._tab.Pos)
+	}
+	return 2
+}
+
+func TestSimpleTableWithEnumStart(builder *flatbuffers.Builder) { builder.StartObject(1) }
+func TestSimpleTableWithEnumAddColor(builder *flatbuffers.Builder, color int8) { builder.PrependInt8Slot(0, color, 2) }
+func TestSimpleTableWithEnumEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT { return builder.EndObject() }

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.java
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.java
@@ -1,0 +1,31 @@
+// automatically generated, do not modify
+
+package MyGame.Example;
+
+import java.nio.*;
+import java.lang.*;
+import java.util.*;
+import com.google.flatbuffers.*;
+
+public final class TestSimpleTableWithEnum extends Table {
+  public static TestSimpleTableWithEnum getRootAsTestSimpleTableWithEnum(ByteBuffer _bb) { return getRootAsTestSimpleTableWithEnum(_bb, new TestSimpleTableWithEnum()); }
+  public static TestSimpleTableWithEnum getRootAsTestSimpleTableWithEnum(ByteBuffer _bb, TestSimpleTableWithEnum obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__init(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public TestSimpleTableWithEnum __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+
+  public byte color() { int o = __offset(4); return o != 0 ? bb.get(o + bb_pos) : 2; }
+
+  public static int createTestSimpleTableWithEnum(FlatBufferBuilder builder,
+      byte color) {
+    builder.startObject(1);
+    TestSimpleTableWithEnum.addColor(builder, color);
+    return TestSimpleTableWithEnum.endTestSimpleTableWithEnum(builder);
+  }
+
+  public static void startTestSimpleTableWithEnum(FlatBufferBuilder builder) { builder.startObject(1); }
+  public static void addColor(FlatBufferBuilder builder, byte color) { builder.addByte(0, color, 2); }
+  public static int endTestSimpleTableWithEnum(FlatBufferBuilder builder) {
+    int o = builder.endObject();
+    return o;
+  }
+};
+

--- a/tests/monster_test.fbs
+++ b/tests/monster_test.fbs
@@ -8,9 +8,13 @@ attribute "priority";
 
 enum Color:byte (bit_flags) { Red = 0, Green, Blue = 3, }
 
-union Any { Monster }  // TODO: add more elements
+union Any { Monster, TestSimpleTableWithEnum }  // TODO: add more elements
 
 struct Test { a:short; b:byte; }
+
+table TestSimpleTableWithEnum {
+  color: Color = Green;
+}
 
 struct Vec3 (force_align: 16) {
   x:float;


### PR DESCRIPTION
When creating a `CreateXxx(...)` method for a “simple table” type, enum-type fields with a non-zero default must have an explicit cast for the respective argument default value, because in C#, there is an implicit cast from int to an enum only for 0.

Also, added an example of such type into the example monster_test type, so that we test this feature.