### PR TITLE
Add @SuppressWarnings("all") to generated Java classes

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -118,7 +118,7 @@ LanguageParameters language_parameters[] = {
     "position()",
     "offset()",
     "import java.nio.*;\nimport java.lang.*;\nimport java.util.*;\n"
-      "import com.google.flatbuffers.*;\n\n",
+      "import com.google.flatbuffers.*;\n\n@SuppressWarnings(\"unused\")\n",
     {
       "/**",
       " *",


### PR DESCRIPTION
Usually generators add @SuppressWarnings("all") to generated Java
classes to prevent IDEs from complaining about unused imports, etc.
Solving used imports seems pretty hard with current generator logic so
IMO this is the next best thing.

Yes, it’s appended to import block but that is the block that gives
these warnings in the first place.