### PR TITLE
Buildfix for VS2010

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -938,6 +938,9 @@ FLATBUFFERS_FINAL_CLASS
       return table_a->KeyCompareLessThan(table_b);
     }
     vector_downward& buf_;
+
+  private:
+    TableKeyComparator& operator= (const TableKeyComparator&);
   };
   /// @endcond
 


### PR DESCRIPTION
Disabled assignment operator of TableKeyComparator; was causing warning C4512 on VS2010 and thus causing the build to fail.