### PR TITLE
Improved Java/C# FlatBufferBuilder's 'required' assert message

### DIFF
--- a/java/com/google/flatbuffers/FlatBufferBuilder.java
+++ b/java/com/google/flatbuffers/FlatBufferBuilder.java
@@ -455,13 +455,13 @@ public class FlatBufferBuilder {
 
     // This checks a required field has been set in a given table that has
     // just been constructed.
-    public void required(int table, int field) {
+    public void required(int table, int field, String fieldName) {
         int table_start = bb.capacity() - table;
         int vtable_start = table_start - bb.getInt(table_start);
         boolean ok = bb.getShort(vtable_start + field) != 0;
         // If this fails, the caller will show what field needs to be set.
         if (!ok)
-            throw new AssertionError("FlatBuffers: field " + field + " must be set");
+            throw new AssertionError("FlatBuffers: field '" + fieldName + "' (offset "+ field +") must be set");
     }
 
     public void finish(int root_table) {

--- a/net/FlatBuffers/FlatBufferBuilder.cs
+++ b/net/FlatBuffers/FlatBufferBuilder.cs
@@ -369,15 +369,16 @@ namespace FlatBuffers
 
         // This checks a required field has been set in a given table that has
         // just been constructed.
-        public void Required(int table, int field)
+        public void Required(int table, int fieldNumber, string fieldName)
         {
-          int table_start = _bb.Length - table;
-          int vtable_start = table_start - _bb.GetInt(table_start);
-          bool ok = _bb.GetShort(vtable_start + field) != 0;
-          // If this fails, the caller will show what field needs to be set.
-          if (!ok)
-            throw new InvalidOperationException("FlatBuffers: field " + field +
-                                                " must be set");
+            int table_start = _bb.Length - table;
+            int vtable_start = table_start - _bb.GetInt(table_start);
+            bool ok = _bb.GetShort(vtable_start + fieldNumber) != 0;
+            // If this fails, the caller will show what field needs to be set.
+            if (!ok)
+            {
+                throw new InvalidOperationException(string.Format("FlatBuffers: field '{0}' (offset {1}) must be set", fieldName, fieldNumber));
+            }
         }
 
         public void Finish(int rootTable)

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -1051,7 +1051,7 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
       if (!field.deprecated && field.required) {
         code += "    builder." + FunctionStart(lang, 'R') + "equired(o, ";
         code += NumToString(field.value.offset);
-        code += ");  // " + field.name + "\n";
+        code += ", \"" + field.name + "\");\n";
       }
     }
     code += "    return " + GenOffsetConstruct(lang, parser, struct_def, "o") + ";\n  }\n";

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -104,7 +104,7 @@ public sealed class Monster : Table {
   public static void StartTestarrayofboolsVector(FlatBufferBuilder builder, int numElems) { builder.StartVector(1, numElems, 1); }
   public static Offset<Monster> EndMonster(FlatBufferBuilder builder) {
     int o = builder.EndObject();
-    builder.Required(o, 10);  // name
+    builder.Required(o, 10, "name");
     return new Offset<Monster>(o);
   }
   public static void FinishMonsterBuffer(FlatBufferBuilder builder, Offset<Monster> offset) { builder.Finish(offset.Value, "MONS"); }

--- a/tests/MyGame/Example/Monster.java
+++ b/tests/MyGame/Example/Monster.java
@@ -115,7 +115,7 @@ public final class Monster extends Table {
   public static void startTestarrayofboolsVector(FlatBufferBuilder builder, int numElems) { builder.startVector(1, numElems, 1); }
   public static int endMonster(FlatBufferBuilder builder) {
     int o = builder.endObject();
-    builder.required(o, 10);  // name
+    builder.required(o, 10, "name");
     return o;
   }
   public static void finishMonsterBuffer(FlatBufferBuilder builder, int offset) { builder.finish(offset, "MONS"); }


### PR DESCRIPTION
Improved Java/C# FlatBufferBuilder's 'required' method assert message by including the field name as a parameter.

Tested with Java/C# on Windows