### PR TITLE
Python: Speedup with cython extension

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,2 @@
+# include the c extensions
+recursive-include flatbuffers *.h *.pxd *.pyx

--- a/python/flatbuffers/__init__.py
+++ b/python/flatbuffers/__init__.py
@@ -12,6 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .builder import Builder
-from .table import Table
-from .compat import range_func as compat_range
+__all__ = [
+    'Table',
+    'Builder',
+    'implementation',
+    'force_implementation',
+]
+
+
+def force_implementation(implname):
+    """Forces flatbuffers to use a specific implementation if it's available"""
+    global Table, Builder, implementation
+
+    if implname == 'python':
+        from . import table, builder
+        Table, Builder = table.Table, builder.Builder
+        implementation = 'python'
+    elif implname == 'cython':
+        from . import fastcodec
+        Table, Builder = fastcodec.FastTable, fastcodec.FastBuilder
+        implementation = 'cython'
+    else:
+        raise ImportError("No implementation named: %r" % implname)
+
+
+try:
+    force_implementation('cython')
+except ImportError:
+    force_implementation('python')

--- a/python/flatbuffers/encode.py
+++ b/python/flatbuffers/encode.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ctypes
-
-from . import number_types as N
-from . import packer
 from .compat import memoryview_type
 
 

--- a/python/flatbuffers/exceptions.py
+++ b/python/flatbuffers/exceptions.py
@@ -1,0 +1,49 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class OffsetArithmeticError(RuntimeError):
+    """
+    Error caused by an Offset arithmetic error. Probably caused by bad
+    writing of fields. This is considered an unreachable situation in
+    normal circumstances.
+    """
+
+
+class NotInObjectError(RuntimeError):
+    """
+    Error caused by using a Builder to write Object data when not inside
+    an Object.
+    """
+
+
+class ObjectIsNestedError(RuntimeError):
+    """
+    Error caused by using a Builder to begin an Object when an Object is
+    already being built.
+    """
+
+
+class StructIsNotInlineError(RuntimeError):
+    """
+    Error caused by using a Builder to write a Struct at a location that
+    is not the current Offset.
+    """
+
+
+class BuilderSizeError(RuntimeError):
+    """
+    Error caused by causing a Builder to exceed the hardcoded limit of 2
+    gigabytes.
+    """

