### PR TITLE
Fix notation of floats when generating json

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -47,7 +47,7 @@ template<typename T> std::string NumToString(T t) {
   // to_string() prints different numbers of digits for floats depending on
   // platform and isn't available on Android, so we use stringstream
   std::stringstream ss;
-  ss << t;
+  ss << std::fixed << t;
   return ss.str();
 }
 // Avoid char types used as character data.


### PR DESCRIPTION
Large floats were written in scientific notation which is not valid JSON. 
Example: `5000000 => "5e+06"`

This request uses the `std::fixed` stream manipulator to fix this.
