### PR TITLE
More bit fields patches

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1509,6 +1509,10 @@ volatile __attribute__((weak)) const char *flatbuffer_version_string =
     inline E operator ^= (E &lhs, E rhs){\
         lhs = lhs ^ rhs;\
         return lhs;\
+    }\
+    inline bool operator !(E rhs) \
+    {\
+        return !bool(T(rhs)); \
     }
 /// @endcond
 }  // namespace flatbuffers

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1485,21 +1485,17 @@ volatile __attribute__((weak)) const char *flatbuffer_version_string =
 
 #endif  // !defined(_WIN32) && !defined(__CYGWIN__)
 
-#define DEFINE_BITMASK_OPERATORS(E)\
+#define DEFINE_BITMASK_OPERATORS(E, T)\
     inline E operator | (E lhs, E rhs){\
-        using T = std::underlying_type<E>::type;\
         return E(T(lhs) | T(rhs));\
     }\
     inline E operator & (E lhs, E rhs){\
-        using T = std::underlying_type<E>::type;\
         return E(T(lhs) & T(rhs));\
     }\
     inline E operator ^ (E lhs, E rhs){\
-        using T = std::underlying_type<E>::type;\
         return E(T(lhs) ^ T(rhs));\
     }\
     inline E operator ~ (E lhs){\
-        using T = std::underlying_type<E>::type;\
         return E(~T(lhs));\
     }\
     inline E operator |= (E &lhs, E rhs){\

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -184,7 +184,7 @@ static void GenEnum(const Parser &parser, EnumDef &enum_def,
   code += GenEnumVal(enum_def, maxv->name, parser.opts) + "\n";
   code += "};\n";
   if (parser.opts.scoped_enums && enum_def.attributes.Lookup("bit_flags"))
-    code += "DEFINE_BITMASK_OPERATORS(" + enum_def.name + ")\n";
+    code += "DEFINE_BITMASK_OPERATORS(" + enum_def.name + ", " +  GenTypeBasic(enum_def.underlying_type, false) + ")\n";
   code += "\n";
 
   // Generate a generate string table for enum values.

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -179,17 +179,19 @@ static void GenEnum(const Parser &parser, EnumDef &enum_def,
     maxv = !maxv || maxv->value < ev.value ? &ev : maxv;
     anyv |= ev.value;
   }
-  assert(minv && maxv);
-  if (enum_def.attributes.Lookup("bit_flags")) {
-    if (minv->value != 0) // If the user didn't defined NONE value
-      code += "  " + GenEnumVal(enum_def, "NONE", parser.opts) + " = 0,\n";
-    if (maxv->value != anyv) // If the user didn't defined ANY value
-      code += "  " + GenEnumVal(enum_def, "ANY", parser.opts) + " = " + NumToString(anyv) + "\n";
-  } else { // MIN & MAX are useless for bit_flags
-    code += "  " + GenEnumVal(enum_def, "MIN", parser.opts) + " = ";
-    code += GenEnumVal(enum_def, minv->name, parser.opts) + ",\n";
-    code += "  " + GenEnumVal(enum_def, "MAX", parser.opts) + " = ";
-    code += GenEnumVal(enum_def, maxv->name, parser.opts) + "\n";
+  if (parser.opts.scoped_enums || parser.opts.prefixed_enums) {
+    assert(minv && maxv);
+    if (enum_def.attributes.Lookup("bit_flags")) {
+      if (minv->value != 0) // If the user didn't defined NONE value
+        code += "  " + GenEnumVal(enum_def, "NONE", parser.opts) + " = 0,\n";
+      if (maxv->value != anyv) // If the user didn't defined ANY value
+        code += "  " + GenEnumVal(enum_def, "ANY", parser.opts) + " = " + NumToString(anyv) + "\n";
+    } else { // MIN & MAX are useless for bit_flags
+      code += "  " + GenEnumVal(enum_def, "MIN", parser.opts) + " = ";
+      code += GenEnumVal(enum_def, minv->name, parser.opts) + ",\n";
+      code += "  " + GenEnumVal(enum_def, "MAX", parser.opts) + " = ";
+      code += GenEnumVal(enum_def, maxv->name, parser.opts) + "\n";
+    }
   }
   code += "};\n";
   if (parser.opts.scoped_enums && enum_def.attributes.Lookup("bit_flags"))


### PR DESCRIPTION
- remove std::underlying_type<E>::type
- add ! operator
- add NONE & ANY enum values to bit_fields enums and remove MIN & MAX ones
- don't generate MIN & MAX enum values if "--no-prefix" is used