### PR TITLE
Fixes issue #348: C# vector of enums doesn't compile

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -194,8 +194,13 @@ static std::string FunctionStart(const LanguageParameters &lang, char upper) {
          : upper);
 }
 
+static bool IsEnum(const Type& type) {
+  return type.enum_def != nullptr && IsInteger(type.base_type);
+}
+
 static std::string GenTypeBasic(const LanguageParameters &lang,
-                                const Type &type) {
+                                const Type &type,
+                                bool enableLangOverrides) {
   static const char *gtypename[] = {
     #define FLATBUFFERS_TD(ENUM, IDLTYPE, CTYPE, JTYPE, GTYPE, NTYPE, PTYPE) \
         #JTYPE, #NTYPE, #GTYPE,
@@ -203,21 +208,18 @@ static std::string GenTypeBasic(const LanguageParameters &lang,
     #undef FLATBUFFERS_TD
   };
 
-  if(lang.language == GeneratorOptions::kCSharp && type.base_type == BASE_TYPE_STRUCT) {
-    return "Offset<" + type.struct_def->name + ">";
+  if (enableLangOverrides) {
+    if (lang.language == GeneratorOptions::kCSharp) {
+      if (IsEnum(type)) return type.enum_def->name;
+      if (type.base_type == BASE_TYPE_STRUCT) return "Offset<" + type.struct_def->name + ">";
+    }
   }
 
   return gtypename[type.base_type * GeneratorOptions::kMAX + lang.language];
 }
 
-// Generate type to be used in user-facing API
-static std::string GenTypeForUser(const LanguageParameters &lang,
-                                  const Type &type) {
-  if (lang.language == GeneratorOptions::kCSharp) {
-    if (type.enum_def != nullptr &&
-          type.base_type != BASE_TYPE_UNION) return type.enum_def->name;
-  }
-  return GenTypeBasic(lang, type);
+static std::string GenTypeBasic(const LanguageParameters &lang, const Type &type) {
+  return GenTypeBasic(lang, type, true);
 }
 
 static std::string GenTypeGet(const LanguageParameters &lang,
@@ -233,6 +235,8 @@ static std::string GenTypePointer(const LanguageParameters &lang,
     case BASE_TYPE_STRUCT:
       return type.struct_def->name;
     case BASE_TYPE_UNION:
+      // Unions in C# use a generic Table-derived type for better type safety
+      if (lang.language == GeneratorOptions::kCSharp) return "TTable";
       // fall through
     default:
       return "Table";
@@ -294,17 +298,6 @@ static std::string GenVectorOffsetType(const LanguageParameters &lang) {
 // Generate destination type name
 static std::string GenTypeNameDest(const LanguageParameters &lang, const Type &type)
 {
-  if (lang.language == GeneratorOptions::kCSharp) {
-    // C# enums are represented by themselves
-    if (type.enum_def != nullptr && type.base_type != BASE_TYPE_UNION)
-      return type.enum_def->name;
-
-    // Unions in C# use a generic Table-derived type for better type safety
-    if (type.base_type == BASE_TYPE_UNION)
-      return "TTable";
-  }
-
-  // default behavior
   return GenTypeGet(lang, DestinationType(lang, type, true));
 }
 
@@ -327,40 +320,25 @@ static std::string DestinationMask(const LanguageParameters &lang,
 // Casts necessary to correctly read serialized data
 static std::string DestinationCast(const LanguageParameters &lang,
                                    const Type &type) {
-  switch (lang.language) {
+  if (type.base_type == BASE_TYPE_VECTOR) {
+    return DestinationCast(lang, type.VectorType());
+  } else {
+    switch (lang.language) {
     case GeneratorOptions::kJava:
       // Cast necessary to correctly read serialized unsigned values.
-      if (type.base_type == BASE_TYPE_UINT ||
-          (type.base_type == BASE_TYPE_VECTOR &&
-           type.element == BASE_TYPE_UINT)) return "(long)";
+      if (type.base_type == BASE_TYPE_UINT) return "(long)";
       break;
 
     case GeneratorOptions::kCSharp:
-      // Cast from raw integral types to enum
-      if (type.enum_def != nullptr &&
-        type.base_type != BASE_TYPE_UNION) return "(" + type.enum_def->name + ")";
-        break;
+      // Cast from raw integral types to enum.
+      if (IsEnum(type)) return "(" + type.enum_def->name + ")";
+      break;
 
     default:
       break;
+    }
   }
   return "";
-}
-
-// Read value and possibly process it to get proper value
-static std::string DestinationValue(const LanguageParameters &lang,
-  const std::string &name,
-  const Type &type) {
-  std::string type_mask = DestinationMask(lang, type, false);
-  // is a typecast needed? (for C# enums and unsigned values in Java)
-  if (type_mask.length() ||
-    (lang.language == GeneratorOptions::kCSharp &&
-    type.enum_def != nullptr &&
-    type.base_type != BASE_TYPE_UNION)) {
-    return "(" + GenTypeBasic(lang, type) + ")(" + name + type_mask + ")";
-  } else {
-    return name;
-  }
 }
 
 // Cast statements for mutator method parameters.
@@ -368,53 +346,52 @@ static std::string DestinationValue(const LanguageParameters &lang,
 // For example, a long holding an unsigned int value would be cast down to int before being put onto the buffer.
 // In C#, one cast directly cast an Enum to its underlying type, which is essential before putting it onto the buffer.
 static std::string SourceCast(const LanguageParameters &lang,
-                              const Type &type) {
+                              const Type &type,
+                              bool castFromDest) {
   if (type.base_type == BASE_TYPE_VECTOR) {
-    return SourceCast(lang, type.VectorType());
+    return SourceCast(lang, type.VectorType(), castFromDest);
   } else {
     switch (lang.language) {
       case GeneratorOptions::kJava:
-        if (type.base_type == BASE_TYPE_UINT) return "(int)";
-        else if (type.base_type == BASE_TYPE_USHORT) return "(short)";
-        else if (type.base_type == BASE_TYPE_UCHAR) return "(byte)";
+        if (castFromDest) {
+          if (type.base_type == BASE_TYPE_UINT) return "(int)";
+          else if (type.base_type == BASE_TYPE_USHORT) return "(short)";
+          else if (type.base_type == BASE_TYPE_UCHAR) return "(byte)";
+        }
         break;
       case GeneratorOptions::kCSharp:
-        if (type.enum_def != nullptr && 
-            type.base_type != BASE_TYPE_UNION) 
-          return "(" + GenTypeGet(lang, type) + ")";
+        if (IsEnum(type)) return "(" + GenTypeBasic(lang, type, false) + ")";
         break;
       default:
         break;
     }
-    return "";
   }
+  return "";
 }
 
-static std::string GenDefaultValue(const LanguageParameters &lang, const Value &value, bool for_buffer) {
-  if(lang.language == GeneratorOptions::kCSharp && !for_buffer) {
-    switch(value.type.base_type) {
-      case BASE_TYPE_STRING:
-        return "default(StringOffset)";
-      case BASE_TYPE_STRUCT:
-        return "default(Offset<" + value.type.struct_def->name + ">)";
-      case BASE_TYPE_VECTOR:
-        return "default(VectorOffset)";
-      default:
-        break;
-    }
-  }
-
-  return value.type.base_type == BASE_TYPE_BOOL
-           ? (value.constant == "0" ? "false" : "true")
-           : value.constant;
+static std::string SourceCast(const LanguageParameters &lang,
+                              const Type &type) {
+  return SourceCast(lang, type, true);
 }
 
-static std::string GenEnumDefaultValue(const FieldDef &field) {
-  auto enum_def = field.value.type.enum_def;
+static std::string SourceCastBasic(const LanguageParameters &lang,
+                                   const Type &type,
+                                   bool castFromDest) {
+  return IsScalar(type.base_type) ? SourceCast(lang, type, castFromDest) : "";
+}
+
+static std::string SourceCastBasic(const LanguageParameters &lang,
+                                   const Type &type) {
+  return SourceCastBasic(lang, type, true);
+}
+
+
+static std::string GenEnumDefaultValue(const Value &value) {
+  auto enum_def = value.type.enum_def;
   auto vec = enum_def->vals.vec;
-  auto default_value = StringToInt(field.value.constant.c_str());
+  auto default_value = StringToInt(value.constant.c_str());
 
-  auto result = field.value.constant;
+  auto result = value.constant;
   for (auto it = vec.begin(); it != vec.end(); ++it) {
     auto enum_val = **it;
     if (enum_val.value == default_value) {
@@ -426,6 +403,48 @@ static std::string GenEnumDefaultValue(const FieldDef &field) {
   return result;
 }
 
+static std::string GenDefaultValue(const LanguageParameters &lang, const Value &value, bool enableLangOverrides) {
+  if (enableLangOverrides) {
+    // handles both enum case and vector of enum case
+    if (lang.language == GeneratorOptions::kCSharp &&
+        value.type.enum_def != nullptr &&
+        value.type.base_type != BASE_TYPE_UNION) {
+      return GenEnumDefaultValue(value);
+    }
+  }
+  return value.type.base_type == BASE_TYPE_BOOL
+           ? (value.constant == "0" ? "false" : "true")
+           : value.constant;
+}
+
+static std::string GenDefaultValue(const LanguageParameters &lang, const Value &value) {
+  return GenDefaultValue(lang, value, true);
+}
+
+static std::string GenDefaultValueBasic(const LanguageParameters &lang, const Value &value, bool enableLangOverrides) {
+  if (!IsScalar(value.type.base_type)) {
+    if (enableLangOverrides) {
+      if (lang.language == GeneratorOptions::kCSharp) {
+        switch (value.type.base_type) {
+        case BASE_TYPE_STRING:
+          return "default(StringOffset)";
+        case BASE_TYPE_STRUCT:
+          return "default(Offset<" + value.type.struct_def->name + ">)";
+        case BASE_TYPE_VECTOR:
+          return "default(VectorOffset)";
+        default:
+          break;
+        }
+      }
+    }
+    return "0";
+  }
+  return GenDefaultValue(lang, value, enableLangOverrides);
+}
+
+static std::string GenDefaultValueBasic(const LanguageParameters &lang, const Value &value) {
+  return GenDefaultValueBasic(lang, value, true);
+}
 
 static void GenEnum(const LanguageParameters &lang, EnumDef &enum_def,
                     std::string *code_ptr) {
@@ -440,7 +459,7 @@ static void GenEnum(const LanguageParameters &lang, EnumDef &enum_def,
   GenComment(enum_def.doc_comment, code_ptr, &lang.comment_config);
   code += std::string("public ") + lang.enum_decl + enum_def.name;
   if (lang.language == GeneratorOptions::kCSharp) {
-    code += lang.inheritance_marker + GenTypeBasic(lang, enum_def.underlying_type);
+    code += lang.inheritance_marker + GenTypeBasic(lang, enum_def.underlying_type, false);
   }
   code += lang.open_curly;
   if (lang.language == GeneratorOptions::kJava) {
@@ -454,7 +473,7 @@ static void GenEnum(const LanguageParameters &lang, EnumDef &enum_def,
     if (lang.language != GeneratorOptions::kCSharp) {
       code += "  public static";
       code += lang.const_decl;
-      code += GenTypeBasic(lang, enum_def.underlying_type);
+      code += GenTypeBasic(lang, enum_def.underlying_type, false);
     }
     code += " " + ev.name + " = ";
     code += NumToString(ev.value);
@@ -511,8 +530,8 @@ static std::string GenGetter(const LanguageParameters &lang,
       std::string getter = "bb." + FunctionStart(lang, 'G') + "et";
       if (type.base_type == BASE_TYPE_BOOL) {
         getter = "0!=" + getter;
-      } else if (GenTypeBasic(lang, type) != "byte") {
-        getter += MakeCamel(GenTypeGet(lang, type));
+      } else if (GenTypeBasic(lang, type, false) != "byte") {
+        getter += MakeCamel(GenTypeBasic(lang, type, false));
       }
       return getter;
     }
@@ -525,9 +544,9 @@ static std::string GenSetter(const LanguageParameters &lang,
                              const Type &type) {
   if (IsScalar(type.base_type)) {
     std::string setter = "bb." + FunctionStart(lang, 'P') + "ut";
-    if (GenTypeBasic(lang, type) != "byte" && 
+    if (GenTypeBasic(lang, type, false) != "byte" && 
         type.base_type != BASE_TYPE_BOOL) {
-      setter += MakeCamel(GenTypeGet(lang, type));
+      setter += MakeCamel(GenTypeBasic(lang, type, false));
     }
     return setter;
   } else {
@@ -538,7 +557,7 @@ static std::string GenSetter(const LanguageParameters &lang,
 // Returns the method name for use with add/put calls.
 static std::string GenMethod(const LanguageParameters &lang, const Type &type) {
   return IsScalar(type.base_type)
-    ? MakeCamel(GenTypeBasic(lang, type))
+    ? MakeCamel(GenTypeBasic(lang, type, false))
     : (IsStruct(type) ? "Struct" : "Offset");
 }
 
@@ -560,8 +579,7 @@ static void GenStructArgs(const LanguageParameters &lang,
                     (nameprefix + (field.name + "_")).c_str());
     } else {
       code += ", ";
-      code += GenTypeForUser(lang,
-                             DestinationType(lang, field.value.type, false));
+      code += GenTypeBasic(lang, DestinationType(lang,field.value.type, false));
       code += " ";
       code += nameprefix;
       code += MakeCamel(field.name, lang.first_camel_upper);
@@ -592,8 +610,9 @@ static void GenStructBody(const LanguageParameters &lang,
     } else {
       code += "    builder." + FunctionStart(lang, 'P') + "ut";
       code += GenMethod(lang, field.value.type) + "(";
+      code += SourceCast(lang, field.value.type);
       auto argname = nameprefix + MakeCamel(field.name, lang.first_camel_upper);
-      code += DestinationValue(lang, argname, field.value.type);
+      code += argname;
       code += ");\n";
     }
   }
@@ -679,7 +698,7 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
         code += "(new ";
         code += type_name + "()); } }\n";
         method_start = "  public " + type_name_dest + " Get" + MakeCamel(field.name, lang.first_camel_upper);
-      }
+      } 
       else {
         code += method_start + "() { return ";
         code += MakeCamel(field.name, lang.first_camel_upper);
@@ -714,8 +733,17 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
     std::string getter = dest_cast + GenGetter(lang, field.value.type);
     code += method_start;
     std::string default_cast = "";
-    if (lang.language == GeneratorOptions::kCSharp)
-      default_cast = "(" + type_name_dest + ")";
+    // only create default casts for c# scalars or vectors of scalars
+    if (lang.language == GeneratorOptions::kCSharp && 
+        (IsScalar(field.value.type.base_type) || 
+         (field.value.type.base_type == BASE_TYPE_VECTOR && IsScalar(field.value.type.element)))) {
+      // For scalars, default value will be returned by GetDefaultValue(). If the scalar is an enum, GetDefaultValue()
+      // returns an actual c# enum that doesn't need to be casted. However, default values for enum elements of
+      // vectors are integer literals ("0") and are still casted for clarity.
+      if (field.value.type.enum_def == nullptr || field.value.type.base_type == BASE_TYPE_VECTOR) {
+          default_cast = "(" + type_name_dest + ")";
+      }
+    }
     std::string member_suffix = "";
     if (IsScalar(field.value.type.base_type)) {
       code += lang.getter_prefix;
@@ -727,7 +755,7 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
       } else {
         code += offset_prefix + getter;
         code += "(o + bb_pos)" + dest_mask + " : " + default_cast;
-        code += GenDefaultValue(lang, field.value, false);
+        code += GenDefaultValue(lang, field.value);
       }
     } else {
       switch (field.value.type.base_type) {
@@ -819,13 +847,11 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
       auto mutator_prefix = MakeCamel("mutate", lang.first_camel_upper);
       //a vector mutator also needs the index of the vector element it should mutate
       auto mutator_params = (field.value.type.base_type == BASE_TYPE_VECTOR ? "(int j, " : "(") +
-                            GenTypeNameDest(lang, underlying_type) + " " + 
+                            GenTypeNameDest(lang, underlying_type) + " " +
                             field.name + ") { ";
       auto setter_index = field.value.type.base_type == BASE_TYPE_VECTOR
                     ? "__vector(o) + j * " + NumToString(InlineSize(underlying_type))
                     : (struct_def.fixed ? "bb_pos + " + NumToString(field.value.offset) : "o + bb_pos");
-      
-
       if (IsScalar(field.value.type.base_type) || 
           (field.value.type.base_type == BASE_TYPE_VECTOR &&
           IsScalar(field.value.type.VectorType().base_type))) {
@@ -883,23 +909,16 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
         auto &field = **it;
         if (field.deprecated) continue;
         code += ",\n      ";
-        code += GenTypeForUser(lang,
-                               DestinationType(lang, field.value.type, false));
+        code += GenTypeBasic(lang, DestinationType(lang, field.value.type, false));
         code += " ";
         code += field.name;
+        if (!IsScalar(field.value.type.base_type)) code += "Offset";
+
         // Java doesn't have defaults, which means this method must always
         // supply all arguments, and thus won't compile when fields are added.
         if (lang.language != GeneratorOptions::kJava) {
           code += " = ";
-          // in C#, enum values have their own type, but Unity (specifically .Net 3.5) can't
-          // cast enum type from numeric value.
-          if (lang.language == GeneratorOptions::kCSharp &&
-            field.value.type.enum_def != nullptr &&
-            field.value.type.base_type != BASE_TYPE_UNION) {
-            code += GenEnumDefaultValue(field);
-          } else {
-            code += GenDefaultValue(lang, field.value, false);
-          }
+          code += GenDefaultValueBasic(lang, field.value);
         }
       }
       code += ") {\n    builder.";
@@ -916,7 +935,9 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
                size == SizeOf(field.value.type.base_type))) {
             code += "    " + struct_def.name + ".";
             code += FunctionStart(lang, 'A') + "dd";
-            code += MakeCamel(field.name) + "(builder, " + field.name + ");\n";
+            code += MakeCamel(field.name) + "(builder, " + field.name;
+            if (!IsScalar(field.value.type.base_type)) code += "Offset";
+            code += ");\n";
           }
         }
       }
@@ -941,18 +962,18 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
       code += "  public static void " + FunctionStart(lang, 'A') + "dd";
       code += MakeCamel(field.name);
       code += "(FlatBufferBuilder builder, ";
-      code += GenTypeForUser(lang,
-                             DestinationType(lang, field.value.type, false));
+      code += GenTypeBasic(lang, DestinationType(lang, field.value.type, false));
       auto argname = MakeCamel(field.name, false);
       if (!IsScalar(field.value.type.base_type)) argname += "Offset";
       code += " " + argname + ") { builder." + FunctionStart(lang, 'A') + "dd";
       code += GenMethod(lang, field.value.type) + "(";
       code += NumToString(it - struct_def.fields.vec.begin()) + ", ";
-      code += DestinationValue(lang, argname, field.value.type);
+      code += SourceCastBasic(lang, field.value.type);
+      code += argname;
       if(!IsScalar(field.value.type.base_type) && field.value.type.base_type != BASE_TYPE_UNION && lang.language == GeneratorOptions::kCSharp) {
         code += ".Value";
       }
-      code += ", " + GenDefaultValue(lang, field.value, true);
+      code += ", " + GenDefaultValue(lang, field.value, false);
       code += "); }\n";
       if (field.value.type.base_type == BASE_TYPE_VECTOR) {
         auto vector_type = field.value.type.VectorType();
@@ -972,10 +993,12 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
           code += FunctionStart(lang, 'L') + "ength - 1; i >= 0; i--) builder.";
           code += FunctionStart(lang, 'A') + "dd";
           code += GenMethod(lang, vector_type);
-          code += "(data[i]";
-          if(lang.language == GeneratorOptions::kCSharp &&
-              (vector_type.base_type == BASE_TYPE_STRUCT || vector_type.base_type == BASE_TYPE_STRING))
-              code += ".Value";
+          code += "(";
+          code += SourceCastBasic(lang, vector_type, false);
+          code += "data[i]";
+          if (lang.language == GeneratorOptions::kCSharp &&
+            (vector_type.base_type == BASE_TYPE_STRUCT || vector_type.base_type == BASE_TYPE_STRING))
+            code += ".Value";
           code += "); return ";
           code += "builder." + FunctionStart(lang, 'E') + "ndVector(); }\n";
         }

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -22,9 +22,9 @@ public sealed class Monster : Table {
   public byte GetInventory(int j) { int o = __offset(14); return o != 0 ? bb.Get(__vector(o) + j * 1) : (byte)0; }
   public int InventoryLength { get { int o = __offset(14); return o != 0 ? __vector_len(o) : 0; } }
   public bool MutateInventory(int j, byte inventory) { int o = __offset(14); if (o != 0) { bb.Put(__vector(o) + j * 1, inventory); return true; } else { return false; } }
-  public Color Color { get { int o = __offset(16); return o != 0 ? (Color)bb.GetSbyte(o + bb_pos) : (Color)8; } }
+  public Color Color { get { int o = __offset(16); return o != 0 ? (Color)bb.GetSbyte(o + bb_pos) : Color.Blue; } }
   public bool MutateColor(Color color) { int o = __offset(16); if (o != 0) { bb.PutSbyte(o + bb_pos, (sbyte)color); return true; } else { return false; } }
-  public Any TestType { get { int o = __offset(18); return o != 0 ? (Any)bb.Get(o + bb_pos) : (Any)0; } }
+  public Any TestType { get { int o = __offset(18); return o != 0 ? (Any)bb.Get(o + bb_pos) : Any.NONE; } }
   public bool MutateTestType(Any test_type) { int o = __offset(18); if (o != 0) { bb.Put(o + bb_pos, (byte)test_type); return true; } else { return false; } }
   public TTable GetTest<TTable>(TTable obj) where TTable : Table { int o = __offset(20); return o != 0 ? __union(obj, o) : null; }
   public Test GetTest4(int j) { return GetTest4(new Test(), j); }
@@ -74,8 +74,8 @@ public sealed class Monster : Table {
   public static void AddInventory(FlatBufferBuilder builder, VectorOffset inventoryOffset) { builder.AddOffset(5, inventoryOffset.Value, 0); }
   public static VectorOffset CreateInventoryVector(FlatBufferBuilder builder, byte[] data) { builder.StartVector(1, data.Length, 1); for (int i = data.Length - 1; i >= 0; i--) builder.AddByte(data[i]); return builder.EndVector(); }
   public static void StartInventoryVector(FlatBufferBuilder builder, int numElems) { builder.StartVector(1, numElems, 1); }
-  public static void AddColor(FlatBufferBuilder builder, Color color) { builder.AddSbyte(6, (sbyte)(color), 8); }
-  public static void AddTestType(FlatBufferBuilder builder, Any testType) { builder.AddByte(7, (byte)(testType), 0); }
+  public static void AddColor(FlatBufferBuilder builder, Color color) { builder.AddSbyte(6, (sbyte)color, 8); }
+  public static void AddTestType(FlatBufferBuilder builder, Any testType) { builder.AddByte(7, (byte)testType, 0); }
   public static void AddTest(FlatBufferBuilder builder, int testOffset) { builder.AddOffset(8, testOffset, 0); }
   public static void AddTest4(FlatBufferBuilder builder, VectorOffset test4Offset) { builder.AddOffset(9, test4Offset.Value, 0); }
   public static void StartTest4Vector(FlatBufferBuilder builder, int numElems) { builder.StartVector(4, numElems, 2); }

--- a/tests/MyGame/Example/Monster.java
+++ b/tests/MyGame/Example/Monster.java
@@ -103,11 +103,11 @@ public final class Monster extends Table {
   public static void addTestempty(FlatBufferBuilder builder, int testemptyOffset) { builder.addOffset(14, testemptyOffset, 0); }
   public static void addTestbool(FlatBufferBuilder builder, boolean testbool) { builder.addBoolean(15, testbool, false); }
   public static void addTesthashs32Fnv1(FlatBufferBuilder builder, int testhashs32Fnv1) { builder.addInt(16, testhashs32Fnv1, 0); }
-  public static void addTesthashu32Fnv1(FlatBufferBuilder builder, long testhashu32Fnv1) { builder.addInt(17, (int)(testhashu32Fnv1 & 0xFFFFFFFFL), 0); }
+  public static void addTesthashu32Fnv1(FlatBufferBuilder builder, long testhashu32Fnv1) { builder.addInt(17, (int)testhashu32Fnv1, 0); }
   public static void addTesthashs64Fnv1(FlatBufferBuilder builder, long testhashs64Fnv1) { builder.addLong(18, testhashs64Fnv1, 0); }
   public static void addTesthashu64Fnv1(FlatBufferBuilder builder, long testhashu64Fnv1) { builder.addLong(19, testhashu64Fnv1, 0); }
   public static void addTesthashs32Fnv1a(FlatBufferBuilder builder, int testhashs32Fnv1a) { builder.addInt(20, testhashs32Fnv1a, 0); }
-  public static void addTesthashu32Fnv1a(FlatBufferBuilder builder, long testhashu32Fnv1a) { builder.addInt(21, (int)(testhashu32Fnv1a & 0xFFFFFFFFL), 0); }
+  public static void addTesthashu32Fnv1a(FlatBufferBuilder builder, long testhashu32Fnv1a) { builder.addInt(21, (int)testhashu32Fnv1a, 0); }
   public static void addTesthashs64Fnv1a(FlatBufferBuilder builder, long testhashs64Fnv1a) { builder.addLong(22, testhashs64Fnv1a, 0); }
   public static void addTesthashu64Fnv1a(FlatBufferBuilder builder, long testhashu64Fnv1a) { builder.addLong(23, testhashu64Fnv1a, 0); }
   public static void addTestarrayofbools(FlatBufferBuilder builder, int testarrayofboolsOffset) { builder.addOffset(24, testarrayofboolsOffset, 0); }

--- a/tests/MyGame/Example/Stat.cs
+++ b/tests/MyGame/Example/Stat.cs
@@ -17,12 +17,12 @@ public sealed class Stat : Table {
   public bool MutateCount(ushort count) { int o = __offset(8); if (o != 0) { bb.PutUshort(o + bb_pos, count); return true; } else { return false; } }
 
   public static Offset<Stat> CreateStat(FlatBufferBuilder builder,
-      StringOffset id = default(StringOffset),
+      StringOffset idOffset = default(StringOffset),
       long val = 0,
       ushort count = 0) {
     builder.StartObject(3);
     Stat.AddVal(builder, val);
-    Stat.AddId(builder, id);
+    Stat.AddId(builder, idOffset);
     Stat.AddCount(builder, count);
     return Stat.EndStat(builder);
   }

--- a/tests/MyGame/Example/Stat.java
+++ b/tests/MyGame/Example/Stat.java
@@ -21,12 +21,12 @@ public final class Stat extends Table {
   public boolean mutateCount(int count) { int o = __offset(8); if (o != 0) { bb.putShort(o + bb_pos, (short)count); return true; } else { return false; } }
 
   public static int createStat(FlatBufferBuilder builder,
-      int id,
+      int idOffset,
       long val,
       int count) {
     builder.startObject(3);
     Stat.addVal(builder, val);
-    Stat.addId(builder, id);
+    Stat.addId(builder, idOffset);
     Stat.addCount(builder, count);
     return Stat.endStat(builder);
   }
@@ -34,7 +34,7 @@ public final class Stat extends Table {
   public static void startStat(FlatBufferBuilder builder) { builder.startObject(3); }
   public static void addId(FlatBufferBuilder builder, int idOffset) { builder.addOffset(0, idOffset, 0); }
   public static void addVal(FlatBufferBuilder builder, long val) { builder.addLong(1, val, 0); }
-  public static void addCount(FlatBufferBuilder builder, int count) { builder.addShort(2, (short)(count & 0xFFFF), 0); }
+  public static void addCount(FlatBufferBuilder builder, int count) { builder.addShort(2, (short)count, 0); }
   public static int endStat(FlatBufferBuilder builder) {
     int o = builder.endObject();
     return o;

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.cs
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.cs
@@ -10,7 +10,7 @@ public sealed class TestSimpleTableWithEnum : Table {
   public static TestSimpleTableWithEnum GetRootAsTestSimpleTableWithEnum(ByteBuffer _bb, TestSimpleTableWithEnum obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
   public TestSimpleTableWithEnum __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
 
-  public Color Color { get { int o = __offset(4); return o != 0 ? (Color)bb.GetSbyte(o + bb_pos) : (Color)2; } }
+  public Color Color { get { int o = __offset(4); return o != 0 ? (Color)bb.GetSbyte(o + bb_pos) : Color.Green; } }
   public bool MutateColor(Color color) { int o = __offset(4); if (o != 0) { bb.PutSbyte(o + bb_pos, (sbyte)color); return true; } else { return false; } }
 
   public static Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnum(FlatBufferBuilder builder,
@@ -21,7 +21,7 @@ public sealed class TestSimpleTableWithEnum : Table {
   }
 
   public static void StartTestSimpleTableWithEnum(FlatBufferBuilder builder) { builder.StartObject(1); }
-  public static void AddColor(FlatBufferBuilder builder, Color color) { builder.AddSbyte(0, (sbyte)(color), 2); }
+  public static void AddColor(FlatBufferBuilder builder, Color color) { builder.AddSbyte(0, (sbyte)color, 2); }
   public static Offset<TestSimpleTableWithEnum> EndTestSimpleTableWithEnum(FlatBufferBuilder builder) {
     int o = builder.EndObject();
     return new Offset<TestSimpleTableWithEnum>(o);

--- a/tests/MyGame/Example/Vec3.cs
+++ b/tests/MyGame/Example/Vec3.cs
@@ -29,7 +29,7 @@ public sealed class Vec3 : Struct {
     builder.PutSbyte(test3_B);
     builder.PutShort(test3_A);
     builder.Pad(1);
-    builder.PutSbyte((sbyte)(Test2));
+    builder.PutSbyte((sbyte)Test2);
     builder.PutDouble(Test1);
     builder.Pad(4);
     builder.PutFloat(Z);


### PR DESCRIPTION
The issue has to do with the logic to support C# enum types.  The existing logic to determine when to use an enum type actually winds up catching both the enum case and the vector of enums case, which may have been deliberate.  While it is the desired behavior in some cases, there are some cases where it isn't.

The fix tightens the checks where necessary and adds some comments where the original logic was left alone.