### PR TITLE
(C#) Add ByteBuffer property to Table

### DIFF
--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -27,6 +27,8 @@ namespace FlatBuffers
         protected int bb_pos;
         protected ByteBuffer bb;
 
+        public ByteBuffer ByteBuffer { get { return bb; } }
+
         // Look up a field in the vtable, return an offset into the object, or 0 if the field is not
         // present.
         protected int __offset(int vtableOffset)


### PR DESCRIPTION
This PR add ByteBuffer property to Table class.
Java already has getByteBuffer method but C# doesn't have it.

https://github.com/google/flatbuffers/blob/master/java/com/google/flatbuffers/Table.java#L28

I want to pass generated table class to function when I communicate to server　(for readability).

```
e.g) sending monster data to server

public static Request(Monster monster) {
  var bytes = monster.ByteBuffer.Data();
  // send bytes to server
}
```