### PR TITLE
MSVC doesn't allow alignment on function params.

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -333,7 +333,7 @@ public:
 
   // Change elements if you have a non-const pointer to this object.
   // Scalars only. See reflection.h, and the documentation.
-  void Mutate(uoffset_t i, T val) {
+  void Mutate(uoffset_t i, const T& val) {
     assert(i < size());
     WriteScalar(data() + i, val);
   }


### PR DESCRIPTION
MSVC doesn't allow alignment on function params. This change avoids copying the object and thus avoids this issue https://msdn.microsoft.com/en-us/library/373ak2y1.aspx

According to MS' documentation for ` __declspec(align(#))`

> The compiler does not guarantee or attempt to preserve the alignment attribute of data during a copy or data transform operation.
https://msdn.microsoft.com/en-us/library/83ythb65.aspx


