### PR TITLE
Added helpers to access objects while creating the flatbuffer.

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1151,6 +1151,17 @@ template<typename T> const T *GetRoot(const void *buf) {
   return GetMutableRoot<T>(const_cast<void *>(buf));
 }
 
+/// Helpers to get a typed pointer to objects that are currently beeing built.
+/// @warning Creating new objects will lead to reallocations and invalidates the pointer!
+template<typename T> T *GetMutableObject(FlatBufferBuilder &fbb, Offset<T> offset) {
+  return reinterpret_cast<T *>(fbb.GetCurrentBufferPointer() +
+    fbb.GetSize() - offset.o);
+}
+
+template<typename T> const T *GetObject(FlatBufferBuilder &fbb, Offset<T> offset) {
+  return GetMutableObject<T>(fbb, offset);
+}
+
 // Helper to see if the identifier in a buffer has the expected value.
 inline bool BufferHasIdentifier(const void *buf, const char *identifier) {
   return strncmp(reinterpret_cast<const char *>(buf) + sizeof(uoffset_t),

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1153,13 +1153,13 @@ template<typename T> const T *GetRoot(const void *buf) {
 
 /// Helpers to get a typed pointer to objects that are currently beeing built.
 /// @warning Creating new objects will lead to reallocations and invalidates the pointer!
-template<typename T> T *GetMutableObject(FlatBufferBuilder &fbb, Offset<T> offset) {
+template<typename T> T *GetMutableTemporaryPointer(FlatBufferBuilder &fbb, Offset<T> offset) {
   return reinterpret_cast<T *>(fbb.GetCurrentBufferPointer() +
     fbb.GetSize() - offset.o);
 }
 
-template<typename T> const T *GetObject(FlatBufferBuilder &fbb, Offset<T> offset) {
-  return GetMutableObject<T>(fbb, offset);
+template<typename T> const T *GetTemporaryPointer(FlatBufferBuilder &fbb, Offset<T> offset) {
+  return GetMutableTemporaryPointer<T>(fbb, offset);
 }
 
 // Helper to see if the identifier in a buffer has the expected value.


### PR DESCRIPTION
GetObject and GetMutableObject are similar to GetRoot and GetMutableRoot,
and can be useful when wanting to access data that has just been created.
Unfortunately there is a danger in using these methods, as it is possible
that the buffer reallocates which will invalidate the pointers.

I have tested this with messages that contain over a million tables, where I
repeatedly access data after I have added some nodes.