### PR TITLE
Allow to overwrite assert with own assert implementation

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -175,7 +175,7 @@ template<typename T> class SymbolTable {
       dict.erase(it);
       dict[newname] = obj;
     } else {
-      assert(false);
+      flatbuffers_assert(false);
     }
   }
 
@@ -411,7 +411,7 @@ class CheckedError {
     *this = other;  // Use assignment operator.
   }
 
-  ~CheckedError() { assert(has_been_checked_); }
+  ~CheckedError() { flatbuffers_assert(has_been_checked_); }
 
   bool Check() { has_been_checked_ = true; return is_error_; }
 

--- a/include/flatbuffers/reflection.h
+++ b/include/flatbuffers/reflection.h
@@ -61,7 +61,7 @@ inline const Table *GetAnyRoot(const uint8_t *flatbuf) {
 // Get a field, if you know it's an integer, and its exact type.
 template<typename T> T GetFieldI(const Table &table,
                                  const reflection::Field &field) {
-  assert(sizeof(T) == GetTypeSize(field.type()->base_type()));
+  flatbuffers_assert(sizeof(T) == GetTypeSize(field.type()->base_type()));
   return table.GetField<T>(field.offset(),
                            static_cast<T>(field.default_integer()));
 }
@@ -69,7 +69,7 @@ template<typename T> T GetFieldI(const Table &table,
 // Get a field, if you know it's floating point and its exact type.
 template<typename T> T GetFieldF(const Table &table,
                                  const reflection::Field &field) {
-  assert(sizeof(T) == GetTypeSize(field.type()->base_type()));
+  flatbuffers_assert(sizeof(T) == GetTypeSize(field.type()->base_type()));
   return table.GetField<T>(field.offset(),
                            static_cast<T>(field.default_real()));
 }
@@ -77,14 +77,14 @@ template<typename T> T GetFieldF(const Table &table,
 // Get a field, if you know it's a string.
 inline const String *GetFieldS(const Table &table,
                                const reflection::Field &field) {
-  assert(field.type()->base_type() == reflection::String);
+  flatbuffers_assert(field.type()->base_type() == reflection::String);
   return table.GetPointer<const String *>(field.offset());
 }
 
 // Get a field, if you know it's a vector.
 template<typename T> Vector<T> *GetFieldV(const Table &table,
                                           const reflection::Field &field) {
-  assert(field.type()->base_type() == reflection::Vector &&
+  flatbuffers_assert(field.type()->base_type() == reflection::Vector &&
          sizeof(T) == GetTypeSize(field.type()->element()));
   return table.GetPointer<Vector<T> *>(field.offset());
 }
@@ -100,7 +100,7 @@ inline VectorOfAny *GetFieldAnyV(const Table &table,
 // Get a field, if you know it's a table.
 inline Table *GetFieldT(const Table &table,
                         const reflection::Field &field) {
-  assert(field.type()->base_type() == reflection::Obj ||
+  flatbuffers_assert(field.type()->base_type() == reflection::Obj ||
          field.type()->base_type() == reflection::Union);
   return table.GetPointer<Table *>(field.offset());
 }
@@ -226,7 +226,7 @@ template<typename T> T *GetAnyFieldAddressOf(const Struct &st,
 // Set any scalar field, if you know its exact type.
 template<typename T> bool SetField(Table *table, const reflection::Field &field,
                                    T val) {
-  assert(sizeof(T) == GetTypeSize(field.type()->base_type()));
+  flatbuffers_assert(sizeof(T) == GetTypeSize(field.type()->base_type()));
   return table->SetField(field.offset(), val);
 }
 
@@ -345,7 +345,7 @@ inline const reflection::Object &GetUnionType(
   // TODO: this is clumsy and slow, but no other way to find it?
   auto type_field = parent.fields()->LookupByKey(
             (unionfield.name()->str() + UnionTypeFieldSuffix()).c_str());
-  assert(type_field);
+  flatbuffers_assert(type_field);
   auto union_type = GetFieldI<uint8_t>(table, *type_field);
   auto enumval = enumdef->values()->LookupByKey(union_type);
   return *enumval->object();
@@ -407,7 +407,7 @@ const uint8_t *AddFlatBuffer(std::vector<uint8_t> &flatbuf,
 
 inline bool SetFieldT(Table *table, const reflection::Field &field,
                       const uint8_t *val) {
-  assert(sizeof(uoffset_t) == GetTypeSize(field.type()->base_type()));
+  flatbuffers_assert(sizeof(uoffset_t) == GetTypeSize(field.type()->base_type()));
   return table->SetPointer(field.offset(), val);
 }
 

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -237,7 +237,7 @@ inline std::string AbsolutePath(const std::string &filepath) {
 // Convert a unicode code point into a UTF-8 representation by appending it
 // to a string. Returns the number of bytes generated.
 inline int ToUTF8(uint32_t ucc, std::string *out) {
-  assert(!(ucc & 0x80000000));  // Top bit can't be set.
+  flatbuffers_assert(!(ucc & 0x80000000));  // Top bit can't be set.
   // 6 possible encodings: http://en.wikipedia.org/wiki/UTF-8
   for (int i = 0; i < 6; i++) {
     // Max bits this encoding can represent.
@@ -255,7 +255,7 @@ inline int ToUTF8(uint32_t ucc, std::string *out) {
       return i + 1;  // Return the number of bytes added.
     }
   }
-  assert(0);  // Impossible to arrive here.
+  flatbuffers_assert(0);  // Impossible to arrive here.
   return -1;
 }
 

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -85,7 +85,7 @@ class CppGenerator : public BaseGenerator {
       if (num_includes) code += "\n";
     }
 
-    assert(!cur_name_space_);
+    flatbuffers_assert(!cur_name_space_);
 
     // Generate forward declarations for all structs/tables, since they may
     // have circular references.
@@ -211,7 +211,7 @@ class CppGenerator : public BaseGenerator {
       code += "); }\n\n";
     }
 
-    assert(cur_name_space_);
+    flatbuffers_assert(cur_name_space_);
     SetNameSpace(nullptr, &code);
 
     // Close the include guard.
@@ -403,7 +403,7 @@ class CppGenerator : public BaseGenerator {
       anyv |= ev.value;
     }
     if (parser_.opts.scoped_enums || parser_.opts.prefixed_enums) {
-      assert(minv && maxv);
+      flatbuffers_assert(minv && maxv);
       if (enum_def.attributes.Lookup("bit_flags")) {
         if (minv->value != 0)  // If the user didn't defined NONE value
           code += "  " + GenEnumVal(enum_def, "NONE", parser_.opts) + " = 0,\n";
@@ -722,7 +722,7 @@ class CppGenerator : public BaseGenerator {
               parser_.namespaces_.back()->GetFullyQualifiedName(
                   nested->constant);
           auto nested_root = parser_.structs_.Lookup(qualified_name);
-          assert(nested_root);  // Guaranteed to exist by parser.
+          flatbuffers_assert(nested_root);  // Guaranteed to exist by parser.
           (void)nested_root;
           std::string cpp_qualified_name = TranslateNameSpace(qualified_name);
 
@@ -1004,7 +1004,7 @@ class CppGenerator : public BaseGenerator {
             }
             case BASE_TYPE_UTYPE: {
               auto &union_field = **(it + 1);
-              assert(union_field.value.type.base_type == BASE_TYPE_UNION);
+              flatbuffers_assert(union_field.value.type.base_type == BASE_TYPE_UNION);
               code += prefix + deref + union_field.name + ".type = _e;";
               break;
             }
@@ -1114,7 +1114,7 @@ class CppGenerator : public BaseGenerator {
       for (int i = 0; i < 4; i++)
         if (static_cast<int>(field.padding) & (1 << i))
           f((1 << i) * 8, code, padding_id);
-      assert(!(field.padding & ~0xF));
+      flatbuffers_assert(!(field.padding & ~0xF));
     }
   }
 

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -195,7 +195,7 @@ class GeneralGenerator : public BaseGenerator {
                    const std::string &file_name)
       : BaseGenerator(parser, path, file_name, "", "."),
         lang_(language_parameters[parser_.opts.lang]) {
-    assert(parser_.opts.lang <= IDLOptions::kMAX);
+    flatbuffers_assert(parser_.opts.lang <= IDLOptions::kMAX);
       };
   GeneralGenerator &operator=(const GeneralGenerator &);
   bool generate() {
@@ -865,7 +865,7 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
           code += "(obj, o) : null";
           break;
         default:
-          assert(0);
+          flatbuffers_assert(0);
       }
     }
     code += "; ";
@@ -1147,7 +1147,7 @@ bool GenerateGeneral(const Parser &parser, const std::string &path,
 
 std::string GeneralMakeRule(const Parser &parser, const std::string &path,
                             const std::string &file_name) {
-  assert(parser.opts.lang <= IDLOptions::kMAX);
+  flatbuffers_assert(parser.opts.lang <= IDLOptions::kMAX);
   auto lang = language_parameters[parser.opts.lang];
 
   std::string make_rule;

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -505,7 +505,7 @@ static void GenStructAccessor(const StructDef &struct_def,
         GetUnionField(struct_def, field, code_ptr);
         break;
       default:
-        assert(0);
+        flatbuffers_assert(0);
     }
   }
   if (field.value.type.base_type == BASE_TYPE_VECTOR) {

--- a/src/idl_gen_grpc.cpp
+++ b/src/idl_gen_grpc.cpp
@@ -125,7 +125,7 @@ class FlatBufPrinter : public grpc_cpp_generator::Printer {
   }
 
   void Indent() { indent_++; }
-  void Outdent() { indent_--; assert(indent_ >= 0); }
+  void Outdent() { indent_--; flatbuffers_assert(indent_ >= 0); }
 
  private:
   std::string *str_;

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -545,7 +545,7 @@ void GenStruct(const Parser &parser, StructDef &struct_def, std::string *code_pt
           break;
 
         default:
-          assert(0);
+          flatbuffers_assert(0);
       }
     }
     code += "};\n\n";

--- a/src/idl_gen_php.cpp
+++ b/src/idl_gen_php.cpp
@@ -714,7 +714,7 @@ namespace php {
           GetUnionField(field, code_ptr);
           break;
         default:
-          assert(0);
+          flatbuffers_assert(0);
         }
       }
       if (field.value.type.base_type == BASE_TYPE_VECTOR) {

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -447,7 +447,7 @@ static void GenStructAccessor(const StructDef &struct_def,
         GetUnionField(struct_def, field, code_ptr);
         break;
       default:
-        assert(0);
+        flatbuffers_assert(0);
     }
   }
   if (field.value.type.base_type == BASE_TYPE_VECTOR) {

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -120,7 +120,7 @@ static void EscapeString(const String &s, std::string *_text, const IDLOptions& 
             } else {
               // We previously checked for non-UTF-8 and returned a parse error,
               // so we shouldn't reach here.
-              assert(0);
+              flatbuffers_assert(0);
             }
           } else {
             if (ucc <= 0xFFFF) {
@@ -157,7 +157,7 @@ template<> void Print<const void *>(const void *val,
     case BASE_TYPE_UNION:
       // If this assert hits, you have an corrupt buffer, a union type field
       // was not present or was out of range.
-      assert(union_sd);
+      flatbuffers_assert(union_sd);
       GenStruct(*union_sd,
                 reinterpret_cast<const Table *>(val),
                 indent,
@@ -189,7 +189,7 @@ template<> void Print<const void *>(const void *val,
         #undef FLATBUFFERS_TD
       }
       break;
-    default: assert(0);
+    default: flatbuffers_assert(0);
   }
 }
 
@@ -212,7 +212,7 @@ static void GenFieldOffset(const FieldDef &fd, const Table *table, bool fixed,
   const void *val = nullptr;
   if (fixed) {
     // The only non-scalar fields in structs are structs.
-    assert(IsStruct(fd.value.type));
+    flatbuffers_assert(IsStruct(fd.value.type));
     val = reinterpret_cast<const Struct *>(table)->
             GetStruct<const void *>(fd.value.offset);
   } else {
@@ -271,7 +271,7 @@ static void GenStruct(const StructDef &struct_def, const Table *table,
         if (fd.value.type.base_type == BASE_TYPE_UTYPE) {
           auto enum_val = fd.value.type.enum_def->ReverseLookup(
                                   table->GetField<uint8_t>(fd.value.offset, 0));
-          assert(enum_val);
+          flatbuffers_assert(enum_val);
           union_sd = enum_val->struct_def;
         }
       }
@@ -290,7 +290,7 @@ static void GenStruct(const StructDef &struct_def, const Table *table,
 void GenerateText(const Parser &parser, const void *flatbuffer,
                   std::string *_text) {
   std::string &text = *_text;
-  assert(parser.root_struct_def_);  // call SetRootType()
+  flatbuffers_assert(parser.root_struct_def_);  // call SetRootType()
   text.reserve(1024);   // Reduce amount of inevitable reallocs.
   GenStruct(*parser.root_struct_def_,
             GetRoot<Table>(flatbuffer),

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -710,7 +710,7 @@ CheckedError Parser::ParseAnyValue(Value &val, FieldDef *field,
                                    const StructDef *parent_struct_def) {
   switch (val.type.base_type) {
     case BASE_TYPE_UNION: {
-      assert(field);
+      flatbuffers_assert(field);
       std::string constant;
       if (!parent_fieldn ||
           field_stack_.back().second->value.type.base_type != BASE_TYPE_UTYPE) {
@@ -718,9 +718,9 @@ CheckedError Parser::ParseAnyValue(Value &val, FieldDef *field,
         // output these in alphabetical order, meaning it comes after this
         // value. So we scan past the value to find it, then come back here.
         auto type_name = field->name + UnionTypeFieldSuffix();
-        assert(parent_struct_def);
+        flatbuffers_assert(parent_struct_def);
         auto type_field = parent_struct_def->fields.Lookup(type_name);
-        assert(type_field);  // Guaranteed by ParseField().
+        flatbuffers_assert(type_field);  // Guaranteed by ParseField().
         // Remember where we are in the source file, so we can come back here.
         auto backup = *static_cast<ParserState *>(this);
         ECHECK(SkipAnyJsonValue());  // The table.
@@ -786,7 +786,7 @@ CheckedError Parser::ParseAnyValue(Value &val, FieldDef *field,
 }
 
 void Parser::SerializeStruct(const StructDef &struct_def, const Value &val) {
-  assert(val.constant.length() == struct_def.bytesize);
+  flatbuffers_assert(val.constant.length() == struct_def.bytesize);
   builder_.Align(struct_def.minalign);
   builder_.PushBytes(reinterpret_cast<const uint8_t *>(val.constant.c_str()),
                      struct_def.bytesize);
@@ -895,14 +895,14 @@ CheckedError Parser::ParseTable(const StructDef &struct_def, std::string *value,
   if (struct_def.fixed) {
     builder_.ClearOffsets();
     builder_.EndStruct();
-    assert(value);
+    flatbuffers_assert(value);
     // Temporarily store this struct in the value string, since it is to
     // be serialized in-place elsewhere.
     value->assign(
           reinterpret_cast<const char *>(builder_.GetCurrentBufferPointer()),
           struct_def.bytesize);
     builder_.PopBytes(struct_def.bytesize);
-    assert(!ovalue);
+    flatbuffers_assert(!ovalue);
   } else {
     auto val = builder_.EndTable(start,
                           static_cast<voffset_t>(struct_def.fields.vec.size()));
@@ -1035,7 +1035,7 @@ CheckedError Parser::ParseEnumFromString(Type &type, int64_t *result) {
 
 
 CheckedError Parser::ParseHash(Value &e, FieldDef* field) {
-  assert(field);
+  flatbuffers_assert(field);
   Value *hash_name = field->attributes.Lookup("hash");
   switch (e.type.base_type) {
     case BASE_TYPE_INT:
@@ -1053,7 +1053,7 @@ CheckedError Parser::ParseHash(Value &e, FieldDef* field) {
       break;
     }
     default:
-      assert(0);
+      flatbuffers_assert(0);
   }
   NEXT();
   return NoError();
@@ -1098,7 +1098,7 @@ CheckedError Parser::ParseSingleValue(Value &e) {
       } else if (IsFloat(e.type.base_type)) {
         e.constant = NumToString(strtod(attribute_.c_str(), nullptr));
       } else {
-        assert(0);  // Shouldn't happen, we covered all types.
+        flatbuffers_assert(0);  // Shouldn't happen, we covered all types.
         e.constant = "0";
       }
       NEXT();
@@ -2094,7 +2094,7 @@ flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<
   std::vector<flatbuffers::Offset<reflection::KeyValue>> attrs;
   for (auto kv = attributes.dict.begin(); kv != attributes.dict.end(); ++kv) {
     auto it = parser.known_attributes_.find(kv->first);
-    assert(it != parser.known_attributes_.end());
+    flatbuffers_assert(it != parser.known_attributes_.end());
     if (!it->second) {  // Custom attribute.
       attrs.push_back(
           reflection::CreateKeyValue(*builder, builder->CreateString(kv->first),

--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -267,7 +267,7 @@ class ResizeContext {
           case reflection::String:
             break;
           default:
-            assert(false);
+            flatbuffers_assert(false);
         }
       }
       // Check if the vtable offset points beyond the insertion point.
@@ -471,7 +471,7 @@ Offset<const Table *> CopyTable(FlatBufferBuilder &fbb,
       }
     }
   }
-  assert(offset_idx == offsets.size());
+  flatbuffers_assert(offset_idx == offsets.size());
   if (objectdef.is_struct()) {
     fbb.ClearOffsets();
     return fbb.EndStruct();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -47,12 +47,12 @@ static LoadFileFunction g_load_file_function = LoadFileRaw;
 static FileExistsFunction g_file_exists_function = FileExistsRaw;
 
 bool LoadFile(const char *name, bool binary, std::string *buf) {
-  assert(g_load_file_function);
+  flatbuffers_assert(g_load_file_function);
   return g_load_file_function(name, binary, buf);
 }
 
 bool FileExists(const char *name) {
-  assert(g_file_exists_function);
+  flatbuffers_assert(g_file_exists_function);
   return g_file_exists_function(name);
 }
 


### PR DESCRIPTION
This is quite useful if you have your own assert implementation to e.g. hook in a debugger (see SDL_assert handling as an example).
