### PR TITLE
Fix flatbuffers::String to std::string and import of Windows.h

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -445,7 +445,7 @@ class vector_downward {
     if (len > static_cast<size_t>(cur_ - buf_)) {
       auto old_size = size();
       auto largest_align = AlignOf<largest_scalar_t>();
-      reserved_ += std::max(len, growth_policy(reserved_));
+      reserved_ += (std::max)(len, growth_policy(reserved_));
       // Round up to avoid undefined behavior from unaligned loads and stores.
       reserved_ = (reserved_ + (largest_align - 1)) & ~(largest_align - 1);
       auto new_buf = allocator_.allocate(reserved_);

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -379,7 +379,7 @@ template<typename T> static inline size_t VectorLength(const Vector<T> *v) {
 
 struct String : public Vector<char> {
   const char *c_str() const { return reinterpret_cast<const char *>(Data()); }
-  std::string str() const { return c_str(); }
+  std::string str() const { return std::string(c_str(), Length()); }
 
   bool operator <(const String &o) const {
     return strcmp(c_str(), o.c_str()) < 0;


### PR DESCRIPTION
When calling str() on a flatbuffers::String, it is truncated if there is a NULL byte within the data.  Additionally, if there is no NULL byte in the data (I haven't checked to see if this is possible or not...) then it could cause an out of bounds read.

As an aside, when importing Windows.h before flatbuffers.h it defines the macro "max" which causes the std::max call to fail.  This is an annoyance of Windows.h, but fairly trivial to fix.