### PR TITLE
Link clang builds against libc++abi on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,9 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
     "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -pedantic -Werror -Wextra -Werror=shadow")
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -std=c++0x -stdlib=libc++ -Wall -pedantic -Werror -Wextra")
+      "${CMAKE_CXX_FLAGS} -std=c++0x -stdlib=libc++ -Wall -pedantic -Werror -Wextra")
+  set(CMAKE_EXE_LINKER_FLAGS
+      "${CMAKE_EXE_LINKER_FLAGS} -lc++abi")
 endif()
 
 if(FLATBUFFERS_CODE_COVERAGE)


### PR DESCRIPTION
Simply running clang with -stdlib=libc++ requires a manual link against
libc++abi on Linux. This is documented in the libc++ documentation:
    http://libcxx.llvm.org/

Tested on Arch Linux, using clang 3.7.0 RELEASE.

Signed-off-by: Perry Hung <iperry@gmail.com>