### PR TITLE
Improve javascript module export to work for browser or server.

### DIFF
--- a/js/flatbuffers.js
+++ b/js/flatbuffers.js
@@ -1101,8 +1101,17 @@ flatbuffers.ByteBuffer.prototype.__has_identifier = function(ident) {
   return true;
 };
 
-// Exports for Node.js and RequireJS
-this.flatbuffers = flatbuffers;
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+  module.exports = flatbuffers;
+} else {
+  if (typeof define === 'function' && define.amd) {
+    define([], function() {
+      return flatbuffers;
+    });
+  } else {
+    window.flatbuffers = flatbuffers;
+  }
+}
 
 /// @endcond
 /// @}

--- a/tests/JavaScriptTest.js
+++ b/tests/JavaScriptTest.js
@@ -2,7 +2,7 @@
 var assert = require('assert');
 var fs = require('fs');
 
-var flatbuffers = require('../js/flatbuffers').flatbuffers;
+var flatbuffers = require('../js/flatbuffers');
 var MyGame = require('./monster_test_generated').MyGame;
 
 function main() {


### PR DESCRIPTION
Remove need for extra .flatbuffers after the require statement.

@evanw 2nd attempt.