### PR TITLE
Allow Unicode values > U+FFFF in string literals, validate UTF-8 by default

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -348,6 +348,7 @@ struct IDLOptions {
   bool escape_proto_identifiers;
   bool generate_object_based_api;
   bool union_value_namespacing;
+  bool allow_non_utf8;
 
   // Possible options for the more general generator below.
   enum Language { kJava, kCSharp, kGo, kMAX };
@@ -370,6 +371,7 @@ struct IDLOptions {
       escape_proto_identifiers(false),
       generate_object_based_api(false),
       union_value_namespacing(true),
+      allow_non_utf8(false),
       lang(IDLOptions::kJava) {}
 };
 

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -276,12 +276,42 @@ inline int FromUTF8(const char **in) {
   }
   if ((**in << len) & 0x80) return -1;  // Bit after leading 1's must be 0.
   if (!len) return *(*in)++;
+  // UTF-8 encoded values with a length are between 2 and 4 bytes.
+  if (len < 2 || len > 4) {
+    return -1;
+  }
   // Grab initial bits of the code.
   int ucc = *(*in)++ & ((1 << (7 - len)) - 1);
   for (int i = 0; i < len - 1; i++) {
     if ((**in & 0xC0) != 0x80) return -1;  // Upper bits must 1 0.
     ucc <<= 6;
     ucc |= *(*in)++ & 0x3F;  // Grab 6 more bits of the code.
+  }
+  // UTF-8 cannot encode values between 0xD800 and 0xDFFF (reserved for
+  // UTF-16 surrogate pairs).
+  if (ucc >= 0xD800 && ucc <= 0xDFFF) {
+    return -1;
+  }
+  // UTF-8 must represent code points in their shortest possible encoding.
+  switch (len) {
+    case 2:
+      // Two bytes of UTF-8 can represent code points from U+0080 to U+07FF.
+      if (ucc < 0x0080 || ucc > 0x07FF) {
+        return -1;
+      }
+      break;
+    case 3:
+      // Three bytes of UTF-8 can represent code points from U+0800 to U+FFFF.
+      if (ucc < 0x0800 || ucc > 0xFFFF) {
+        return -1;
+      }
+      break;
+    case 4:
+      // Four bytes of UTF-8 can represent code points from U+10000 to U+10FFFF.
+      if (ucc < 0x10000 || ucc > 0x10FFFF) {
+        return -1;
+      }
+      break;
   }
   return ucc;
 }

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -106,6 +106,9 @@ static void Error(const std::string &err, bool usage, bool show_exe_name) {
       "  --version          Print the version number of flatc and exit.\n"
       "  --strict-json      Strict JSON: field names must be / will be quoted,\n"
       "                     no trailing commas in tables/vectors.\n"
+      "  --allow-non-utf8   Pass non-UTF-8 input through parser and emit nonstandard\n"
+      "                     \\x escapes in JSON. (Default is to raise parse error on\n"
+      "                     non-UTF-8 input.)\n"
       "  --defaults-json    Output fields whose value is the default when\n"
       "                     writing JSON\n"
       "  --unknown-json     Allow fields in JSON that are not defined in the\n"
@@ -184,6 +187,8 @@ int main(int argc, const char *argv[]) {
         conform_to_schema = argv[argi];
       } else if(arg == "--strict-json") {
         opts.strict_json = true;
+      } else if(arg == "--allow-non-utf8") {
+        opts.allow_non_utf8 = true;
       } else if(arg == "--no-js-exports") {
         opts.skip_js_exports = true;
       } else if(arg == "--defaults-json") {

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -61,6 +61,17 @@ static_assert(BASE_TYPE_UNION ==
 #define NEXT() ECHECK(Next())
 #define EXPECT(tok) ECHECK(Expect(tok))
 
+static bool ValidateUTF8(const std::string &str) {
+  const char *s = &str[0];
+  const char * const sEnd = s + str.length();
+  while (s < sEnd) {
+    if (FromUTF8(&s) < 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
 CheckedError Parser::Error(const std::string &msg) {
   error_ = file_being_parsed_.length() ? AbsolutePath(file_being_parsed_) : "";
   #ifdef _WIN32
@@ -320,6 +331,9 @@ CheckedError Parser::Next() {
             "illegal Unicode sequence (unpaired high surrogate)");
         }
         cursor_++;
+        if (!opts.allow_non_utf8 && !ValidateUTF8(attribute_)) {
+          return Error("illegal UTF-8 sequence");
+        }
         token_ = kTokenStringConstant;
         return NoError();
       }


### PR DESCRIPTION
Previously, `idl_gen_text.cpp` treated Unicode values > `U+FFFF` as unrepresentable in JSON, and fell back to the nonstandard `\xAB` syntax to encode the raw UTF-8 bytes as pseudo-JSON.

The correct way to encode values > `U+FFFF` in JSON is to use two `\uXXXX\uXXXX` escapes representing the UTF-16 surrogate pair encoding the Unicode code point. This diff fixes that issue.

When I added support for this, I found the existing behavior for Unicode code points < `U+00FF` was ambiguous: if they were "printable", they were encoded as-is, but otherwise they were represented with the non-standard `\xAB` syntax. So, parsing input with any of:

1. `\u0080`
2. `\xC2\x80` (UTF-8 encoding of U+0080)
3. `\x80`

would all result in an output of `\x80`, which is ambiguous. This is actually a really big problem, since such code points are totally valid and should be represented as `\u00AB`, not `\xAB`.

In addition, I found the IDL parser was never actually validating UTF-8, so it was allowing all sorts of invalid strings as input. Fixing this is a breaking change, so I added a new IDL option `allow_non_utf8` (defaulting to `false`) which makes the parser ensure all data is valid UTF-8.

I added a bunch of new tests to cover the new functionality.