### PR TITLE
Fixed bug with negative hex constants (2).

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -423,6 +423,12 @@ CheckedError Parser::Next() {
           return NoError();
         } else if (isdigit(static_cast<unsigned char>(c)) || c == '-') {
           const char *start = cursor_ - 1;
+          if (c == '-' && *cursor_ == '0' && (cursor_[1] == 'x' || cursor_[1] == 'X')) {
+            ++start;
+            ++cursor_;
+            attribute_.append(&c, &c + 1);
+            c = '0';
+          }
           if (c == '0' && (*cursor_ == 'x' || *cursor_ == 'X')) {
               cursor_++;
               while (isxdigit(static_cast<unsigned char>(*cursor_))) cursor_++;

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -837,6 +837,9 @@ void ValueTest() {
 
   // Test conversion functions.
   TEST_EQ(FloatCompare(TestValue("{ Y:cos(rad(180)) }"), -1), true);
+  
+  // Test negative hex constant.
+  TEST_EQ(TestValue("{ Y:-0x80 }") == -128, true);
 }
 
 void EnumStringsTest() {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -833,7 +833,7 @@ bool FloatCompare(float a, float b) { return fabs(a - b) < 0.001; }
 // Additional parser testing not covered elsewhere.
 void ValueTest() {
   // Test scientific notation numbers.
-  TEST_EQ(FloatCompare(TestValue<float>("{ Y:0.0314159e+2 }"), 3.14159), true);
+  TEST_EQ(FloatCompare(TestValue<float>("{ Y:0.0314159e+2 }"), (float)3.14159), true);
 
   // Test conversion functions.
   TEST_EQ(FloatCompare(TestValue<float>("{ Y:cos(rad(180)) }"), -1), true);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -814,11 +814,11 @@ void ErrorTest() {
   TestError("table X { Y:byte; } root_type X; { Y:1, Y:2 }", "more than once");
 }
 
-template<typename T> T TestValue(const char *json) {
+template<typename T> T TestValue(const char *json, const char *type_name) {
   flatbuffers::Parser parser;
 
   // Simple schema.
-  TEST_EQ(parser.Parse(std::string("table X { Y:" + std::string(typeid(T).name()) + "; } root_type X;").c_str()), true);
+  TEST_EQ(parser.Parse(std::string("table X { Y:" + std::string(type_name) + "; } root_type X;").c_str()), true);
 
   TEST_EQ(parser.Parse(json), true);
   auto root = flatbuffers::GetRoot<T>(parser.builder_.GetBufferPointer());
@@ -833,13 +833,13 @@ bool FloatCompare(float a, float b) { return fabs(a - b) < 0.001; }
 // Additional parser testing not covered elsewhere.
 void ValueTest() {
   // Test scientific notation numbers.
-  TEST_EQ(FloatCompare(TestValue<float>("{ Y:0.0314159e+2 }"), (float)3.14159), true);
+  TEST_EQ(FloatCompare(TestValue<float>("{ Y:0.0314159e+2 }","float"), (float)3.14159), true);
 
   // Test conversion functions.
-  TEST_EQ(FloatCompare(TestValue<float>("{ Y:cos(rad(180)) }"), -1), true);
+  TEST_EQ(FloatCompare(TestValue<float>("{ Y:cos(rad(180)) }","float"), -1), true);
   
   // Test negative hex constant.
-  TEST_EQ(TestValue<int>("{ Y:-0x80 }") == -128, true);
+  TEST_EQ(TestValue<int>("{ Y:-0x80 }","int") == -128, true);
 }
 
 void EnumStringsTest() {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -814,14 +814,14 @@ void ErrorTest() {
   TestError("table X { Y:byte; } root_type X; { Y:1, Y:2 }", "more than once");
 }
 
-float TestValue(const char *json) {
+template<typename T> T TestValue(const char *json) {
   flatbuffers::Parser parser;
 
   // Simple schema.
-  TEST_EQ(parser.Parse("table X { Y:float; } root_type X;"), true);
+  TEST_EQ(parser.Parse(std::string("table X { Y:" + std::string(typeid(T).name()) + "; } root_type X;").c_str()), true);
 
   TEST_EQ(parser.Parse(json), true);
-  auto root = flatbuffers::GetRoot<float>(parser.builder_.GetBufferPointer());
+  auto root = flatbuffers::GetRoot<T>(parser.builder_.GetBufferPointer());
   // root will point to the table, which is a 32bit vtable offset followed
   // by a float:
   TEST_EQ(sizeof(flatbuffers::soffset_t), 4);  // Test assumes 32bit offsets
@@ -833,13 +833,13 @@ bool FloatCompare(float a, float b) { return fabs(a - b) < 0.001; }
 // Additional parser testing not covered elsewhere.
 void ValueTest() {
   // Test scientific notation numbers.
-  TEST_EQ(FloatCompare(TestValue("{ Y:0.0314159e+2 }"), 3.14159), true);
+  TEST_EQ(FloatCompare(TestValue<float>("{ Y:0.0314159e+2 }"), 3.14159), true);
 
   // Test conversion functions.
-  TEST_EQ(FloatCompare(TestValue("{ Y:cos(rad(180)) }"), -1), true);
+  TEST_EQ(FloatCompare(TestValue<float>("{ Y:cos(rad(180)) }"), -1), true);
   
   // Test negative hex constant.
-  TEST_EQ(TestValue("{ Y:-0x80 }") == -128, true);
+  TEST_EQ(TestValue<int>("{ Y:-0x80 }") == -128, true);
 }
 
 void EnumStringsTest() {


### PR DESCRIPTION
Fixed bug, described in [#3807](https://github.com/google/flatbuffers/issues/3807).