--- a/python/flatbuffers/fastcodec.pyx
+++ b/python/flatbuffers/fastcodec.pyx
@@ -1,0 +1,677 @@
+# -*- coding:utf8 -*-
+# distutils: language = c++
+# cython: always_allow_keywords = False
+#
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from libc.stdint cimport (
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+    uintmax_t)
+from libc.stddef cimport size_t
+from libcpp cimport bool as bool_t
+from cpython.bytes cimport PyBytes_AS_STRING
+
+from .exceptions import (
+    OffsetArithmeticError,
+    NotInObjectError,
+    ObjectIsNestedError,
+    StructIsNotInlineError,
+    BuilderSizeError)
+
+
+cdef extern from "flatbuffers/flatwrapper.h" namespace "flatbuffers":
+    ctypedef uint32_t uoffset_t
+    ctypedef int32_t soffset_t
+    ctypedef uint16_t voffset_t
+    ctypedef uintmax_t largest_scalar_t
+
+    cdef cppclass Offset[T]:
+        uoffset_t o
+        Offset()
+        Offset(uoffset_t _o)
+
+    void EndianCheck()
+    T EndianScalar[T](T t)
+    T ReadScalar[T](const void *p)
+    void WriteScalar[T](void *p, T t)
+    size_t AlignOf[T]()
+
+    cdef cppclass Vector[T]:
+        uoffset_t size()
+        const uint8_t *Data()
+
+    size_t VectorLength[T](const Vector[T] *v)
+
+    cdef cppclass String(Vector[char]):
+        pass
+
+    cdef cppclass simple_allocator:
+        pass
+
+    voffset_t FieldIndexToOffset(voffset_t field_id)
+    size_t PaddingBytes(size_t buf_size, size_t scalar_size)
+
+    cdef cppclass FlatBufferBuilder:
+        FlatBufferBuilder()
+        FlatBufferBuilder(uoffset_t initial_size)
+        FlatBufferBuilder(uoffset_t initial_size, const simple_allocator *allocator)
+        void Clear()
+        uoffset_t GetSize()
+        uint8_t *GetBufferPointer()
+        void ForceDefaults(bool_t fd)
+        void Pad(size_t num_bytes)
+        void Align(size_t elem_size)
+        void PushBytes(const uint8_t *bytes, size_t size)
+        void PopBytes(size_t amount)
+        void AssertScalarT[T]()
+        uoffset_t PushElement[T](T element)
+        void TrackField(voffset_t field, uoffset_t off)
+        void AddElement[T](voffset_t field, T e, T def_)
+        void AddOffset[T](voffset_t field, Offset[T] off)
+        void AddStruct[T](voffset_t field, const T *structptr)
+        void AddStructOffset(voffset_t field, uoffset_t off)
+        uoffset_t ReferTo(uoffset_t off)
+        void NotNested()
+        uoffset_t StartTable()
+        uoffset_t EndTable(uoffset_t start, voffset_t numfields)
+        void Required[T](Offset[T] table, voffset_t field)
+        uoffset_t StartStruct(size_t alignment)
+        uoffset_t EndStruct()
+        void ClearOffsets()
+        void PreAlign(size_t len, size_t alignment)
+        void PreAlign[T](size_t len)
+        Offset[String] CreateString(const char *str)
+        Offset[String] CreateString(const char *str, size_t len)
+        uoffset_t EndVector(size_t len)
+        void StartVector(size_t len, size_t elemsize)
+        uint8_t *ReserveElements(size_t len, size_t elemsize)
+        Offset[Vector[T]] CreateVector[T](const T *v, size_t len)
+        Offset[Vector[T]] CreateVectorOfStructs[T](T v, size_t len)
+        Offset[Vector[Offset[T]]] CreateVectorOfSortedTables[T](Offset[T] *v, size_t len)
+        uoffset_t CreateUninitializedVector(size_t len, size_t elemsize, uint8_t **buf)
+        Offset[Vector[T]] CreateUninitializedVector[T](size_t len, T **buf)
+        void Finish[T](Offset[T] root, const char *file_identifier)
+        void Finish[T](Offset[T] root)
+
+    T GetMutableRoot[T](void *buf)
+    const T GetRoot[T](const void *buf)
+    bool_t BufferHasIdentifier(const void *buf, const char *identifier)
+
+    cdef cppclass Verifier:
+        Verifier(const uint8_t *buf, size_t buf_len)
+        Verifier(const uint8_t *buf, size_t buf_len, size_t _max_depth)
+        Verifier(const uint8_t *buf, size_t buf_len, size_t _max_depth, size_t _max_tables)
+        bool_t Check(bool_t ok)
+        bool_t Verify(const void *elem, size_t elem_len)
+        bool_t Verify[T](const void *elem)
+        bool_t VerifyTable[T](const T *table)
+        bool_t Verify[T](const Vector[T] *vec)
+        bool_t Verify(const String *str)
+        bool_t VerifyVector(const uint8_t *vec, size_t elem_size, const uint8_t **end)
+        bool_t VerifyVectorOfStrings[T](const Vector[Offset[String]] *vec)
+        bool_t VerifyVectorOfTables[T](const Vector[Offset[T]] *vec)
+        bool_t VerifyBuffer[T]()
+        bool_t VerifyComplexity()
+        bool_t EndTable()
+
+    cdef cppclass Struct:
+        T GetField[T](uoffset_t o)
+        T GetPointer[T](uoffset_t o)
+        T GetStruct[T](uoffset_t o)
+
+    cdef cppclass Table:
+        voffset_t GetOptionalFieldOffset(voffset_t field)
+        T GetField[T](voffset_t field, T defaultval)
+        P GetPointer[P](voffset_t field)
+        P GetStruct[P](voffset_t field)
+        bool_t SetField[T](voffset_t field, T val)
+        uint8_t *GetAddressOf(voffset_t field)
+        uint8_t *GetVTable()
+        bool_t CheckField(voffset_t field)
+        bool_t VerifyTableStart(Verifier &verifier)
+        bool_t VerifyField[T](const Verifier &verifier, voffset_t field)
+        bool_t VerifyFieldRequired[T](const Verifier &verifier, voffset_t field)
+
+
+cdef extern from "flatwrapper.h":
+    cdef cppclass PythonAllocator(simple_allocator):
+        pass
+
+    uoffset_t PushUOffsetElement(FlatBufferBuilder *builder, Offset[void] off)
+    const Table *GetTable(const void *buf)
+
+
+cdef PythonAllocator pyallocator
+
+
+cdef class FastBuilder(object):
+    cdef FlatBufferBuilder* thisptr
+    cdef uoffset_t table_offset
+    cdef voffset_t table_numfields
+    cdef bool_t    table_started
+
+    def __cinit__(self, uoffset_t initial_size):
+        self.thisptr = new FlatBufferBuilder(initial_size, &pyallocator)
+        self.table_started = False
+
+    def __dealloc__(self):
+        if self.thisptr:
+            del self.thisptr
+
+    property Bytes:
+        def __get__(self): return self.Output()
+
+    def Head(self):
+        return 0
+
+    def Offset(self):
+        return self.thisptr.GetSize()
+
+    cpdef bytes Output(self):
+        cdef uint8_t *buf
+        buf = self.thisptr.GetBufferPointer()
+        return buf[:self.thisptr.GetSize()]
+
+    def Reset(self):
+        self.thisptr.Clear()
+        self.table_started = False
+
+    def StartObject(self, voffset_t numfields):
+        if self.table_started:
+            raise ObjectIsNestedError("flatbuffers: Tried to write a new "
+                "Object when the Builder was already writing an Object.")
+        self.table_offset = self.thisptr.StartTable()
+        self.table_numfields = numfields
+        self.table_started = True
+
+    def EndObject(self):
+        cdef uoffset_t offset
+        if not self.table_started:
+            raise NotInObjectError("flatbuffers: Tried to write the end of an "
+                "Object when the Builder was not currently writing an Object.")
+        offset = self.thisptr.EndTable(self.table_offset, self.table_numfields)
+        self.table_started = False
+        return offset
+
+    def Pad(self, size_t num_bytes):
+        self.thisptr.Pad(num_bytes)
+
+    def Prep(self, size_t alignment, size_t len):
+        self.thisptr.PreAlign(len, alignment)
+
+    def PrependUOffsetTRelative(self, uoffset_t off):
+        self.thisptr.PreAlign(0, 4)
+        if off > self.thisptr.GetSize():
+            raise OffsetArithmeticError("flatbuffers: Offset arithmetic error.")
+        # self.thisptr.PushElement[void](Offset[void](off))
+        PushUOffsetElement(self.thisptr, Offset[void](off))
+
+    def StartVector(self, size_t elemsize, size_t len, size_t alignment):
+        if self.table_started:
+            raise ObjectIsNestedError("flatbuffers: Tried to write a new "
+                "Object when the Builder was already writing an Object.")
+        self.thisptr.StartVector(len, elemsize)
+        return self.thisptr.GetSize()
+
+    def EndVector(self, size_t len):
+        return self.thisptr.EndVector(len)
+
+    def CreateString(self, bytes s not None):
+        cdef Offset[String] off
+        if self.table_started:
+            raise ObjectIsNestedError("flatbuffers: Tried to write a new "
+                "Object when the Builder was already writing an Object.")
+        off = self.thisptr.CreateString(PyBytes_AS_STRING(s), <size_t>len(s))
+        return off.o
+
+    def Finish(self, uoffset_t root):
+        self.thisptr.Finish(Offset[Table](root))
+        return 0
+
+    def PrependBoolSlot(self, voffset_t field_id, bool_t e, bool_t d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[uint8_t](field, <uint8_t>e, <uint8_t>d)
+
+    def PrependByteSlot(self, voffset_t field_id, uint8_t e, uint8_t d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[uint8_t](field, e, d)
+
+    def PrependUint8Slot(self, voffset_t field_id, uint8_t e, uint8_t d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[uint8_t](field, e, d)
+
+    def PrependUint16Slot(self, voffset_t field_id, uint16_t e, uint16_t d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[uint16_t](field, e, d)
+
+    def PrependUint32Slot(self, voffset_t field_id, uint32_t e, uint32_t d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[uint32_t](field, e, d)
+
+    def PrependUint64Slot(self, voffset_t field_id, uint64_t e, uint64_t d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[uint64_t](field, e, d)
+
+    def PrependInt8Slot(self, voffset_t field_id, int8_t e, int8_t d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[int8_t](field, e, d)
+
+    def PrependInt16Slot(self, voffset_t field_id, int16_t e, int16_t d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[int16_t](field, e, d)
+
+    def PrependInt32Slot(self, voffset_t field_id, int32_t e, int32_t d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[int32_t](field, e, d)
+
+    def PrependInt64Slot(self, voffset_t field_id, int64_t e, int64_t d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[int64_t](field, e, d)
+
+    def PrependFloat32Slot(self, voffset_t field_id, float e, float d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[float](field, e, d)
+
+    def PrependFloat64Slot(self, voffset_t field_id, double e, double d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddElement[double](field, e, d)
+
+    def PrependUOffsetTRelativeSlot(self, voffset_t field_id, uoffset_t e, uoffset_t d):
+        cdef voffset_t field
+        field = FieldIndexToOffset(field_id)
+        self.thisptr.AddOffset[void](field, Offset[void](e))
+
+    def PrependStructSlot(self, voffset_t field_id, uoffset_t e, uoffset_t d):
+        cdef voffset_t field
+        if e != d:
+            if self.thisptr.GetSize() != e:
+                raise StructIsNotInlineError("flatbuffers: Tried to write a "
+                    "Struct at an Offset that is different from the current "
+                    "Offset of the Builder.")
+            field = FieldIndexToOffset(field_id)
+            self.thisptr.AddStructOffset(field, e)
+
+    def PrependBool(self, bool_t e):
+        self.thisptr.PushElement[uint8_t](e)
+
+    def PrependByte(self, uint8_t e):
+        self.thisptr.PushElement[uint8_t](e)
+
+    def PrependUint8(self, uint8_t e):
+        self.thisptr.PushElement[uint8_t](e)
+
+    def PrependUint16(self, uint16_t e):
+        self.thisptr.PushElement[uint16_t](e)
+
+    def PrependUint32(self, uint32_t e):
+        self.thisptr.PushElement[uint32_t](e)
+
+    def PrependUint64(self, uint64_t e):
+        self.thisptr.PushElement[uint64_t](e)
+
+    def PrependInt8(self, int8_t e):
+        self.thisptr.PushElement[int8_t](e)
+
+    def PrependInt16(self, int16_t e):
+        self.thisptr.PushElement[int16_t](e)
+
+    def PrependInt32(self, int32_t e):
+        self.thisptr.PushElement[int32_t](e)
+
+    def PrependInt64(self, int64_t e):
+        self.thisptr.PushElement[int64_t](e)
+
+    def PrependFloat32(self, float e):
+        self.thisptr.PushElement[float](e)
+
+    def PrependFloat64(self, double e):
+        self.thisptr.PushElement[double](e)
+
+    def PrependVOffsetT(self, voffset_t e):
+        self.thisptr.PushElement[voffset_t](e)
+
+
+def _FastTable_GetRoot(cls, bytes buf not None, uoffset_t pos):
+    cdef size_t size
+    cdef uoffset_t off
+    cdef const uint8_t *raw
+    cdef const uint8_t *tab
+
+    size = <size_t>len(buf)
+    if sizeof(uoffset_t) > size \
+            or pos > size - sizeof(uoffset_t):
+        raise IndexError
+    raw = <const uint8_t*>PyBytes_AS_STRING(buf)
+    tab = <const uint8_t*>GetTable(raw + pos)
+    off = <uoffset_t>(tab - raw)
+    if off < pos \
+            or off > size - sizeof(soffset_t) \
+            or (<Table*>tab).GetVTable() < raw + pos:
+        raise IndexError
+    return cls(buf, off)
+
+
+cdef class FastTable(object):
+    cdef readonly bytes Bytes
+    cdef readonly uoffset_t Pos
+    cdef size_t size
+    cdef const uint8_t *tab
+
+    def __cinit__(self, bytes buf not None, uoffset_t pos):
+        self.Bytes = buf
+        self.Pos = pos
+        if pos < <size_t>len(buf):
+            self.tab = <const uint8_t*>PyBytes_AS_STRING(buf) + pos
+            self.size = <size_t>len(buf) - pos
+        else:
+            self.tab = NULL
+            self.size = 0
+
+    GetRoot = classmethod(_FastTable_GetRoot)
+
+    def Offset(self, voffset_t field):
+        return (<const Table*>self.tab).GetOptionalFieldOffset(field)
+
+    def Indirect(self, uoffset_t off):
+        cdef uoffset_t body
+
+        if sizeof(uoffset_t) > self.size or off > self.size - sizeof(uoffset_t):
+            raise IndexError
+        body = (<const Struct*>self.tab).GetField[uoffset_t](off) + off
+        if body < off or body > self.size:
+            raise IndexError
+        return body
+
+    def String(self, uoffset_t off):
+        cdef uoffset_t body
+        cdef uoffset_t start
+        cdef uoffset_t end
+
+        if sizeof(uoffset_t) > self.size or off > self.size - sizeof(uoffset_t):
+            raise IndexError
+        body = (<const Struct*>self.tab).GetField[uoffset_t](off) + off
+        if body < off or body > self.size - sizeof(uoffset_t):
+            raise IndexError
+        start = body + sizeof(uoffset_t)
+        end = start + (<const Struct*>self.tab).GetField[uoffset_t](body)
+        if end < start or end > self.size:
+            raise IndexError
+        return self.tab[start:end]
+
+    def VectorLen(self, uoffset_t off):
+        cdef uoffset_t body
+
+        if sizeof(uoffset_t) > self.size or off > self.size - sizeof(uoffset_t):
+            raise IndexError
+        body = (<const Struct*>self.tab).GetField[uoffset_t](off) + off
+        if body < off or body > self.size - sizeof(uoffset_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[uoffset_t](body)
+
+    def Vector(self, uoffset_t off):
+        cdef uoffset_t body
+
+        if sizeof(uoffset_t) > self.size or off > self.size - sizeof(uoffset_t):
+            raise IndexError
+        body = (<const Struct*>self.tab).GetField[uoffset_t](off) + off
+        if body < off or body > self.size - sizeof(uoffset_t):
+            raise IndexError
+        return body + sizeof(uoffset_t)
+
+    def Union(self, uoffset_t off):
+        cdef uoffset_t body
+
+        if sizeof(uoffset_t) > self.size or off > self.size - sizeof(uoffset_t):
+            raise IndexError
+        body = (<const Struct*>self.tab).GetField[uoffset_t](off) + off
+        if body < off or body > self.size:
+            raise IndexError
+        return FastTable(self.Bytes, self.Pos + body)
+
+    def GetBool(self, uoffset_t off):
+        if sizeof(bool_t) > self.size or off > self.size - sizeof(bool_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[bool_t](off)
+
+    def GetByte(self, uoffset_t off):
+        if sizeof(uint8_t) > self.size or off > self.size - sizeof(uint8_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[uint8_t](off)
+
+    def GetUint8(self, uoffset_t off):
+        if sizeof(uint8_t) > self.size or off > self.size - sizeof(uint8_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[uint8_t](off)
+
+    def GetUint16(self, uoffset_t off):
+        if sizeof(uint16_t) > self.size or off > self.size - sizeof(uint16_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[uint16_t](off)
+
+    def GetUint32(self, uoffset_t off):
+        if sizeof(uint32_t) > self.size or off > self.size - sizeof(uint32_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[uint32_t](off)
+
+    def GetUint64(self, uoffset_t off):
+        if sizeof(uint64_t) > self.size or off > self.size - sizeof(uint64_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[uint64_t](off)
+
+    def GetInt8(self, uoffset_t off):
+        if sizeof(int8_t) > self.size or off > self.size - sizeof(int8_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[int8_t](off)
+
+    def GetInt16(self, uoffset_t off):
+        if sizeof(int16_t) > self.size or off > self.size - sizeof(int16_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[int16_t](off)
+
+    def GetInt32(self, uoffset_t off):
+        if sizeof(int32_t) > self.size or off > self.size - sizeof(int32_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[int32_t](off)
+
+    def GetInt64(self, uoffset_t off):
+        if sizeof(int64_t) > self.size or off > self.size - sizeof(int64_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[int64_t](off)
+
+    def GetFloat32(self, uoffset_t off):
+        if sizeof(float) > self.size or off > self.size - sizeof(float):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[float](off)
+
+    def GetFloat64(self, uoffset_t off):
+        if sizeof(double) > self.size or off > self.size - sizeof(double):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[double](off)
+
+    def GetUOffsetT(self, uoffset_t off):
+        if sizeof(uoffset_t) > self.size or off > self.size - sizeof(uoffset_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[uoffset_t](off)
+
+    def GetVOffsetT(self, uoffset_t off):
+        if sizeof(voffset_t) > self.size or off > self.size - sizeof(voffset_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[voffset_t](off)
+
+    def GetSOffsetT(self, uoffset_t off):
+        if sizeof(soffset_t) > self.size or off > self.size - sizeof(soffset_t):
+            raise IndexError
+        return (<const Struct*>self.tab).GetField[soffset_t](off)
+
+    def GetBoolSlot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <bool_t>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(bool_t) > self.size or off > self.size - sizeof(bool_t):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[bool_t](off)
+        return default
+
+    def GetByteSlot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <uint8_t>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(uint8_t) > self.size or off > self.size - sizeof(uint8_t):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[uint8_t](off)
+        return default
+
+    def GetUint8Slot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <uint8_t>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(uint8_t) > self.size or off > self.size - sizeof(uint8_t):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[uint8_t](off)
+        return default
+
+    def GetUint16Slot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <uint16_t>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(uint16_t) > self.size or off > self.size - sizeof(uint16_t):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[uint16_t](off)
+        return default
+
+    def GetUint32Slot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <uint32_t>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(uint32_t) > self.size or off > self.size - sizeof(uint32_t):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[uint32_t](off)
+        return default
+
+    def GetUint64Slot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <uint64_t>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(uint64_t) > self.size or off > self.size - sizeof(uint64_t):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[uint64_t](off)
+        return default
+
+    def GetInt8Slot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <int8_t>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(int8_t) > self.size or off > self.size - sizeof(int8_t):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[int8_t](off)
+        return default
+
+    def GetInt16Slot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <int16_t>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(int16_t) > self.size or off > self.size - sizeof(int16_t):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[int16_t](off)
+        return default
+
+    def GetInt32Slot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <int32_t>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(int32_t) > self.size or off > self.size - sizeof(int32_t):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[int32_t](off)
+        return default
+
+    def GetInt64Slot(self, voffset_t field, int64_t default):
+        cdef uoffset_t off
+
+        <int64_t>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(int64_t) > self.size or off > self.size - sizeof(int64_t):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[int64_t](off)
+        return default
+
+    def GetFloat32Slot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <float>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(float) > self.size or off > self.size - sizeof(float):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[float](off)
+        return default
+
+    def GetFloat64Slot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <double>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            if sizeof(double) > self.size or off > self.size - sizeof(double):
+                raise IndexError
+            return (<const Struct*>self.tab).GetField[double](off)
+        return default
+
+    def GetVOffsetTSlot(self, voffset_t field, default):
+        cdef uoffset_t off
+
+        <voffset_t>default
+        off = (<const Table*>self.tab).GetOptionalFieldOffset(field)
+        if off != 0:
+            return off
+        return default

--- a/python/flatbuffers/flatwrapper.h
+++ b/python/flatbuffers/flatwrapper.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLATWRAPPER_H_
+#define FLATWRAPPER_H_
+
+#include <cstddef>
+#include <memory>
+#include <Python.h>
+
+#include "flatbuffers/flatbuffers.h"
+
+
+class PythonAllocator : public flatbuffers::simple_allocator {
+ public:
+  PythonAllocator() {}
+  virtual ~PythonAllocator() {}
+
+  virtual uint8_t *allocate(size_t size) const {
+    uint8_t *p = static_cast<uint8_t *>(PyMem_Malloc(size));
+    if (!p) {
+      throw std::bad_alloc();
+    }
+    return p;
+  }
+
+  virtual void deallocate(uint8_t *p) const {
+    PyMem_Free((void*)p);
+  }
+};
+
+
+inline flatbuffers::uoffset_t PushUOffsetElement(
+    flatbuffers::FlatBufferBuilder *builder,
+    flatbuffers::Offset<void> off) {
+  return builder->PushElement<void>(off);
+}
+
+
+inline const flatbuffers::Table *GetTable(const void *buf) {
+  return flatbuffers::GetRoot<flatbuffers::Table>(buf);
+}
+
+
+#endif  // FLATWRAPPER_H_

--- a/python/flatbuffers/number_types.py
+++ b/python/flatbuffers/number_types.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ctypes
-import collections
 import struct
-from ctypes import sizeof
 
 from . import packer
 

--- a/python/flatbuffers/table.py
+++ b/python/flatbuffers/table.py
@@ -17,6 +17,7 @@ from . import number_types as N
 
 
 class Table(object):
+
     """Table wraps a byte slice and provides read access to its data.
 
     The variable `Pos` indicates the root of the FlatBuffers object therein."""
@@ -29,38 +30,48 @@ class Table(object):
         self.Bytes = buf
         self.Pos = pos
 
+    @classmethod
+    def GetRoot(cls, buf, offset):
+        """GetRoot retrieves the root object contained in the `buffer`."""
+        n = encode.Get(N.UOffsetTFlags.packer_type, buf, offset)
+        return cls(buf, n + offset)
+
     def Offset(self, vtableOffset):
         """Offset provides access into the Table's vtable.
 
         Deprecated fields are ignored by checking the vtable's length."""
 
-        vtable = self.Pos - self.Get(N.SOffsetTFlags, self.Pos)
-        vtableEnd = self.Get(N.VOffsetTFlags, vtable)
+        vtable = self.Pos - encode.Get(N.SOffsetTFlags.packer_type,
+                                       self.Bytes,
+                                       self.Pos)
+        vtableEnd = encode.Get(N.VOffsetTFlags.packer_type, self.Bytes, vtable)
         if vtableOffset < vtableEnd:
-            return self.Get(N.VOffsetTFlags, vtable + vtableOffset)
+            return encode.Get(N.VOffsetTFlags.packer_type,
+                              self.Bytes,
+                              vtable + vtableOffset)
         return 0
 
     def Indirect(self, off):
         """Indirect retrieves the relative offset stored at `offset`."""
         N.enforce_number(off, N.UOffsetTFlags)
-        return off + encode.Get(N.UOffsetTFlags.packer_type, self.Bytes, off)
+        return off + self.Get(N.UOffsetTFlags, off)
 
     def String(self, off):
         """String gets a string from data stored inside the flatbuffer."""
         N.enforce_number(off, N.UOffsetTFlags)
-        off += encode.Get(N.UOffsetTFlags.packer_type, self.Bytes, off)
-        start = off + N.UOffsetTFlags.bytewidth
-        length = encode.Get(N.UOffsetTFlags.packer_type, self.Bytes, off)
-        return bytes(self.Bytes[start:start+length])
+
+        off += self.Get(N.UOffsetTFlags, off)
+        length = self.Get(N.UOffsetTFlags, off)
+        start = self.Pos + off + N.UOffsetTFlags.bytewidth
+        return bytes(self.Bytes[start:start + length])
 
     def VectorLen(self, off):
         """VectorLen retrieves the length of the vector whose offset is stored
            at "off" in this object."""
         N.enforce_number(off, N.UOffsetTFlags)
 
-        off += self.Pos
-        off += encode.Get(N.UOffsetTFlags.packer_type, self.Bytes, off)
-        ret = encode.Get(N.UOffsetTFlags.packer_type, self.Bytes, off)
+        off += self.Get(N.UOffsetTFlags, off)
+        ret = self.Get(N.UOffsetTFlags, off)
         return ret
 
     def Vector(self, off):
@@ -68,21 +79,18 @@ class Table(object):
            stored at "off" in this object."""
         N.enforce_number(off, N.UOffsetTFlags)
 
-        off += self.Pos
         x = off + self.Get(N.UOffsetTFlags, off)
         # data starts after metadata containing the vector length
         x += N.UOffsetTFlags.bytewidth
         return x
 
-    def Union(self, t2, off):
+    def Union(self, off):
         """Union initializes any Table-derived type to point to the union at
            the given offset."""
-        assert type(t2) is Table
         N.enforce_number(off, N.UOffsetTFlags)
 
-        off += self.Pos
-        t2.Pos = off + self.Get(N.UOffsetTFlags, off)
-        t2.Bytes = self.Bytes
+        off += self.Get(N.UOffsetTFlags, off)
+        return Table(self.Bytes, self.Pos + off)
 
     def Get(self, flags, off):
         """
@@ -90,16 +98,72 @@ class Table(object):
         given offset.
         """
         N.enforce_number(off, N.UOffsetTFlags)
+
+        off += self.Pos
         return flags.py_type(encode.Get(flags.packer_type, self.Bytes, off))
 
-    def GetSlot(self, slot, d, validator_flags):
+    def GetBool(self, off): return self.Get(N.BoolFlags, off)
+
+    def GetByte(self, off): return self.Get(N.Uint8Flags, off)
+
+    def GetUint8(self, off): return self.Get(N.Uint8Flags, off)
+
+    def GetUint16(self, off): return self.Get(N.Uint16Flags, off)
+
+    def GetUint32(self, off): return self.Get(N.Uint32Flags, off)
+
+    def GetUint64(self, off): return self.Get(N.Uint64Flags, off)
+
+    def GetInt8(self, off): return self.Get(N.Int8Flags, off)
+
+    def GetInt16(self, off): return self.Get(N.Int16Flags, off)
+
+    def GetInt32(self, off): return self.Get(N.Int32Flags, off)
+
+    def GetInt64(self, off): return self.Get(N.Int64Flags, off)
+
+    def GetFloat32(self, off): return self.Get(N.Float32Flags, off)
+
+    def GetFloat64(self, off): return self.Get(N.Float64Flags, off)
+
+    def GetUOffsetT(self, off): return self.Get(N.UOffsetTFlags, off)
+
+    def GetVOffsetT(self, off): return self.Get(N.VOffsetTFlags, off)
+
+    def GetSOffsetT(self, off): return self.Get(N.SOffsetTFlags, off)
+
+    def GetSlot(self, flags, slot, d):
         N.enforce_number(slot, N.VOffsetTFlags)
-        if validator_flags is not None:
-            N.enforce_number(d, validator_flags)
+        N.enforce_number(d, flags)
+
         off = self.Offset(slot)
         if off == 0:
             return d
-        return self.Get(validator_flags, self.Pos + off)
+        return self.Get(flags, off)
+
+    def GetBoolSlot(self, slot, d): return self.GetSlot(N.BoolFlags, slot, d)
+
+    def GetByteSlot(self, slot, d): return self.GetSlot(N.Uint8Flags, slot, d)
+
+    def GetUint8Slot(self, slot, d): return self.GetSlot(N.Uint8Flags, slot, d)
+
+    def GetUint16Slot(self, slot, d): return self.GetSlot(N.Uint16Flags, slot, d)
+
+    def GetUint32Slot(self, slot, d): return self.GetSlot(N.Uint32Flags, slot, d)
+
+    def GetUint64Slot(self, slot, d): return self.GetSlot(N.Uint64Flags, slot, d)
+
+    def GetInt8Slot(self, slot, d): return self.GetSlot(N.Int8Flags, slot, d)
+
+    def GetInt16Slot(self, slot, d): return self.GetSlot(N.Int16Flags, slot, d)
+
+    def GetInt32Slot(self, slot, d): return self.GetSlot(N.Int32Flags, slot, d)
+
+    def GetInt64Slot(self, slot, d): return self.GetSlot(N.Int64Flags, slot, d)
+
+    def GetFloat32Slot(self, slot, d): return self.GetSlot(N.Float32Flags, slot, d)
+
+    def GetFloat64Slot(self, slot, d): return self.GetSlot(N.Float64Flags, slot, d)
 
     def GetVOffsetTSlot(self, slot, d):
         """
@@ -113,5 +177,5 @@ class Table(object):
 
         off = self.Offset(slot)
         if off == 0:
-                return d
+            return d
         return off

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,34 +1,73 @@
 # -*- coding: utf-8 -*-
+import os
 import sys
+import platform
 import glob
 import shutil
 
-from setuptools import setup
+from distutils import errors
+from setuptools import Extension, setup
 
 try:
-    from Cython.Build import cythonize
     from Cython.Distutils import build_ext
 except ImportError:
-    extra_kwds = dict()
+    has_cython = False
 else:
-    from setuptools import Extension
+    has_cython = True
 
-    if sys.platform == "win32":
-        extra_compile_args = ['/EHsc']
-    elif sys.platform == "darwin":
-        extra_compile_args = ['-std=c++11']
-    else:
-        extra_compile_args = ['-std=c++0x']
-    extra_kwds = dict(
-        ext_modules=cythonize([
-            Extension('flatbuffers.fastcodec',
-                      sources=['flatbuffers/fastcodec.pyx'],
-                      include_dirs=['.'],
-                      extra_compile_args=extra_compile_args,
-                      language='c++')
-        ]),
-        cmdclass={'build_ext': build_ext},
-    )
+    class BuildFailed(Exception):
+        """Raised when building Cython extension failed."""
+
+        def __init__(self):
+            # work around py 2/3 different syntax
+            self.cause = sys.exc_info()[1]
+
+    class ve_build_ext(build_ext):
+        """This class allows Cython extension building to fail."""
+
+        def run(self):
+            try:
+                build_ext.run(self)
+            except errors.DistutilsPlatformError:
+                raise BuildFailed()
+
+        def build_extension(self, ext):
+            try:
+                build_ext.build_extension(self, ext)
+            except ext_errors:
+                raise BuildFailed()
+            except ValueError:
+                # this can happen on Windows 64 bit, see Python issue 7511
+                # works with both py 2/3
+                if "'path'" in str(sys.exc_info()[1]):
+                    raise BuildFailed()
+                raise
+
+
+cpython = platform.python_implementation() == 'CPython'
+
+if sys.platform == "win32":
+    extra_compile_args = ['/EHsc']  # catch C++ exceptions
+elif sys.platform == "darwin":
+    extra_compile_args = ['-std=c++11']
+else:
+    extra_compile_args = ['-std=c++0x']
+
+ext_modules = [
+    Extension('flatbuffers.fastcodec',
+              sources=['flatbuffers/fastcodec.pyx'],
+              include_dirs=['.'],
+              extra_compile_args=extra_compile_args,
+              language='c++'),
+]
+
+ext_errors = (errors.CCompilerError,
+              errors.DistutilsExecError,
+              errors.DistutilsPlatformError)
+if sys.platform == 'win32':
+    # 2.6's distutils.msvc9compiler can raise an IOError when failing to
+    # find the compiler
+    ext_errors += (IOError,)
 
 
 # copy `*.h` as package data, source distribution need these files
@@ -36,19 +75,72 @@ for cxx_source_file in glob.glob('../include/flatbuffers/*.h'):
     shutil.copy(cxx_source_file, 'flatbuffers')
 
 
-setup_kwds = dict(
-    name='flatbuffers',
-    version='2015.05.14.0',
-    license='Apache 2.0',
-    author='FlatBuffers Contributors',
-    author_email='me@rwinslow.com',
-    url='https://github.com/google/flatbuffers',
-    long_description=('Python runtime library for use with the Flatbuffers'
-                      'serialization format.'),
-    packages=['flatbuffers'],
-    include_package_data=True,
-    requires=[],
-    description='The FlatBuffers serialization format for Python',
-)
-setup_kwds.update(extra_kwds)
-setup(**setup_kwds)
+def status_msgs(*msgs):
+    print('*' * 75)
+    for msg in msgs:
+        print(msg)
+    print('*' * 75)
+
+
+def run_setup(with_cext):
+    setup_kwds = dict(
+        name='flatbuffers',
+        version='2015.05.14.0',
+        license='Apache 2.0',
+        author='FlatBuffers Contributors',
+        author_email='me@rwinslow.com',
+        url='https://github.com/google/flatbuffers',
+        long_description=('Python runtime library for use with the Flatbuffers'
+                          'serialization format.'),
+        packages=['flatbuffers'],
+        include_package_data=True,
+        requires=[],
+        description='The FlatBuffers serialization format for Python',
+    )
+
+    if with_cext:
+        setup_kwds.update(
+            ext_modules=ext_modules,
+            cmdclass={'build_ext': ve_build_ext},
+        )
+    setup(**setup_kwds)
+
+
+if not cpython:
+    run_setup(False)
+    status_msgs(
+        "Cython extensions are not supported on this Python platform.",
+        "Plain-Python build succeeded."
+    )
+elif os.environ.get('DISABLE_FLATBUFFERS_CEXT'):
+    run_setup(False)
+    status_msgs(
+        "DISABLE_FLATBUFFERS_CEXT is set; " +
+        "not attempting to build Cython extensions.",
+        "Plain-Python build succeeded."
+    )
+elif not has_cython:
+    run_setup(False)
+    status_msgs(
+        "Cython does not appear to be installed; " +
+        "not attempting to build Cython extensions.",
+        "Plain-Python build succeeded."
+    )
+else:
+    try:
+        run_setup(True)
+    except BuildFailed as exc:
+        status_msgs(
+            exc.cause,
+            "WARNING: The Cython extension could not be compiled, " +
+            "speedups are not enabled.",
+            "Failure information, if any, is above.",
+            "Retrying the build without the Cython extension now."
+        )
+
+        run_setup(False)
+        status_msgs(
+            "WARNING: The Cython extension could not be compiled, " +
+            "speedups are not enabled.",
+            "Plain-Python build succeeded."
+        )

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,42 @@
+# -*- coding: utf-8 -*-
+import sys
+import glob
+import shutil
+
 from setuptools import setup
 
-setup(
+try:
+    from Cython.Build import cythonize
+    from Cython.Distutils import build_ext
+except ImportError:
+    extra_kwds = dict()
+else:
+    from setuptools import Extension
+
+    if sys.platform == "win32":
+        extra_compile_args = ['/EHsc']
+    elif sys.platform == "darwin":
+        extra_compile_args = ['-std=c++11']
+    else:
+        extra_compile_args = ['-std=c++0x']
+    extra_kwds = dict(
+        ext_modules=cythonize([
+            Extension('flatbuffers.fastcodec',
+                      sources=['flatbuffers/fastcodec.pyx'],
+                      include_dirs=['.'],
+                      extra_compile_args=extra_compile_args,
+                      language='c++')
+        ]),
+        cmdclass={'build_ext': build_ext},
+    )
+
+
+# copy `*.h` as package data, source distribution need these files
+for cxx_source_file in glob.glob('../include/flatbuffers/*.h'):
+    shutil.copy(cxx_source_file, 'flatbuffers')
+
+
+setup_kwds = dict(
     name='flatbuffers',
     version='2015.05.14.0',
     license='Apache 2.0',
@@ -14,3 +50,5 @@ setup(
     requires=[],
     description='The FlatBuffers serialization format for Python',
 )
+setup_kwds.update(extra_kwds)
+setup(**setup_kwds)

--- a/tests/MyGame/Example/Monster.py
+++ b/tests/MyGame/Example/Monster.py
@@ -10,117 +10,108 @@ class Monster(object):
 
     @classmethod
     def GetRootAsMonster(cls, buf, offset):
-        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
-        x = Monster()
-        x.Init(buf, n + offset)
+        x = cls(flatbuffers.Table.GetRoot(buf, offset))
         return x
 
 
     # Monster
-    def Init(self, buf, pos):
-        self._tab = flatbuffers.table.Table(buf, pos)
+    def __init__(self, tab):
+        self._tab = tab
 
     # Monster
     def Pos(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        o = self._tab.Offset(4)
         if o != 0:
-            x = o + self._tab.Pos
             from .Vec3 import Vec3
-            obj = Vec3()
-            obj.Init(self._tab.Bytes, x)
+            obj = Vec3(flatbuffers.Table(self._tab.Bytes, self._tab.Pos + o))
             return obj
         return None
 
     # Monster
     def Mana(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        o = self._tab.Offset(6)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Int16Flags, o + self._tab.Pos)
+            return self._tab.GetInt16(o)
         return 150
 
     # Monster
     def Hp(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
+        o = self._tab.Offset(8)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Int16Flags, o + self._tab.Pos)
+            return self._tab.GetInt16(o)
         return 100
 
     # Monster
     def Name(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        o = self._tab.Offset(10)
         if o != 0:
-            return self._tab.String(o + self._tab.Pos)
-        return ""
+            return self._tab.String(o)
+        return b""
 
     # Monster
     def Inventory(self, j):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
+        o = self._tab.Offset(14)
         if o != 0:
-            a = self._tab.Vector(o)
-            return self._tab.Get(flatbuffers.number_types.Uint8Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 1))
+            x = self._tab.Vector(o) + int(j) * 1
+            return self._tab.GetUint8(x)
         return 0
 
     # Monster
     def InventoryLength(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
+        o = self._tab.Offset(14)
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
 
     # Monster
     def Color(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
+        o = self._tab.Offset(16)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
+            return self._tab.GetInt8(o)
         return 8
 
     # Monster
     def TestType(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
+        o = self._tab.Offset(18)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Uint8Flags, o + self._tab.Pos)
+            return self._tab.GetUint8(o)
         return 0
 
     # Monster
     def Test(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(20))
+        o = self._tab.Offset(20)
         if o != 0:
-            from flatbuffers.table import Table
-            obj = Table(bytearray(), 0)
-            self._tab.Union(obj, o)
-            return obj
+            return self._tab.Union(o)
         return None
 
     # Monster
     def Test4(self, j):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(22))
+        o = self._tab.Offset(22)
         if o != 0:
-            x = self._tab.Vector(o)
-            x += flatbuffers.number_types.UOffsetTFlags.py_type(j) * 4
+            x = self._tab.Vector(o) + int(j) * 4
             from .Test import Test
-            obj = Test()
-            obj.Init(self._tab.Bytes, x)
+            obj = Test(flatbuffers.Table(self._tab.Bytes, self._tab.Pos + x))
             return obj
         return None
 
     # Monster
     def Test4Length(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(22))
+        o = self._tab.Offset(22)
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
 
     # Monster
     def Testarrayofstring(self, j):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(24))
+        o = self._tab.Offset(24)
         if o != 0:
-            a = self._tab.Vector(o)
-            return self._tab.String(a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
-        return ""
+            x = self._tab.Vector(o) + int(j) * 4
+            return self._tab.String(x)
+        return b""
 
     # Monster
     def TestarrayofstringLength(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(24))
+        o = self._tab.Offset(24)
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
@@ -129,159 +120,155 @@ class Monster(object):
 # /// multiline too
     # Monster
     def Testarrayoftables(self, j):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(26))
+        o = self._tab.Offset(26)
         if o != 0:
-            x = self._tab.Vector(o)
-            x += flatbuffers.number_types.UOffsetTFlags.py_type(j) * 4
+            x = self._tab.Vector(o) + int(j) * 4
             x = self._tab.Indirect(x)
             from .Monster import Monster
-            obj = Monster()
-            obj.Init(self._tab.Bytes, x)
+            obj = Monster(flatbuffers.Table(self._tab.Bytes, self._tab.Pos + x))
             return obj
         return None
 
     # Monster
     def TestarrayoftablesLength(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(26))
+        o = self._tab.Offset(26)
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
 
     # Monster
     def Enemy(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(28))
+        o = self._tab.Offset(28)
         if o != 0:
-            x = self._tab.Indirect(o + self._tab.Pos)
+            o = self._tab.Indirect(o)
             from .Monster import Monster
-            obj = Monster()
-            obj.Init(self._tab.Bytes, x)
+            obj = Monster(flatbuffers.Table(self._tab.Bytes, self._tab.Pos + o))
             return obj
         return None
 
     # Monster
     def Testnestedflatbuffer(self, j):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(30))
+        o = self._tab.Offset(30)
         if o != 0:
-            a = self._tab.Vector(o)
-            return self._tab.Get(flatbuffers.number_types.Uint8Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 1))
+            x = self._tab.Vector(o) + int(j) * 1
+            return self._tab.GetUint8(x)
         return 0
 
     # Monster
     def TestnestedflatbufferLength(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(30))
+        o = self._tab.Offset(30)
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
 
     # Monster
     def Testempty(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(32))
+        o = self._tab.Offset(32)
         if o != 0:
-            x = self._tab.Indirect(o + self._tab.Pos)
+            o = self._tab.Indirect(o)
             from .Stat import Stat
-            obj = Stat()
-            obj.Init(self._tab.Bytes, x)
+            obj = Stat(flatbuffers.Table(self._tab.Bytes, self._tab.Pos + o))
             return obj
         return None
 
     # Monster
     def Testbool(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(34))
+        o = self._tab.Offset(34)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos)
+            return self._tab.GetBool(o)
         return 0
 
     # Monster
     def Testhashs32Fnv1(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(36))
+        o = self._tab.Offset(36)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+            return self._tab.GetInt32(o)
         return 0
 
     # Monster
     def Testhashu32Fnv1(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(38))
+        o = self._tab.Offset(38)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Uint32Flags, o + self._tab.Pos)
+            return self._tab.GetUint32(o)
         return 0
 
     # Monster
     def Testhashs64Fnv1(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(40))
+        o = self._tab.Offset(40)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Int64Flags, o + self._tab.Pos)
+            return self._tab.GetInt64(o)
         return 0
 
     # Monster
     def Testhashu64Fnv1(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(42))
+        o = self._tab.Offset(42)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Uint64Flags, o + self._tab.Pos)
+            return self._tab.GetUint64(o)
         return 0
 
     # Monster
     def Testhashs32Fnv1a(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(44))
+        o = self._tab.Offset(44)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+            return self._tab.GetInt32(o)
         return 0
 
     # Monster
     def Testhashu32Fnv1a(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(46))
+        o = self._tab.Offset(46)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Uint32Flags, o + self._tab.Pos)
+            return self._tab.GetUint32(o)
         return 0
 
     # Monster
     def Testhashs64Fnv1a(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(48))
+        o = self._tab.Offset(48)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Int64Flags, o + self._tab.Pos)
+            return self._tab.GetInt64(o)
         return 0
 
     # Monster
     def Testhashu64Fnv1a(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(50))
+        o = self._tab.Offset(50)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Uint64Flags, o + self._tab.Pos)
+            return self._tab.GetUint64(o)
         return 0
 
     # Monster
     def Testarrayofbools(self, j):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(52))
+        o = self._tab.Offset(52)
         if o != 0:
-            a = self._tab.Vector(o)
-            return self._tab.Get(flatbuffers.number_types.BoolFlags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 1))
+            x = self._tab.Vector(o) + int(j) * 1
+            return self._tab.GetBool(x)
         return 0
 
     # Monster
     def TestarrayofboolsLength(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(52))
+        o = self._tab.Offset(52)
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
 
 def MonsterStart(builder): builder.StartObject(25)
-def MonsterAddPos(builder, pos): builder.PrependStructSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(pos), 0)
+def MonsterAddPos(builder, pos): builder.PrependStructSlot(0, pos, 0)
 def MonsterAddMana(builder, mana): builder.PrependInt16Slot(1, mana, 150)
 def MonsterAddHp(builder, hp): builder.PrependInt16Slot(2, hp, 100)
-def MonsterAddName(builder, name): builder.PrependUOffsetTRelativeSlot(3, flatbuffers.number_types.UOffsetTFlags.py_type(name), 0)
-def MonsterAddInventory(builder, inventory): builder.PrependUOffsetTRelativeSlot(5, flatbuffers.number_types.UOffsetTFlags.py_type(inventory), 0)
+def MonsterAddName(builder, name): builder.PrependUOffsetTRelativeSlot(3, name, 0)
+def MonsterAddInventory(builder, inventory): builder.PrependUOffsetTRelativeSlot(5, inventory, 0)
 def MonsterStartInventoryVector(builder, numElems): return builder.StartVector(1, numElems, 1)
 def MonsterAddColor(builder, color): builder.PrependInt8Slot(6, color, 8)
 def MonsterAddTestType(builder, testType): builder.PrependUint8Slot(7, testType, 0)
-def MonsterAddTest(builder, test): builder.PrependUOffsetTRelativeSlot(8, flatbuffers.number_types.UOffsetTFlags.py_type(test), 0)
-def MonsterAddTest4(builder, test4): builder.PrependUOffsetTRelativeSlot(9, flatbuffers.number_types.UOffsetTFlags.py_type(test4), 0)
+def MonsterAddTest(builder, test): builder.PrependUOffsetTRelativeSlot(8, test, 0)
+def MonsterAddTest4(builder, test4): builder.PrependUOffsetTRelativeSlot(9, test4, 0)
 def MonsterStartTest4Vector(builder, numElems): return builder.StartVector(4, numElems, 2)
-def MonsterAddTestarrayofstring(builder, testarrayofstring): builder.PrependUOffsetTRelativeSlot(10, flatbuffers.number_types.UOffsetTFlags.py_type(testarrayofstring), 0)
+def MonsterAddTestarrayofstring(builder, testarrayofstring): builder.PrependUOffsetTRelativeSlot(10, testarrayofstring, 0)
 def MonsterStartTestarrayofstringVector(builder, numElems): return builder.StartVector(4, numElems, 4)
-def MonsterAddTestarrayoftables(builder, testarrayoftables): builder.PrependUOffsetTRelativeSlot(11, flatbuffers.number_types.UOffsetTFlags.py_type(testarrayoftables), 0)
+def MonsterAddTestarrayoftables(builder, testarrayoftables): builder.PrependUOffsetTRelativeSlot(11, testarrayoftables, 0)
 def MonsterStartTestarrayoftablesVector(builder, numElems): return builder.StartVector(4, numElems, 4)
-def MonsterAddEnemy(builder, enemy): builder.PrependUOffsetTRelativeSlot(12, flatbuffers.number_types.UOffsetTFlags.py_type(enemy), 0)
-def MonsterAddTestnestedflatbuffer(builder, testnestedflatbuffer): builder.PrependUOffsetTRelativeSlot(13, flatbuffers.number_types.UOffsetTFlags.py_type(testnestedflatbuffer), 0)
+def MonsterAddEnemy(builder, enemy): builder.PrependUOffsetTRelativeSlot(12, enemy, 0)
+def MonsterAddTestnestedflatbuffer(builder, testnestedflatbuffer): builder.PrependUOffsetTRelativeSlot(13, testnestedflatbuffer, 0)
 def MonsterStartTestnestedflatbufferVector(builder, numElems): return builder.StartVector(1, numElems, 1)
-def MonsterAddTestempty(builder, testempty): builder.PrependUOffsetTRelativeSlot(14, flatbuffers.number_types.UOffsetTFlags.py_type(testempty), 0)
+def MonsterAddTestempty(builder, testempty): builder.PrependUOffsetTRelativeSlot(14, testempty, 0)
 def MonsterAddTestbool(builder, testbool): builder.PrependBoolSlot(15, testbool, 0)
 def MonsterAddTesthashs32Fnv1(builder, testhashs32Fnv1): builder.PrependInt32Slot(16, testhashs32Fnv1, 0)
 def MonsterAddTesthashu32Fnv1(builder, testhashu32Fnv1): builder.PrependUint32Slot(17, testhashu32Fnv1, 0)
@@ -291,6 +278,6 @@ def MonsterAddTesthashs32Fnv1a(builder, testhashs32Fnv1a): builder.PrependInt32S
 def MonsterAddTesthashu32Fnv1a(builder, testhashu32Fnv1a): builder.PrependUint32Slot(21, testhashu32Fnv1a, 0)
 def MonsterAddTesthashs64Fnv1a(builder, testhashs64Fnv1a): builder.PrependInt64Slot(22, testhashs64Fnv1a, 0)
 def MonsterAddTesthashu64Fnv1a(builder, testhashu64Fnv1a): builder.PrependUint64Slot(23, testhashu64Fnv1a, 0)
-def MonsterAddTestarrayofbools(builder, testarrayofbools): builder.PrependUOffsetTRelativeSlot(24, flatbuffers.number_types.UOffsetTFlags.py_type(testarrayofbools), 0)
+def MonsterAddTestarrayofbools(builder, testarrayofbools): builder.PrependUOffsetTRelativeSlot(24, testarrayofbools, 0)
 def MonsterStartTestarrayofboolsVector(builder, numElems): return builder.StartVector(1, numElems, 1)
 def MonsterEnd(builder): return builder.EndObject()

--- a/tests/MyGame/Example/Stat.py
+++ b/tests/MyGame/Example/Stat.py
@@ -8,32 +8,32 @@ class Stat(object):
     __slots__ = ['_tab']
 
     # Stat
-    def Init(self, buf, pos):
-        self._tab = flatbuffers.table.Table(buf, pos)
+    def __init__(self, tab):
+        self._tab = tab
 
     # Stat
     def Id(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        o = self._tab.Offset(4)
         if o != 0:
-            return self._tab.String(o + self._tab.Pos)
-        return ""
+            return self._tab.String(o)
+        return b""
 
     # Stat
     def Val(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        o = self._tab.Offset(6)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Int64Flags, o + self._tab.Pos)
+            return self._tab.GetInt64(o)
         return 0
 
     # Stat
     def Count(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
+        o = self._tab.Offset(8)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Uint16Flags, o + self._tab.Pos)
+            return self._tab.GetUint16(o)
         return 0
 
 def StatStart(builder): builder.StartObject(3)
-def StatAddId(builder, id): builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(id), 0)
+def StatAddId(builder, id): builder.PrependUOffsetTRelativeSlot(0, id, 0)
 def StatAddVal(builder, val): builder.PrependInt64Slot(1, val, 0)
 def StatAddCount(builder, count): builder.PrependUint16Slot(2, count, 0)
 def StatEnd(builder): return builder.EndObject()

--- a/tests/MyGame/Example/Test.py
+++ b/tests/MyGame/Example/Test.py
@@ -8,13 +8,13 @@ class Test(object):
     __slots__ = ['_tab']
 
     # Test
-    def Init(self, buf, pos):
-        self._tab = flatbuffers.table.Table(buf, pos)
+    def __init__(self, tab):
+        self._tab = tab
 
     # Test
-    def A(self): return self._tab.Get(flatbuffers.number_types.Int16Flags, self._tab.Pos + flatbuffers.number_types.UOffsetTFlags.py_type(0))
+    def A(self): return self._tab.GetInt16(0)
     # Test
-    def B(self): return self._tab.Get(flatbuffers.number_types.Int8Flags, self._tab.Pos + flatbuffers.number_types.UOffsetTFlags.py_type(2))
+    def B(self): return self._tab.GetInt8(2)
 
 def CreateTest(builder, a, b):
     builder.Prep(2, 4)

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.py
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.py
@@ -8,14 +8,14 @@ class TestSimpleTableWithEnum(object):
     __slots__ = ['_tab']
 
     # TestSimpleTableWithEnum
-    def Init(self, buf, pos):
-        self._tab = flatbuffers.table.Table(buf, pos)
+    def __init__(self, tab):
+        self._tab = tab
 
     # TestSimpleTableWithEnum
     def Color(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        o = self._tab.Offset(4)
         if o != 0:
-            return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
+            return self._tab.GetInt8(o)
         return 2
 
 def TestSimpleTableWithEnumStart(builder): builder.StartObject(1)

--- a/tests/MyGame/Example/Vec3.py
+++ b/tests/MyGame/Example/Vec3.py
@@ -8,22 +8,23 @@ class Vec3(object):
     __slots__ = ['_tab']
 
     # Vec3
-    def Init(self, buf, pos):
-        self._tab = flatbuffers.table.Table(buf, pos)
+    def __init__(self, tab):
+        self._tab = tab
 
     # Vec3
-    def X(self): return self._tab.Get(flatbuffers.number_types.Float32Flags, self._tab.Pos + flatbuffers.number_types.UOffsetTFlags.py_type(0))
+    def X(self): return self._tab.GetFloat32(0)
     # Vec3
-    def Y(self): return self._tab.Get(flatbuffers.number_types.Float32Flags, self._tab.Pos + flatbuffers.number_types.UOffsetTFlags.py_type(4))
+    def Y(self): return self._tab.GetFloat32(4)
     # Vec3
-    def Z(self): return self._tab.Get(flatbuffers.number_types.Float32Flags, self._tab.Pos + flatbuffers.number_types.UOffsetTFlags.py_type(8))
+    def Z(self): return self._tab.GetFloat32(8)
     # Vec3
-    def Test1(self): return self._tab.Get(flatbuffers.number_types.Float64Flags, self._tab.Pos + flatbuffers.number_types.UOffsetTFlags.py_type(16))
+    def Test1(self): return self._tab.GetFloat64(16)
     # Vec3
-    def Test2(self): return self._tab.Get(flatbuffers.number_types.Int8Flags, self._tab.Pos + flatbuffers.number_types.UOffsetTFlags.py_type(24))
+    def Test2(self): return self._tab.GetInt8(24)
     # Vec3
-    def Test3(self, obj):
-        obj.Init(self._tab.Bytes, self._tab.Pos + 26)
+    def Test3(self):
+        from .Test import Test
+        obj = Test(flatbuffers.Table(self._tab.Bytes, self._tab.Pos + 26))
         return obj
 
 


### PR DESCRIPTION
Tested in `python2.6.9`, `python2.7.10`, `python3.5.0`, `PyPy 2.6.1(Python 2.7.10)`.

```shell
$ cd flatbuffers/python
$ python2.7 setup.py build  # build package in-place
$ mv build/lib.macosx-10.11-intel-2.7/flatbuffers ../tests/  # move package to tests directory
$ cd ../tests
$ python2.7 py_test.py 10000 10000 10000  # import flatbuffers locally
----------------------------------------------------------------------
Ran 58 tests in 0.007s

OK
vtable deduplication rate: 433385.41/sec
traversed 10000 288-byte flatbuffers in 0.31sec: 31841.75/sec, 8.75MB/sec
built 10000 288-byte flatbuffers in 0.13sec: 75267.23/sec, 20.67MB/sec
$ rm flatbuffers/fastcodec.so  # remove extension, test in pure python
$ python2.7 py_test.py 10000 10000 10000
----------------------------------------------------------------------
Ran 58 tests in 0.066s

OK
vtable deduplication rate: 12294.36/sec
traversed 10000 288-byte flatbuffers in 1.92sec: 5212.67/sec, 2.55MB/sec
built 10000 288-byte flatbuffers in 4.76sec: 2099.42/sec, 0.58MB/sec
```