### PR TITLE
Fixed missing -lc++abi on FreeBSD.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,10 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -std=c++0x -stdlib=libc++ -Wall -pedantic -Werror -Wextra")
-  set(CMAKE_EXE_LINKER_FLAGS
-      "${CMAKE_EXE_LINKER_FLAGS} -lc++abi")
+  if(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
+    set(CMAKE_EXE_LINKER_FLAGS
+        "${CMAKE_EXE_LINKER_FLAGS} -lc++abi")
+  endif()
 endif()
 
 if(FLATBUFFERS_CODE_COVERAGE)


### PR DESCRIPTION
Ref: https://github.com/google/flatbuffers/issues/3792