### PR TITLE
Javascript helper to get typed array views

### DIFF
--- a/tests/JavaScriptTest.js
+++ b/tests/JavaScriptTest.js
@@ -122,21 +122,23 @@ function testUnicode() {
   var json = JSON.parse(fs.readFileSync('unicode_test.json', 'utf8'));
 
   // Test reading
-  var bb = new flatbuffers.ByteBuffer(new Uint8Array(correct));
-  var monster = MyGame.Example.Monster.getRootAsMonster(bb);
-  assert.strictEqual(monster.name(), json.name);
-  assert.deepEqual(new Buffer(monster.name(flatbuffers.Encoding.UTF8_BYTES)), new Buffer(json.name));
-  assert.strictEqual(monster.testarrayoftablesLength(), json.testarrayoftables.length);
-  json.testarrayoftables.forEach(function(table, i) {
-    var value = monster.testarrayoftables(i);
-    assert.strictEqual(value.name(), table.name);
-    assert.deepEqual(new Buffer(value.name(flatbuffers.Encoding.UTF8_BYTES)), new Buffer(table.name));
-  });
-  assert.strictEqual(monster.testarrayofstringLength(), json.testarrayofstring.length);
-  json.testarrayofstring.forEach(function(string, i) {
-    assert.strictEqual(monster.testarrayofstring(i), string);
-    assert.deepEqual(new Buffer(monster.testarrayofstring(i, flatbuffers.Encoding.UTF8_BYTES)), new Buffer(string));
-  });
+  function testReadingUnicode(bb) {
+    var monster = MyGame.Example.Monster.getRootAsMonster(bb);
+    assert.strictEqual(monster.name(), json.name);
+    assert.deepEqual(new Buffer(monster.name(flatbuffers.Encoding.UTF8_BYTES)), new Buffer(json.name));
+    assert.strictEqual(monster.testarrayoftablesLength(), json.testarrayoftables.length);
+    json.testarrayoftables.forEach(function(table, i) {
+      var value = monster.testarrayoftables(i);
+      assert.strictEqual(value.name(), table.name);
+      assert.deepEqual(new Buffer(value.name(flatbuffers.Encoding.UTF8_BYTES)), new Buffer(table.name));
+    });
+    assert.strictEqual(monster.testarrayofstringLength(), json.testarrayofstring.length);
+    json.testarrayofstring.forEach(function(string, i) {
+      assert.strictEqual(monster.testarrayofstring(i), string);
+      assert.deepEqual(new Buffer(monster.testarrayofstring(i, flatbuffers.Encoding.UTF8_BYTES)), new Buffer(string));
+    });
+  }
+  testReadingUnicode(new flatbuffers.ByteBuffer(new Uint8Array(correct)));
 
   // Test writing
   var fbb = new flatbuffers.Builder();
@@ -156,7 +158,7 @@ function testUnicode() {
   MyGame.Example.Monster.addTestarrayoftables(fbb, testarrayoftablesOffset);
   MyGame.Example.Monster.addName(fbb, name);
   MyGame.Example.Monster.finishMonsterBuffer(fbb, MyGame.Example.Monster.endMonster(fbb));
-  assert.deepEqual(new Buffer(fbb.asUint8Array()), correct);
+  testReadingUnicode(new flatbuffers.ByteBuffer(fbb.asUint8Array()));
 }
 
 var __imul = Math.imul ? Math.imul : function(a, b) {

--- a/tests/JavaScriptTest.js
+++ b/tests/JavaScriptTest.js
@@ -105,6 +105,13 @@ function testBuffer(bb) {
   }
   assert.strictEqual(invsum, 10);
 
+  var invsum2 = 0;
+  var invArr = monster.inventoryArray();
+  for (var i = 0; i < invArr.length; i++) {
+    invsum2 += invArr[i];
+  }
+  assert.strictEqual(invsum2, 10);
+
   var test_0 = monster.test4(0);
   var test_1 = monster.test4(1);
   assert.strictEqual(monster.test4Length(), 2);

--- a/tests/monster_test_generated.js
+++ b/tests/monster_test_generated.js
@@ -448,6 +448,14 @@ MyGame.Example.Monster.prototype.inventoryLength = function() {
 };
 
 /**
+ * @returns {Uint8Array}
+ */
+MyGame.Example.Monster.prototype.inventoryArray = function() {
+  var offset = this.bb.__offset(this.bb_pos, 14);
+  return offset ? new Uint8Array(this.bb.bytes().buffer, this.bb.__vector(this.bb_pos + offset), this.bb.__vector_len(this.bb_pos + offset)) : null;
+};
+
+/**
  * @returns {MyGame.Example.Color}
  */
 MyGame.Example.Monster.prototype.color = function() {
@@ -556,6 +564,14 @@ MyGame.Example.Monster.prototype.testnestedflatbufferLength = function() {
 };
 
 /**
+ * @returns {Uint8Array}
+ */
+MyGame.Example.Monster.prototype.testnestedflatbufferArray = function() {
+  var offset = this.bb.__offset(this.bb_pos, 30);
+  return offset ? new Uint8Array(this.bb.bytes().buffer, this.bb.__vector(this.bb_pos + offset), this.bb.__vector_len(this.bb_pos + offset)) : null;
+};
+
+/**
  * @param {MyGame.Example.Stat=} obj
  * @returns {MyGame.Example.Stat}
  */
@@ -651,6 +667,14 @@ MyGame.Example.Monster.prototype.testarrayofbools = function(index) {
 MyGame.Example.Monster.prototype.testarrayofboolsLength = function() {
   var offset = this.bb.__offset(this.bb_pos, 52);
   return offset ? this.bb.__vector_len(this.bb_pos + offset) : 0;
+};
+
+/**
+ * @returns {Int8Array}
+ */
+MyGame.Example.Monster.prototype.testarrayofboolsArray = function() {
+  var offset = this.bb.__offset(this.bb_pos, 52);
+  return offset ? new Int8Array(this.bb.bytes().buffer, this.bb.__vector(this.bb_pos + offset), this.bb.__vector_len(this.bb_pos + offset)) : null;
 };
 
 /**


### PR DESCRIPTION
It's convenient when working with e.g. WebGL APIs to, instead of having to iterate and copy a vector field's elements, directly grab a typed array view representing the vector field.