### PR TITLE
Non smart pointers --gen-object-api version

### DIFF
--- a/docs/source/CppUsage.md
+++ b/docs/source/CppUsage.md
@@ -99,11 +99,19 @@ construction, access and mutation.
 To use:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-    auto monsterobj = GetMonster(buffer)->UnPack();
-    cout << monsterobj->name;  // This is now a std::string!
-    monsterobj->name = "Bob";  // Change the name.
+    MonsterT monsterobj(GetMonster(buffer));
+    cout << monsterobj.name;  // This is now a std::string!
+    monsterobj.name = "Bob";  // Change the name.
     FlatBufferBuilder fbb;
-    CreateMonster(fbb, monsterobj.get());     // Serialize into new buffer.
+    monsterobj.Pack(fbb);     // Serialize into new buffer.
+
+    // You can even copy one struct to another
+    MonsterT another; // Create another monster
+    another = monsterobj; // Copy the original monster
+    another.name = "Good monster"; // Change only the name
+    FlatBufferBuilder fbb1;
+    another.Pack(fbb1);     // Serialize into new buffer.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ## Reflection (& Resizing)

--- a/include/flatbuffers/code_generators.h
+++ b/include/flatbuffers/code_generators.h
@@ -100,16 +100,16 @@ class BaseGenerator {
 
   // Ensure that a type is prefixed with its namespace whenever it is used
   // outside of its namespace.
-  std::string WrapInNameSpace(const Namespace *ns, const std::string &name) {
-    if (CurrentNameSpace() == ns) return name;
+  std::string WrapInNameSpace(const Namespace *ns, const std::string &name, bool forceFullyQualifiedNamesapce = false) {
+    if (!forceFullyQualifiedNamesapce && CurrentNameSpace() == ns) return name;
     std::string qualified_name = qualifying_start_;
     for (auto it = ns->components.begin(); it != ns->components.end(); ++it)
       qualified_name += *it + qualifying_separator_;
     return qualified_name + name;
   }
 
-  std::string WrapInNameSpace(const Definition &def) {
-    return WrapInNameSpace(def.defined_namespace, def.name);
+  std::string WrapInNameSpace(const Definition &def, bool forceFullyQualifiedNamesapce = false) {
+    return WrapInNameSpace(def.defined_namespace, def.name, forceFullyQualifiedNamesapce);
   }
 
   const Parser &parser_;

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1693,9 +1693,9 @@ public:
 
   inline operator bool() const { return val_; }
 
-  inline const T *get() const { return val_; }
-  inline operator const T * () const { return val_; }
-  inline const T * operator ->() const { return val_; }
+  inline T *get() const { return val_; }
+  inline operator T * () const { return val_; }
+  inline T * operator ->() const { return val_; }
 
   inline T *create() { delete val_; val_ = new T(); return val_; }
   inline void release() { delete val_; val_ = nullptr; }

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1565,6 +1565,83 @@ class Table {
 struct NativeTable {
 };
 
+template<typename T>
+class Optional {
+public:
+  Optional() : val_(nullptr) {}
+  Optional(T *val) : val_(val) {}
+  Optional(const T &other) : val_(new T(other)) {}
+  Optional(const Optional<T> &other) {
+    if (other)
+      val_ = new T(*other.val_);
+    else
+      val_ = nullptr;
+  }
+  ~Optional() { delete val_;}
+
+  inline operator bool() const { return val_; }
+
+  inline const T *get() const { return val_; }
+  inline operator const T * () const { return val_; }
+  inline const T * operator ->() const { return val_; }
+  inline T * operator ->() { return val_; }
+
+  inline T *create() { delete val_; val_ = new T(); return val_; }
+  inline void release() { delete val_; val_ = nullptr; }
+
+  inline Optional &operator =(const Optional<T> &other) {
+    if (!other) {
+      release();
+      return *this;
+    }
+    if (!val_)
+      val_ = new T(*other.val_);
+    else
+      *val_ = *other.val_;
+    return *this;
+  }
+
+  inline Optional &operator =(const T &other) {
+    if (!val_)
+      val_ = new T(other);
+    else
+      *val_ = other;
+    return *this;
+  }
+
+  inline Optional &operator =(const T *other) {
+    if (!other) {
+      release();
+      return *this;
+    }
+
+    if (!val_)
+      val_ = new T(*other);
+    else
+      *val_ = *other;
+    return *this;
+  }
+
+protected:
+  T *val_;
+};
+
+template<typename T, typename S>
+class OptionalTable : public Optional<T> {
+public:
+  using Optional<T>::operator=;
+  inline OptionalTable &operator =(const S *other) {
+    if (!other) {
+      this->release();
+      return *this;
+    }
+    if (!this->val_)
+      this->val_ = new T(other);
+    else
+      *(this->val_) = other;
+    return *this;
+  }
+};
 // Helper function to test if a field is present, using any of the field
 // enums in the generated code.
 // `table` must be a generated table type. Since this is a template parameter,

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -198,7 +198,7 @@ struct Namespace {
   // With max_components you can request less than the number of components
   // the current namespace has.
   std::string GetFullyQualifiedName(const std::string &name,
-                                    size_t max_components = 1000) const;
+                                    size_t max_components = 1000, const std::string &separator = ".") const;
 };
 
 // Base class for all definition types (fields, structs_, enums_).
@@ -358,6 +358,9 @@ struct IDLOptions {
   enum CPPVariants { Cpp0x, Cpp11 };
   CPPVariants cpp_variant;
 
+  enum CPPFramewors { Stl, Qt5 };
+  CPPFramewors cpp_frameowork;
+
   IDLOptions()
     : strict_json(false),
       skip_js_exports(false),
@@ -376,7 +379,8 @@ struct IDLOptions {
       union_value_namespacing(true),
       allow_non_utf8(false),
       lang(IDLOptions::kJava),
-      cpp_variant(IDLOptions::Cpp0x){}
+      cpp_variant(IDLOptions::Cpp0x),
+      cpp_frameowork(Stl){}
 };
 
 // This encapsulates where the parser is in the current source file.

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -355,6 +355,9 @@ struct IDLOptions {
 
   Language lang;
 
+  enum CPPVariants { Cpp0x, Cpp11 };
+  CPPVariants cpp_variant;
+
   IDLOptions()
     : strict_json(false),
       skip_js_exports(false),
@@ -372,7 +375,8 @@ struct IDLOptions {
       generate_object_based_api(false),
       union_value_namespacing(true),
       allow_non_utf8(false),
-      lang(IDLOptions::kJava) {}
+      lang(IDLOptions::kJava),
+      cpp_variant(IDLOptions::Cpp0x){}
 };
 
 // This encapsulates where the parser is in the current source file.

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -47,10 +47,11 @@ struct EquipmentUnion {
   EquipmentUnion &operator=(const EquipmentUnion &);
   ~EquipmentUnion();
 
-  static flatbuffers::NativeTable *UnPack(const void *union_obj, Equipment type);
+  void UnPack(const void *union_obj, Equipment _t);
   flatbuffers::Offset<void> Pack(flatbuffers::FlatBufferBuilder &_fbb) const;
 
   WeaponT *AsWeapon() { return type == Equipment_Weapon ? reinterpret_cast<WeaponT *>(table) : nullptr; }
+  EquipmentUnion &operator=(const WeaponT &_o);
 };
 
 inline const char **EnumNamesEquipment() {
@@ -82,17 +83,6 @@ MANUALLY_ALIGNED_STRUCT(4) Vec3 FLATBUFFERS_FINAL_CLASS {
   void mutate_z(float _z) { flatbuffers::WriteScalar(&z_, _z); }
 };
 STRUCT_END(Vec3, 12);
-
-struct MonsterT : public flatbuffers::NativeTable {
-  std::unique_ptr<Vec3> pos;
-  int16_t mana;
-  int16_t hp;
-  std::string name;
-  std::vector<uint8_t> inventory;
-  Color color;
-  std::vector<std::unique_ptr<WeaponT>> weapons;
-  EquipmentUnion equipped;
-};
 
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum {
@@ -142,7 +132,27 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyEquipment(verifier, equipped(), equipped_type()) &&
            verifier.EndTable();
   }
-  std::unique_ptr<MonsterT> UnPack() const;
+};
+
+struct MonsterT : public flatbuffers::NativeTable {
+  flatbuffers::Offset<Monster> Pack(flatbuffers::FlatBufferBuilder &_fbb) const;
+  void UnPack(const Monster *object);
+  inline MonsterT& operator=(const Monster *object) { UnPack(object); return *this;}
+  explicit MonsterT(const Monster *object) { UnPack(object); }
+
+  flatbuffers::Optional<Vec3> pos;
+  int16_t mana;
+  int16_t hp;
+  std::string name;
+  std::vector<uint8_t> inventory;
+  Color color;
+  std::vector<WeaponT> weapons;
+  EquipmentUnion equipped;
+  MonsterT()
+    : mana(150)
+    , hp(100)
+    , color(Color_Blue) {}
+
 };
 
 struct MonsterBuilder {
@@ -201,13 +211,6 @@ inline flatbuffers::Offset<Monster> CreateMonsterDirect(flatbuffers::FlatBufferB
   return CreateMonster(_fbb, pos, mana, hp, name ? _fbb.CreateString(name) : 0, inventory ? _fbb.CreateVector<uint8_t>(*inventory) : 0, color, weapons ? _fbb.CreateVector<flatbuffers::Offset<Weapon>>(*weapons) : 0, equipped_type, equipped);
 }
 
-inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o);
-
-struct WeaponT : public flatbuffers::NativeTable {
-  std::string name;
-  int16_t damage;
-};
-
 struct Weapon FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum {
     VT_NAME = 4,
@@ -224,7 +227,19 @@ struct Weapon FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<int16_t>(verifier, VT_DAMAGE) &&
            verifier.EndTable();
   }
-  std::unique_ptr<WeaponT> UnPack() const;
+};
+
+struct WeaponT : public flatbuffers::NativeTable {
+  flatbuffers::Offset<Weapon> Pack(flatbuffers::FlatBufferBuilder &_fbb) const;
+  void UnPack(const Weapon *object);
+  inline WeaponT& operator=(const Weapon *object) { UnPack(object); return *this;}
+  explicit WeaponT(const Weapon *object) { UnPack(object); }
+
+  std::string name;
+  int16_t damage;
+  WeaponT()
+    : damage(0) {}
+
 };
 
 struct WeaponBuilder {
@@ -255,46 +270,49 @@ inline flatbuffers::Offset<Weapon> CreateWeaponDirect(flatbuffers::FlatBufferBui
   return CreateWeapon(_fbb, name ? _fbb.CreateString(name) : 0, damage);
 }
 
-inline flatbuffers::Offset<Weapon> CreateWeapon(flatbuffers::FlatBufferBuilder &_fbb, const WeaponT *_o);
-
-inline std::unique_ptr<MonsterT> Monster::UnPack() const {
-  auto _o = new MonsterT();
-  { auto _e = pos(); if (_e) _o->pos = std::unique_ptr<Vec3>(new Vec3(*_e)); };
-  { auto _e = mana(); _o->mana = _e; };
-  { auto _e = hp(); _o->hp = _e; };
-  { auto _e = name(); if (_e) _o->name = _e->str(); };
-  { auto _e = inventory(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->inventory.push_back(_e->Get(_i)); } } };
-  { auto _e = color(); _o->color = _e; };
-  { auto _e = weapons(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->weapons.push_back(_e->Get(_i)->UnPack()); } } };
-  { auto _e = equipped_type(); _o->equipped.type = _e; };
-  { auto _e = equipped(); if (_e) _o->equipped.table = EquipmentUnion::UnPack(_e, equipped_type()); };
-  return std::unique_ptr<MonsterT>(_o);
+inline void MonsterT::UnPack(const Monster *_o) {
+  pos = _o->pos();
+  mana = _o->mana();
+  hp = _o->hp();
+  name.assign(_o->name()->c_str(), _o->name()->size());
+  inventory.clear();
+  if (_o->inventory()) {
+    inventory.reserve(_o->inventory()->size());
+    for (auto it = _o->inventory()->begin(), __end = _o->inventory()->end(); it != __end; ++it)
+      inventory.push_back((*it));
+  }
+  color = _o->color();
+  weapons.clear();
+  if (_o->weapons()) {
+    weapons.reserve(_o->weapons()->size());
+    for (auto it = _o->weapons()->begin(), __end = _o->weapons()->end(); it != __end; ++it)
+      weapons.push_back(WeaponT((*it)));
+  }
+  equipped.UnPack(_o->equipped(), _o->equipped_type());
 }
 
-inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o) {
+inline flatbuffers::Offset<Monster> MonsterT::Pack(flatbuffers::FlatBufferBuilder &_fbb) const {
   return CreateMonster(_fbb,
-    _o->pos ? _o->pos.get() : 0,
-    _o->mana,
-    _o->hp,
-    _o->name.size() ? _fbb.CreateString(_o->name) : 0,
-    _o->inventory.size() ? _fbb.CreateVector(_o->inventory) : 0,
-    _o->color,
-    _o->weapons.size() ? _fbb.CreateVector<flatbuffers::Offset<Weapon>>(_o->weapons.size(), [&](size_t i) { return CreateWeapon(_fbb, _o->weapons[i].get()); }) : 0,
-    _o->equipped.type,
-    _o->equipped.Pack(_fbb));
+    pos,
+    mana,
+    hp,
+    name.size() ? _fbb.CreateString(name) : 0,
+    inventory.size() ? _fbb.CreateVector(inventory) : 0,
+    color,
+    weapons.size() ? _fbb.CreateVector<flatbuffers::Offset<Weapon>>(weapons.size(), [&](size_t i) { return weapons[i].Pack(_fbb); }) : 0,
+    equipped.type,
+    equipped.Pack(_fbb));
 }
 
-inline std::unique_ptr<WeaponT> Weapon::UnPack() const {
-  auto _o = new WeaponT();
-  { auto _e = name(); if (_e) _o->name = _e->str(); };
-  { auto _e = damage(); _o->damage = _e; };
-  return std::unique_ptr<WeaponT>(_o);
+inline void WeaponT::UnPack(const Weapon *_o) {
+  name.assign(_o->name()->c_str(), _o->name()->size());
+  damage = _o->damage();
 }
 
-inline flatbuffers::Offset<Weapon> CreateWeapon(flatbuffers::FlatBufferBuilder &_fbb, const WeaponT *_o) {
+inline flatbuffers::Offset<Weapon> WeaponT::Pack(flatbuffers::FlatBufferBuilder &_fbb) const {
   return CreateWeapon(_fbb,
-    _o->name.size() ? _fbb.CreateString(_o->name) : 0,
-    _o->damage);
+    name.size() ? _fbb.CreateString(name) : 0,
+    damage);
 }
 
 inline bool VerifyEquipment(flatbuffers::Verifier &verifier, const void *union_obj, Equipment type) {
@@ -305,27 +323,51 @@ inline bool VerifyEquipment(flatbuffers::Verifier &verifier, const void *union_o
   }
 }
 
-inline flatbuffers::NativeTable *EquipmentUnion::UnPack(const void *union_obj, Equipment type) {
-  switch (type) {
-    case Equipment_NONE: return nullptr;
-    case Equipment_Weapon: return reinterpret_cast<const Weapon *>(union_obj)->UnPack().release();
-    default: return nullptr;
+inline void EquipmentUnion::UnPack(const void *union_obj, Equipment _t) {
+  type = _t;
+  delete table;
+  if (!union_obj) { table = nullptr; type = Equipment_NONE; return; }
+  switch (_t) {
+    case Equipment_NONE: table = nullptr; break;
+    case Equipment_Weapon: table = new WeaponT(reinterpret_cast<const Weapon *>(union_obj)); break;
+    default: table = nullptr; type = Equipment_NONE;
   }
 }
 
 inline flatbuffers::Offset<void> EquipmentUnion::Pack(flatbuffers::FlatBufferBuilder &_fbb) const {
   switch (type) {
     case Equipment_NONE: return 0;
-    case Equipment_Weapon: return CreateWeapon(_fbb, reinterpret_cast<const WeaponT *>(table)).Union();
+    case Equipment_Weapon: return static_cast<const WeaponT *>(table)->Pack(_fbb).Union();
     default: return 0;
   }
 }
 
+inline EquipmentUnion::EquipmentUnion(const EquipmentUnion &other) : type(Equipment_NONE), table(nullptr) { *this = other; }
+inline EquipmentUnion& EquipmentUnion::operator=(const EquipmentUnion &other) {
+  type = other.type;
+  delete table;
+  switch (other.type) {
+    case Equipment_Weapon: table = new WeaponT(*(static_cast<WeaponT *>(other.table))); break;
+    default:
+      type = Equipment_NONE;
+      table = nullptr;
+      break;
+  }
+  return *this;
+}
+
 inline EquipmentUnion::~EquipmentUnion() {
   switch (type) {
-    case Equipment_Weapon: delete reinterpret_cast<WeaponT *>(table); break;
-    default:;
+    case Equipment_Weapon: delete static_cast<WeaponT *>(table); break;
+    default: assert(!table); break;
   }
+}
+
+inline EquipmentUnion& EquipmentUnion::operator=(const WeaponT &_o) {
+  type = Equipment_Weapon;
+  delete table;
+  table = new WeaponT(_o);
+  return *this;
 }
 
 inline const MyGame::Sample::Monster *GetMonster(const void *buf) { return flatbuffers::GetRoot<MyGame::Sample::Monster>(buf); }

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -127,6 +127,9 @@ static void Error(const std::string &err, bool usage, bool show_exe_name) {
       "  --gen-name-strings Generate type name functions for C++.\n"
       "  --escape-proto-ids Disable appending '_' in namespaces names.\n"
       "  --gen-object-api   Generate an additional object-based API\n"
+      "  --cpp-variant VAR  What C++ variant to generate code for:\n"
+      "                       c++0x (default): Minimal c++11 functionality at the level of VS2010 / GCC 4.6.2).\n"
+      "                       c++11: Code for a fully compliant c++11 compiler (VS2015 / GCC 4.8).\n"
       "  --raw-binary       Allow binaries without file_indentifier to be read.\n"
       "                     This may crash flatc given a mismatched schema.\n"
       "  --proto            Input is a .proto, translate to .fbs.\n"
@@ -208,6 +211,15 @@ int main(int argc, const char *argv[]) {
         opts.generate_name_strings = true;
       } else if(arg == "--gen-object-api") {
         opts.generate_object_based_api = true;
+      } else if(arg == "--cpp-variant") {
+        if (++argi >= argc) Error("missing param following" + arg, true);
+        arg = std::string(argv[argi]);
+        if (arg == "c++0x")
+            opts.cpp_variant = flatbuffers::IDLOptions::Cpp0x;
+        else if (arg == "c++11")
+            opts.cpp_variant = flatbuffers::IDLOptions::Cpp11;
+        else
+            Error("Invalid cpp variant " + arg, true);
       } else if(arg == "--gen-all") {
         opts.generate_all = true;
         opts.include_dependence_headers = false;

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -130,6 +130,9 @@ static void Error(const std::string &err, bool usage, bool show_exe_name) {
       "  --cpp-variant VAR  What C++ variant to generate code for:\n"
       "                       c++0x (default): Minimal c++11 functionality at the level of VS2010 / GCC 4.6.2).\n"
       "                       c++11: Code for a fully compliant c++11 compiler (VS2015 / GCC 4.8).\n"
+      "  --cpp-framework FR What C++ framework to generate code for:\n"
+      "                       stl (default): uses STL for strings & containers.\n"
+      "                       qt5: use Qt5 strings and add specific macros (Qt 5.8+ is needed).\n"
       "  --raw-binary       Allow binaries without file_indentifier to be read.\n"
       "                     This may crash flatc given a mismatched schema.\n"
       "  --proto            Input is a .proto, translate to .fbs.\n"
@@ -220,6 +223,15 @@ int main(int argc, const char *argv[]) {
             opts.cpp_variant = flatbuffers::IDLOptions::Cpp11;
         else
             Error("Invalid cpp variant " + arg, true);
+      } else if(arg == "--cpp-framework") {
+        if (++argi >= argc) Error("missing param following" + arg, true);
+        arg = std::string(argv[argi]);
+        if (arg == "stl")
+            opts.cpp_frameowork = flatbuffers::IDLOptions::Stl;
+        else if (arg == "qt5")
+            opts.cpp_frameowork = flatbuffers::IDLOptions::Qt5;
+        else
+            Error("Invalid cpp framework " + arg, true);
       } else if(arg == "--gen-all") {
         opts.generate_all = true;
         opts.include_dependence_headers = false;

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -293,29 +293,31 @@ class CppGenerator : public BaseGenerator {
   // TODO(wvo): make this configurable.
   std::string NativeName(const std::string &name) { return name + "T"; }
 
-  std::string GenTypeNative(const Type &type, bool invector) {
+  std::string GenTypeNative(const Type &type) {
     switch (type.base_type) {
       case BASE_TYPE_STRING:
         return "std::string";
       case BASE_TYPE_VECTOR:
-        return "std::vector<" + GenTypeNative(type.VectorType(), true) + ">";
+        return "std::vector<" + GenTypeNative(type.VectorType()) + ">";
       case BASE_TYPE_STRUCT:
         if (IsStruct(type)) {
-          if (invector) {
-            return WrapInNameSpace(*type.struct_def);
-          } else {
-            return "std::unique_ptr<" +
-                   WrapInNameSpace(*type.struct_def) + ">";
-          }
+          return WrapInNameSpace(*type.struct_def);
         } else {
-          return "std::unique_ptr<" +
-                 NativeName(WrapInNameSpace(*type.struct_def)) + ">";
+          return NativeName(WrapInNameSpace(*type.struct_def));
         }
       case BASE_TYPE_UNION:
         return type.enum_def->name + "Union";
       default:
         return GenTypeBasic(type, true);
     }
+  }
+
+  // generate push_back/emplace_back item
+  std::string GenPushBack(const std::string &type, const std::string &params)
+  {
+      if (parser_.opts.cpp_variant != IDLOptions::Cpp0x)
+          return params;
+      return "(" + type + params + ")";
   }
 
   // Return a C++ type for any type (scalar/pointer) specifically for
@@ -335,7 +337,9 @@ class CppGenerator : public BaseGenerator {
 
   static std::string GenEnumVal(const EnumDef &enum_def,
                                 const std::string &enum_val,
-                                const IDLOptions &opts) {
+                                const IDLOptions &opts, bool outside = false) {
+    if (outside && opts.scoped_enums)
+        return enum_def.name + "::" + enum_val;
     return opts.prefixed_enums ? enum_def.name + "_" + enum_val : enum_val;
   }
 
@@ -358,10 +362,9 @@ class CppGenerator : public BaseGenerator {
   }
 
   std::string UnionUnPackSignature(EnumDef &enum_def, bool inclass) {
-    return (inclass ? "static " : "") +
-           std::string("flatbuffers::NativeTable *") +
+    return std::string("void ") +
            (inclass ? "" : enum_def.name + "Union::") +
-           "UnPack(const void *union_obj, " + enum_def.name + " type)";
+           "UnPack(const void *union_obj, " + enum_def.name + " _t)";
   }
 
   std::string UnionPackSignature(EnumDef &enum_def, bool inclass) {
@@ -370,16 +373,14 @@ class CppGenerator : public BaseGenerator {
            "Pack(flatbuffers::FlatBufferBuilder &_fbb) const";
   }
 
-  std::string TableCreateSignature(StructDef &struct_def) {
-    return "inline flatbuffers::Offset<" + struct_def.name + "> Create" +
-           struct_def.name  +
-           "(flatbuffers::FlatBufferBuilder &_fbb, const " +
-           NativeName(struct_def.name) + " *_o)";
+  std::string TablePackSignature(StructDef &struct_def) {
+    return "inline flatbuffers::Offset<" + struct_def.name + "> " +
+            NativeName(struct_def.name) +
+           "::Pack(flatbuffers::FlatBufferBuilder &_fbb) const";
   }
 
-  std::string TableUnPackSignature(StructDef &struct_def, bool inclass) {
-    return "std::unique_ptr<" + NativeName(struct_def.name) + "> " +
-           (inclass ? "" : struct_def.name + "::") + "UnPack() const";
+  std::string TableUnPackSignature(StructDef &struct_def) {
+    return "inline void " + NativeName(struct_def.name) + "::UnPack(const " + struct_def.name + " *_o)";
   }
 
   // Generate an enum declaration and an enum string lookup table.
@@ -429,7 +430,7 @@ class CppGenerator : public BaseGenerator {
       code += "  " + enum_def.name + " type;\n\n";
       code += "  flatbuffers::NativeTable *table;\n";
       code += "  " + enum_def.name + "Union() : type(";
-      code += GenEnumVal(enum_def, "NONE", parser_.opts);
+      code += GenEnumVal(enum_def, "NONE", parser_.opts, true);
       code += "), table(nullptr) {}\n";
       code += "  " + enum_def.name + "Union(const ";
       code += enum_def.name + "Union &);\n";
@@ -448,6 +449,7 @@ class CppGenerator : public BaseGenerator {
           code += GetEnumVal(enum_def, ev, parser_.opts);
           code += " ? reinterpret_cast<" + native_name;
           code += " *>(table) : nullptr; }\n";
+          code += "  " + enum_def.name + "Union &operator=(const " + native_name + " &_o);\n";
         }
       }
       code += "};\n\n";
@@ -514,20 +516,28 @@ class CppGenerator : public BaseGenerator {
     if (parser_.opts.generate_object_based_api) {
       // Generate a union pack & unpack function.
       code += "inline " + UnionUnPackSignature(enum_def, false);
-      code += " {\n  switch (type) {\n";
+      code += " {\n  type = _t;\n  delete table;\n";
+      code += "  if (!union_obj) { table = nullptr; type = ";
+      std::string case_code;
+      std::string  none_enum_name;
       for (auto it = enum_def.vals.vec.begin(); it != enum_def.vals.vec.end();
            ++it) {
         auto &ev = **it;
-        code += "    case " + GetEnumVal(enum_def, ev, parser_.opts);
+        case_code += "    case " + GetEnumVal(enum_def, ev, parser_.opts);
         if (!ev.value) {
-          code += ": return nullptr;\n";  // "NONE" enum value.
+          case_code += ": table = nullptr;";  // "NONE" enum value.
+          none_enum_name = GetEnumVal(enum_def, ev, parser_.opts);
         } else {
-          code += ": return reinterpret_cast<const ";
-          code += WrapInNameSpace(*ev.struct_def);
-          code += " *>(union_obj)->UnPack().release();\n";
+          case_code += ": table = new " + NativeName(WrapInNameSpace(*ev.struct_def));
+          case_code += "(reinterpret_cast<const ";
+          case_code += WrapInNameSpace(*ev.struct_def);
+          case_code += " *>(union_obj));";
         }
+        case_code += " break;\n";
       }
-      code += "    default: return nullptr;\n  }\n}\n\n";
+      code += none_enum_name + "; return; }\n";
+      code += "  switch (_t) {\n" + case_code;
+      code += "    default: table = nullptr; type = " + none_enum_name + ";\n  }\n}\n\n";
       code += "inline " + UnionPackSignature(enum_def, false);
       code += " {\n  switch (type) {\n";
       for (auto it = enum_def.vals.vec.begin(); it != enum_def.vals.vec.end();
@@ -537,29 +547,58 @@ class CppGenerator : public BaseGenerator {
         if (!ev.value) {
           code += ": return 0;\n";  // "NONE" enum value.
         } else {
-          code += ": return Create" + ev.struct_def->name;
-          code += "(_fbb, reinterpret_cast<const ";
+          code += ": return static_cast<const ";
           code += NativeName(WrapInNameSpace(*ev.struct_def));
-          code += " *>(table)).Union();\n";
+          code += " *>(table)->Pack(_fbb).Union();\n";
         }
       }
       code += "    default: return 0;\n  }\n}\n\n";
 
-      // Generate a union destructor.
-      code += "inline " + enum_def.name + "Union::~";
-      code += enum_def.name + "Union() {\n";
-      code += "  switch (type) {\n";
-      for (auto it = enum_def.vals.vec.begin(); it != enum_def.vals.vec.end();
-           ++it) {
-        auto &ev = **it;
-        if (ev.value) {
-          code += "    case " + GenEnumVal(enum_def, ev.name, parser_.opts);
-          code += ": delete reinterpret_cast<";
-          code += NativeName(WrapInNameSpace(*ev.struct_def));
-          code += " *>(table); break;\n";
+      // Generate an union copy constructor and operator=.
+      auto unionTypeName = enum_def.name + "Union";
+      std::string unionDestructor = "inline " + unionTypeName + "::~" + unionTypeName + "() {\n";
+      unionDestructor += "  switch (type) {\n";
+      code += "inline " + unionTypeName + "::" + unionTypeName;
+      code += "(const " + unionTypeName + " &other) : type(";
+      code += GenEnumVal(enum_def, "NONE", parser_.opts, true);
+      code += "), table(nullptr) { *this = other; }\n";
+      code += "inline " + unionTypeName + "& " + unionTypeName + "::operator=(const ";
+      code += unionTypeName + " &other) {\n";
+      code += "  type = other.type;\n";
+      code += "  delete table;\n";
+      code += "  switch (other.type) {\n";
+      for (auto it = enum_def.vals.vec.begin(); it != enum_def.vals.vec.end(); ++it) {
+        auto ev = (*it);
+        if (ev->value) {
+          auto caseCode = "    case " + GenEnumVal(enum_def, ev->name, parser_.opts, true);
+          code += caseCode + ": table = new ";
+          auto name = NativeName(WrapInNameSpace(*ev->struct_def));
+          code += name + "(*(static_cast<" + name + " *>(other.table)))";
+          code += "; break;\n";
+          unionDestructor += caseCode +": delete static_cast<" + name + " *>(table); break;\n";
         }
       }
-      code += "    default:;\n  }\n}\n\n";
+      code += "    default:\n";
+      code += "      type = " + GenEnumVal(enum_def, "NONE", parser_.opts, true) + ";\n";
+      code += "      table = nullptr;\n";
+      code += "      break;";
+      code += "\n  }\n  return *this;\n}\n\n";
+      code += unionDestructor + "    default: assert(!table); break;\n  }\n}\n\n";
+
+      // Generate unions's operator=(const SupportedStructs &_o)
+      for (auto it = enum_def.vals.vec.begin(); it != enum_def.vals.vec.end(); ++it) {
+        auto ev = (*it);
+        if (!ev->value)
+          continue;
+        auto native_name = NativeName(WrapInNameSpace(*ev->struct_def));
+        code += "inline " + unionTypeName + "& " + unionTypeName + "::operator=(const " + native_name;
+        code += " &_o) {\n  type = ";
+        code += GetEnumVal(enum_def, *ev, parser_.opts);
+        code += ";\n  delete table;\n";
+        code += "  table = new " + native_name + "(_o);\n";
+        code += "  return *this;\n}\n";
+      }
+      code += "\n";
     }
   }
 
@@ -604,46 +643,35 @@ class CppGenerator : public BaseGenerator {
                : field.value.constant;
   }
 
+  std::string GenDefaultParam(FieldDef &field) {
+      std::string res;
+      if (field.value.type.enum_def && IsScalar(field.value.type.base_type)) {
+        auto ev = field.value.type.enum_def->ReverseLookup(
+            static_cast<int>(StringToInt(field.value.constant.c_str())), false);
+        if (ev) {
+          res =  WrapInNameSpace(
+              field.value.type.enum_def->defined_namespace,
+              GetEnumVal(*field.value.type.enum_def, *ev, parser_.opts));
+        } else {
+          res = GenUnderlyingCast(field, true, field.value.constant);
+        }
+      } else if (field.value.type.base_type == BASE_TYPE_BOOL) {
+        res =  field.value.constant == "0" ? "false" : "true";
+      } else {
+        res =  GenDefaultConstant(field);
+      }
+      return res;
+  }
+
   void GenSimpleParam(std::string &code, FieldDef &field) {
     code += ",\n    " + GenTypeWire(field.value.type, " ", true);
-    code += field.name + " = ";
-    if (field.value.type.enum_def && IsScalar(field.value.type.base_type)) {
-      auto ev = field.value.type.enum_def->ReverseLookup(
-          static_cast<int>(StringToInt(field.value.constant.c_str())), false);
-      if (ev) {
-        code += WrapInNameSpace(
-            field.value.type.enum_def->defined_namespace,
-            GetEnumVal(*field.value.type.enum_def, *ev, parser_.opts));
-      } else {
-        code += GenUnderlyingCast(field, true, field.value.constant);
-      }
-    } else if (field.value.type.base_type == BASE_TYPE_BOOL) {
-      code += field.value.constant == "0" ? "false" : "true";
-    } else {
-      code += GenDefaultConstant(field);
-    }
+    code += field.name + " = " + GenDefaultParam(field);
   }
 
   // Generate an accessor struct, builder structs & function for a table.
   void GenTable(StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    if (parser_.opts.generate_object_based_api) {
-      // Generate a C++ object that can hold an unpacked version of this
-      // table.
-      code += "struct " + NativeName(struct_def.name);
-      code += " : public flatbuffers::NativeTable {\n";
-      for (auto it = struct_def.fields.vec.begin();
-           it != struct_def.fields.vec.end(); ++it) {
-        auto &field = **it;
-        if (!field.deprecated &&  // Deprecated fields won't be accessible.
-            field.value.type.base_type != BASE_TYPE_UTYPE) {
-          code += "  " + GenTypeNative(field.value.type, false) + " ";
-          code += field.name + ";\n";
-        }
-      }
-      code += "};\n\n";
-    }
 
     // Generate an accessor struct, with methods of the form:
     // type name() const { return GetField<type>(offset, defaultval); }
@@ -808,15 +836,49 @@ class CppGenerator : public BaseGenerator {
         }
       }
     }
-    code += prefix + "verifier.EndTable()";
-    code += ";\n  }\n";
+    code += prefix + "verifier.EndTable();\n  }\n";
+    code += "};\n\n";  // End of table.
 
     if (parser_.opts.generate_object_based_api) {
-      // Generate the UnPack() pre declaration.
-      code += "  " + TableUnPackSignature(struct_def, true) + ";\n";
-    }
+      // Generate a C++ object that can hold an unpacked version of this
+      // table.
+      auto structName = NativeName(struct_def.name);
+      code += "struct " + structName;
+      code += " : public flatbuffers::NativeTable {\n";
+      code += "  flatbuffers::Offset<" + struct_def.name + "> Pack(flatbuffers::FlatBufferBuilder &_fbb) const;\n";
+      code += "  void UnPack(const " + struct_def.name + " *object);\n";
+      code += "  inline " + structName + "& operator=(const " + struct_def.name + " *object) { UnPack(object); return *this;}\n";
+      code += "  explicit " + structName + "(const " + struct_def.name + " *object) { UnPack(object); }\n\n";
 
-    code += "};\n\n";  // End of table.
+      std::string fields_init;
+      for (auto it = struct_def.fields.vec.begin();
+           it != struct_def.fields.vec.end(); ++it) {
+        auto &field = **it;
+        if (!field.deprecated &&  // Deprecated fields won't be accessible.
+            field.value.type.base_type != BASE_TYPE_UTYPE) {
+          code += "  ";
+          if (field.value.type.base_type == BASE_TYPE_STRUCT) {
+            if (IsStruct(field.value.type))
+              code += "flatbuffers::Optional<";
+            else
+              code += "flatbuffers::OptionalTable<";
+          }
+          code += GenTypeNative(field.value.type);
+          if (field.value.type.base_type == BASE_TYPE_STRUCT) {
+            if (!IsStruct(field.value.type))
+              code += ", " + WrapInNameSpace(*field.value.type.struct_def);
+            code += ">";
+          }
+          code += " " + field.name;
+          if (IsScalar(field.value.type.base_type))
+            fields_init += (fields_init.empty() ? "\n    : "  : "\n    , ") + field.name + "(" + GenDefaultParam(field) + ")";
+          code += ";\n";
+        }
+      }
+      code += "  " + structName + "()" + fields_init + " {}\n\n";
+
+      code += "};\n\n";
+    }
 
     // Generate a builder struct, with methods of the form:
     // void add_name(type name) { fbb_.AddElement<type>(offset, name, default);
@@ -941,12 +1003,6 @@ class CppGenerator : public BaseGenerator {
       }
       code += ");\n}\n\n";
     }
-
-    if (parser_.opts.generate_object_based_api) {
-      // Generate a pre-declaration for a CreateX method that works with an
-      // unpacked C++ object.
-      code += TableCreateSignature(struct_def) + ";\n\n";
-    }
   }
 
   // Generate code for tables that needs to come after the regular definition.
@@ -955,104 +1011,99 @@ class CppGenerator : public BaseGenerator {
 
     if (parser_.opts.generate_object_based_api) {
       // Generate the UnPack() method.
-      code += "inline " + TableUnPackSignature(struct_def, false) + " {\n";
-      code += "  auto _o = new " + NativeName(struct_def.name) + "();\n";
+      code += TableUnPackSignature(struct_def) + " {\n";
+      bool any_fields = false;
       for (auto it = struct_def.fields.vec.begin();
            it != struct_def.fields.vec.end(); ++it) {
+        any_fields = true;
         auto &field = **it;
         if (!field.deprecated) {
-          auto prefix = "  { auto _e = " + field.name + "(); ";
-          if (!IsScalar(field.value.type.base_type)) prefix += "if (_e) ";
-          auto deref = "_o->";
-          auto dest = deref + field.name;
-          auto assign = prefix + dest + " = ";
           auto gen_unpack_val = [&](const Type &type, const std::string &val,
-                                    bool invector) -> std::string {
+                                    bool invector, const std::string &structName) -> std::string {
             switch (type.base_type) {
               case BASE_TYPE_STRING:
-                return val + "->str()";
+                if (invector)
+                    return GenPushBack("std::string", "(" + val + "->c_str(), " + val + "->size())");
+                return "(_o->" + val + "()->c_str(), _o->" + val + "()->size())";
               case BASE_TYPE_STRUCT:
                 if (IsStruct(type)) {
-                  if (invector) {
-                    return "*" + val;
-                  } else {
-                    return "std::unique_ptr<" +
-                           WrapInNameSpace (*type.struct_def) +
-                           ">(new " +
-                           WrapInNameSpace (*type.struct_def) + "(*" + val + "))";
-                  }
-                } else {
-                  return val + "->UnPack()";
+                    if (invector)
+                      return "(*" + val + ")";
+                    return " = _o->" + val + "()";
                 }
+                if (invector)
+                  return GenPushBack(structName, "(" + val + ")");
+                return " = _o->" + val + "()";
+              case BASE_TYPE_BOOL:
+                if (invector)
+                  return "(" + val + " != 0)";
+                // fall trough
               default:
-                return val;
+                if (invector)
+                    return "(" + val + ")";
+                return " = _o->" + val + "()";
                 break;
             }
           };
           switch (field.value.type.base_type) {
             case BASE_TYPE_VECTOR: {
-              code += prefix;
-              code += "{ for (flatbuffers::uoffset_t _i = 0;";
-              code += " _i < _e->size(); _i++) { ";
-              code += dest + ".push_back(";
-              std::string indexing = "_e->Get(_i)";
-              if (field.value.type.element == BASE_TYPE_BOOL)
-                indexing += "!=0";
+              code += "  " + field.name + ".clear();\n";
+              code += "  if (_o->" + field.name + "()) {\n";
+              code += "    " + field.name + ".reserve(_o->" + field.name + "()->size());\n";
+              code += "    for (auto it = _o->" + field.name + "()->begin(), __end = _o->" + field.name + "()->end(); it != __end; ++it)\n";
+              code += "      " + field.name + (parser_.opts.cpp_variant == IDLOptions::Cpp0x ? ".push_back" : ".emplace_back");
+              auto type_name = field.value.type.struct_def ? WrapInNameSpace(*field.value.type.struct_def) : "";
+              if (!type_name.empty() && !IsStruct(field.value.type))
+                  type_name = NativeName(type_name);
               code += gen_unpack_val(field.value.type.VectorType(),
-                                     indexing, true);
-              code += "); } }";
-              break;
+                                     "(*it)", true, type_name) + ";\n";
+              code += "  }\n";
+              continue; // Don't add ; at the end
             }
-            case BASE_TYPE_UTYPE: {
-              auto &union_field = **(it + 1);
-              assert(union_field.value.type.base_type == BASE_TYPE_UNION);
-              code += prefix + deref + union_field.name + ".type = _e;";
-              break;
-            }
+            case BASE_TYPE_UTYPE:
+              continue;
             case BASE_TYPE_UNION:
-              code += prefix + dest + ".table = ";
-              code += field.value.type.enum_def->name;
-              code += "Union::UnPack(_e, ";
-              code += field.name + UnionTypeFieldSuffix() + "());";
+                code += "  " + field.name + ".UnPack(_o->" + field.name + "(), _o->" + field.name + "_type())";
               break;
             default:
-              code += assign + gen_unpack_val(field.value.type, "_e", false);
-              code += ";";
+              code += "  " + field.name;
+              if (field.value.type.base_type == BASE_TYPE_STRING)
+                code += ".assign";
+              auto struct_name = field.value.type.struct_def ? WrapInNameSpace(*field.value.type.struct_def) : "";
+              if (!struct_name.empty() && !IsStruct(field.value.type))
+                  struct_name = NativeName(struct_name);
+              code += gen_unpack_val(field.value.type, field.name, false, struct_name);
               break;
           }
-          code += " };\n";
+          code += ";\n";
         }
       }
-      code += "  return std::unique_ptr<" + NativeName(struct_def.name);
-      code += ">(_o);\n}\n\n";
+      if (!any_fields)
+          code += "  (void)_o;\n";
+      code += "}\n\n";
 
-      // Generate a CreateX method that works with an unpacked C++ object.
-      code += TableCreateSignature(struct_def) + " {\n";
-      auto before_return_statement = code.size();
+      // Generate the Pack method.
+      code += TablePackSignature(struct_def) + " {\n";
       code += "  return Create";
       code += struct_def.name + "(_fbb";
-      bool any_fields = false;
       for (auto it = struct_def.fields.vec.begin();
            it != struct_def.fields.vec.end(); ++it) {
         auto &field = **it;
         if (!field.deprecated) {
-          any_fields = true;
           auto field_name = field.name;
           if (field.value.type.base_type == BASE_TYPE_UTYPE) {
             field_name = field_name.substr(0, field_name.size() -
                                               strlen(UnionTypeFieldSuffix()));
             field_name += ".type";
           }
-          auto accessor = "_o->" + field_name;
-          auto ptrprefix = accessor + " ? ";
+          auto accessor = field_name;
           auto stlprefix = accessor + ".size() ? ";
           auto postfix = " : 0";
-          if (field.required &&
-              (field.value.type.base_type == BASE_TYPE_STRING ||
-               field.value.type.base_type == BASE_TYPE_VECTOR)) {
-            stlprefix = "";
+          if (field.value.type.base_type != BASE_TYPE_STRING &&
+               field.value.type.base_type != BASE_TYPE_VECTOR) {
             postfix = "";
           }
+
           code += ",\n    ";
           switch (field.value.type.base_type) {
             case BASE_TYPE_STRING:
@@ -1072,9 +1123,8 @@ class CppGenerator : public BaseGenerator {
                   } else {
                     code += "_fbb.CreateVector<flatbuffers::Offset<";
                     code += vector_type.struct_def->name + ">>(" + accessor;
-                    code += ".size(), [&](size_t i) { return Create";
-                    code += vector_type.struct_def->name + "(_fbb, " + accessor;
-                    code += "[i].get()); })";
+                    code += ".size(), [&](size_t i) { return " + accessor;
+                    code += "[i].Pack(_fbb); })";
                   }
                   break;
                 default:
@@ -1089,11 +1139,9 @@ class CppGenerator : public BaseGenerator {
               break;
             case BASE_TYPE_STRUCT:
               if (IsStruct(field.value.type)) {
-                code += ptrprefix + accessor + ".get()" + postfix;
+                code += accessor;
               } else {
-                code += ptrprefix + "Create";
-                code += field.value.type.struct_def->name;
-                code += "(_fbb, " + accessor + ".get())" + postfix;
+                code += accessor + " ? " + accessor + "->Pack(_fbb) : 0";
               }
               break;
             default:
@@ -1103,7 +1151,6 @@ class CppGenerator : public BaseGenerator {
         }
       }
       code += ");\n}\n\n";
-      if (!any_fields) code.insert(before_return_statement, "  (void)_o;\n");
     }
   }
 

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -136,7 +136,7 @@ template<> inline CheckedError atot<Offset<void>>(const char *s, Parser &parser,
 }
 
 std::string Namespace::GetFullyQualifiedName(const std::string &name,
-                                             size_t max_components) const {
+                                             size_t max_components, const std::string &separator) const {
   // Early exit if we don't have a defined namespace.
   if (components.size() == 0 || !max_components) {
     return name;
@@ -145,12 +145,12 @@ std::string Namespace::GetFullyQualifiedName(const std::string &name,
   for (size_t i = 0; i < std::min(components.size(), max_components);
        i++) {
     if (i) {
-      stream << ".";
+      stream << separator;
     }
     stream << components[i];
   }
 
-  stream << "." << name;
+  stream << separator << name;
   return stream.str();
 }
 

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -61,12 +61,15 @@ struct AnyUnion {
   AnyUnion &operator=(const AnyUnion &);
   ~AnyUnion();
 
-  static flatbuffers::NativeTable *UnPack(const void *union_obj, Any type);
+  void UnPack(const void *union_obj, Any _t);
   flatbuffers::Offset<void> Pack(flatbuffers::FlatBufferBuilder &_fbb) const;
 
   MonsterT *AsMonster() { return type == Any_Monster ? reinterpret_cast<MonsterT *>(table) : nullptr; }
+  AnyUnion &operator=(const MonsterT &_o);
   TestSimpleTableWithEnumT *AsTestSimpleTableWithEnum() { return type == Any_TestSimpleTableWithEnum ? reinterpret_cast<TestSimpleTableWithEnumT *>(table) : nullptr; }
+  AnyUnion &operator=(const TestSimpleTableWithEnumT &_o);
   MyGame::Example2::MonsterT *AsMyGame_Example2_Monster() { return type == Any_MyGame_Example2_Monster ? reinterpret_cast<MyGame::Example2::MonsterT *>(table) : nullptr; }
+  AnyUnion &operator=(const MyGame::Example2::MonsterT &_o);
 };
 
 inline const char **EnumNamesAny() {
@@ -134,15 +137,21 @@ STRUCT_END(Vec3, 32);
 
 namespace Example2 {
 
-struct MonsterT : public flatbuffers::NativeTable {
-};
-
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
   }
-  std::unique_ptr<MonsterT> UnPack() const;
+};
+
+struct MonsterT : public flatbuffers::NativeTable {
+  flatbuffers::Offset<Monster> Pack(flatbuffers::FlatBufferBuilder &_fbb) const;
+  void UnPack(const Monster *object);
+  inline MonsterT& operator=(const Monster *object) { UnPack(object); return *this;}
+  explicit MonsterT(const Monster *object) { UnPack(object); }
+
+  MonsterT() {}
+
 };
 
 struct MonsterBuilder {
@@ -161,15 +170,9 @@ inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o);
-
 }  // namespace Example2
 
 namespace Example {
-
-struct TestSimpleTableWithEnumT : public flatbuffers::NativeTable {
-  Color color;
-};
 
 struct TestSimpleTableWithEnum FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum {
@@ -182,7 +185,18 @@ struct TestSimpleTableWithEnum FLATBUFFERS_FINAL_CLASS : private flatbuffers::Ta
            VerifyField<int8_t>(verifier, VT_COLOR) &&
            verifier.EndTable();
   }
-  std::unique_ptr<TestSimpleTableWithEnumT> UnPack() const;
+};
+
+struct TestSimpleTableWithEnumT : public flatbuffers::NativeTable {
+  flatbuffers::Offset<TestSimpleTableWithEnum> Pack(flatbuffers::FlatBufferBuilder &_fbb) const;
+  void UnPack(const TestSimpleTableWithEnum *object);
+  inline TestSimpleTableWithEnumT& operator=(const TestSimpleTableWithEnum *object) { UnPack(object); return *this;}
+  explicit TestSimpleTableWithEnumT(const TestSimpleTableWithEnum *object) { UnPack(object); }
+
+  Color color;
+  TestSimpleTableWithEnumT()
+    : color(Color_Green) {}
+
 };
 
 struct TestSimpleTableWithEnumBuilder {
@@ -204,14 +218,6 @@ inline flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnu
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnum(flatbuffers::FlatBufferBuilder &_fbb, const TestSimpleTableWithEnumT *_o);
-
-struct StatT : public flatbuffers::NativeTable {
-  std::string id;
-  int64_t val;
-  uint16_t count;
-};
-
 struct Stat FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum {
     VT_ID = 4,
@@ -232,7 +238,21 @@ struct Stat FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<uint16_t>(verifier, VT_COUNT) &&
            verifier.EndTable();
   }
-  std::unique_ptr<StatT> UnPack() const;
+};
+
+struct StatT : public flatbuffers::NativeTable {
+  flatbuffers::Offset<Stat> Pack(flatbuffers::FlatBufferBuilder &_fbb) const;
+  void UnPack(const Stat *object);
+  inline StatT& operator=(const Stat *object) { UnPack(object); return *this;}
+  explicit StatT(const Stat *object) { UnPack(object); }
+
+  std::string id;
+  int64_t val;
+  uint16_t count;
+  StatT()
+    : val(0)
+    , count(0) {}
+
 };
 
 struct StatBuilder {
@@ -266,38 +286,6 @@ inline flatbuffers::Offset<Stat> CreateStatDirect(flatbuffers::FlatBufferBuilder
     uint16_t count = 0) {
   return CreateStat(_fbb, id ? _fbb.CreateString(id) : 0, val, count);
 }
-
-inline flatbuffers::Offset<Stat> CreateStat(flatbuffers::FlatBufferBuilder &_fbb, const StatT *_o);
-
-struct MonsterT : public flatbuffers::NativeTable {
-  std::unique_ptr<Vec3> pos;
-  int16_t mana;
-  int16_t hp;
-  std::string name;
-  std::vector<uint8_t> inventory;
-  Color color;
-  AnyUnion test;
-  std::vector<Test> test4;
-  std::vector<std::string> testarrayofstring;
-  std::vector<std::unique_ptr<MonsterT>> testarrayoftables;
-  std::unique_ptr<MonsterT> enemy;
-  std::vector<uint8_t> testnestedflatbuffer;
-  std::unique_ptr<StatT> testempty;
-  bool testbool;
-  int32_t testhashs32_fnv1;
-  uint32_t testhashu32_fnv1;
-  int64_t testhashs64_fnv1;
-  uint64_t testhashu64_fnv1;
-  int32_t testhashs32_fnv1a;
-  uint32_t testhashu32_fnv1a;
-  int64_t testhashs64_fnv1a;
-  uint64_t testhashu64_fnv1a;
-  std::vector<bool> testarrayofbools;
-  float testf;
-  float testf2;
-  float testf3;
-  std::vector<std::string> testarrayofstring2;
-};
 
 /// an example documentation comment: monster object
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -438,7 +426,58 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVectorOfStrings(testarrayofstring2()) &&
            verifier.EndTable();
   }
-  std::unique_ptr<MonsterT> UnPack() const;
+};
+
+struct MonsterT : public flatbuffers::NativeTable {
+  flatbuffers::Offset<Monster> Pack(flatbuffers::FlatBufferBuilder &_fbb) const;
+  void UnPack(const Monster *object);
+  inline MonsterT& operator=(const Monster *object) { UnPack(object); return *this;}
+  explicit MonsterT(const Monster *object) { UnPack(object); }
+
+  flatbuffers::Optional<Vec3> pos;
+  int16_t mana;
+  int16_t hp;
+  std::string name;
+  std::vector<uint8_t> inventory;
+  Color color;
+  AnyUnion test;
+  std::vector<Test> test4;
+  std::vector<std::string> testarrayofstring;
+  std::vector<MonsterT> testarrayoftables;
+  flatbuffers::OptionalTable<MonsterT, Monster> enemy;
+  std::vector<uint8_t> testnestedflatbuffer;
+  flatbuffers::OptionalTable<StatT, Stat> testempty;
+  bool testbool;
+  int32_t testhashs32_fnv1;
+  uint32_t testhashu32_fnv1;
+  int64_t testhashs64_fnv1;
+  uint64_t testhashu64_fnv1;
+  int32_t testhashs32_fnv1a;
+  uint32_t testhashu32_fnv1a;
+  int64_t testhashs64_fnv1a;
+  uint64_t testhashu64_fnv1a;
+  std::vector<bool> testarrayofbools;
+  float testf;
+  float testf2;
+  float testf3;
+  std::vector<std::string> testarrayofstring2;
+  MonsterT()
+    : mana(150)
+    , hp(100)
+    , color(Color_Blue)
+    , testbool(false)
+    , testhashs32_fnv1(0)
+    , testhashu32_fnv1(0)
+    , testhashs64_fnv1(0)
+    , testhashu64_fnv1(0)
+    , testhashs32_fnv1a(0)
+    , testhashu32_fnv1a(0)
+    , testhashs64_fnv1a(0)
+    , testhashu64_fnv1a(0)
+    , testf(3.14159f)
+    , testf2(3.0f)
+    , testf3(0.0f) {}
+
 };
 
 struct MonsterBuilder {
@@ -574,19 +613,15 @@ inline flatbuffers::Offset<Monster> CreateMonsterDirect(flatbuffers::FlatBufferB
   return CreateMonster(_fbb, pos, mana, hp, name ? _fbb.CreateString(name) : 0, inventory ? _fbb.CreateVector<uint8_t>(*inventory) : 0, color, test_type, test, test4 ? _fbb.CreateVector<const Test *>(*test4) : 0, testarrayofstring ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*testarrayofstring) : 0, testarrayoftables ? _fbb.CreateVector<flatbuffers::Offset<Monster>>(*testarrayoftables) : 0, enemy, testnestedflatbuffer ? _fbb.CreateVector<uint8_t>(*testnestedflatbuffer) : 0, testempty, testbool, testhashs32_fnv1, testhashu32_fnv1, testhashs64_fnv1, testhashu64_fnv1, testhashs32_fnv1a, testhashu32_fnv1a, testhashs64_fnv1a, testhashu64_fnv1a, testarrayofbools ? _fbb.CreateVector<uint8_t>(*testarrayofbools) : 0, testf, testf2, testf3, testarrayofstring2 ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*testarrayofstring2) : 0);
 }
 
-inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o);
-
 }  // namespace Example
 
 namespace Example2 {
 
-inline std::unique_ptr<MonsterT> Monster::UnPack() const {
-  auto _o = new MonsterT();
-  return std::unique_ptr<MonsterT>(_o);
+inline void MonsterT::UnPack(const Monster *_o) {
+  (void)_o;
 }
 
-inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o) {
-  (void)_o;
+inline flatbuffers::Offset<Monster> MonsterT::Pack(flatbuffers::FlatBufferBuilder &_fbb) const {
   return CreateMonster(_fbb);
 }
 
@@ -594,95 +629,123 @@ inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder
 
 namespace Example {
 
-inline std::unique_ptr<TestSimpleTableWithEnumT> TestSimpleTableWithEnum::UnPack() const {
-  auto _o = new TestSimpleTableWithEnumT();
-  { auto _e = color(); _o->color = _e; };
-  return std::unique_ptr<TestSimpleTableWithEnumT>(_o);
+inline void TestSimpleTableWithEnumT::UnPack(const TestSimpleTableWithEnum *_o) {
+  color = _o->color();
 }
 
-inline flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnum(flatbuffers::FlatBufferBuilder &_fbb, const TestSimpleTableWithEnumT *_o) {
+inline flatbuffers::Offset<TestSimpleTableWithEnum> TestSimpleTableWithEnumT::Pack(flatbuffers::FlatBufferBuilder &_fbb) const {
   return CreateTestSimpleTableWithEnum(_fbb,
-    _o->color);
+    color);
 }
 
-inline std::unique_ptr<StatT> Stat::UnPack() const {
-  auto _o = new StatT();
-  { auto _e = id(); if (_e) _o->id = _e->str(); };
-  { auto _e = val(); _o->val = _e; };
-  { auto _e = count(); _o->count = _e; };
-  return std::unique_ptr<StatT>(_o);
+inline void StatT::UnPack(const Stat *_o) {
+  id.assign(_o->id()->c_str(), _o->id()->size());
+  val = _o->val();
+  count = _o->count();
 }
 
-inline flatbuffers::Offset<Stat> CreateStat(flatbuffers::FlatBufferBuilder &_fbb, const StatT *_o) {
+inline flatbuffers::Offset<Stat> StatT::Pack(flatbuffers::FlatBufferBuilder &_fbb) const {
   return CreateStat(_fbb,
-    _o->id.size() ? _fbb.CreateString(_o->id) : 0,
-    _o->val,
-    _o->count);
+    id.size() ? _fbb.CreateString(id) : 0,
+    val,
+    count);
 }
 
-inline std::unique_ptr<MonsterT> Monster::UnPack() const {
-  auto _o = new MonsterT();
-  { auto _e = pos(); if (_e) _o->pos = std::unique_ptr<Vec3>(new Vec3(*_e)); };
-  { auto _e = mana(); _o->mana = _e; };
-  { auto _e = hp(); _o->hp = _e; };
-  { auto _e = name(); if (_e) _o->name = _e->str(); };
-  { auto _e = inventory(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->inventory.push_back(_e->Get(_i)); } } };
-  { auto _e = color(); _o->color = _e; };
-  { auto _e = test_type(); _o->test.type = _e; };
-  { auto _e = test(); if (_e) _o->test.table = AnyUnion::UnPack(_e, test_type()); };
-  { auto _e = test4(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->test4.push_back(*_e->Get(_i)); } } };
-  { auto _e = testarrayofstring(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->testarrayofstring.push_back(_e->Get(_i)->str()); } } };
-  { auto _e = testarrayoftables(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->testarrayoftables.push_back(_e->Get(_i)->UnPack()); } } };
-  { auto _e = enemy(); if (_e) _o->enemy = _e->UnPack(); };
-  { auto _e = testnestedflatbuffer(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->testnestedflatbuffer.push_back(_e->Get(_i)); } } };
-  { auto _e = testempty(); if (_e) _o->testempty = _e->UnPack(); };
-  { auto _e = testbool(); _o->testbool = _e; };
-  { auto _e = testhashs32_fnv1(); _o->testhashs32_fnv1 = _e; };
-  { auto _e = testhashu32_fnv1(); _o->testhashu32_fnv1 = _e; };
-  { auto _e = testhashs64_fnv1(); _o->testhashs64_fnv1 = _e; };
-  { auto _e = testhashu64_fnv1(); _o->testhashu64_fnv1 = _e; };
-  { auto _e = testhashs32_fnv1a(); _o->testhashs32_fnv1a = _e; };
-  { auto _e = testhashu32_fnv1a(); _o->testhashu32_fnv1a = _e; };
-  { auto _e = testhashs64_fnv1a(); _o->testhashs64_fnv1a = _e; };
-  { auto _e = testhashu64_fnv1a(); _o->testhashu64_fnv1a = _e; };
-  { auto _e = testarrayofbools(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->testarrayofbools.push_back(_e->Get(_i)!=0); } } };
-  { auto _e = testf(); _o->testf = _e; };
-  { auto _e = testf2(); _o->testf2 = _e; };
-  { auto _e = testf3(); _o->testf3 = _e; };
-  { auto _e = testarrayofstring2(); if (_e) { for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->testarrayofstring2.push_back(_e->Get(_i)->str()); } } };
-  return std::unique_ptr<MonsterT>(_o);
+inline void MonsterT::UnPack(const Monster *_o) {
+  pos = _o->pos();
+  mana = _o->mana();
+  hp = _o->hp();
+  name.assign(_o->name()->c_str(), _o->name()->size());
+  inventory.clear();
+  if (_o->inventory()) {
+    inventory.reserve(_o->inventory()->size());
+    for (auto it = _o->inventory()->begin(), __end = _o->inventory()->end(); it != __end; ++it)
+      inventory.push_back((*it));
+  }
+  color = _o->color();
+  test.UnPack(_o->test(), _o->test_type());
+  test4.clear();
+  if (_o->test4()) {
+    test4.reserve(_o->test4()->size());
+    for (auto it = _o->test4()->begin(), __end = _o->test4()->end(); it != __end; ++it)
+      test4.push_back(*(*it));
+  }
+  testarrayofstring.clear();
+  if (_o->testarrayofstring()) {
+    testarrayofstring.reserve(_o->testarrayofstring()->size());
+    for (auto it = _o->testarrayofstring()->begin(), __end = _o->testarrayofstring()->end(); it != __end; ++it)
+      testarrayofstring.push_back(std::string((*it)->c_str(), (*it)->size()));
+  }
+  testarrayoftables.clear();
+  if (_o->testarrayoftables()) {
+    testarrayoftables.reserve(_o->testarrayoftables()->size());
+    for (auto it = _o->testarrayoftables()->begin(), __end = _o->testarrayoftables()->end(); it != __end; ++it)
+      testarrayoftables.push_back(MonsterT((*it)));
+  }
+  enemy = _o->enemy();
+  testnestedflatbuffer.clear();
+  if (_o->testnestedflatbuffer()) {
+    testnestedflatbuffer.reserve(_o->testnestedflatbuffer()->size());
+    for (auto it = _o->testnestedflatbuffer()->begin(), __end = _o->testnestedflatbuffer()->end(); it != __end; ++it)
+      testnestedflatbuffer.push_back((*it));
+  }
+  testempty = _o->testempty();
+  testbool = _o->testbool();
+  testhashs32_fnv1 = _o->testhashs32_fnv1();
+  testhashu32_fnv1 = _o->testhashu32_fnv1();
+  testhashs64_fnv1 = _o->testhashs64_fnv1();
+  testhashu64_fnv1 = _o->testhashu64_fnv1();
+  testhashs32_fnv1a = _o->testhashs32_fnv1a();
+  testhashu32_fnv1a = _o->testhashu32_fnv1a();
+  testhashs64_fnv1a = _o->testhashs64_fnv1a();
+  testhashu64_fnv1a = _o->testhashu64_fnv1a();
+  testarrayofbools.clear();
+  if (_o->testarrayofbools()) {
+    testarrayofbools.reserve(_o->testarrayofbools()->size());
+    for (auto it = _o->testarrayofbools()->begin(), __end = _o->testarrayofbools()->end(); it != __end; ++it)
+      testarrayofbools.push_back((*it) != 0);
+  }
+  testf = _o->testf();
+  testf2 = _o->testf2();
+  testf3 = _o->testf3();
+  testarrayofstring2.clear();
+  if (_o->testarrayofstring2()) {
+    testarrayofstring2.reserve(_o->testarrayofstring2()->size());
+    for (auto it = _o->testarrayofstring2()->begin(), __end = _o->testarrayofstring2()->end(); it != __end; ++it)
+      testarrayofstring2.push_back(std::string((*it)->c_str(), (*it)->size()));
+  }
 }
 
-inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o) {
+inline flatbuffers::Offset<Monster> MonsterT::Pack(flatbuffers::FlatBufferBuilder &_fbb) const {
   return CreateMonster(_fbb,
-    _o->pos ? _o->pos.get() : 0,
-    _o->mana,
-    _o->hp,
-    _fbb.CreateString(_o->name),
-    _o->inventory.size() ? _fbb.CreateVector(_o->inventory) : 0,
-    _o->color,
-    _o->test.type,
-    _o->test.Pack(_fbb),
-    _o->test4.size() ? _fbb.CreateVectorOfStructs(_o->test4) : 0,
-    _o->testarrayofstring.size() ? _fbb.CreateVectorOfStrings(_o->testarrayofstring) : 0,
-    _o->testarrayoftables.size() ? _fbb.CreateVector<flatbuffers::Offset<Monster>>(_o->testarrayoftables.size(), [&](size_t i) { return CreateMonster(_fbb, _o->testarrayoftables[i].get()); }) : 0,
-    _o->enemy ? CreateMonster(_fbb, _o->enemy.get()) : 0,
-    _o->testnestedflatbuffer.size() ? _fbb.CreateVector(_o->testnestedflatbuffer) : 0,
-    _o->testempty ? CreateStat(_fbb, _o->testempty.get()) : 0,
-    _o->testbool,
-    _o->testhashs32_fnv1,
-    _o->testhashu32_fnv1,
-    _o->testhashs64_fnv1,
-    _o->testhashu64_fnv1,
-    _o->testhashs32_fnv1a,
-    _o->testhashu32_fnv1a,
-    _o->testhashs64_fnv1a,
-    _o->testhashu64_fnv1a,
-    _o->testarrayofbools.size() ? _fbb.CreateVector(_o->testarrayofbools) : 0,
-    _o->testf,
-    _o->testf2,
-    _o->testf3,
-    _o->testarrayofstring2.size() ? _fbb.CreateVectorOfStrings(_o->testarrayofstring2) : 0);
+    pos,
+    mana,
+    hp,
+    name.size() ? _fbb.CreateString(name) : 0,
+    inventory.size() ? _fbb.CreateVector(inventory) : 0,
+    color,
+    test.type,
+    test.Pack(_fbb),
+    test4.size() ? _fbb.CreateVectorOfStructs(test4) : 0,
+    testarrayofstring.size() ? _fbb.CreateVectorOfStrings(testarrayofstring) : 0,
+    testarrayoftables.size() ? _fbb.CreateVector<flatbuffers::Offset<Monster>>(testarrayoftables.size(), [&](size_t i) { return testarrayoftables[i].Pack(_fbb); }) : 0,
+    enemy ? enemy->Pack(_fbb) : 0,
+    testnestedflatbuffer.size() ? _fbb.CreateVector(testnestedflatbuffer) : 0,
+    testempty ? testempty->Pack(_fbb) : 0,
+    testbool,
+    testhashs32_fnv1,
+    testhashu32_fnv1,
+    testhashs64_fnv1,
+    testhashu64_fnv1,
+    testhashs32_fnv1a,
+    testhashu32_fnv1a,
+    testhashs64_fnv1a,
+    testhashu64_fnv1a,
+    testarrayofbools.size() ? _fbb.CreateVector(testarrayofbools) : 0,
+    testf,
+    testf2,
+    testf3,
+    testarrayofstring2.size() ? _fbb.CreateVectorOfStrings(testarrayofstring2) : 0);
 }
 
 inline bool VerifyAny(flatbuffers::Verifier &verifier, const void *union_obj, Any type) {
@@ -695,33 +758,71 @@ inline bool VerifyAny(flatbuffers::Verifier &verifier, const void *union_obj, An
   }
 }
 
-inline flatbuffers::NativeTable *AnyUnion::UnPack(const void *union_obj, Any type) {
-  switch (type) {
-    case Any_NONE: return nullptr;
-    case Any_Monster: return reinterpret_cast<const Monster *>(union_obj)->UnPack().release();
-    case Any_TestSimpleTableWithEnum: return reinterpret_cast<const TestSimpleTableWithEnum *>(union_obj)->UnPack().release();
-    case Any_MyGame_Example2_Monster: return reinterpret_cast<const MyGame::Example2::Monster *>(union_obj)->UnPack().release();
-    default: return nullptr;
+inline void AnyUnion::UnPack(const void *union_obj, Any _t) {
+  type = _t;
+  delete table;
+  if (!union_obj) { table = nullptr; type = Any_NONE; return; }
+  switch (_t) {
+    case Any_NONE: table = nullptr; break;
+    case Any_Monster: table = new MonsterT(reinterpret_cast<const Monster *>(union_obj)); break;
+    case Any_TestSimpleTableWithEnum: table = new TestSimpleTableWithEnumT(reinterpret_cast<const TestSimpleTableWithEnum *>(union_obj)); break;
+    case Any_MyGame_Example2_Monster: table = new MyGame::Example2::MonsterT(reinterpret_cast<const MyGame::Example2::Monster *>(union_obj)); break;
+    default: table = nullptr; type = Any_NONE;
   }
 }
 
 inline flatbuffers::Offset<void> AnyUnion::Pack(flatbuffers::FlatBufferBuilder &_fbb) const {
   switch (type) {
     case Any_NONE: return 0;
-    case Any_Monster: return CreateMonster(_fbb, reinterpret_cast<const MonsterT *>(table)).Union();
-    case Any_TestSimpleTableWithEnum: return CreateTestSimpleTableWithEnum(_fbb, reinterpret_cast<const TestSimpleTableWithEnumT *>(table)).Union();
-    case Any_MyGame_Example2_Monster: return CreateMonster(_fbb, reinterpret_cast<const MyGame::Example2::MonsterT *>(table)).Union();
+    case Any_Monster: return static_cast<const MonsterT *>(table)->Pack(_fbb).Union();
+    case Any_TestSimpleTableWithEnum: return static_cast<const TestSimpleTableWithEnumT *>(table)->Pack(_fbb).Union();
+    case Any_MyGame_Example2_Monster: return static_cast<const MyGame::Example2::MonsterT *>(table)->Pack(_fbb).Union();
     default: return 0;
   }
 }
 
+inline AnyUnion::AnyUnion(const AnyUnion &other) : type(Any_NONE), table(nullptr) { *this = other; }
+inline AnyUnion& AnyUnion::operator=(const AnyUnion &other) {
+  type = other.type;
+  delete table;
+  switch (other.type) {
+    case Any_Monster: table = new MonsterT(*(static_cast<MonsterT *>(other.table))); break;
+    case Any_TestSimpleTableWithEnum: table = new TestSimpleTableWithEnumT(*(static_cast<TestSimpleTableWithEnumT *>(other.table))); break;
+    case Any_MyGame_Example2_Monster: table = new MyGame::Example2::MonsterT(*(static_cast<MyGame::Example2::MonsterT *>(other.table))); break;
+    default:
+      type = Any_NONE;
+      table = nullptr;
+      break;
+  }
+  return *this;
+}
+
 inline AnyUnion::~AnyUnion() {
   switch (type) {
-    case Any_Monster: delete reinterpret_cast<MonsterT *>(table); break;
-    case Any_TestSimpleTableWithEnum: delete reinterpret_cast<TestSimpleTableWithEnumT *>(table); break;
-    case Any_MyGame_Example2_Monster: delete reinterpret_cast<MyGame::Example2::MonsterT *>(table); break;
-    default:;
+    case Any_Monster: delete static_cast<MonsterT *>(table); break;
+    case Any_TestSimpleTableWithEnum: delete static_cast<TestSimpleTableWithEnumT *>(table); break;
+    case Any_MyGame_Example2_Monster: delete static_cast<MyGame::Example2::MonsterT *>(table); break;
+    default: assert(!table); break;
   }
+}
+
+inline AnyUnion& AnyUnion::operator=(const MonsterT &_o) {
+  type = Any_Monster;
+  delete table;
+  table = new MonsterT(_o);
+  return *this;
+}
+inline AnyUnion& AnyUnion::operator=(const TestSimpleTableWithEnumT &_o) {
+  type = Any_TestSimpleTableWithEnum;
+  delete table;
+  table = new TestSimpleTableWithEnumT(_o);
+  return *this;
+}
+inline AnyUnion& AnyUnion::operator=(const MyGame::Example2::MonsterT &_o) {
+  type = Any_MyGame_Example2_Monster;
+  delete table;
+  table = new MyGame::Example2::MonsterT(_o);
+  return *this;
 }
 
 inline const MyGame::Example::Monster *GetMonster(const void *buf) { return flatbuffers::GetRoot<MyGame::Example::Monster>(buf); }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -315,16 +315,18 @@ void MutateFlatBuffersTest(uint8_t *flatbuf, std::size_t length) {
 // Unpack a FlatBuffer into objects.
 void ObjectFlatBuffersTest(uint8_t *flatbuf) {
   // Turn a buffer into C++ objects.
-  auto monster1 = GetMonster(flatbuf)->UnPack();
+  MyGame::Example::MonsterT monster1(GetMonster(flatbuf));
 
   // Re-serialize the data.
   flatbuffers::FlatBufferBuilder fbb1;
-  fbb1.Finish(CreateMonster(fbb1, monster1.get()), MonsterIdentifier());
+  fbb1.Finish(monster1.Pack(fbb1), MonsterIdentifier());
 
   // Unpack again, and re-serialize again.
-  auto monster2 = GetMonster(fbb1.GetBufferPointer())->UnPack();
+  auto monster2 = monster1;
   flatbuffers::FlatBufferBuilder fbb2;
-  fbb2.Finish(CreateMonster(fbb2, monster2.get()), MonsterIdentifier());
+  fbb2.Finish(monster2.Pack(fbb2), MonsterIdentifier());
+
+
 
   // Now we've gone full round-trip, the two buffers should match.
   auto len1 = fbb1.GetSize();
@@ -337,46 +339,45 @@ void ObjectFlatBuffersTest(uint8_t *flatbuf) {
   AccessFlatBufferTest(fbb2.GetBufferPointer(), len2, false);
 
   // Test accessing fields, similar to AccessFlatBufferTest above.
-  TEST_EQ(monster2->hp, 80);
-  TEST_EQ(monster2->mana, 150);  // default
-  TEST_EQ_STR(monster2->name.c_str(), "MyMonster");
+  TEST_EQ(monster2.hp, 80);
+  TEST_EQ(monster2.mana, 150);  // default
+  TEST_EQ_STR(monster2.name.c_str(), "MyMonster");
 
-  auto &pos = monster2->pos;
-  TEST_NOTNULL(pos);
+  auto &pos = monster2.pos;
   TEST_EQ(pos->z(), 3);
   TEST_EQ(pos->test3().a(), 10);
   TEST_EQ(pos->test3().b(), 20);
 
-  auto &inventory = monster2->inventory;
+  auto &inventory = monster2.inventory;
   TEST_EQ(inventory.size(), 10UL);
   unsigned char inv_data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   for (auto it = inventory.begin(); it != inventory.end(); ++it)
     TEST_EQ(*it, inv_data[it - inventory.begin()]);
 
-  TEST_EQ(monster2->color, Color_Blue);
+  TEST_EQ(monster2.color, Color_Blue);
 
-  auto monster3 = monster2->test.AsMonster();
+  auto monster3 = monster2.test.AsMonster();
   TEST_NOTNULL(monster3);
   TEST_EQ_STR(monster3->name.c_str(), "Fred");
 
-  auto &vecofstrings = monster2->testarrayofstring;
+  auto &vecofstrings = monster2.testarrayofstring;
   TEST_EQ(vecofstrings.size(), 4U);
   TEST_EQ_STR(vecofstrings[0].c_str(), "bob");
   TEST_EQ_STR(vecofstrings[1].c_str(), "fred");
 
-  auto &vecofstrings2 = monster2->testarrayofstring2;
+  auto &vecofstrings2 = monster2.testarrayofstring2;
   TEST_EQ(vecofstrings2.size(), 2U);
   TEST_EQ_STR(vecofstrings2[0].c_str(), "jane");
   TEST_EQ_STR(vecofstrings2[1].c_str(), "mary");
 
-  auto &vecoftables = monster2->testarrayoftables;
+  auto &vecoftables = monster2.testarrayoftables;
   TEST_EQ(vecoftables.size(), 3U);
-  TEST_EQ_STR(vecoftables[0]->name.c_str(), "Barney");
-  TEST_EQ(vecoftables[0]->hp, 1000);
-  TEST_EQ_STR(vecoftables[1]->name.c_str(), "Fred");
-  TEST_EQ_STR(vecoftables[2]->name.c_str(), "Wilma");
+  TEST_EQ_STR(vecoftables[0].name.c_str(), "Barney");
+  TEST_EQ(vecoftables[0].hp, 1000);
+  TEST_EQ_STR(vecoftables[1].name.c_str(), "Fred");
+  TEST_EQ_STR(vecoftables[2].name.c_str(), "Wilma");
 
-  auto &tests = monster2->test4;
+  auto &tests = monster2.test4;
   TEST_EQ(tests[0].a(), 10);
   TEST_EQ(tests[0].b(), 20);
   TEST_EQ(tests[1].a(), 30);


### PR DESCRIPTION
It is needed to allow the users to assign one struct to another.

I also added implementation for operator= for unions, now you can do:
union1 = union2;
or
union1 = supportedStruct;

It is also needed for the upcoming (in the (near) future) Qt support.
