### PR TITLE
Fix for make

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -39,8 +39,8 @@ class CppGenerator : public BaseGenerator {
  public:
   CppGenerator(const Parser &parser, const std::string &path,
                const std::string &file_name)
-      : BaseGenerator(parser, path, file_name, "", "::"), 
-      cur_name_space_(nullptr){};
+      : BaseGenerator(parser, path, file_name, "", "::"),
+        cur_name_space_(nullptr){};
   // Iterate through all definitions we haven't generate code for (enums,
   // structs,
   // and tables) and output them to a single file.

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -39,7 +39,8 @@ class CppGenerator : public BaseGenerator {
  public:
   CppGenerator(const Parser &parser, const std::string &path,
                const std::string &file_name)
-      : BaseGenerator(parser, path, file_name, "", "::"){};
+      : BaseGenerator(parser, path, file_name, "", "::"), 
+      cur_name_space_(nullptr){};
   // Iterate through all definitions we haven't generate code for (enums,
   // structs,
   // and tables) and output them to a single file.
@@ -206,7 +207,7 @@ class CppGenerator : public BaseGenerator {
 
  private:
   // This tracks the current namespace so we can insert namespace declarations.
-  const Namespace *cur_name_space_ = nullptr;
+  const Namespace *cur_name_space_;
 
   const Namespace *CurrentNameSpace() { return cur_name_space_; }
 


### PR DESCRIPTION
Working to fix issue https://github.com/google/flatbuffers/issues/3926

I'm affraid that the first commit change will only fix the error for idl_gen_cpp.cpp.

There are probably other places in the new class where this kind of instanciation will break old versions of make...  in idl_gen_general.cpp, for example, we have : 
    const LanguageParameters & lang_ = language_parameters[parser_.opts.lang];
I guessed that it should be moved to the constructor too (but I'll wait for feedback first before doing that)

@gwvo Should I fix all such instanciations in all files ? 
