### PR TITLE
Added Visual Studio transient files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ java/*.iml
 java/target
 **/*.pyc
 .idea
+build/VS2010/FlatBuffers.sdf
+build/VS2010/FlatBuffers.opensdf
+build/VS2010/ipch/**/*.ipch


### PR DESCRIPTION
Added .sdf, .opensdf and .ipch to the .gitignore. These files get created by VS2010 when working in the  FlatBuffers.sln and will never be committed to the repository.