### PR TITLE
Remove Remaining FBB#createString Allocation

### DIFF
--- a/java/com/google/flatbuffers/FlatBufferBuilder.java
+++ b/java/com/google/flatbuffers/FlatBufferBuilder.java
@@ -368,7 +368,8 @@ public class FlatBufferBuilder {
     /// @endcond
 
    /**
-    * Encode the string `s` in the buffer using UTF-8.
+    * Encode the string `s` in the buffer using UTF-8.  If {@code s} is
+    * already a {@link CharBuffer}, this method is allocation free.
     *
     * @param s The string to encode.
     * @return The offset in the buffer where the encoded string starts.

--- a/java/com/google/flatbuffers/FlatBufferBuilder.java
+++ b/java/com/google/flatbuffers/FlatBufferBuilder.java
@@ -382,7 +382,8 @@ public class FlatBufferBuilder {
 
         dst.clear();
 
-        CharBuffer src = CharBuffer.wrap(s);
+        CharBuffer src = s instanceof CharBuffer ? (CharBuffer) s :
+            CharBuffer.wrap(s);
         CoderResult result = encoder.encode(src, dst, true);
         if (result.isError()) {
             try {


### PR DESCRIPTION
If a user passes in a ``CharBuffer`` himself, reward him by eliminating the last remaining allocation in string creation.