### PR TITLE
Fix docs for object API usage

### DIFF
--- a/docs/source/CppUsage.md
+++ b/docs/source/CppUsage.md
@@ -103,7 +103,7 @@ To use:
     cout << monsterobj->name;  // This is now a std::string!
     monsterobj->name = "Bob";  // Change the name.
     FlatBufferBuilder fbb;
-    monsterobj->Pack(fbb);     // Serialize into new buffer.
+    CreateMonster(fbb, monsterobj->get());     // Serialize into new buffer.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ## Reflection (& Resizing)


### PR DESCRIPTION
I don't see `FooT.Pack` methods being generated in the Object API.  I think `CreateMonster` is the correct usage here.