### PR TITLE
add attributes declaration export for refection/schema

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -184,7 +184,7 @@ template<typename T> class SymbolTable {
     return it == dict.end() ? nullptr : it->second;
   }
 
- private:
+ public:
   std::map<std::string, T *> dict;      // quick lookup
 
  public:
@@ -340,46 +340,6 @@ struct IDLOptions {
       lang(IDLOptions::kJava) {}
 };
 
-// A way to make error propagation less error prone by requiring values to be
-// checked.
-// Once you create a value of this type you must either:
-// - Call Check() on it.
-// - Copy or assign it to another value.
-// Failure to do so leads to an assert.
-// This guarantees that this as return value cannot be ignored.
-class CheckedError {
- public:
-  explicit CheckedError(bool error)
-    : is_error_(error), has_been_checked_(false) {}
-
-  CheckedError &operator=(const CheckedError &other) {
-    is_error_ = other.is_error_;
-    has_been_checked_ = false;
-    other.has_been_checked_ = true;
-    return *this;
-  }
-
-  CheckedError(const CheckedError &other) {
-    *this = other;  // Use assignment operator.
-  }
-
-  ~CheckedError() { assert(has_been_checked_); }
-
-  bool Check() { has_been_checked_ = true; return is_error_; }
-
- private:
-  bool is_error_;
-  mutable bool has_been_checked_;
-};
-
-// Additionally, in GCC we can get these errors statically, for additional
-// assurance:
-#ifdef __GNUC__
-#define CHECKED_ERROR CheckedError __attribute__((warn_unused_result))
-#else
-#define CHECKED_ERROR CheckedError
-#endif
-
 class Parser {
  public:
   explicit Parser(const IDLOptions &options = IDLOptions())
@@ -435,51 +395,44 @@ class Parser {
   // See reflection/reflection.fbs
   void Serialize();
 
-  CHECKED_ERROR CheckBitsFit(int64_t val, size_t bits);
-
-private:
-  CHECKED_ERROR Error(const std::string &msg);
-  CHECKED_ERROR ParseHexNum(int nibbles, int64_t *val);
-  CHECKED_ERROR Next();
-  bool Is(int t);
-  CHECKED_ERROR Expect(int t);
+ private:
+  int64_t ParseHexNum(int nibbles);
+  void Next();
+  bool IsNext(int t);
+  void Expect(int t);
   std::string TokenToStringId(int t);
   EnumDef *LookupEnum(const std::string &id);
-  CHECKED_ERROR ParseNamespacing(std::string *id, std::string *last);
-  CHECKED_ERROR ParseTypeIdent(Type &type);
-  CHECKED_ERROR ParseType(Type &type);
-  CHECKED_ERROR AddField(StructDef &struct_def, const std::string &name,
-                         const Type &type, FieldDef **dest);
-  CHECKED_ERROR ParseField(StructDef &struct_def);
-  CHECKED_ERROR ParseAnyValue(Value &val, FieldDef *field, size_t parent_fieldn);
-  CHECKED_ERROR ParseTable(const StructDef &struct_def, std::string *value,
-                           uoffset_t *ovalue);
+  void ParseNamespacing(std::string *id, std::string *last);
+  void ParseTypeIdent(Type &type);
+  void ParseType(Type &type);
+  FieldDef &AddField(StructDef &struct_def,
+                     const std::string &name,
+                     const Type &type);
+  void ParseField(StructDef &struct_def);
+  void ParseAnyValue(Value &val, FieldDef *field, size_t parent_fieldn);
+  uoffset_t ParseTable(const StructDef &struct_def, std::string *value);
   void SerializeStruct(const StructDef &struct_def, const Value &val);
   void AddVector(bool sortbysize, int count);
-  CHECKED_ERROR ParseVector(const Type &type, uoffset_t *ovalue);
-  CHECKED_ERROR ParseMetaData(Definition &def);
-  CHECKED_ERROR TryTypedValue(int dtoken, bool check, Value &e, BaseType req,
-                              bool *destmatch);
-  CHECKED_ERROR ParseHash(Value &e, FieldDef* field);
-  CHECKED_ERROR ParseSingleValue(Value &e);
-  CHECKED_ERROR ParseIntegerFromString(Type &type, int64_t *result);
+  uoffset_t ParseVector(const Type &type);
+  void ParseMetaData(Definition &def);
+  bool TryTypedValue(int dtoken, bool check, Value &e, BaseType req);
+  void ParseHash(Value &e, FieldDef* field);
+  void ParseSingleValue(Value &e);
+  int64_t ParseIntegerFromString(Type &type);
   StructDef *LookupCreateStruct(const std::string &name,
                                 bool create_if_new = true,
                                 bool definition = false);
-  CHECKED_ERROR ParseEnum(bool is_union, EnumDef **dest);
-  CHECKED_ERROR ParseNamespace();
-  CHECKED_ERROR StartStruct(const std::string &name, StructDef **dest);
-  CHECKED_ERROR ParseDecl();
-  CHECKED_ERROR ParseProtoFields(StructDef *struct_def, bool isextend,
-                                 bool inside_oneof);
-  CHECKED_ERROR ParseProtoOption();
-  CHECKED_ERROR ParseProtoKey();
-  CHECKED_ERROR ParseProtoDecl();
-  CHECKED_ERROR ParseProtoCurliesOrIdent();
-  CHECKED_ERROR ParseTypeFromProtoType(Type *type);
-
-  CHECKED_ERROR DoParse(const char *_source, const char **include_paths,
-                        const char *source_filename);
+  EnumDef &ParseEnum(bool is_union);
+  void ParseNamespace();
+  StructDef &StartStruct(const std::string &name);
+  void ParseDecl();
+  void ParseProtoFields(StructDef *struct_def, bool isextend,
+                        bool inside_oneof);
+  void ParseProtoOption();
+  void ParseProtoKey();
+  void ParseProtoDecl();
+  void ParseProtoCurliesOrIdent();
+  Type ParseTypeFromProtoType();
 
  public:
   SymbolTable<StructDef> structs_;
@@ -501,7 +454,7 @@ private:
   const char *source_, *cursor_;
   int line_;  // the current line being parsed
   int token_;
-  std::string file_being_parsed_;
+  std::string files_being_parsed_;
 
   std::string attribute_;
   std::vector<std::string> doc_comment_;

--- a/reflection/reflection.fbs
+++ b/reflection/reflection.fbs
@@ -26,6 +26,11 @@ enum BaseType : byte {
     Union
 }
 
+table Attribute {
+    name:string (required);
+    value:string (required);
+}
+
 table Type {
     base_type:BaseType;
     element:BaseType = None;  // Only if base_type == Vector.
@@ -45,6 +50,7 @@ table Enum {
     values:[EnumVal] (required);  // In order of their values.
     is_union:bool = false;
     underlying_type:Type (required);
+    attributes:[Attribute] (required);
 }
 
 table Field {
@@ -57,6 +63,7 @@ table Field {
     deprecated:bool = false;
     required:bool = false;
     key:bool = false;
+    attributes:[Attribute] (required);
 }
 
 table Object {  // Used for both tables and structs.
@@ -65,6 +72,8 @@ table Object {  // Used for both tables and structs.
     is_struct:bool = false;
     minalign:int;
     bytesize:int;  // For structs.
+
+    attributes:[Attribute] (required);
 }
 
 table Schema {


### PR DESCRIPTION
Hi, I want to write a plugin which export all the message(table/struct) 's id and generated class/name pair.

Like Protocol Buffers I could use shame self description .proto to write in Python instead of change protoc. but flatbuffers reflection.fbs miss attributes, I add the "attributes" field for Object/Field/Enum in this PR .

//////////////
in my case, I use attribute to describe the meta information of a message,
the message id which used to identity which message it is, when serialize/unserialize on network.

eg:
//////////////
table AuthRequest  (message_id: 1, message_category: 0)
{
    account:        string;     // (chinese) 账号
    sign:           string;     // 密码签名
    game:           string;     //游戏
    lang:           string;     //语言
}
/////////////////////
