### PR TITLE
Fix crash when duplicate types are encountered

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1499,7 +1499,7 @@ bool Parser::Parse(const char *source, const char **include_paths,
       error_ += NumToString(line_) + ":0";  // gcc alike
     #endif
     error_ += ": error: " + msg;
-    if (source_filename) files_being_parsed_.pop();
+    if (source_filename && !files_being_parsed_.empty()) files_being_parsed_.pop();
     return false;
   }
   if (source_filename) files_being_parsed_.pop();


### PR DESCRIPTION
If duplicate types are encountered, the compiler crashes when attempting to pop from an already empty queue.

Repro is fairly simple (done with VS2015):

1) Create Test.fbs with the following:
```
table Bar { }
```
2) Run the compiler:
```
flatc -c Test.fbs Test.fbs
```
3) Receive segfault.

Although I doubt anybody is going to be feeding in the same file multiple times, it's pretty easy to run into this problem when feeding in schemas with includes in the wrong order.