### PR TITLE
Change js export/require approach for better webpack compatibility

### DIFF
--- a/js/flatbuffers.js
+++ b/js/flatbuffers.js
@@ -1102,7 +1102,7 @@ flatbuffers.ByteBuffer.prototype.__has_identifier = function(ident) {
 };
 
 // Exports for Node.js and RequireJS
-this.flatbuffers = flatbuffers;
+module.exports = flatbuffers;
 
 /// @endcond
 /// @}

--- a/tests/JavaScriptTest.js
+++ b/tests/JavaScriptTest.js
@@ -2,7 +2,7 @@
 var assert = require('assert');
 var fs = require('fs');
 
-var flatbuffers = require('../js/flatbuffers').flatbuffers;
+var flatbuffers = require('../js/flatbuffers');
 var MyGame = require('./monster_test_generated').MyGame;
 
 function main() {


### PR DESCRIPTION
Was running into trouble getting flatbuffers working with webpack and needed to remove the extra layer of indirection (the `.flatbuffers` after the require). With this change, I'm able to use the webpack.ProvidePlugin to make flatbuffers available globally (and so I don't need to modify my autogenerated flatbuffer code which references `flatbuffers` but doesn't require the necessary file).

I'm far from an expert in any of this so I'm trying to learn why the current module approach was chosen (with the extra .flatbuffers needed after the require) and whether or not this change will be safe.

@gwvo suggested this PR to gather feedback from @evanw and @evolutional Thanks!