### PR TITLE
Fix undefined behavior when CheckBitsFit left-shifts 64-bit value by 64 bits

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -819,6 +819,33 @@ void EnumStringsTest() {
                         "{ F:[ \"E.C\", \"E.A E.B E.C\" ] }"), true);
 }
 
+void IntegerOutOfRangeTest() {
+  TestError("table T { F:byte; } root_type T; { F:256 }",
+            "constant does not fit");
+  TestError("table T { F:byte; } root_type T; { F:-257 }",
+            "constant does not fit");
+  TestError("table T { F:ubyte; } root_type T; { F:256 }",
+            "constant does not fit");
+  TestError("table T { F:ubyte; } root_type T; { F:-257 }",
+            "constant does not fit");
+  TestError("table T { F:short; } root_type T; { F:65536 }",
+            "constant does not fit");
+  TestError("table T { F:short; } root_type T; { F:-65537 }",
+            "constant does not fit");
+  TestError("table T { F:ushort; } root_type T; { F:65536 }",
+            "constant does not fit");
+  TestError("table T { F:ushort; } root_type T; { F:-65537 }",
+            "constant does not fit");
+  TestError("table T { F:int; } root_type T; { F:4294967296 }",
+            "constant does not fit");
+  TestError("table T { F:int; } root_type T; { F:-4294967297 }",
+            "constant does not fit");
+  TestError("table T { F:uint; } root_type T; { F:4294967296 }",
+            "constant does not fit");
+  TestError("table T { F:uint; } root_type T; { F:-4294967297 }",
+            "constant does not fit");
+}
+
 void UnicodeTest() {
   flatbuffers::Parser parser;
   TEST_EQ(parser.Parse("table T { F:string; }"
@@ -878,6 +905,7 @@ int main(int /*argc*/, const char * /*argv*/[]) {
   ErrorTest();
   ScientificTest();
   EnumStringsTest();
+  IntegerOutOfRangeTest();
   UnicodeTest();
   UnknownFieldsTest();
 


### PR DESCRIPTION
We ran the Clang static analyzer on the flatbuffers codebase, and it found an undefined behavior issue in `Parser::CheckBitsFit()`:

```
flatbuffers/src/idl_parser.cpp:63:3: Calling 'CheckBitsFit'
flatbuffers/src/idl_parser.cpp:51:1: Entered call from 'atot'
flatbuffers/src/idl_parser.cpp:53:42: The result of the '<<' expression is undefined
```

C99 § 6.5.7 says that left-shifting a 64-bit value by 64 or more bits is undefined behavior, so the compiler and optimizer are free to do any crazy shenanigans they want whenever flatbuffers invokes `Parser::CheckBitsFit(val, sizeof(int64_t) * 8)`.

Thankfully, we already had a check for this case—but it was performed after the shift, not before. So, this diff fixes the undefined behavior by moving the check before the shift, so we never shift a 64-bit value 64 or more bits.

I added unit tests to cover the 8, 16, and 32-bit cases, but I found that flatbuffers doesn't currently check for 64-bit overflow (signed or unsigned)—it just relies on `strtoll()`'s clamping behavior.

flatbuffers also currently allows initializing a signed value (say, a `byte`) with an unsigned value (say, `255`). I assume we want to keep that behavior and wrote the tests that way.

I can send a separate pull request to fix either of those issues, but I didn't want to unnecessarily change existing behavior in this diff.