### PR TITLE
Removed call to pop_back on std::string.

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -68,7 +68,8 @@ template<> inline std::string NumToString<double>(double t) {
   auto p = s.find_last_not_of('0');
   if (p != std::string::npos) {
     s.resize(p + 1);  // Strip trailing zeroes.
-    if (s.back() == '.') s.pop_back();  // Strip '.' if a whole number.
+    if (s.back() == '.')
+      s.erase(s.size() - 1, 1);  // Strip '.' if a whole number.
   }
   return s;
 }


### PR DESCRIPTION
The pop_back function was added to strings in C++11 and it appears not
all compilers we target support it. The call to pop_back has been
replaced with a call to erase.

Tested on Linux. All unit tests pass.