### PR TITLE
Fix build on Cygwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,15 @@ if(APPLE)
   set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++ -Wall -pedantic -Werror -Wextra")
 elseif(CMAKE_COMPILER_IS_GNUCXX)
+  if(CYGWIN)
+    set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -std=gnu++11")
+  else(CYGWIN)
+    set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -std=c++0x")
+  endif(CYGWIN)
   set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -pedantic -Werror -Wextra -Werror=shadow")
+    "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror -Wextra -Werror=shadow")
   if (GCC_VERSION VERSION_GREATER 4.4)
     set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -Wunused-result -Werror=unused-result")


### PR DESCRIPTION
use `-std=gnu++11` instead of `c++0x` on cygwin to avoid
`error: realpath was not declared in this scope`

ref http://www.cygwin.com/ml/cygwin/2016-03/msg00005.html