### PR TITLE
be C++11 to disable auto-generated copy-ctor

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -489,9 +489,8 @@ class vector_downward {
   void pop(size_t bytes_to_remove) { cur_ += bytes_to_remove; }
 
  private:
-  // You shouldn't really be copying instances of this class.
-  vector_downward(const vector_downward &);
-  vector_downward &operator=(const vector_downward &);
+  vector_downward(const vector_downward &) = delete;
+  vector_downward &operator=(const vector_downward &) = delete;
 
   size_t reserved_;
   uint8_t *buf_;
@@ -841,9 +840,8 @@ class FlatBufferBuilder FLATBUFFERS_FINAL_CLASS {
   }
 
  private:
-  // You shouldn't really be copying instances of this class.
-  FlatBufferBuilder(const FlatBufferBuilder &);
-  FlatBufferBuilder &operator=(const FlatBufferBuilder &);
+  FlatBufferBuilder(const FlatBufferBuilder &) = delete;
+  FlatBufferBuilder &operator=(const FlatBufferBuilder &) = delete;
 
   struct FieldLoc {
     uoffset_t off;


### PR DESCRIPTION
Hi,

In this change, I'm using _delete_ specifier to explicitly indicate that _vector_downward_ and _FlatBufferBuilder_ are noncopyable.

The local regression tests passed with biicode=true & false in Linux.

I'm new to flatbuffers and this is my first trial pull request to the project.  Therefore I would try something simple at first while I learn how it works.

Your advice are welcomed.

Cheers,
Kai