### PR TITLE
Add ability to create a default empty flatbuffer

### DIFF
--- a/java/com/google/flatbuffers/Table.java
+++ b/java/com/google/flatbuffers/Table.java
@@ -57,6 +57,7 @@ public class Table {
    * @return Returns an offset into the object, or `0` if the field is not present.
    */
   protected int __offset(int vtable_offset) {
+    if (bb == null) return 0;
     int vtable = bb_pos - bb.getInt(bb_pos);
     return vtable_offset < bb.getShort(vtable) ? bb.getShort(vtable + vtable_offset) : 0;
   }


### PR DESCRIPTION
This allows to call the default constructor and not have a broken object anymore. This also drastically reduces boilerplate when creating a flatbuffer with default values.

Solves issue #3945 