### PR TITLE
Allow builds on platforms with unsigned chars by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,12 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -Wunused-result -Werror=unused-result")
   endif()
+
+  # Certain platforms such as ARM do not use signed chars by default
+  # which causes issues with certain bounds checks.
+  set(CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -fsigned-char")
+
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -std=c++0x -stdlib=libc++ -Wall -pedantic -Werror -Wextra")
@@ -93,6 +99,12 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     set(CMAKE_EXE_LINKER_FLAGS
         "${CMAKE_EXE_LINKER_FLAGS} -lc++abi")
   endif()
+
+  # Certain platforms such as ARM do not use signed chars by default
+  # which causes issues with certain bounds checks.
+  set(CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -fsigned-char")
+
 endif()
 
 if(FLATBUFFERS_CODE_COVERAGE)


### PR DESCRIPTION
Certain architectures, such as ARM, use unsigned chars by default
so require the `-fsigned-char` for certain value comparisons to
make sense and in order to compile.