### PR TITLE
Fix build for platforms not supporting realpath

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -219,19 +219,19 @@ inline void EnsureDirExists(const std::string &filepath) {
 // Obtains the absolute path from any other path.
 // Returns the input path if the absolute path couldn't be resolved.
 inline std::string AbsolutePath(const std::string &filepath) {
-#ifdef NO_ABSOLUTE_PATH_RESOLUTION
-	return filepath;
-#else
-  #ifdef _WIN32
-    char abs_path[MAX_PATH];
-    return GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr)
+  #ifdef FLATBUFFERS_NO_ABSOLUTE_PATH_RESOLUTION
+    return filepath;
   #else
-    char abs_path[PATH_MAX];
-    return realpath(filepath.c_str(), abs_path)
-  #endif
-    ? abs_path
-    : filepath;
-#endif // NO_ABSOLUTE_PATH_RESOLUTION
+    #ifdef _WIN32
+      char abs_path[MAX_PATH];
+      return GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr)
+    #else
+      char abs_path[PATH_MAX];
+      return realpath(filepath.c_str(), abs_path)
+    #endif
+      ? abs_path
+      : filepath;
+  #endif // NO_ABSOLUTE_PATH_RESOLUTION
 }
 
 // To and from UTF-8 unicode conversion functions

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -219,6 +219,9 @@ inline void EnsureDirExists(const std::string &filepath) {
 // Obtains the absolute path from any other path.
 // Returns the input path if the absolute path couldn't be resolved.
 inline std::string AbsolutePath(const std::string &filepath) {
+#ifdef NO_ABSOLUTE_PATH_RESOLUTION
+	return filepath;
+#else
   #ifdef _WIN32
     char abs_path[MAX_PATH];
     return GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr)
@@ -228,6 +231,7 @@ inline std::string AbsolutePath(const std::string &filepath) {
   #endif
     ? abs_path
     : filepath;
+#endif // NO_ABSOLUTE_PATH_RESOLUTION
 }
 
 // To and from UTF-8 unicode conversion functions

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -231,7 +231,7 @@ inline std::string AbsolutePath(const std::string &filepath) {
     #endif
       ? abs_path
       : filepath;
-  #endif // NO_ABSOLUTE_PATH_RESOLUTION
+  #endif // FLATBUFFERS_NO_ABSOLUTE_PATH_RESOLUTION
 }
 
 // To and from UTF-8 unicode conversion functions


### PR DESCRIPTION
Added a check for a preprocessor definition that can be set if the platform you're building for doesn't support any notion of absolute path resolution/realpath()/etc.