### PR TITLE
Python: remove ctypes dependency in runtime library.

### DIFF
--- a/python/flatbuffers/encode.py
+++ b/python/flatbuffers/encode.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ctypes
-
 from . import number_types as N
 from . import packer
 from .compat import memoryview_type

--- a/python/flatbuffers/number_types.py
+++ b/python/flatbuffers/number_types.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ctypes
 import collections
 import struct
-from ctypes import sizeof
 
 from . import packer
 


### PR DESCRIPTION
Fixes #3756 