### PR TITLE
[PHP] Use mb_detect_encoding when available

### DIFF
--- a/php/FlatbufferBuilder.php
+++ b/php/FlatbufferBuilder.php
@@ -593,6 +593,10 @@ class FlatbufferBuilder
 
     protected function is_utf8($bytes)
     {
+        if (function_exists('mb_detect_encoding')) {
+            return (bool) mb_detect_encoding($bytes, 'UTF-8', true);
+        }
+    
         $len = strlen($bytes);
         if ($len < 1) {
             /* NOTE: always return 1 when passed string is null */


### PR DESCRIPTION
I've faced an issue where I want to serialize UTF-8 emojis and FlatBufferBuilder::is_utf8 would return false on them.
I was not able to add the corresponding hexadecimal code because I don't understand how the whole thing works but what i've done is using the `mb_detect_encoding` function which handles correctly all supposed UTF-8 characters.
