### PR TITLE
Fix an out-of bounds read when the element is bigger than the buffer.

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -898,7 +898,7 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
 
   // Verify any range within the buffer.
   bool Verify(const void *elem, size_t elem_len) const {
-    return Check(elem >= buf_ && elem <= end_ - elem_len);
+    return Check(elem_len <= (size_t) (end_ - buf_) && elem >= buf_ && elem <= end_ - elem_len);
   }
 
   // Verify a range indicated by sizeof(T).


### PR DESCRIPTION
Ensure the size of the buffer being checked is bigger than the element
of the buffer being checked. The buffer can be triggered when, for
example, the buffer is of length zero and we are checking for:

    Verify<uoffset_t>(buf_)

The condition above should fail.