### PR TITLE
Added support for C# partial class generation using attribute

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -403,6 +403,7 @@ class Parser {
     known_attributes_.insert("bit_flags");
     known_attributes_.insert("original_order");
     known_attributes_.insert("nested_flatbuffer");
+    known_attributes_.insert("csharp_partial");
   }
 
   ~Parser() {

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -659,7 +659,15 @@ static void GenStruct(const LanguageParameters &lang, const Parser &parser,
   //   int o = __offset(offset); return o != 0 ? bb.getType(o + i) : default;
   // }
   GenComment(struct_def.doc_comment, code_ptr, &lang.comment_config);
-  code += std::string("public ") + lang.unsubclassable_decl;
+  code += "public ";
+  if (lang.language == IDLOptions::kCSharp &&
+      struct_def.attributes.Lookup("csharp_partial")) {
+    // generate a partial class for this C# struct/table
+    code += "partial ";
+  }
+  else {
+    code += lang.unsubclassable_decl;
+  }
   code += "class " + struct_def.name + lang.inheritance_marker;
   code += struct_def.fixed ? "Struct" : "Table";
   code += " {\n";

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.cs
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.cs
@@ -6,7 +6,7 @@ namespace MyGame.Example
 using System;
 using FlatBuffers;
 
-public sealed class TestSimpleTableWithEnum : Table {
+public partial class TestSimpleTableWithEnum : Table {
   public static TestSimpleTableWithEnum GetRootAsTestSimpleTableWithEnum(ByteBuffer _bb) { return GetRootAsTestSimpleTableWithEnum(_bb, new TestSimpleTableWithEnum()); }
   public static TestSimpleTableWithEnum GetRootAsTestSimpleTableWithEnum(ByteBuffer _bb, TestSimpleTableWithEnum obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
   public TestSimpleTableWithEnum __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }

--- a/tests/monster_test.fbs
+++ b/tests/monster_test.fbs
@@ -12,7 +12,7 @@ union Any { Monster, TestSimpleTableWithEnum }  // TODO: add more elements
 
 struct Test { a:short; b:byte; }
 
-table TestSimpleTableWithEnum {
+table TestSimpleTableWithEnum (csharp_partial) {
   color: Color = Green;
 }
 


### PR DESCRIPTION
Added support for C# partial class generation when the `csharp_partial` attribute is used on a table/struct.