### PR TITLE
C#: added #define BYTEBUFFER_NO_BOUNDS_CHECK 

### DIFF
--- a/tests/FlatBuffers.Test/ByteBufferTests.cs
+++ b/tests/FlatBuffers.Test/ByteBufferTests.cs
@@ -40,6 +40,7 @@ namespace FlatBuffers.Test
             Assert.AreEqual((byte)99, buffer[0]);
         }
 
+#if !BYTEBUFFER_NO_BOUNDS_CHECK
         [FlatBuffersTestMethod]
         public void ByteBuffer_PutByteCannotPutAtOffsetPastLength()
         {
@@ -47,6 +48,7 @@ namespace FlatBuffers.Test
             var uut = new ByteBuffer(buffer);
             Assert.Throws<ArgumentOutOfRangeException>(() => uut.PutByte(1, 99));
         }
+#endif
 
         [FlatBuffersTestMethod]
         public void ByteBuffer_PutShortPopulatesBufferCorrectly()
@@ -60,6 +62,7 @@ namespace FlatBuffers.Test
             Assert.AreEqual((byte)0, buffer[1]);
         }
 
+#if !BYTEBUFFER_NO_BOUNDS_CHECK
         [FlatBuffersTestMethod]
         public void ByteBuffer_PutShortCannotPutAtOffsetPastLength()
         {
@@ -67,7 +70,9 @@ namespace FlatBuffers.Test
             var uut = new ByteBuffer(buffer);
             Assert.Throws<ArgumentOutOfRangeException>(() => uut.PutShort(2, 99));
         }
+#endif
 
+#if !BYTEBUFFER_NO_BOUNDS_CHECK
         [FlatBuffersTestMethod]
         public void ByteBuffer_PutShortChecksLength()
         {
@@ -83,6 +88,7 @@ namespace FlatBuffers.Test
             var uut = new ByteBuffer(buffer);
             Assert.Throws<ArgumentOutOfRangeException>(() => uut.PutShort(1, 99));
         }
+#endif
 
         [FlatBuffersTestMethod]
         public void ByteBuffer_PutIntPopulatesBufferCorrectly()
@@ -98,6 +104,7 @@ namespace FlatBuffers.Test
             Assert.AreEqual(0x0A, buffer[3]);
         }
 
+ #if !BYTEBUFFER_NO_BOUNDS_CHECK
         [FlatBuffersTestMethod]
         public void ByteBuffer_PutIntCannotPutAtOffsetPastLength()
         {
@@ -121,6 +128,7 @@ namespace FlatBuffers.Test
             var uut = new ByteBuffer(buffer);
             Assert.Throws<ArgumentOutOfRangeException>(() => uut.PutInt(2, 0x0A0B0C0D));
         }
+#endif
 
         [FlatBuffersTestMethod]
         public void ByteBuffer_PutLongPopulatesBufferCorrectly()
@@ -140,6 +148,7 @@ namespace FlatBuffers.Test
             Assert.AreEqual(0x01, buffer[7]);
         }
 
+#if !BYTEBUFFER_NO_BOUNDS_CHECK
         [FlatBuffersTestMethod]
         public void ByteBuffer_PutLongCannotPutAtOffsetPastLength()
         {
@@ -163,6 +172,7 @@ namespace FlatBuffers.Test
             var uut = new ByteBuffer(buffer);
             Assert.Throws<ArgumentOutOfRangeException>(() => uut.PutLong(2, 0x010203040A0B0C0D));
         }
+#endif
 
         [FlatBuffersTestMethod]
         public void ByteBuffer_GetByteReturnsCorrectData()
@@ -173,6 +183,7 @@ namespace FlatBuffers.Test
             Assert.AreEqual((byte)99, uut.Get(0));
         }
 
+#if !BYTEBUFFER_NO_BOUNDS_CHECK
         [FlatBuffersTestMethod]
         public void ByteBuffer_GetByteChecksOffset()
         {
@@ -180,6 +191,7 @@ namespace FlatBuffers.Test
             var uut = new ByteBuffer(buffer);
             Assert.Throws<ArgumentOutOfRangeException>(()=>uut.Get(1));
         }
+#endif
 
         [FlatBuffersTestMethod]
         public void ByteBuffer_GetShortReturnsCorrectData()
@@ -191,6 +203,7 @@ namespace FlatBuffers.Test
             Assert.AreEqual(1, uut.GetShort(0));
         }
 
+#if !BYTEBUFFER_NO_BOUNDS_CHECK
         [FlatBuffersTestMethod]
         public void ByteBuffer_GetShortChecksOffset()
         {
@@ -206,6 +219,7 @@ namespace FlatBuffers.Test
             var uut = new ByteBuffer(buffer);
             Assert.Throws<ArgumentOutOfRangeException>(() => uut.GetShort(1));
         }
+#endif
 
         [FlatBuffersTestMethod]
         public void ByteBuffer_GetIntReturnsCorrectData()
@@ -219,6 +233,7 @@ namespace FlatBuffers.Test
             Assert.AreEqual(0x0A0B0C0D, uut.GetInt(0));
         }
 
+#if !BYTEBUFFER_NO_BOUNDS_CHECK
         [FlatBuffersTestMethod]
         public void ByteBuffer_GetIntChecksOffset()
         {
@@ -234,6 +249,7 @@ namespace FlatBuffers.Test
             var uut = new ByteBuffer(buffer);
             Assert.Throws<ArgumentOutOfRangeException>(() => uut.GetInt(0));
         }
+#endif
 
         [FlatBuffersTestMethod]
         public void ByteBuffer_GetLongReturnsCorrectData()
@@ -251,6 +267,7 @@ namespace FlatBuffers.Test
             Assert.AreEqual(0x010203040A0B0C0D, uut.GetLong(0));
         }
 
+#if !BYTEBUFFER_NO_BOUNDS_CHECK
         [FlatBuffersTestMethod]
         public void ByteBuffer_GetLongChecksOffset()
         {
@@ -266,6 +283,7 @@ namespace FlatBuffers.Test
             var uut = new ByteBuffer(buffer);
             Assert.Throws<ArgumentOutOfRangeException>(() => uut.GetLong(0));
         }
+#endif
 
         [FlatBuffersTestMethod]
         public void ByteBuffer_ReverseBytesUshort()


### PR DESCRIPTION
Removes the bounds checking on the ByteBuffer Get/Put operations. Can be dangerous when used with UNSAFE_BYTEBUFFER but results in increased performance. Use at your own risk!