### PR TITLE
Remove unnecessary condition in AssertOffsetAndLength.

### DIFF
--- a/net/FlatBuffers/ByteBuffer.cs
+++ b/net/FlatBuffers/ByteBuffer.cs
@@ -129,8 +129,7 @@ namespace FlatBuffers
         private void AssertOffsetAndLength(int offset, int length)
         {
             if (offset < 0 ||
-                offset >= _buffer.Length ||
-                offset + length > _buffer.Length)
+                offset > _buffer.Length - length)
                 throw new ArgumentOutOfRangeException();
         }
 


### PR DESCRIPTION
Condition is already checked and covered in the following condition, the second one was excess.

As discussed in issue #3837