### PR TITLE
[BUG] [MINOR] Use buffer for specific py versions

### DIFF
--- a/python/flatbuffers/compat.py
+++ b/python/flatbuffers/compat.py
@@ -4,6 +4,8 @@ import sys
 
 PY2 = sys.version_info[0] == 2
 PY26 = sys.version_info[0:2] == (2, 6)
+PY27 = sys.version_info[0:2] == (2, 7)
+PY275 = sys.version_info[0:3] >= (2, 7, 5)
 PY3 = sys.version_info[0] == 3
 PY34 = sys.version_info[0:2] >= (3, 4)
 
@@ -17,7 +19,7 @@ else:
     string_types = (basestring,)
     binary_type = str
     range_func = xrange
-    if PY26:
+    if PY26 or (PY27 and not PY275):
         memoryview_type = buffer
         struct_bool_decl = "<b"
     else:


### PR DESCRIPTION
Fix for Issue 1741
Minor bug where python versions 2.7.x where x < 5 do not support
unpacking from memoryview objects. Versions 2.7.5 and above will
use memoryview while 2.7 versions below 2.7.5  will use buffer
objects.

Manual testing was performed on versions 2.7.5 and 2.7.2 to
confirm both worked correctly.