### PR TITLE
Check (& skip) of the utf-8 byte order mark

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -444,6 +444,7 @@ private:
   FLATBUFFERS_CHECKED_ERROR Error(const std::string &msg);
   FLATBUFFERS_CHECKED_ERROR ParseHexNum(int nibbles, int64_t *val);
   FLATBUFFERS_CHECKED_ERROR Next();
+  FLATBUFFERS_CHECKED_ERROR SkipByteOrderMark();
   bool Is(int t);
   FLATBUFFERS_CHECKED_ERROR Expect(int t);
   std::string TokenToStringId(int t);

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -200,6 +200,14 @@ CheckedError Parser::ParseHexNum(int nibbles, int64_t *val) {
   return NoError();
 }
 
+CheckedError Parser::SkipByteOrderMark() {
+  if (static_cast<unsigned char>(*cursor_) != 0xef) return NoError();
+  cursor_++;
+  if (static_cast<unsigned char>(*cursor_++) != 0xbb) return Error("invalid utf-8 byte order mark");
+  if (static_cast<unsigned char>(*cursor_++) != 0xbf) return Error("invalid utf-8 byte order mark");
+  return NoError();
+}
+
 CheckedError Parser::Next() {
   doc_comment_.clear();
   bool seen_newline = false;
@@ -1584,6 +1592,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
   builder_.Clear();
   // Start with a blank namespace just in case this file doesn't have one.
   namespaces_.push_back(new Namespace());
+  ECHECK(SkipByteOrderMark());
   NEXT();
   // Includes must come before type declarations:
   for (;;) {


### PR DESCRIPTION
Added check and skipping of the UTF-8 [byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8) sequence (-> 0xEF BB BF) at the start of the file. This can be added invisibly when using software such as Visual Studio to create fbs files.

Fixes #3506 