### PR TITLE
Check & skip of the utf-8 byte order mark

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -444,6 +444,7 @@ private:
   FLATBUFFERS_CHECKED_ERROR Error(const std::string &msg);
   FLATBUFFERS_CHECKED_ERROR ParseHexNum(int nibbles, int64_t *val);
   FLATBUFFERS_CHECKED_ERROR Next();
+  FLATBUFFERS_CHECKED_ERROR SkipByteOrderMark();
   bool Is(int t);
   FLATBUFFERS_CHECKED_ERROR Expect(int t);
   std::string TokenToStringId(int t);

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -200,6 +200,13 @@ CheckedError Parser::ParseHexNum(int nibbles, int64_t *val) {
   return NoError();
 }
 
+CheckedError Parser::SkipByteOrderMark() {
+  if (static_cast<unsigned char>(*cursor_++) != 0xef) return NoError();
+  if (static_cast<unsigned char>(*cursor_++) != 0xbb) return Error("invalid utf-8 byte order mark");
+  if (static_cast<unsigned char>(*cursor_++) != 0xff) return Error("invalid utf-8 byte order mark");
+  return NoError();
+}
+
 CheckedError Parser::Next() {
   doc_comment_.clear();
   bool seen_newline = false;
@@ -1584,6 +1591,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
   builder_.Clear();
   // Start with a blank namespace just in case this file doesn't have one.
   namespaces_.push_back(new Namespace());
+  ECHECK(SkipByteOrderMark());
   NEXT();
   // Includes must come before type declarations:
   for (;;) {


### PR DESCRIPTION
Added check (& skipping) of the utf-8 byte order mark (0xEF BB FF) at the beginning of the file.

Fixes #3506