### PR TITLE
Fix CreateString with already-encoded string or bytearray in Python 2.7.

### DIFF
--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -401,7 +401,7 @@ class Builder(object):
 
         if isinstance(s, compat.string_types):
             x = s.encode(encoding, errors)
-        elif isinstance(s, compat.binary_type):
+        elif isinstance(s, compat.binary_types):
             x = s
         else:
             raise TypeError("non-string passed to CreateString")

--- a/python/flatbuffers/compat.py
+++ b/python/flatbuffers/compat.py
@@ -11,13 +11,16 @@ PY34 = sys.version_info[0:2] >= (3, 4)
 
 if PY3:
     string_types = (str,)
-    binary_type = bytes
+    binary_types = (bytes,bytearray)
     range_func = range
     memoryview_type = memoryview
     struct_bool_decl = "?"
 else:
-    string_types = (basestring,)
-    binary_type = str
+    string_types = (unicode,)
+    if PY26 or PY27:
+        binary_types = (str,bytearray)
+    else:
+        binary_types = (str,)
     range_func = xrange
     if PY26 or (PY27 and not PY275):
         memoryview_type = buffer


### PR DESCRIPTION
There was no way to pass an already-encoded string to 
`builder.CreateString` in Python 2.7:

- Passing a `bytearray` raised a TypeError because `bytearray` was not
  recognized as an instance of `compat.binary_type`.
- Passing a utf-8 encoded `str` would cause the string to be
  double-encoded, because `compat.string_types = (basestring,)` and
  `basestring` is the base class of `str` and `unicode`, so the logic
  would never reach the `elif isinstance(s, compat.binary_type)` case.
- Converting a utf-8 encoded bytearray to `bytes` like
  `builder.CreateString(bytes(encoded_string))` does not work because
  in Python 2.7, bytes is just an alias for `str` so it behaves as
  above.

This change allows either `bytes` or `bytearray` as an already-encoded
string to be passed to `CreateString` in versions of Python that support
`bytearray`, and falls back to `str` in older versions.

In Python 2, it restricts unencoded string types to `unicode`, so `str`
can be used as an encoded, binary representaiton.