### PR TITLE
(C#) Create API should cast float default value

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -957,8 +957,13 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
         // Java doesn't have defaults, which means this method must always
         // supply all arguments, and thus won't compile when fields are added.
         if (lang.language != IDLOptions::kJava) {
+          std::string default_cast = "";
+          if (lang.language == IDLOptions::kCSharp && field.value.type.base_type == BASE_TYPE_FLOAT) {
+            // CSharp needs `f` suffix. for now, use cast.
+            default_cast = "(float)";
+          }
           code += " = ";
-          code += GenDefaultValueBasic(lang, parser, field.value);
+          code += default_cast + GenDefaultValueBasic(lang, parser, field.value);
         }
       }
       code += ") {\n    builder.";


### PR DESCRIPTION
I've found C# type issue on generated code.

defaultvalue.fbs
```
table FloatDefaultValue {
  value:float = 1.0;
}
```

generated create method like this:

```
public static Offset<FloatDefaultValue> CreateFloatDefaultValue(FlatBufferBuilder builder,
      float value = 1.0) {
    //  float value = 1.0 is syntax error
    //  it should be
    // `float value = (float)1.0` or `float value = 1.0f`
    builder.StartObject(1);
    FloatDefaultValue.AddValue(builder, value);
    return FloatDefaultValue.EndFloatDefaultValue(builder);
  }
```

I think to modify `GenDefaultValueBasic` function is much better than current PR'ed code. 
but it has slightly bigger effect: (at least should check getter properties due to remove duplicate (float)cast) 

do you have any good ideas?