### PR TITLE
C# Unity (.NET 3.5) can't cast enum default value.

### DIFF
--- a/tests/MyGame/Example/TestSimpleTableWithEnum.cs
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.cs
@@ -14,7 +14,7 @@ public sealed class TestSimpleTableWithEnum : Table {
   public bool MutateColor(Color color) { int o = __offset(4); if (o != 0) { bb.PutSbyte(o + bb_pos, (sbyte)color); return true; } else { return false; } }
 
   public static Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnum(FlatBufferBuilder builder,
-      Color color = (Color)2) {
+      Color color = Color.Green) {
     builder.StartObject(1);
     TestSimpleTableWithEnum.AddColor(builder, color);
     return TestSimpleTableWithEnum.EndTestSimpleTableWithEnum(builder);


### PR DESCRIPTION
This is just workaround (probably not god solution). 

Unity uses .NET 3.5 profile so it can't cast default value. 

for example,

```
namespace MyGame;

enum CommandType : byte {
	None = 0,
}

table Command {
	id:int;
	type:CommandType;
}
```

then generate c# files. it'll output compile error like these.

```
Assets/MyGame/Command.cs(18,39): error CS1041: Identifier expected
Assets/MyGame/Command.cs(18,39): error CS1737: Optional parameter cannot precede required parameters

16:   public static Offset<Command> CreateCommand(FlatBufferBuilder builder,
17:   int id = 0,
18:   CommandType type = (CommandType)0) {
# NOTE:                               ^cast is problem
```

I don't have a good solution for this kind of C# version issue.