### PR TITLE
Transition 1 : BaseGenerator class for general, cpp and go code gener…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ if(NOT FLATBUFFERS_BUILD_FLATC AND FLATBUFFERS_BUILD_TESTS)
 endif()
 
 set(FlatBuffers_Library_SRCS
+  include/flatbuffers/code_generators.h
   include/flatbuffers/flatbuffers.h
   include/flatbuffers/hash.h
   include/flatbuffers/idl.h

--- a/include/flatbuffers/code_generators.h
+++ b/include/flatbuffers/code_generators.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLATBUFFERS_CODE_GENERATORS_H_
+#define FLATBUFFERS_CODE_GENERATORS_H_
+
+#include <set>
+#include <stack>
+#include "flatbuffers/util.h"
+
+/** This file defines some classes, that code generators should extend to gain
+   common functionalities :
+
+   BaseGenerator is the base class for all (binary, textual, strongly typed,
+   dynamically typed, whatever) generators.
+   It is really abstract, general and flexible and doesn't do much appart from
+   holding the parser, a path and a filename being processed.
+   Still, it brings a common structure (normalization) among generators
+
+   The many advantages of object based generators will come later from   :
+
+   A) the CodeWriter class (semi-automatic indentation (python), semi-automatic
+   (C++) namespace scopes, export to different files (classic, top level
+   methods),
+   simpler code to generate string from things (comments (vector of strings),
+   indentation commands (TAB BAT), newlines (NL), numbers, const char* or
+   std::string)
+
+   B) the Generator subclass (heritance for supporting different versions of a
+   language, avoid field name clash, write text/binary to file, types
+   management,
+   common computations and sctructures :  enum analysis (function, array, map,
+   ordered list + binarysearch),...)
+
+*/
+namespace flatbuffers {
+
+class BaseGenerator {
+public:
+  BaseGenerator(const Parser &parser_, const std::string &path_,
+                const std::string &file_name_)
+      : parser(parser_), path(path_), file_name(file_name_){};
+  virtual bool generate() = 0;
+
+protected:
+  virtual ~BaseGenerator(){};
+
+  const Parser &parser;
+  const std::string &path;
+  const std::string &file_name;
+};
+
+} // namespace flatbuffers
+
+#endif // FLATBUFFERS_CODE_GENERATORS_H_

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -19,6 +19,7 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
+#include "flatbuffers/code_generators.h"
 #include <algorithm>
 
 namespace flatbuffers {
@@ -1146,11 +1147,15 @@ static bool SaveClass(const LanguageParameters &lang, const Parser &parser,
   return SaveFile(filename.c_str(), code, false);
 }
 
-bool GenerateGeneral(const Parser &parser,
-                     const std::string &path,
-                     const std::string & file_name) {
-
-  assert(parser.opts.lang <= IDLOptions::kMAX);
+/** it'll be split later in java/csharp... and moved to separate files */
+namespace general {
+  /** members methods signature will be simpler as they won't have to pass parser, filename & path */
+  /** more features coming through the JavaGenerator, CSharpGenerator ...*/
+  class GeneralGenerator : public BaseGenerator {
+  public:
+    GeneralGenerator(const Parser &parser_, const std::string &path_, const std::string &file_name_) : BaseGenerator(parser_, path_, file_name_){};
+    bool generate() {
+     assert(parser.opts.lang <= IDLOptions::kMAX);
   auto lang = language_parameters[parser.opts.lang];
   std::string one_file_code;
 
@@ -1184,6 +1189,16 @@ bool GenerateGeneral(const Parser &parser,
     return SaveClass(lang, parser, file_name, one_file_code,path, true, true);
   }
   return true;
+    }
+  };
+} // namespace general
+
+bool GenerateGeneral(const Parser &parser,
+                     const std::string &path,
+                     const std::string & file_name) {
+  general::GeneralGenerator *generator =
+      new general::GeneralGenerator(parser, path, file_name);
+  return generator->generate();
 }
 
 static std::string ClassFileName(const LanguageParameters &lang,


### PR DESCRIPTION
First (baby) step towards class backed code generators : 

Instead of calling the code generator with a function, create an object that holds const parameters. This doesn't change much but is really flexible (no loss of generality) and code generators writers that use this won't need to pass those argument in every method

Next : move the methods into a LanguageGenerator class that extends BaseGenerator (and some interfaces to get common methods for free), and remove the useless duplicated stuff