### PR TITLE
* Added .csproj files to target .NET framework 2.0, 3.0, 3.5, 4.0 and…

### DIFF
--- a/net/FlatBuffers.sln
+++ b/net/FlatBuffers.sln
@@ -1,0 +1,70 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net35", "FlatBuffers_Net35\FlatBuffers_Net35.csproj", "{28C00774-1E73-4A75-AD8F-844CD21A064D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net20", "FlatBuffers_Net20\FlatBuffers_Net20.csproj", "{F32B2F97-5019-42C5-B975-358F53801EAA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net40", "FlatBuffers_Net40\FlatBuffers_Net40.csproj", "{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net45", "FlatBuffers_Net45\FlatBuffers_Net45.csproj", "{897723C7-4BE8-46D5-9348-14417722DB0C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Unsafe", "Unsafe", "{3FDE9A7E-E768-415F-8C90-53A6B217ACA2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net20.Unsafe", "FlatBuffers_Net20.Unsafe\FlatBuffers_Net20.Unsafe.csproj", "{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net35.Unsafe", "FlatBuffers_Net35.Unsafe\FlatBuffers_Net35.Unsafe.csproj", "{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net40.Unsafe", "FlatBuffers_Net40.Unsafe\FlatBuffers_Net40.Unsafe.csproj", "{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatBuffers_Net45.Unsafe", "FlatBuffers_Net45.Unsafe\FlatBuffers_Net45.Unsafe.csproj", "{C5797601-BA0D-4E5A-91D1-A133806167E2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{28C00774-1E73-4A75-AD8F-844CD21A064D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{28C00774-1E73-4A75-AD8F-844CD21A064D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28C00774-1E73-4A75-AD8F-844CD21A064D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{28C00774-1E73-4A75-AD8F-844CD21A064D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F32B2F97-5019-42C5-B975-358F53801EAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F32B2F97-5019-42C5-B975-358F53801EAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F32B2F97-5019-42C5-B975-358F53801EAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F32B2F97-5019-42C5-B975-358F53801EAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{897723C7-4BE8-46D5-9348-14417722DB0C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{897723C7-4BE8-46D5-9348-14417722DB0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{897723C7-4BE8-46D5-9348-14417722DB0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{897723C7-4BE8-46D5-9348-14417722DB0C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5797601-BA0D-4E5A-91D1-A133806167E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5797601-BA0D-4E5A-91D1-A133806167E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5797601-BA0D-4E5A-91D1-A133806167E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5797601-BA0D-4E5A-91D1-A133806167E2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E} = {3FDE9A7E-E768-415F-8C90-53A6B217ACA2}
+		{E15E055E-1722-40B5-AB07-DF96EE7A9FA6} = {3FDE9A7E-E768-415F-8C90-53A6B217ACA2}
+		{B7ED12D8-C4A2-4753-97AB-0E6A943F7751} = {3FDE9A7E-E768-415F-8C90-53A6B217ACA2}
+		{C5797601-BA0D-4E5A-91D1-A133806167E2} = {3FDE9A7E-E768-415F-8C90-53A6B217ACA2}
+	EndGlobalSection
+EndGlobal

--- a/net/FlatBuffers/FlatBufferConstants.cs
+++ b/net/FlatBuffers/FlatBufferConstants.cs
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace FlatBuffers
 {
     public static class FlatBufferConstants

--- a/net/FlatBuffers_Net20.Unsafe/FlatBuffers_Net20.Unsafe.csproj
+++ b/net/FlatBuffers_Net20.Unsafe/FlatBuffers_Net20.Unsafe.csproj
@@ -1,46 +1,50 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{28C00774-1E73-4A75-AD8F-844CD21A064D}</ProjectGuid>
+    <ProjectGuid>{2EE2C35B-FB5A-4863-9BB6-6F88DA4EB80E}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FlatBuffers</RootNamespace>
     <AssemblyName>FlatBuffers</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;UNSAFE_BYTEBUFFER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;UNSAFE_BYTEBUFFER</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ByteBuffer.cs" />
-    <Compile Include="FlatBufferBuilder.cs" />
-    <Compile Include="FlatBufferConstants.cs" />
-    <Compile Include="Offset.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Struct.cs" />
-    <Compile Include="Table.cs" />
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/net/FlatBuffers_Net20/FlatBuffers_Net20.csproj
+++ b/net/FlatBuffers_Net20/FlatBuffers_Net20.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F32B2F97-5019-42C5-B975-358F53801EAA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net35.Unsafe/FlatBuffers_Net35.Unsafe.csproj
+++ b/net/FlatBuffers_Net35.Unsafe/FlatBuffers_Net35.Unsafe.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E15E055E-1722-40B5-AB07-DF96EE7A9FA6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net35/FlatBuffers_Net35.csproj
+++ b/net/FlatBuffers_Net35/FlatBuffers_Net35.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{28C00774-1E73-4A75-AD8F-844CD21A064D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net40.Unsafe/FlatBuffers_Net40.Unsafe.csproj
+++ b/net/FlatBuffers_Net40.Unsafe/FlatBuffers_Net40.Unsafe.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B7ED12D8-C4A2-4753-97AB-0E6A943F7751}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net40/FlatBuffers_Net40.csproj
+++ b/net/FlatBuffers_Net40/FlatBuffers_Net40.csproj
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BF9D2B59-FC8D-4A3F-AF8F-514E09DCDD52}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net45.Unsafe/FlatBuffers_Net45.Unsafe.csproj
+++ b/net/FlatBuffers_Net45.Unsafe/FlatBuffers_Net45.Unsafe.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C5797601-BA0D-4E5A-91D1-A133806167E2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;UNSAFE_BYTEBUFFER</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/net/FlatBuffers_Net45/FlatBuffers_Net45.csproj
+++ b/net/FlatBuffers_Net45/FlatBuffers_Net45.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{897723C7-4BE8-46D5-9348-14417722DB0C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FlatBuffers</RootNamespace>
+    <AssemblyName>FlatBuffers</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\FlatBuffers\ByteBuffer.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferBuilder.cs" />
+    <Compile Include="..\FlatBuffers\FlatBufferConstants.cs" />
+    <Compile Include="..\FlatBuffers\Offset.cs">
+      <Link>Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\FlatBuffers\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\FlatBuffers\Struct.cs" />
+    <Compile Include="..\FlatBuffers\Table.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
* Added .csproj files to target .NET framework 2.0, 3.0, 3.5, 4.0 and 4.5 (including unsafe build) - making it simpler for users to consume the assembly
* Included a single .sln file to build all projects
* Removed unnecessary using statements from FlatBufferConstants.cs