### PR TITLE
Added csproj files to target multiple .NET framework versions

### DIFF
--- a/net/FlatBuffers.sln
+++ b/net/FlatBuffers.sln
@@ -1,0 +1,76 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net35", "FlatBuffers_Net35\FlatBuffers_Net35.csproj", "{28C00774-1E73-4A75-AD8F-844CD21A064D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net20", "FlatBuffers_Net20\FlatBuffers_Net20.csproj", "{F32B2F97-5019-42C5-B975-358F53801EAA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net30", "FlatBuffers_Net30\FlatBuffers_Net30.csproj", "{A531E9EE-556C-4DD9-BC30-56546EFB1C90}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net40", "FlatBuffers_Net40\FlatBuffers_Net40.csproj", "{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net45", "FlatBuffers_Net45\FlatBuffers_Net45.csproj", "{897723C7-4BE8-46D5-9348-14417722DB0C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net20.Unsafe", "FlatBuffers_Net20\FlatBuffers_Net20.Unsafe.csproj", "{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net30.Unsafe", "FlatBuffers_Net30\FlatBuffers_Net30.Unsafe.csproj", "{AC8E7699-7C3A-4859-B928-11F6CCD6460C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net35.Unsafe", "FlatBuffers_Net35\FlatBuffers_Net35.Unsafe.csproj", "{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net40.Unsafe", "FlatBuffers_Net40\FlatBuffers_Net40.Unsafe.csproj", "{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net45.Unsafe", "FlatBuffers_Net45\FlatBuffers_Net45.Unsafe.csproj", "{C5797601-BA0D-4E5A-91D1-A133806167E2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{28C00774-1E73-4A75-AD8F-844CD21A064D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{28C00774-1E73-4A75-AD8F-844CD21A064D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28C00774-1E73-4A75-AD8F-844CD21A064D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{28C00774-1E73-4A75-AD8F-844CD21A064D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F32B2F97-5019-42C5-B975-358F53801EAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F32B2F97-5019-42C5-B975-358F53801EAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F32B2F97-5019-42C5-B975-358F53801EAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F32B2F97-5019-42C5-B975-358F53801EAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A531E9EE-556C-4DD9-BC30-56546EFB1C90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A531E9EE-556C-4DD9-BC30-56546EFB1C90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A531E9EE-556C-4DD9-BC30-56546EFB1C90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A531E9EE-556C-4DD9-BC30-56546EFB1C90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{897723C7-4BE8-46D5-9348-14417722DB0C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{897723C7-4BE8-46D5-9348-14417722DB0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{897723C7-4BE8-46D5-9348-14417722DB0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{897723C7-4BE8-46D5-9348-14417722DB0C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC8E7699-7C3A-4859-B928-11F6CCD6460C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC8E7699-7C3A-4859-B928-11F6CCD6460C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC8E7699-7C3A-4859-B928-11F6CCD6460C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC8E7699-7C3A-4859-B928-11F6CCD6460C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5797601-BA0D-4E5A-91D1-A133806167E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5797601-BA0D-4E5A-91D1-A133806167E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5797601-BA0D-4E5A-91D1-A133806167E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5797601-BA0D-4E5A-91D1-A133806167E2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/net/FlatBuffers/AssemblyInfo.cs
+++ b/net/FlatBuffers/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("FlatBuffers")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("oli")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]
+

--- a/net/FlatBuffers/FlatBufferConstants.cs
+++ b/net/FlatBuffers/FlatBufferConstants.cs
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace FlatBuffers
 {
     public static class FlatBufferConstants

--- a/net/FlatBuffers_Net20/FlatBuffers_Net20.Unsafe.csproj
+++ b/net/FlatBuffers_Net20/FlatBuffers_Net20.Unsafe.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net20/FlatBuffers_Net20.csproj
+++ b/net/FlatBuffers_Net20/FlatBuffers_Net20.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F32B2F97-5019-42C5-B975-358F53801EAA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net30/FlatBuffers_Net30.Unsafe.csproj
+++ b/net/FlatBuffers_Net30/FlatBuffers_Net30.Unsafe.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AC8E7699-7C3A-4859-B928-11F6CCD6460C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net30/FlatBuffers_Net30.csproj
+++ b/net/FlatBuffers_Net30/FlatBuffers_Net30.csproj
@@ -4,13 +4,14 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{28C00774-1E73-4A75-AD8F-844CD21A064D}</ProjectGuid>
+    <ProjectGuid>{A531E9EE-556C-4DD9-BC30-56546EFB1C90}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FlatBuffers</RootNamespace>
     <AssemblyName>FlatBuffers</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,16 +32,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ByteBuffer.cs" />
-    <Compile Include="FlatBufferBuilder.cs" />
-    <Compile Include="FlatBufferConstants.cs" />
-    <Compile Include="Offset.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Struct.cs" />
-    <Compile Include="Table.cs" />
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/net/FlatBuffers_Net35/FlatBuffers_Net35.Unsafe.csproj
+++ b/net/FlatBuffers_Net35/FlatBuffers_Net35.Unsafe.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net35/FlatBuffers_Net35.csproj
+++ b/net/FlatBuffers_Net35/FlatBuffers_Net35.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{28C00774-1E73-4A75-AD8F-844CD21A064D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net40/FlatBuffers_Net40.Unsafe.csproj
+++ b/net/FlatBuffers_Net40/FlatBuffers_Net40.Unsafe.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net40/FlatBuffers_Net40.csproj
+++ b/net/FlatBuffers_Net40/FlatBuffers_Net40.csproj
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net45/FlatBuffers_Net45.Unsafe.csproj
+++ b/net/FlatBuffers_Net45/FlatBuffers_Net45.Unsafe.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C5797601-BA0D-4E5A-91D1-A133806167E2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net45/FlatBuffers_Net45.csproj
+++ b/net/FlatBuffers_Net45/FlatBuffers_Net45.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{897723C7-4BE8-46D5-9348-14417722DB0C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
* Added .csproj files to target .NET framework 2.0, 3.0, 3.5, 4.0 and 4.5 (including unsafe build) - making it simpler for users to consume the assembly
* Included a single .sln file to build all projects
* Removed unnecessary using statements from FlatBufferConstants.cs