### PR TITLE
Fixed MS static analysis warnings

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -211,7 +211,7 @@ inline void EnsureDirExists(const std::string &filepath) {
   if (parent.length()) EnsureDirExists(parent);
   #ifdef _WIN32
     #ifdef _MSC_VER
-    #pragma warning(suppress: 6031)
+      #pragma warning(suppress: 6031) // "return value ignored: <function> could return unexpected value"
     #endif
     _mkdir(filepath.c_str());
   #else

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -210,6 +210,9 @@ inline void EnsureDirExists(const std::string &filepath) {
   auto parent = StripFileName(filepath);
   if (parent.length()) EnsureDirExists(parent);
   #ifdef _WIN32
+    #ifdef _MSC_VER
+    #pragma warning(suppress: 6031)
+    #endif
     _mkdir(filepath.c_str());
   #else
     mkdir(filepath.c_str(), S_IRWXU|S_IRGRP|S_IXGRP);

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -210,10 +210,7 @@ inline void EnsureDirExists(const std::string &filepath) {
   auto parent = StripFileName(filepath);
   if (parent.length()) EnsureDirExists(parent);
   #ifdef _WIN32
-    #ifdef _MSC_VER
-      #pragma warning(suppress: 6031) // "return value ignored: <function> could return unexpected value"
-    #endif
-    _mkdir(filepath.c_str());
+    (void)_mkdir(filepath.c_str());
   #else
     mkdir(filepath.c_str(), S_IRWXU|S_IRGRP|S_IXGRP);
   #endif

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -191,7 +191,7 @@ std::string Parser::TokenToStringId(int t) {
 // Parses exactly nibbles worth of hex digits into a number, or error.
 CheckedError Parser::ParseHexNum(int nibbles, int64_t *val) {
   for (int i = 0; i < nibbles; i++)
-    if (!isxdigit(cursor_[i]))
+    if (!isxdigit(static_cast<const unsigned char>(cursor_[i])))
       return Error("escape code must be followed by " + NumToString(nibbles) +
                    " hex digits");
   std::string target(cursor_, cursor_ + nibbles);
@@ -214,7 +214,7 @@ CheckedError Parser::Next() {
       case '{': case '}': case '(': case ')': case '[': case ']':
       case ',': case ':': case ';': case '=': return NoError();
       case '.':
-        if(!isdigit(*cursor_)) return NoError();
+        if(!isdigit(static_cast<const unsigned char>(*cursor_))) return NoError();
         return Error("floating point constant can\'t start with \".\"");
       case '\"':
       case '\'':


### PR DESCRIPTION
Cleaned up a few warnings to allow VS2012 to compile idl_parser and idl_gen_text (for exporting binary protobuf blobs as JSON) cleanly under static analysis.