### PR TITLE
Fix docs for object API usage

### DIFF
--- a/docs/source/CppUsage.md
+++ b/docs/source/CppUsage.md
@@ -103,7 +103,7 @@ To use:
     cout << monsterobj->name;  // This is now a std::string!
     monsterobj->name = "Bob";  // Change the name.
     FlatBufferBuilder fbb;
-    monsterobj->Pack(fbb);     // Serialize into new buffer.
+    CreateMonster(fbb, monsterobj->get());     // Serialize into new buffer.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ## Reflection (& Resizing)


### PR DESCRIPTION
I don't see any `Pack` method created for a table.  I think the `CreateMonster` function is the correct one to use here.