### PR TITLE
Switched C# accessors from classes to structs

### DIFF
--- a/net/FlatBuffers/FlatBufferBuilder.cs
+++ b/net/FlatBuffers/FlatBufferBuilder.cs
@@ -295,12 +295,12 @@ namespace FlatBuffers
             PutInt(_vectorNumElems);
             return new VectorOffset(Offset);
         }
-		
+
         /// <summary>
         /// Creates a vector of tables.
         /// </summary>
         /// <param name="offsets">Offsets of the tables.</param>
-        public VectorOffset CreateVectorOfTables<T>(Offset<T>[] offsets) where T : class
+        public VectorOffset CreateVectorOfTables<T>(Offset<T>[] offsets) where T : struct
         {
             NotNested();
             StartVector(sizeof(int), offsets.Length, sizeof(int));

--- a/net/FlatBuffers/IFlatbufferObject .cs
+++ b/net/FlatBuffers/IFlatbufferObject .cs
@@ -17,32 +17,10 @@
 namespace FlatBuffers
 {
     /// <summary>
-    /// Offset class for typesafe assignments.
+    /// This is the base for both structs and tables.
     /// </summary>
-    public struct Offset<T> where T : struct
+    public interface IFlatbufferObject
     {
-        public int Value;
-        public Offset(int value)
-        {
-            Value = value;
-        }
-    }
-
-    public struct StringOffset
-    {
-        public int Value;
-        public StringOffset(int value)
-        {
-            Value = value;
-        }
-    }
-
-    public struct VectorOffset
-    {
-        public int Value;
-        public VectorOffset(int value)
-        {
-            Value = value;
-        }
+        void __init(int _i, ByteBuffer _bb);
     }
 }

--- a/net/FlatBuffers/Struct.cs
+++ b/net/FlatBuffers/Struct.cs
@@ -19,9 +19,9 @@ namespace FlatBuffers
     /// <summary>
     /// All structs in the generated code derive from this class, and add their own accessors.
     /// </summary>
-    public abstract class Struct
+    public struct Struct
     {
-        protected int bb_pos;
-        protected ByteBuffer bb;
+        public int bb_pos;
+        public ByteBuffer bb;
     }
 }

--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -20,42 +20,42 @@ using System.Text;
 namespace FlatBuffers
 {
     /// <summary>
-    /// All tables in the generated code derive from this class, and add their own accessors.
+    /// All tables in the generated code derive from this struct, and add their own accessors.
     /// </summary>
-    public abstract class Table
+    public struct Table
     {
-        protected int bb_pos;
-        protected ByteBuffer bb;
+        public int bb_pos;
+        public ByteBuffer bb;
 
         public ByteBuffer ByteBuffer { get { return bb; } }
 
         // Look up a field in the vtable, return an offset into the object, or 0 if the field is not
         // present.
-        protected int __offset(int vtableOffset)
+        public int __offset(int vtableOffset)
         {
             int vtable = bb_pos - bb.GetInt(bb_pos);
             return vtableOffset < bb.GetShort(vtable) ? (int)bb.GetShort(vtable + vtableOffset) : 0;
         }
 
-        protected static int __offset(int vtableOffset, int offset, ByteBuffer bb)
+        public static int __offset(int vtableOffset, int offset, ByteBuffer bb)
         {
             int vtable = bb.Length - offset;
             return (int)bb.GetShort(vtable + vtableOffset - bb.GetInt(vtable)) + vtable;
         }
 
         // Retrieve the relative offset stored at "offset"
-        protected int __indirect(int offset)
+        public int __indirect(int offset)
         {
             return offset + bb.GetInt(offset);
         }
-		
-        protected static int __indirect(int offset, ByteBuffer bb)
+
+        public static int __indirect(int offset, ByteBuffer bb)
         {
             return offset + bb.GetInt(offset);
         }
 
         // Create a .NET String from UTF-8 data stored inside the flatbuffer.
-        protected string __string(int offset)
+        public string __string(int offset)
         {
             offset += bb.GetInt(offset);
             var len = bb.GetInt(offset);
@@ -64,7 +64,7 @@ namespace FlatBuffers
         }
 
         // Get the length of a vector whose offset is stored at "offset" in this object.
-        protected int __vector_len(int offset)
+        public int __vector_len(int offset)
         {
             offset += bb_pos;
             offset += bb.GetInt(offset);
@@ -72,7 +72,7 @@ namespace FlatBuffers
         }
 
         // Get the start of data of a vector whose offset is stored at "offset" in this object.
-        protected int __vector(int offset)
+        public int __vector(int offset)
         {
             offset += bb_pos;
             return offset + bb.GetInt(offset) + sizeof(int);  // data starts after the length
@@ -81,7 +81,8 @@ namespace FlatBuffers
         // Get the data of a vector whoses offset is stored at "offset" in this object as an
         // ArraySegment&lt;byte&gt;. If the vector is not present in the ByteBuffer,
         // then a null value will be returned.
-        protected ArraySegment<byte>? __vector_as_arraysegment(int offset) {
+        public ArraySegment<byte>? __vector_as_arraysegment(int offset)
+        {
             var o = this.__offset(offset);
             if (0 == o)
             {
@@ -94,15 +95,15 @@ namespace FlatBuffers
         }
 
         // Initialize any Table-derived type to point to the union at the given offset.
-        protected TTable __union<TTable>(TTable t, int offset) where TTable : Table
+        public T __union<T>(int offset) where T : struct, IFlatbufferObject
         {
             offset += bb_pos;
-            t.bb_pos = offset + bb.GetInt(offset);
-            t.bb = bb;
+            T t = new T();
+            t.__init(offset + bb.GetInt(offset), bb);
             return t;
         }
 
-        protected static bool __has_identifier(ByteBuffer bb, string ident)
+        public static bool __has_identifier(ByteBuffer bb, string ident)
         {
             if (ident.Length != FlatBufferConstants.FileIdentifierLength)
                 throw new ArgumentException("FlatBuffers: file identifier must be length " + FlatBufferConstants.FileIdentifierLength, "ident");
@@ -114,9 +115,9 @@ namespace FlatBuffers
 
             return true;
         }
-		
+
         // Compare strings in the ByteBuffer.
-        protected static int CompareStrings(int offset_1, int offset_2, ByteBuffer bb)
+        public static int CompareStrings(int offset_1, int offset_2, ByteBuffer bb)
         {
             offset_1 += bb.GetInt(offset_1);
             offset_2 += bb.GetInt(offset_2);
@@ -132,9 +133,9 @@ namespace FlatBuffers
             }
             return len_1 - len_2;
         }
-		
+
         // Compare string from the ByteBuffer with the string object
-        protected static int CompareStrings(int offset_1, byte[] key, ByteBuffer bb)
+        public static int CompareStrings(int offset_1, byte[] key, ByteBuffer bb)
         {
             offset_1 += bb.GetInt(offset_1);
             var len_1 = bb.GetInt(offset_1);
@@ -148,6 +149,5 @@ namespace FlatBuffers
             }
             return len_1 - len_2;
         }
-
     }
 }

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -76,24 +76,28 @@ struct LanguageParameters {
   IDLOptions::Language language;
   // Whether function names in the language typically start with uppercase.
   bool first_camel_upper;
-  const char *file_extension;
-  const char *string_type;
-  const char *bool_type;
-  const char *open_curly;
-  const char *const_decl;
-  const char *unsubclassable_decl;
-  const char *enum_decl;
-  const char *enum_separator;
-  const char *getter_prefix;
-  const char *getter_suffix;
-  const char *inheritance_marker;
-  const char *namespace_ident;
-  const char *namespace_begin;
-  const char *namespace_end;
-  const char *set_bb_byteorder;
-  const char *get_bb_position;
-  const char *get_fbb_offset;
-  const char *includes;
+  std::string file_extension;
+  std::string string_type;
+  std::string bool_type;
+  std::string open_curly;
+  std::string accessor_type;
+  std::string const_decl;
+  std::string unsubclassable_decl;
+  std::string enum_decl;
+  std::string enum_separator;
+  std::string getter_prefix;
+  std::string getter_suffix;
+  std::string inheritance_marker;
+  std::string namespace_ident;
+  std::string namespace_begin;
+  std::string namespace_end;
+  std::string set_bb_byteorder;
+  std::string get_bb_position;
+  std::string get_fbb_offset;
+  std::string accessor_prefix;
+  std::string accessor_prefix_static;
+  std::string optional_suffix;
+  std::string includes;
   CommentConfig comment_config;
 };
 
@@ -105,6 +109,7 @@ LanguageParameters language_parameters[] = {
     "String",
     "boolean ",
     " {\n",
+    "class ",
     " final ",
     "final ",
     "final class ",
@@ -118,6 +123,9 @@ LanguageParameters language_parameters[] = {
     "_bb.order(ByteOrder.LITTLE_ENDIAN); ",
     "position()",
     "offset()",
+    "",
+    "",
+    "",
     "import java.nio.*;\nimport java.lang.*;\nimport java.util.*;\n"
       "import com.google.flatbuffers.*;\n\n@SuppressWarnings(\"unused\")\n",
     {
@@ -133,8 +141,9 @@ LanguageParameters language_parameters[] = {
     "string",
     "bool ",
     "\n{\n",
+    "struct ",
     " readonly ",
-    "sealed ",
+    "",
     "enum ",
     ",\n",
     " { get",
@@ -146,6 +155,9 @@ LanguageParameters language_parameters[] = {
     "",
     "Position",
     "Offset",
+    "__p.",
+    "Table.",
+    "?",
     "using System;\nusing FlatBuffers;\n\n",
     {
       nullptr,
@@ -162,6 +174,7 @@ LanguageParameters language_parameters[] = {
     "string",
     "bool ",
     "\n{\n",
+    "class ",
     "const ",
     " ",
     "class ",
@@ -175,6 +188,9 @@ LanguageParameters language_parameters[] = {
     "",
     "position()",
     "offset()",
+    "",
+    "",
+    "",
     "import (\n\tflatbuffers \"github.com/google/flatbuffers/go\"\n)",
     {
       nullptr,
@@ -343,7 +359,8 @@ std::string GenOffsetConstruct(const StructDef &struct_def,
                                       const std::string &variable_name)
 {
   if(lang_.language == IDLOptions::kCSharp) {
-    return "new Offset<" + WrapInNameSpace(struct_def) + ">(" + variable_name + ")";
+    return "new Offset<" + WrapInNameSpace(struct_def) + ">(" + variable_name +
+           ")";
   }
   return variable_name;
 }
@@ -401,9 +418,11 @@ std::string DestinationCast(const Type &type) {
 }
 
 // Cast statements for mutator method parameters.
-// In Java, parameters representing unsigned numbers need to be cast down to their respective type.
-// For example, a long holding an unsigned int value would be cast down to int before being put onto the buffer.
-// In C#, one cast directly cast an Enum to its underlying type, which is essential before putting it onto the buffer.
+// In Java, parameters representing unsigned numbers need to be cast down to
+// their respective type. For example, a long holding an unsigned int value
+// would be cast down to int before being put onto the buffer. In C#, one cast
+// directly cast an Enum to its underlying type, which is essential before
+// putting it onto the buffer.
 std::string SourceCast(const Type &type, bool castFromDest) {
   if (type.base_type == BASE_TYPE_VECTOR) {
     return SourceCast(type.VectorType(), castFromDest);
@@ -484,7 +503,8 @@ std::string GenDefaultValueBasic(const Value &value, bool enableLangOverrides) {
         case BASE_TYPE_STRING:
           return "default(StringOffset)";
         case BASE_TYPE_STRUCT:
-          return "default(Offset<" + WrapInNameSpace(*value.type.struct_def) + ">)";
+          return "default(Offset<" + WrapInNameSpace(*value.type.struct_def) +
+                 ">)";
         case BASE_TYPE_VECTOR:
           return "default(VectorOffset)";
         default:
@@ -513,7 +533,8 @@ void GenEnum(EnumDef &enum_def, std::string *code_ptr) {
   GenComment(enum_def.doc_comment, code_ptr, &lang_.comment_config);
   code += std::string("public ") + lang_.enum_decl + enum_def.name;
   if (lang_.language == IDLOptions::kCSharp) {
-    code += lang_.inheritance_marker + GenTypeBasic(enum_def.underlying_type, false);
+    code += lang_.inheritance_marker +
+            GenTypeBasic(enum_def.underlying_type, false);
   }
   code += lang_.open_curly;
   if (lang_.language == IDLOptions::kJava) {
@@ -578,12 +599,13 @@ void GenEnum(EnumDef &enum_def, std::string *code_ptr) {
 // Returns the function name that is able to read a value of the given type.
 std::string GenGetter(const Type &type) {
   switch (type.base_type) {
-    case BASE_TYPE_STRING: return "__string";
-    case BASE_TYPE_STRUCT: return "__struct";
-    case BASE_TYPE_UNION:  return "__union";
+    case BASE_TYPE_STRING: return lang_.accessor_prefix + "__string";
+    case BASE_TYPE_STRUCT: return lang_.accessor_prefix + "__struct";
+    case BASE_TYPE_UNION:  return lang_.accessor_prefix + "__union";
     case BASE_TYPE_VECTOR: return GenGetter(type.VectorType());
     default: {
-      std::string getter = "bb." + FunctionStart('G') + "et";
+      std::string getter =
+        lang_.accessor_prefix + "bb." + FunctionStart('G') + "et";
       if (type.base_type == BASE_TYPE_BOOL) {
         getter = "0!=" + getter;
       } else if (GenTypeBasic(type, false) != "byte") {
@@ -598,7 +620,8 @@ std::string GenGetter(const Type &type) {
 // Hence a setter method will only be generated for such fields.
 std::string GenSetter(const Type &type) {
   if (IsScalar(type.base_type)) {
-    std::string setter = "bb." + FunctionStart('P') + "ut";
+    std::string setter =
+      lang_.accessor_prefix + "bb." + FunctionStart('P') + "ut";
     if (GenTypeBasic(type, false) != "byte" &&
         type.base_type != BASE_TYPE_BOOL) {
       setter += MakeCamel(GenTypeBasic(type, false));
@@ -618,7 +641,8 @@ std::string GenMethod(const Type &type) {
 
 // Recursively generate arguments for a constructor, to deal with nested
 // structs.
-void GenStructArgs(const StructDef &struct_def, std::string *code_ptr, const char *nameprefix) {
+void GenStructArgs(const StructDef &struct_def, std::string *code_ptr,
+                   const char *nameprefix) {
   std::string &code = *code_ptr;
   for (auto it = struct_def.fields.vec.begin();
        it != struct_def.fields.vec.end();
@@ -643,7 +667,8 @@ void GenStructArgs(const StructDef &struct_def, std::string *code_ptr, const cha
 // Recusively generate struct construction statements of the form:
 // builder.putType(name);
 // and insert manual padding.
-void GenStructBody(const StructDef &struct_def, std::string *code_ptr, const char *nameprefix) {
+void GenStructBody(const StructDef &struct_def, std::string *code_ptr,
+                   const char *nameprefix) {
   std::string &code = *code_ptr;
   code += "    builder." + FunctionStart('P') + "rep(";
   code += NumToString(struct_def.minalign) + ", ";
@@ -676,9 +701,10 @@ std::string GenByteBufferLength(const char *bb_name) {
   return bb_len;
 }
 
-std::string GenOffsetGetter(flatbuffers::FieldDef *key_field, const char *num = nullptr) {
+std::string GenOffsetGetter(flatbuffers::FieldDef *key_field,
+                            const char *num = nullptr) {
   std::string key_offset = "";
-  key_offset += "__offset(" +
+  key_offset += lang_.accessor_prefix_static + "__offset(" +
     NumToString(key_field->value.offset) + ", ";
   if (num) {
     key_offset += num;
@@ -693,10 +719,12 @@ std::string GenOffsetGetter(flatbuffers::FieldDef *key_field, const char *num = 
 
 std::string GenLookupKeyGetter(flatbuffers::FieldDef *key_field) {
   std::string key_getter = "      ";
-  key_getter += "int tableOffset = __indirect(vectorLocation + 4 * (start + middle)";
+  key_getter += "int tableOffset = " + lang_.accessor_prefix_static;
+  key_getter += "__indirect(vectorLocation + 4 * (start + middle)";
   key_getter += ", bb);\n      ";
   if (key_field->value.type.base_type == BASE_TYPE_STRING) {
-    key_getter += "int comp = " + FunctionStart('C') + "ompareStrings(";
+    key_getter += "int comp = " + lang_.accessor_prefix_static;
+    key_getter += FunctionStart('C') + "ompareStrings(";
     key_getter += GenOffsetGetter(key_field);
     key_getter += ", byteKey, bb);\n";
   } else {
@@ -721,6 +749,7 @@ std::string GenKeyGetter(flatbuffers::FieldDef *key_field) {
   if (key_field->value.type.base_type == BASE_TYPE_STRING) {
     if (lang_.language == IDLOptions::kJava)
       key_getter += " return ";
+    key_getter += lang_.accessor_prefix_static;
     key_getter += FunctionStart('C') + "ompareStrings(";
     key_getter += GenOffsetGetter(key_field, "o1") + ", ";
     key_getter += GenOffsetGetter(key_field, "o2") + ", " + data_buffer + ")";
@@ -765,18 +794,27 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
       struct_def.attributes.Lookup("csharp_partial")) {
     // generate a partial class for this C# struct/table
     code += "partial ";
-  }
-  else {
+  } else {
     code += lang_.unsubclassable_decl;
   }
-  code += "class " + struct_def.name + lang_.inheritance_marker;
-  code += struct_def.fixed ? "Struct" : "Table";
-  code += " {\n";
+  code += lang_.accessor_type + struct_def.name;
+  if (lang_.language == IDLOptions::kCSharp) {
+    code += " : IFlatbufferObject";
+    code += lang_.open_curly;
+    code += "  private ";
+    code += struct_def.fixed ? "Struct" : "Table";
+    code += " __p;\n";
+  } else {
+    code += lang_.inheritance_marker;
+    code += struct_def.fixed ? "Struct" : "Table";
+    code += lang_.open_curly;
+  }
   if (!struct_def.fixed) {
     // Generate a special accessor for the table that when used as the root
     // of a FlatBuffer
     std::string method_name = FunctionStart('G') + "etRootAs" + struct_def.name;
-    std::string method_signature = "  public static " + struct_def.name + " " + method_name;
+    std::string method_signature = "  public static " + struct_def.name + " " +
+                                   method_name;
 
     // create convenience method that doesn't require an existing object
     code += method_signature + "(ByteBuffer _bb) ";
@@ -785,8 +823,7 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
     // create method that allows object reuse
     code += method_signature + "(ByteBuffer _bb, " + struct_def.name + " obj) { ";
     code += lang_.set_bb_byteorder;
-    code += "return (obj.__init(_bb." + FunctionStart('G');
-    code += "etInt(_bb.";
+    code += "return (obj.__assign(_bb." + FunctionStart('G') + "etInt(_bb.";
     code += lang_.get_bb_position;
     code += ") + _bb.";
     code += lang_.get_bb_position;
@@ -797,16 +834,19 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
         code += "  public static ";
         code += lang_.bool_type + struct_def.name;
         code += "BufferHasIdentifier(ByteBuffer _bb) { return ";
-        code += "__has_identifier(_bb, \"" + parser_.file_identifier_;
+        code += lang_.accessor_prefix_static + "__has_identifier(_bb, \"";
+        code += parser_.file_identifier_;
         code += "\"); }\n";
       }
     }
   }
   // Generate the __init method that sets the field in a pre-existing
   // accessor object. This is to allow object reuse.
-  code += "  public " + struct_def.name;
-  code += " __init(int _i, ByteBuffer _bb) ";
-  code += "{ bb_pos = _i; bb = _bb; return this; }\n\n";
+  code += "  public void __init(int _i, ByteBuffer _bb) ";
+  code += "{ " + lang_.accessor_prefix + "bb_pos = _i; ";
+  code += lang_.accessor_prefix + "bb = _bb; }\n";
+  code += "  public " + struct_def.name + " __assign(int _i, ByteBuffer _bb) ";
+  code += "{ __init(_i, _bb); return this; }\n\n";
   for (auto it = struct_def.fields.vec.begin();
        it != struct_def.fields.vec.end();
        ++it) {
@@ -815,28 +855,35 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
     GenComment(field.doc_comment, code_ptr, &lang_.comment_config, "  ");
     std::string type_name = GenTypeGet(field.value.type);
     std::string type_name_dest = GenTypeNameDest(field.value.type);
+    std::string conditional_cast = "";
+    std::string optional = "";
+    if (lang_.language == IDLOptions::kCSharp &&
+        !struct_def.fixed &&
+        (field.value.type.base_type == BASE_TYPE_STRUCT ||
+         field.value.type.base_type == BASE_TYPE_UNION ||
+         (field.value.type.base_type == BASE_TYPE_VECTOR &&
+          field.value.type.element == BASE_TYPE_STRUCT))) {
+      optional = lang_.optional_suffix;
+      conditional_cast = "(" + type_name_dest + optional + ")";
+    }
     std::string dest_mask = DestinationMask(field.value.type, true);
     std::string dest_cast = DestinationCast(field.value.type);
     std::string src_cast = SourceCast(field.value.type);
-    std::string method_start = "  public " + type_name_dest + " " +
+    std::string method_start = "  public " + type_name_dest + optional + " " +
                                MakeCamel(field.name, lang_.first_camel_upper);
+    std::string obj = lang_.language == IDLOptions::kCSharp
+      ? "(new " + type_name + "())"
+      : "obj";
 
     // Most field accessors need to retrieve and test the field offset first,
     // this is the prefix code for that:
-    auto offset_prefix = " { int o = __offset(" +
-      NumToString(field.value.offset) +
-      "); return o != 0 ? ";
+    auto offset_prefix = " { int o = " + lang_.accessor_prefix + "__offset(" +
+                         NumToString(field.value.offset) +
+                         "); return o != 0 ? ";
     // Generate the accessors that don't do object reuse.
     if (field.value.type.base_type == BASE_TYPE_STRUCT) {
       // Calls the accessor that takes an accessor object with a new object.
-      if (lang_.language == IDLOptions::kCSharp) {
-        code += method_start + " { get { return Get";
-        code += MakeCamel(field.name, lang_.first_camel_upper);
-        code += "(new ";
-        code += type_name + "()); } }\n";
-        method_start = "  public " + type_name_dest + " Get" + MakeCamel(field.name, lang_.first_camel_upper);
-      }
-      else {
+      if (lang_.language != IDLOptions::kCSharp) {
         code += method_start + "() { return ";
         code += MakeCamel(field.name, lang_.first_camel_upper);
         code += "(new ";
@@ -846,24 +893,16 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
                field.value.type.element == BASE_TYPE_STRUCT) {
       // Accessors for vectors of structs also take accessor objects, this
       // generates a variant without that argument.
-      if (lang_.language == IDLOptions::kCSharp) {
-        method_start = "  public " + type_name_dest + " Get" + MakeCamel(field.name, lang_.first_camel_upper);
-        code += method_start + "(int j) { return Get";
-      } else {
+      if (lang_.language != IDLOptions::kCSharp) {
         code += method_start + "(int j) { return ";
-      }
-      code += MakeCamel(field.name, lang_.first_camel_upper);
-      code += "(new ";
-      code += type_name + "(), j); }\n";
-    } else if (field.value.type.base_type == BASE_TYPE_VECTOR) {
-      if (lang_.language == IDLOptions::kCSharp) {
-        method_start = "  public " + type_name_dest + " Get" + MakeCamel(field.name, lang_.first_camel_upper);
+        code += MakeCamel(field.name, lang_.first_camel_upper);
+        code += "(new " + type_name + "(), j); }\n";
       }
     } else if (field.value.type.base_type == BASE_TYPE_UNION) {
       if (lang_.language == IDLOptions::kCSharp) {
-        // union types in C# use generic Table-derived type for better type safety
-        method_start = "  public " + type_name_dest + " Get" + MakeCamel(field.name, lang_.first_camel_upper) + "<TTable>";
-        offset_prefix = " where TTable : Table" + offset_prefix;
+        // Union types in C# use generic Table-derived type for better type
+        // safety.
+        method_start += "<TTable>";
         type_name = type_name_dest;
       }
     }
@@ -873,64 +912,78 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
     // only create default casts for c# scalars or vectors of scalars
     if (lang_.language == IDLOptions::kCSharp &&
         (IsScalar(field.value.type.base_type) ||
-         (field.value.type.base_type == BASE_TYPE_VECTOR && IsScalar(field.value.type.element)))) {
-      // For scalars, default value will be returned by GetDefaultValue(). If the scalar is an enum, GetDefaultValue()
-      // returns an actual c# enum that doesn't need to be casted. However, default values for enum elements of
-      // vectors are integer literals ("0") and are still casted for clarity.
-      if (field.value.type.enum_def == nullptr || field.value.type.base_type == BASE_TYPE_VECTOR) {
+         (field.value.type.base_type == BASE_TYPE_VECTOR &&
+          IsScalar(field.value.type.element)))) {
+      // For scalars, default value will be returned by GetDefaultValue().
+      // If the scalar is an enum, GetDefaultValue() returns an actual c# enum
+      // that doesn't need to be casted. However, default values for enum
+      // elements of vectors are integer literals ("0") and are still casted
+      // for clarity.
+      if (field.value.type.enum_def == nullptr ||
+          field.value.type.base_type == BASE_TYPE_VECTOR) {
           default_cast = "(" + type_name_dest + ")";
       }
     }
-    std::string member_suffix = "";
+    std::string member_suffix = "; ";
     if (IsScalar(field.value.type.base_type)) {
       code += lang_.getter_prefix;
-      member_suffix = lang_.getter_suffix;
+      member_suffix += lang_.getter_suffix;
       if (struct_def.fixed) {
         code += " { return " + getter;
-        code += "(bb_pos + " + NumToString(field.value.offset) + ")";
+        code += "(" + lang_.accessor_prefix + "bb_pos + ";
+        code += NumToString(field.value.offset) + ")";
         code += dest_mask;
       } else {
         code += offset_prefix + getter;
-        code += "(o + bb_pos)" + dest_mask + " : " + default_cast;
+        code += "(o + " + lang_.accessor_prefix + "bb_pos)" + dest_mask;
+        code += " : " + default_cast;
         code += GenDefaultValue(field.value);
       }
     } else {
       switch (field.value.type.base_type) {
         case BASE_TYPE_STRUCT:
-          code += "(" + type_name + " obj";
-          if (struct_def.fixed) {
-            code += ") { return obj.__init(bb_pos + ";
-            code += NumToString(field.value.offset) + ", bb)";
+          if (lang_.language != IDLOptions::kCSharp) {
+            code += "(" + type_name + " obj" + ")";
           } else {
-            code += ")";
-            code += offset_prefix;
-            code += "obj.__init(";
+            code += lang_.getter_prefix;
+            member_suffix += lang_.getter_suffix;
+          }
+          if (struct_def.fixed) {
+            code += " { return " + obj + ".__assign(" + lang_.accessor_prefix;
+            code += "bb_pos + " + NumToString(field.value.offset) + ", ";
+            code += lang_.accessor_prefix + "bb)";
+          } else {
+            code += offset_prefix + conditional_cast;
+            code += obj + ".__assign(";
             code += field.value.type.struct_def->fixed
-                      ? "o + bb_pos"
-                      : "__indirect(o + bb_pos)";
-            code += ", bb) : null";
+                      ? "o + " + lang_.accessor_prefix + "bb_pos"
+                      : lang_.accessor_prefix + "__indirect(o + " +
+                        lang_.accessor_prefix + "bb_pos)";
+            code += ", " + lang_.accessor_prefix + "bb) : null";
           }
           break;
         case BASE_TYPE_STRING:
           code += lang_.getter_prefix;
-          member_suffix = lang_.getter_suffix;
-          code += offset_prefix + getter + "(o + bb_pos) : null";
+          member_suffix += lang_.getter_suffix;
+          code += offset_prefix + getter + "(o + " + lang_.accessor_prefix;
+          code += "bb_pos) : null";
           break;
         case BASE_TYPE_VECTOR: {
           auto vectortype = field.value.type.VectorType();
           code += "(";
           if (vectortype.base_type == BASE_TYPE_STRUCT) {
-            code += type_name + " obj, ";
-            getter = "obj.__init";
+            if (lang_.language != IDLOptions::kCSharp)
+              code += type_name + " obj, ";
+            getter = obj + ".__assign";
           }
-          code += "int j)" + offset_prefix + getter +"(";
-          auto index = "__vector(o) + j * " +
+          code += "int j)" + offset_prefix + conditional_cast + getter +"(";
+          auto index = lang_.accessor_prefix + "__vector(o) + j * " +
                        NumToString(InlineSize(vectortype));
           if (vectortype.base_type == BASE_TYPE_STRUCT) {
             code += vectortype.struct_def->fixed
                       ? index
-                      : "__indirect(" + index + ")";
-            code += ", bb";
+                      : lang_.accessor_prefix + "__indirect(" + index + ")";
+            code += ", " + lang_.accessor_prefix + "bb";
           } else {
             code += index;
           }
@@ -941,14 +994,19 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
           break;
         }
         case BASE_TYPE_UNION:
-          code += "(" + type_name + " obj)" + offset_prefix + getter;
-          code += "(obj, o) : null";
+          if (lang_.language == IDLOptions::kCSharp) {
+            code += "() where TTable : struct, IFlatbufferObject";
+            code += offset_prefix + "(TTable?)" + getter;
+            code += "<TTable>(o) : null";
+          } else {
+            code += "(" + type_name + " obj)" + offset_prefix + getter;
+            code += "(obj, o) : null";
+          }
           break;
         default:
           assert(0);
       }
     }
-    code += "; ";
     code += member_suffix;
     code += "}\n";
     if (field.value.type.base_type == BASE_TYPE_VECTOR) {
@@ -956,7 +1014,7 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
       code += "Length";
       code += lang_.getter_prefix;
       code += offset_prefix;
-      code += "__vector_len(o) : 0; ";
+      code += lang_.accessor_prefix + "__vector_len(o) : 0; ";
       code += lang_.getter_suffix;
       code += "}\n";
     }
@@ -968,16 +1026,19 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
         case IDLOptions::kJava:
           code += "  public ByteBuffer ";
           code += MakeCamel(field.name, lang_.first_camel_upper);
-          code += "AsByteBuffer() { return __vector_as_bytebuffer(";
+          code += "AsByteBuffer() { return ";
+          code += lang_.accessor_prefix + "__vector_as_bytebuffer(";
           code += NumToString(field.value.offset) + ", ";
-          code += NumToString(field.value.type.base_type == BASE_TYPE_STRING ? 1 :
-                              InlineSize(field.value.type.VectorType()));
+          code += NumToString(field.value.type.base_type == BASE_TYPE_STRING
+                              ? 1
+                              : InlineSize(field.value.type.VectorType()));
           code += "); }\n";
           break;
         case IDLOptions::kCSharp:
           code += "  public ArraySegment<byte>? Get";
           code += MakeCamel(field.name, lang_.first_camel_upper);
-          code += "Bytes() { return __vector_as_arraysegment(";
+          code += "Bytes() { return ";
+          code += lang_.accessor_prefix + "__vector_as_arraysegment(";
           code += NumToString(field.value.offset);
           code += "); }\n";
           break;
@@ -997,30 +1058,49 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
     auto getNestedMethodName = nestedMethodName;
     if (lang_.language == IDLOptions::kCSharp) {
       getNestedMethodName = "Get" + nestedMethodName;
+      conditional_cast = "(" + nested_type_name + lang_.optional_suffix + ")";
     }
-    code += "  public " + nested_type_name + " ";
-    code += nestedMethodName + "() { return ";
-    code += getNestedMethodName + "(new " + nested_type_name + "()); }\n";
-    code += "  public " + nested_type_name + " " + getNestedMethodName;
-    code += "(" + nested_type_name + " obj) { ";
-    code += "int o = __offset(" + NumToString(field.value.offset) +"); ";
-    code += "return o != 0 ? obj.__init(__indirect(__vector(o)), bb) : null; }\n";
+    if (lang_.language != IDLOptions::kCSharp) {
+      code += "  public " + nested_type_name + lang_.optional_suffix + " ";
+      code += nestedMethodName + "() { return ";
+      code += getNestedMethodName + "(new " + nested_type_name + "()); }\n";
+    } else {
+      obj = "(new " + nested_type_name + "())";
+    }
+    code += "  public " + nested_type_name + lang_.optional_suffix + " ";
+    code += getNestedMethodName + "(";
+    if (lang_.language != IDLOptions::kCSharp)
+      code += nested_type_name + " obj";
+    code += ") { int o = " + lang_.accessor_prefix + "__offset(";
+    code += NumToString(field.value.offset) +"); ";
+    code += "return o != 0 ? " + conditional_cast + obj + ".__assign(";
+    code += lang_.accessor_prefix;
+    code += "__indirect(" + lang_.accessor_prefix + "__vector(o)), ";
+    code += lang_.accessor_prefix + "bb) : null; }\n";
   }
-    // generate mutators for scalar fields or vectors of scalars
+    // Generate mutators for scalar fields or vectors of scalars.
     if (parser_.opts.mutable_buffer) {
       auto underlying_type = field.value.type.base_type == BASE_TYPE_VECTOR
                     ? field.value.type.VectorType()
                     : field.value.type;
-      // boolean parameters have to be explicitly converted to byte representation
-      auto setter_parameter = underlying_type.base_type == BASE_TYPE_BOOL ? "(byte)(" + field.name + " ? 1 : 0)" : field.name;
+      // Boolean parameters have to be explicitly converted to byte
+      // representation.
+      auto setter_parameter = underlying_type.base_type == BASE_TYPE_BOOL
+        ? "(byte)(" + field.name + " ? 1 : 0)"
+        : field.name;
       auto mutator_prefix = MakeCamel("mutate", lang_.first_camel_upper);
-      //a vector mutator also needs the index of the vector element it should mutate
-      auto mutator_params = (field.value.type.base_type == BASE_TYPE_VECTOR ? "(int j, " : "(") +
-                            GenTypeNameDest(underlying_type) + " " +
-                            field.name + ") { ";
+      // A vector mutator also needs the index of the vector element it should
+      // mutate.
+      auto mutator_params = (field.value.type.base_type == BASE_TYPE_VECTOR
+        ? "(int j, "
+        : "(") + GenTypeNameDest(underlying_type) + " " + field.name + ") { ";
       auto setter_index = field.value.type.base_type == BASE_TYPE_VECTOR
-                    ? "__vector(o) + j * " + NumToString(InlineSize(underlying_type))
-                    : (struct_def.fixed ? "bb_pos + " + NumToString(field.value.offset) : "o + bb_pos");
+        ? lang_.accessor_prefix + "__vector(o) + j * " +
+          NumToString(InlineSize(underlying_type))
+        : (struct_def.fixed
+            ? lang_.accessor_prefix + "bb_pos + " +
+              NumToString(field.value.offset)
+            : "o + " + lang_.accessor_prefix + "bb_pos");
       if (IsScalar(field.value.type.base_type) ||
           (field.value.type.base_type == BASE_TYPE_VECTOR &&
           IsScalar(field.value.type.VectorType().base_type))) {
@@ -1032,9 +1112,11 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
           code += GenSetter(underlying_type) + "(" + setter_index + ", ";
           code += src_cast + setter_parameter + "); }\n";
         } else {
-          code += "int o = __offset(" + NumToString(field.value.offset) + ");";
+          code += "int o = " + lang_.accessor_prefix + "__offset(";
+          code += NumToString(field.value.offset) + ");";
           code += " if (o != 0) { " + GenSetter(underlying_type);
-          code += "(" + setter_index + ", " + src_cast + setter_parameter + "); return true; } else { return false; } }\n";
+          code += "(" + setter_index + ", " + src_cast + setter_parameter +
+                  "); return true; } else { return false; } }\n";
         }
       }
     }
@@ -1050,7 +1132,8 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
     code += ") {\n";
     GenStructBody(struct_def, code_ptr, "");
     code += "    return ";
-    code += GenOffsetConstruct(struct_def, "builder." + std::string(lang_.get_fbb_offset));
+    code += GenOffsetConstruct(struct_def,
+                               "builder." + std::string(lang_.get_fbb_offset));
     code += ";\n  }\n";
   } else {
     // Generate a method that creates a table in one go. This is only possible
@@ -1141,7 +1224,9 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
       code += NumToString(it - struct_def.fields.vec.begin()) + ", ";
       code += SourceCastBasic(field.value.type);
       code += argname;
-      if(!IsScalar(field.value.type.base_type) && field.value.type.base_type != BASE_TYPE_UNION && lang_.language == IDLOptions::kCSharp) {
+      if (!IsScalar(field.value.type.base_type) &&
+          field.value.type.base_type != BASE_TYPE_UNION &&
+          lang_.language == IDLOptions::kCSharp) {
         code += ".Value";
       }
       code += ", " + GenDefaultValue(field.value, false);
@@ -1152,7 +1237,8 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
         auto elem_size = InlineSize(vector_type);
         if (!IsStruct(vector_type)) {
           // Generate a method to create a vector from a Java array.
-          code += "  public static " + GenVectorOffsetType() + " " + FunctionStart('C') + "reate";
+          code += "  public static " + GenVectorOffsetType() + " ";
+          code += FunctionStart('C') + "reate";
           code += MakeCamel(field.name);
           code += "Vector(FlatBufferBuilder builder, ";
           code += GenTypeBasic(vector_type) + "[] data) ";
@@ -1168,7 +1254,8 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
           code += SourceCastBasic(vector_type, false);
           code += "data[i]";
           if (lang_.language == IDLOptions::kCSharp &&
-            (vector_type.base_type == BASE_TYPE_STRUCT || vector_type.base_type == BASE_TYPE_STRING))
+              (vector_type.base_type == BASE_TYPE_STRUCT ||
+               vector_type.base_type == BASE_TYPE_STRING))
             code += ".Value";
           code += "); return ";
           code += "builder." + FunctionStart('E') + "ndVector(); }\n";
@@ -1201,7 +1288,8 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
     if (parser_.root_struct_def_ == &struct_def) {
       code += "  public static void ";
       code += FunctionStart('F') + "inish" + struct_def.name;
-      code += "Buffer(FlatBufferBuilder builder, " + GenOffsetType(struct_def) + " offset) {";
+      code += "Buffer(FlatBufferBuilder builder, " + GenOffsetType(struct_def);
+      code += " offset) {";
       code += " builder." + FunctionStart('F') + "inish(offset";
       if (lang_.language == IDLOptions::kCSharp) {
         code += ".Value";
@@ -1230,8 +1318,8 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
       code += "    return builder.CreateVectorOfTables(offsets);\n  }\n";
     }
 
-    code += "\n  public static " + struct_def.name + " " + FunctionStart('L');
-    code += "ookupByKey(" + GenVectorOffsetType();
+    code += "\n  public static " + struct_def.name + lang_.optional_suffix;
+    code += " " + FunctionStart('L') + "ookupByKey(" + GenVectorOffsetType();
     code += " vectorOffset, " + GenTypeGet(key_field->value.type);
     code += " key, ByteBuffer bb) {\n";
     if (key_field->value.type.base_type == BASE_TYPE_STRING) {
@@ -1259,7 +1347,7 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
     code += "        span -= middle;\n";
     code += "      } else {\n";
     code += "        return new " + struct_def.name;
-    code += "().__init(tableOffset, bb);\n";
+    code += "().__assign(tableOffset, bb);\n";
     code += "      }\n    }\n";
     code += "    return null;\n";
     code += "  }\n";

--- a/tests/FlatBuffers.Test/FlatBuffers.Test.csproj
+++ b/tests/FlatBuffers.Test/FlatBuffers.Test.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,6 +40,9 @@
   <ItemGroup>
     <Compile Include="..\..\net\FlatBuffers\ByteBuffer.cs">
       <Link>FlatBuffers\ByteBuffer.cs</Link>
+    </Compile>
+    <Compile Include="..\..\net\FlatBuffers\IFlatbufferObject .cs">
+      <Link>FlatBuffers\IFlatbufferObject .cs</Link>
     </Compile>
     <Compile Include="..\..\net\FlatBuffers\Offset.cs">
       <Link>FlatBuffers\Offset.cs</Link>

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -51,7 +51,7 @@ namespace FlatBuffers.Test
             Monster.AddName(fbb, names[2]);
             off[2] = Monster.EndMonster(fbb);
             var sortMons = Monster.CreateMySortedVectorOfTables(fbb, off);
-			
+
             // We set up the same values as monsterdata.json:
 
             var str = fbb.CreateString("MyMonster");
@@ -116,12 +116,12 @@ namespace FlatBuffers.Test
             // the mana field should retain its default value
             Assert.AreEqual(monster.MutateMana((short)10), false);
             Assert.AreEqual(monster.Mana, (short)150);
-			
+
             // Accessing a vector of sorted by the key tables
-            Assert.AreEqual(monster.GetTestarrayoftables(0).Name, "Barney");
-            Assert.AreEqual(monster.GetTestarrayoftables(1).Name, "Frodo");
-            Assert.AreEqual(monster.GetTestarrayoftables(2).Name, "Wilma");
-			
+            Assert.AreEqual(monster.Testarrayoftables(0).Value.Name, "Barney");
+            Assert.AreEqual(monster.Testarrayoftables(1).Value.Name, "Frodo");
+            Assert.AreEqual(monster.Testarrayoftables(2).Value.Name, "Wilma");
+
             // Example of searching for a table by the key
             Assert.IsTrue(Monster.LookupByKey(sortMons, "Frodo", fbb.DataBuffer) != null);
             Assert.IsTrue(Monster.LookupByKey(sortMons, "Barney", fbb.DataBuffer) != null);
@@ -143,7 +143,7 @@ namespace FlatBuffers.Test
 
             for (int i = 0; i < monster.InventoryLength; i++)
             {
-                Assert.AreEqual(monster.GetInventory(i), i + 1);
+                Assert.AreEqual(monster.Inventory(i), i + 1);
             }
 
             //reverse mutation
@@ -154,7 +154,7 @@ namespace FlatBuffers.Test
             Assert.AreEqual(monster.MutateInventory(4, 4), true);
 
             // get a struct field and edit one of its fields
-            Vec3 pos = monster.Pos;
+            Vec3 pos = (Vec3)monster.Pos;
             Assert.AreEqual(pos.X, 1.0f);
             pos.MutateX(55.0f);
             Assert.AreEqual(pos.X, 55.0f);
@@ -172,21 +172,20 @@ namespace FlatBuffers.Test
             Assert.AreEqual(150, monster.Mana);
             Assert.AreEqual("MyMonster", monster.Name);
 
-            var pos = monster.Pos;
+            var pos = monster.Pos.Value;
             Assert.AreEqual(1.0f, pos.X);
             Assert.AreEqual(2.0f, pos.Y);
             Assert.AreEqual(3.0f, pos.Z);
 
             Assert.AreEqual(3.0f, pos.Test1);
             Assert.AreEqual(Color.Green, pos.Test2);
-            var t = pos.Test3;
+            var t = (MyGame.Example.Test)pos.Test3;
             Assert.AreEqual((short)5, t.A);
             Assert.AreEqual((sbyte)6, t.B);
 
             Assert.AreEqual(Any.Monster, monster.TestType);
 
-            var monster2 = new Monster();
-            Assert.IsTrue(monster.GetTest(monster2) != null);
+            var monster2 = monster.Test<Monster>().Value;
             Assert.AreEqual("Fred", monster2.Name);
 
 
@@ -194,19 +193,19 @@ namespace FlatBuffers.Test
             var invsum = 0;
             for (var i = 0; i < monster.InventoryLength; i++)
             {
-                invsum += monster.GetInventory(i);
+                invsum += monster.Inventory(i);
             }
             Assert.AreEqual(10, invsum);
 
-            var test0 = monster.GetTest4(0);
-            var test1 = monster.GetTest4(1);
+            var test0 = monster.Test4(0).Value;
+            var test1 = monster.Test4(1).Value;
             Assert.AreEqual(2, monster.Test4Length);
 
             Assert.AreEqual(100, test0.A + test0.B + test1.A + test1.B);
 
             Assert.AreEqual(2, monster.TestarrayofstringLength);
-            Assert.AreEqual("test1", monster.GetTestarrayofstring(0));
-            Assert.AreEqual("test2", monster.GetTestarrayofstring(1));
+            Assert.AreEqual("test1", monster.Testarrayofstring(0));
+            Assert.AreEqual("test2", monster.Testarrayofstring(1));
 
             Assert.AreEqual(false, monster.Testbool);
 
@@ -269,10 +268,10 @@ namespace FlatBuffers.Test
             Monster.AddTestnestedflatbuffer(fbb2, nestedBuffer);
             var monster = Monster.EndMonster(fbb2);
             Monster.FinishMonsterBuffer(fbb2, monster);
-            
+
             // Now test the data extracted from the nested buffer
             var mons = Monster.GetRootAsMonster(fbb2.DataBuffer);
-            var nestedMonster = mons.TestnestedflatbufferAsMonster();
+            var nestedMonster = mons.GetTestnestedflatbufferAsMonster().Value;
 
             Assert.AreEqual(nestedMonsterMana, nestedMonster.Mana);
             Assert.AreEqual(nestedMonsterHp, nestedMonster.Hp);

--- a/tests/FlatBuffers.Test/TestTable.cs
+++ b/tests/FlatBuffers.Test/TestTable.cs
@@ -19,133 +19,135 @@ namespace FlatBuffers.Test
     /// <summary>
     /// A test Table object that gives easy access to the slot data
     /// </summary>
-    internal class TestTable : Table
+    internal struct TestTable
     {
+        Table t;
+
         public TestTable(ByteBuffer bb, int pos)
         {
-            base.bb = bb;
-            base.bb_pos = pos;
+            t.bb = bb;
+            t.bb_pos = pos;
         }
 
         public bool GetSlot(int slot, bool def)
         {
-            var off = base.__offset(slot);
+            var off = t.__offset(slot);
 
             if (off == 0)
             {
                 return def;
             }
-            return bb.GetSbyte(bb_pos + off) != 0;
+            return t.bb.GetSbyte(t.bb_pos + off) != 0;
         }
 
         public sbyte GetSlot(int slot, sbyte def)
         {
-            var off = base.__offset(slot);
+            var off = t.__offset(slot);
 
             if (off == 0)
             {
                 return def;
             }
-            return bb.GetSbyte(bb_pos + off);
+            return t.bb.GetSbyte(t.bb_pos + off);
         }
 
         public byte GetSlot(int slot, byte def)
         {
-            var off = base.__offset(slot);
+            var off = t.__offset(slot);
 
             if (off == 0)
             {
                 return def;
             }
-            return bb.Get(bb_pos + off);
+            return t.bb.Get(t.bb_pos + off);
         }
 
         public short GetSlot(int slot, short def)
         {
-            var off = base.__offset(slot);
+            var off = t.__offset(slot);
 
             if (off == 0)
             {
                 return def;
             }
-            return bb.GetShort(bb_pos + off);
+            return t.bb.GetShort(t.bb_pos + off);
         }
 
         public ushort GetSlot(int slot, ushort def)
         {
-            var off = base.__offset(slot);
+            var off = t.__offset(slot);
 
             if (off == 0)
             {
                 return def;
             }
-            return bb.GetUshort(bb_pos + off);
+            return t.bb.GetUshort(t.bb_pos + off);
         }
 
         public int GetSlot(int slot, int def)
         {
-            var off = base.__offset(slot);
+            var off = t.__offset(slot);
 
             if (off == 0)
             {
                 return def;
             }
-            return bb.GetInt(bb_pos + off);
+            return t.bb.GetInt(t.bb_pos + off);
         }
 
         public uint GetSlot(int slot, uint def)
         {
-            var off = base.__offset(slot);
+            var off = t.__offset(slot);
 
             if (off == 0)
             {
                 return def;
             }
-            return bb.GetUint(bb_pos + off);
+            return t.bb.GetUint(t.bb_pos + off);
         }
 
         public long GetSlot(int slot, long def)
         {
-            var off = base.__offset(slot);
+            var off = t.__offset(slot);
 
             if (off == 0)
             {
                 return def;
             }
-            return bb.GetLong(bb_pos + off);
+            return t.bb.GetLong(t.bb_pos + off);
         }
 
         public ulong GetSlot(int slot, ulong def)
         {
-            var off = base.__offset(slot);
+            var off = t.__offset(slot);
 
             if (off == 0)
             {
                 return def;
             }
-            return bb.GetUlong(bb_pos + off);
+            return t.bb.GetUlong(t.bb_pos + off);
         }
 
         public float GetSlot(int slot, float def)
         {
-            var off = base.__offset(slot);
+            var off = t.__offset(slot);
 
             if (off == 0)
             {
                 return def;
             }
-            return bb.GetFloat(bb_pos + off);
+            return t.bb.GetFloat(t.bb_pos + off);
         }
 
         public double GetSlot(int slot, double def)
         {
-            var off = base.__offset(slot);
+            var off = t.__offset(slot);
 
             if (off == 0)
             {
                 return def;
             }
-            return bb.GetDouble(bb_pos + off);
+            return t.bb.GetDouble(t.bb_pos + off);
         }
     }
 }

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -7,79 +7,76 @@ using System;
 using FlatBuffers;
 
 /// an example documentation comment: monster object
-public sealed class Monster : Table {
+public struct Monster : IFlatbufferObject
+{
+  private Table __p;
   public static Monster GetRootAsMonster(ByteBuffer _bb) { return GetRootAsMonster(_bb, new Monster()); }
-  public static Monster GetRootAsMonster(ByteBuffer _bb, Monster obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
-  public static bool MonsterBufferHasIdentifier(ByteBuffer _bb) { return __has_identifier(_bb, "MONS"); }
-  public Monster __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static Monster GetRootAsMonster(ByteBuffer _bb, Monster obj) { return (obj.__assign(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
+  public static bool MonsterBufferHasIdentifier(ByteBuffer _bb) { return Table.__has_identifier(_bb, "MONS"); }
+  public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
+  public Monster __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public Vec3 Pos { get { return GetPos(new Vec3()); } }
-  public Vec3 GetPos(Vec3 obj) { int o = __offset(4); return o != 0 ? obj.__init(o + bb_pos, bb) : null; }
-  public short Mana { get { int o = __offset(6); return o != 0 ? bb.GetShort(o + bb_pos) : (short)150; } }
-  public bool MutateMana(short mana) { int o = __offset(6); if (o != 0) { bb.PutShort(o + bb_pos, mana); return true; } else { return false; } }
-  public short Hp { get { int o = __offset(8); return o != 0 ? bb.GetShort(o + bb_pos) : (short)100; } }
-  public bool MutateHp(short hp) { int o = __offset(8); if (o != 0) { bb.PutShort(o + bb_pos, hp); return true; } else { return false; } }
-  public string Name { get { int o = __offset(10); return o != 0 ? __string(o + bb_pos) : null; } }
-  public ArraySegment<byte>? GetNameBytes() { return __vector_as_arraysegment(10); }
-  public byte GetInventory(int j) { int o = __offset(14); return o != 0 ? bb.Get(__vector(o) + j * 1) : (byte)0; }
-  public int InventoryLength { get { int o = __offset(14); return o != 0 ? __vector_len(o) : 0; } }
-  public ArraySegment<byte>? GetInventoryBytes() { return __vector_as_arraysegment(14); }
-  public bool MutateInventory(int j, byte inventory) { int o = __offset(14); if (o != 0) { bb.Put(__vector(o) + j * 1, inventory); return true; } else { return false; } }
-  public Color Color { get { int o = __offset(16); return o != 0 ? (Color)bb.GetSbyte(o + bb_pos) : Color.Blue; } }
-  public bool MutateColor(Color color) { int o = __offset(16); if (o != 0) { bb.PutSbyte(o + bb_pos, (sbyte)color); return true; } else { return false; } }
-  public Any TestType { get { int o = __offset(18); return o != 0 ? (Any)bb.Get(o + bb_pos) : Any.NONE; } }
-  public bool MutateTestType(Any test_type) { int o = __offset(18); if (o != 0) { bb.Put(o + bb_pos, (byte)test_type); return true; } else { return false; } }
-  public TTable GetTest<TTable>(TTable obj) where TTable : Table { int o = __offset(20); return o != 0 ? __union(obj, o) : null; }
-  public Test GetTest4(int j) { return GetTest4(new Test(), j); }
-  public Test GetTest4(Test obj, int j) { int o = __offset(22); return o != 0 ? obj.__init(__vector(o) + j * 4, bb) : null; }
-  public int Test4Length { get { int o = __offset(22); return o != 0 ? __vector_len(o) : 0; } }
-  public string GetTestarrayofstring(int j) { int o = __offset(24); return o != 0 ? __string(__vector(o) + j * 4) : null; }
-  public int TestarrayofstringLength { get { int o = __offset(24); return o != 0 ? __vector_len(o) : 0; } }
+  public Vec3? Pos { get { int o = __p.__offset(4); return o != 0 ? (Vec3?)(new Vec3()).__assign(o + __p.bb_pos, __p.bb) : null; } }
+  public short Mana { get { int o = __p.__offset(6); return o != 0 ? __p.bb.GetShort(o + __p.bb_pos) : (short)150; } }
+  public bool MutateMana(short mana) { int o = __p.__offset(6); if (o != 0) { __p.bb.PutShort(o + __p.bb_pos, mana); return true; } else { return false; } }
+  public short Hp { get { int o = __p.__offset(8); return o != 0 ? __p.bb.GetShort(o + __p.bb_pos) : (short)100; } }
+  public bool MutateHp(short hp) { int o = __p.__offset(8); if (o != 0) { __p.bb.PutShort(o + __p.bb_pos, hp); return true; } else { return false; } }
+  public string Name { get { int o = __p.__offset(10); return o != 0 ? __p.__string(o + __p.bb_pos) : null; } }
+  public ArraySegment<byte>? GetNameBytes() { return __p.__vector_as_arraysegment(10); }
+  public byte Inventory(int j) { int o = __p.__offset(14); return o != 0 ? __p.bb.Get(__p.__vector(o) + j * 1) : (byte)0; }
+  public int InventoryLength { get { int o = __p.__offset(14); return o != 0 ? __p.__vector_len(o) : 0; } }
+  public ArraySegment<byte>? GetInventoryBytes() { return __p.__vector_as_arraysegment(14); }
+  public bool MutateInventory(int j, byte inventory) { int o = __p.__offset(14); if (o != 0) { __p.bb.Put(__p.__vector(o) + j * 1, inventory); return true; } else { return false; } }
+  public Color Color { get { int o = __p.__offset(16); return o != 0 ? (Color)__p.bb.GetSbyte(o + __p.bb_pos) : Color.Blue; } }
+  public bool MutateColor(Color color) { int o = __p.__offset(16); if (o != 0) { __p.bb.PutSbyte(o + __p.bb_pos, (sbyte)color); return true; } else { return false; } }
+  public Any TestType { get { int o = __p.__offset(18); return o != 0 ? (Any)__p.bb.Get(o + __p.bb_pos) : Any.NONE; } }
+  public bool MutateTestType(Any test_type) { int o = __p.__offset(18); if (o != 0) { __p.bb.Put(o + __p.bb_pos, (byte)test_type); return true; } else { return false; } }
+  public TTable? Test<TTable>() where TTable : struct, IFlatbufferObject { int o = __p.__offset(20); return o != 0 ? (TTable?)__p.__union<TTable>(o) : null; }
+  public Test? Test4(int j) { int o = __p.__offset(22); return o != 0 ? (Test?)(new Test()).__assign(__p.__vector(o) + j * 4, __p.bb) : null; }
+  public int Test4Length { get { int o = __p.__offset(22); return o != 0 ? __p.__vector_len(o) : 0; } }
+  public string Testarrayofstring(int j) { int o = __p.__offset(24); return o != 0 ? __p.__string(__p.__vector(o) + j * 4) : null; }
+  public int TestarrayofstringLength { get { int o = __p.__offset(24); return o != 0 ? __p.__vector_len(o) : 0; } }
   /// an example documentation comment: this will end up in the generated code
   /// multiline too
-  public Monster GetTestarrayoftables(int j) { return GetTestarrayoftables(new Monster(), j); }
-  public Monster GetTestarrayoftables(Monster obj, int j) { int o = __offset(26); return o != 0 ? obj.__init(__indirect(__vector(o) + j * 4), bb) : null; }
-  public int TestarrayoftablesLength { get { int o = __offset(26); return o != 0 ? __vector_len(o) : 0; } }
-  public Monster Enemy { get { return GetEnemy(new Monster()); } }
-  public Monster GetEnemy(Monster obj) { int o = __offset(28); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
-  public byte GetTestnestedflatbuffer(int j) { int o = __offset(30); return o != 0 ? bb.Get(__vector(o) + j * 1) : (byte)0; }
-  public int TestnestedflatbufferLength { get { int o = __offset(30); return o != 0 ? __vector_len(o) : 0; } }
-  public ArraySegment<byte>? GetTestnestedflatbufferBytes() { return __vector_as_arraysegment(30); }
-  public Monster TestnestedflatbufferAsMonster() { return GetTestnestedflatbufferAsMonster(new Monster()); }
-  public Monster GetTestnestedflatbufferAsMonster(Monster obj) { int o = __offset(30); return o != 0 ? obj.__init(__indirect(__vector(o)), bb) : null; }
-  public bool MutateTestnestedflatbuffer(int j, byte testnestedflatbuffer) { int o = __offset(30); if (o != 0) { bb.Put(__vector(o) + j * 1, testnestedflatbuffer); return true; } else { return false; } }
-  public Stat Testempty { get { return GetTestempty(new Stat()); } }
-  public Stat GetTestempty(Stat obj) { int o = __offset(32); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
-  public bool Testbool { get { int o = __offset(34); return o != 0 ? 0!=bb.Get(o + bb_pos) : (bool)false; } }
-  public bool MutateTestbool(bool testbool) { int o = __offset(34); if (o != 0) { bb.Put(o + bb_pos, (byte)(testbool ? 1 : 0)); return true; } else { return false; } }
-  public int Testhashs32Fnv1 { get { int o = __offset(36); return o != 0 ? bb.GetInt(o + bb_pos) : (int)0; } }
-  public bool MutateTesthashs32Fnv1(int testhashs32_fnv1) { int o = __offset(36); if (o != 0) { bb.PutInt(o + bb_pos, testhashs32_fnv1); return true; } else { return false; } }
-  public uint Testhashu32Fnv1 { get { int o = __offset(38); return o != 0 ? bb.GetUint(o + bb_pos) : (uint)0; } }
-  public bool MutateTesthashu32Fnv1(uint testhashu32_fnv1) { int o = __offset(38); if (o != 0) { bb.PutUint(o + bb_pos, testhashu32_fnv1); return true; } else { return false; } }
-  public long Testhashs64Fnv1 { get { int o = __offset(40); return o != 0 ? bb.GetLong(o + bb_pos) : (long)0; } }
-  public bool MutateTesthashs64Fnv1(long testhashs64_fnv1) { int o = __offset(40); if (o != 0) { bb.PutLong(o + bb_pos, testhashs64_fnv1); return true; } else { return false; } }
-  public ulong Testhashu64Fnv1 { get { int o = __offset(42); return o != 0 ? bb.GetUlong(o + bb_pos) : (ulong)0; } }
-  public bool MutateTesthashu64Fnv1(ulong testhashu64_fnv1) { int o = __offset(42); if (o != 0) { bb.PutUlong(o + bb_pos, testhashu64_fnv1); return true; } else { return false; } }
-  public int Testhashs32Fnv1a { get { int o = __offset(44); return o != 0 ? bb.GetInt(o + bb_pos) : (int)0; } }
-  public bool MutateTesthashs32Fnv1a(int testhashs32_fnv1a) { int o = __offset(44); if (o != 0) { bb.PutInt(o + bb_pos, testhashs32_fnv1a); return true; } else { return false; } }
-  public uint Testhashu32Fnv1a { get { int o = __offset(46); return o != 0 ? bb.GetUint(o + bb_pos) : (uint)0; } }
-  public bool MutateTesthashu32Fnv1a(uint testhashu32_fnv1a) { int o = __offset(46); if (o != 0) { bb.PutUint(o + bb_pos, testhashu32_fnv1a); return true; } else { return false; } }
-  public long Testhashs64Fnv1a { get { int o = __offset(48); return o != 0 ? bb.GetLong(o + bb_pos) : (long)0; } }
-  public bool MutateTesthashs64Fnv1a(long testhashs64_fnv1a) { int o = __offset(48); if (o != 0) { bb.PutLong(o + bb_pos, testhashs64_fnv1a); return true; } else { return false; } }
-  public ulong Testhashu64Fnv1a { get { int o = __offset(50); return o != 0 ? bb.GetUlong(o + bb_pos) : (ulong)0; } }
-  public bool MutateTesthashu64Fnv1a(ulong testhashu64_fnv1a) { int o = __offset(50); if (o != 0) { bb.PutUlong(o + bb_pos, testhashu64_fnv1a); return true; } else { return false; } }
-  public bool GetTestarrayofbools(int j) { int o = __offset(52); return o != 0 ? 0!=bb.Get(__vector(o) + j * 1) : false; }
-  public int TestarrayofboolsLength { get { int o = __offset(52); return o != 0 ? __vector_len(o) : 0; } }
-  public ArraySegment<byte>? GetTestarrayofboolsBytes() { return __vector_as_arraysegment(52); }
-  public bool MutateTestarrayofbools(int j, bool testarrayofbools) { int o = __offset(52); if (o != 0) { bb.Put(__vector(o) + j * 1, (byte)(testarrayofbools ? 1 : 0)); return true; } else { return false; } }
-  public float Testf { get { int o = __offset(54); return o != 0 ? bb.GetFloat(o + bb_pos) : (float)3.14159f; } }
-  public bool MutateTestf(float testf) { int o = __offset(54); if (o != 0) { bb.PutFloat(o + bb_pos, testf); return true; } else { return false; } }
-  public float Testf2 { get { int o = __offset(56); return o != 0 ? bb.GetFloat(o + bb_pos) : (float)3.0f; } }
-  public bool MutateTestf2(float testf2) { int o = __offset(56); if (o != 0) { bb.PutFloat(o + bb_pos, testf2); return true; } else { return false; } }
-  public float Testf3 { get { int o = __offset(58); return o != 0 ? bb.GetFloat(o + bb_pos) : (float)0.0f; } }
-  public bool MutateTestf3(float testf3) { int o = __offset(58); if (o != 0) { bb.PutFloat(o + bb_pos, testf3); return true; } else { return false; } }
-  public string GetTestarrayofstring2(int j) { int o = __offset(60); return o != 0 ? __string(__vector(o) + j * 4) : null; }
-  public int Testarrayofstring2Length { get { int o = __offset(60); return o != 0 ? __vector_len(o) : 0; } }
+  public Monster? Testarrayoftables(int j) { int o = __p.__offset(26); return o != 0 ? (Monster?)(new Monster()).__assign(__p.__indirect(__p.__vector(o) + j * 4), __p.bb) : null; }
+  public int TestarrayoftablesLength { get { int o = __p.__offset(26); return o != 0 ? __p.__vector_len(o) : 0; } }
+  public Monster? Enemy { get { int o = __p.__offset(28); return o != 0 ? (Monster?)(new Monster()).__assign(__p.__indirect(o + __p.bb_pos), __p.bb) : null; } }
+  public byte Testnestedflatbuffer(int j) { int o = __p.__offset(30); return o != 0 ? __p.bb.Get(__p.__vector(o) + j * 1) : (byte)0; }
+  public int TestnestedflatbufferLength { get { int o = __p.__offset(30); return o != 0 ? __p.__vector_len(o) : 0; } }
+  public ArraySegment<byte>? GetTestnestedflatbufferBytes() { return __p.__vector_as_arraysegment(30); }
+  public Monster? GetTestnestedflatbufferAsMonster() { int o = __p.__offset(30); return o != 0 ? (Monster?)(new Monster()).__assign(__p.__indirect(__p.__vector(o)), __p.bb) : null; }
+  public bool MutateTestnestedflatbuffer(int j, byte testnestedflatbuffer) { int o = __p.__offset(30); if (o != 0) { __p.bb.Put(__p.__vector(o) + j * 1, testnestedflatbuffer); return true; } else { return false; } }
+  public Stat? Testempty { get { int o = __p.__offset(32); return o != 0 ? (Stat?)(new Stat()).__assign(__p.__indirect(o + __p.bb_pos), __p.bb) : null; } }
+  public bool Testbool { get { int o = __p.__offset(34); return o != 0 ? 0!=__p.bb.Get(o + __p.bb_pos) : (bool)false; } }
+  public bool MutateTestbool(bool testbool) { int o = __p.__offset(34); if (o != 0) { __p.bb.Put(o + __p.bb_pos, (byte)(testbool ? 1 : 0)); return true; } else { return false; } }
+  public int Testhashs32Fnv1 { get { int o = __p.__offset(36); return o != 0 ? __p.bb.GetInt(o + __p.bb_pos) : (int)0; } }
+  public bool MutateTesthashs32Fnv1(int testhashs32_fnv1) { int o = __p.__offset(36); if (o != 0) { __p.bb.PutInt(o + __p.bb_pos, testhashs32_fnv1); return true; } else { return false; } }
+  public uint Testhashu32Fnv1 { get { int o = __p.__offset(38); return o != 0 ? __p.bb.GetUint(o + __p.bb_pos) : (uint)0; } }
+  public bool MutateTesthashu32Fnv1(uint testhashu32_fnv1) { int o = __p.__offset(38); if (o != 0) { __p.bb.PutUint(o + __p.bb_pos, testhashu32_fnv1); return true; } else { return false; } }
+  public long Testhashs64Fnv1 { get { int o = __p.__offset(40); return o != 0 ? __p.bb.GetLong(o + __p.bb_pos) : (long)0; } }
+  public bool MutateTesthashs64Fnv1(long testhashs64_fnv1) { int o = __p.__offset(40); if (o != 0) { __p.bb.PutLong(o + __p.bb_pos, testhashs64_fnv1); return true; } else { return false; } }
+  public ulong Testhashu64Fnv1 { get { int o = __p.__offset(42); return o != 0 ? __p.bb.GetUlong(o + __p.bb_pos) : (ulong)0; } }
+  public bool MutateTesthashu64Fnv1(ulong testhashu64_fnv1) { int o = __p.__offset(42); if (o != 0) { __p.bb.PutUlong(o + __p.bb_pos, testhashu64_fnv1); return true; } else { return false; } }
+  public int Testhashs32Fnv1a { get { int o = __p.__offset(44); return o != 0 ? __p.bb.GetInt(o + __p.bb_pos) : (int)0; } }
+  public bool MutateTesthashs32Fnv1a(int testhashs32_fnv1a) { int o = __p.__offset(44); if (o != 0) { __p.bb.PutInt(o + __p.bb_pos, testhashs32_fnv1a); return true; } else { return false; } }
+  public uint Testhashu32Fnv1a { get { int o = __p.__offset(46); return o != 0 ? __p.bb.GetUint(o + __p.bb_pos) : (uint)0; } }
+  public bool MutateTesthashu32Fnv1a(uint testhashu32_fnv1a) { int o = __p.__offset(46); if (o != 0) { __p.bb.PutUint(o + __p.bb_pos, testhashu32_fnv1a); return true; } else { return false; } }
+  public long Testhashs64Fnv1a { get { int o = __p.__offset(48); return o != 0 ? __p.bb.GetLong(o + __p.bb_pos) : (long)0; } }
+  public bool MutateTesthashs64Fnv1a(long testhashs64_fnv1a) { int o = __p.__offset(48); if (o != 0) { __p.bb.PutLong(o + __p.bb_pos, testhashs64_fnv1a); return true; } else { return false; } }
+  public ulong Testhashu64Fnv1a { get { int o = __p.__offset(50); return o != 0 ? __p.bb.GetUlong(o + __p.bb_pos) : (ulong)0; } }
+  public bool MutateTesthashu64Fnv1a(ulong testhashu64_fnv1a) { int o = __p.__offset(50); if (o != 0) { __p.bb.PutUlong(o + __p.bb_pos, testhashu64_fnv1a); return true; } else { return false; } }
+  public bool Testarrayofbools(int j) { int o = __p.__offset(52); return o != 0 ? 0!=__p.bb.Get(__p.__vector(o) + j * 1) : false; }
+  public int TestarrayofboolsLength { get { int o = __p.__offset(52); return o != 0 ? __p.__vector_len(o) : 0; } }
+  public ArraySegment<byte>? GetTestarrayofboolsBytes() { return __p.__vector_as_arraysegment(52); }
+  public bool MutateTestarrayofbools(int j, bool testarrayofbools) { int o = __p.__offset(52); if (o != 0) { __p.bb.Put(__p.__vector(o) + j * 1, (byte)(testarrayofbools ? 1 : 0)); return true; } else { return false; } }
+  public float Testf { get { int o = __p.__offset(54); return o != 0 ? __p.bb.GetFloat(o + __p.bb_pos) : (float)3.14159f; } }
+  public bool MutateTestf(float testf) { int o = __p.__offset(54); if (o != 0) { __p.bb.PutFloat(o + __p.bb_pos, testf); return true; } else { return false; } }
+  public float Testf2 { get { int o = __p.__offset(56); return o != 0 ? __p.bb.GetFloat(o + __p.bb_pos) : (float)3.0f; } }
+  public bool MutateTestf2(float testf2) { int o = __p.__offset(56); if (o != 0) { __p.bb.PutFloat(o + __p.bb_pos, testf2); return true; } else { return false; } }
+  public float Testf3 { get { int o = __p.__offset(58); return o != 0 ? __p.bb.GetFloat(o + __p.bb_pos) : (float)0.0f; } }
+  public bool MutateTestf3(float testf3) { int o = __p.__offset(58); if (o != 0) { __p.bb.PutFloat(o + __p.bb_pos, testf3); return true; } else { return false; } }
+  public string Testarrayofstring2(int j) { int o = __p.__offset(60); return o != 0 ? __p.__string(__p.__vector(o) + j * 4) : null; }
+  public int Testarrayofstring2Length { get { int o = __p.__offset(60); return o != 0 ? __p.__vector_len(o) : 0; } }
 
   public static void StartMonster(FlatBufferBuilder builder) { builder.StartObject(29); }
   public static void AddPos(FlatBufferBuilder builder, Offset<Vec3> posOffset) { builder.AddStruct(0, posOffset.Value, 0); }
@@ -131,11 +128,11 @@ public sealed class Monster : Table {
   public static void FinishMonsterBuffer(FlatBufferBuilder builder, Offset<Monster> offset) { builder.Finish(offset.Value, "MONS"); }
 
   public static VectorOffset CreateMySortedVectorOfTables(FlatBufferBuilder builder, Offset<Monster>[] offsets) {
-    Array.Sort(offsets, (Offset<Monster> o1, Offset<Monster> o2) => CompareStrings(__offset(10, o1.Value, builder.DataBuffer), __offset(10, o2.Value, builder.DataBuffer), builder.DataBuffer));
+    Array.Sort(offsets, (Offset<Monster> o1, Offset<Monster> o2) => Table.CompareStrings(Table.__offset(10, o1.Value, builder.DataBuffer), Table.__offset(10, o2.Value, builder.DataBuffer), builder.DataBuffer));
     return builder.CreateVectorOfTables(offsets);
   }
 
-  public static Monster LookupByKey(VectorOffset vectorOffset, string key, ByteBuffer bb) {
+  public static Monster? LookupByKey(VectorOffset vectorOffset, string key, ByteBuffer bb) {
     byte[] byteKey = System.Text.Encoding.UTF8.GetBytes(key);
     int vectorLocation = bb.Length - vectorOffset.Value;
     int span = bb.GetInt(vectorLocation);
@@ -143,8 +140,8 @@ public sealed class Monster : Table {
     vectorLocation += 4;
     while (span != 0) {
       int middle = span / 2;
-      int tableOffset = __indirect(vectorLocation + 4 * (start + middle), bb);
-      int comp = CompareStrings(__offset(10, bb.Length - tableOffset, bb), byteKey, bb);
+      int tableOffset = Table.__indirect(vectorLocation + 4 * (start + middle), bb);
+      int comp = Table.CompareStrings(Table.__offset(10, bb.Length - tableOffset, bb), byteKey, bb);
       if (comp > 0) {
         span = middle;
       } else if (comp < 0) {
@@ -152,7 +149,7 @@ public sealed class Monster : Table {
         start += middle;
         span -= middle;
       } else {
-        return new Monster().__init(tableOffset, bb);
+        return new Monster().__assign(tableOffset, bb);
       }
     }
     return null;

--- a/tests/MyGame/Example/Monster.java
+++ b/tests/MyGame/Example/Monster.java
@@ -13,12 +13,13 @@ import com.google.flatbuffers.*;
  */
 public final class Monster extends Table {
   public static Monster getRootAsMonster(ByteBuffer _bb) { return getRootAsMonster(_bb, new Monster()); }
-  public static Monster getRootAsMonster(ByteBuffer _bb, Monster obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__init(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public static Monster getRootAsMonster(ByteBuffer _bb, Monster obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public static boolean MonsterBufferHasIdentifier(ByteBuffer _bb) { return __has_identifier(_bb, "MONS"); }
-  public Monster __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public Monster __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
   public Vec3 pos() { return pos(new Vec3()); }
-  public Vec3 pos(Vec3 obj) { int o = __offset(4); return o != 0 ? obj.__init(o + bb_pos, bb) : null; }
+  public Vec3 pos(Vec3 obj) { int o = __offset(4); return o != 0 ? obj.__assign(o + bb_pos, bb) : null; }
   public short mana() { int o = __offset(6); return o != 0 ? bb.getShort(o + bb_pos) : 150; }
   public boolean mutateMana(short mana) { int o = __offset(6); if (o != 0) { bb.putShort(o + bb_pos, mana); return true; } else { return false; } }
   public short hp() { int o = __offset(8); return o != 0 ? bb.getShort(o + bb_pos) : 100; }
@@ -35,7 +36,7 @@ public final class Monster extends Table {
   public boolean mutateTestType(byte test_type) { int o = __offset(18); if (o != 0) { bb.put(o + bb_pos, test_type); return true; } else { return false; } }
   public Table test(Table obj) { int o = __offset(20); return o != 0 ? __union(obj, o) : null; }
   public Test test4(int j) { return test4(new Test(), j); }
-  public Test test4(Test obj, int j) { int o = __offset(22); return o != 0 ? obj.__init(__vector(o) + j * 4, bb) : null; }
+  public Test test4(Test obj, int j) { int o = __offset(22); return o != 0 ? obj.__assign(__vector(o) + j * 4, bb) : null; }
   public int test4Length() { int o = __offset(22); return o != 0 ? __vector_len(o) : 0; }
   public String testarrayofstring(int j) { int o = __offset(24); return o != 0 ? __string(__vector(o) + j * 4) : null; }
   public int testarrayofstringLength() { int o = __offset(24); return o != 0 ? __vector_len(o) : 0; }
@@ -44,18 +45,18 @@ public final class Monster extends Table {
    * multiline too
    */
   public Monster testarrayoftables(int j) { return testarrayoftables(new Monster(), j); }
-  public Monster testarrayoftables(Monster obj, int j) { int o = __offset(26); return o != 0 ? obj.__init(__indirect(__vector(o) + j * 4), bb) : null; }
+  public Monster testarrayoftables(Monster obj, int j) { int o = __offset(26); return o != 0 ? obj.__assign(__indirect(__vector(o) + j * 4), bb) : null; }
   public int testarrayoftablesLength() { int o = __offset(26); return o != 0 ? __vector_len(o) : 0; }
   public Monster enemy() { return enemy(new Monster()); }
-  public Monster enemy(Monster obj) { int o = __offset(28); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
+  public Monster enemy(Monster obj) { int o = __offset(28); return o != 0 ? obj.__assign(__indirect(o + bb_pos), bb) : null; }
   public int testnestedflatbuffer(int j) { int o = __offset(30); return o != 0 ? bb.get(__vector(o) + j * 1) & 0xFF : 0; }
   public int testnestedflatbufferLength() { int o = __offset(30); return o != 0 ? __vector_len(o) : 0; }
   public ByteBuffer testnestedflatbufferAsByteBuffer() { return __vector_as_bytebuffer(30, 1); }
   public Monster testnestedflatbufferAsMonster() { return testnestedflatbufferAsMonster(new Monster()); }
-  public Monster testnestedflatbufferAsMonster(Monster obj) { int o = __offset(30); return o != 0 ? obj.__init(__indirect(__vector(o)), bb) : null; }
+  public Monster testnestedflatbufferAsMonster(Monster obj) { int o = __offset(30); return o != 0 ? obj.__assign(__indirect(__vector(o)), bb) : null; }
   public boolean mutateTestnestedflatbuffer(int j, int testnestedflatbuffer) { int o = __offset(30); if (o != 0) { bb.put(__vector(o) + j * 1, (byte)testnestedflatbuffer); return true; } else { return false; } }
   public Stat testempty() { return testempty(new Stat()); }
-  public Stat testempty(Stat obj) { int o = __offset(32); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
+  public Stat testempty(Stat obj) { int o = __offset(32); return o != 0 ? obj.__assign(__indirect(o + bb_pos), bb) : null; }
   public boolean testbool() { int o = __offset(34); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
   public boolean mutateTestbool(boolean testbool) { int o = __offset(34); if (o != 0) { bb.put(o + bb_pos, (byte)(testbool ? 1 : 0)); return true; } else { return false; } }
   public int testhashs32Fnv1() { int o = __offset(36); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
@@ -156,7 +157,7 @@ public final class Monster extends Table {
         start += middle;
         span -= middle;
       } else {
-        return new Monster().__init(tableOffset, bb);
+        return new Monster().__assign(tableOffset, bb);
       }
     }
     return null;

--- a/tests/MyGame/Example/Stat.cs
+++ b/tests/MyGame/Example/Stat.cs
@@ -6,17 +6,20 @@ namespace MyGame.Example
 using System;
 using FlatBuffers;
 
-public sealed class Stat : Table {
+public struct Stat : IFlatbufferObject
+{
+  private Table __p;
   public static Stat GetRootAsStat(ByteBuffer _bb) { return GetRootAsStat(_bb, new Stat()); }
-  public static Stat GetRootAsStat(ByteBuffer _bb, Stat obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
-  public Stat __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static Stat GetRootAsStat(ByteBuffer _bb, Stat obj) { return (obj.__assign(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
+  public Stat __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public string Id { get { int o = __offset(4); return o != 0 ? __string(o + bb_pos) : null; } }
-  public ArraySegment<byte>? GetIdBytes() { return __vector_as_arraysegment(4); }
-  public long Val { get { int o = __offset(6); return o != 0 ? bb.GetLong(o + bb_pos) : (long)0; } }
-  public bool MutateVal(long val) { int o = __offset(6); if (o != 0) { bb.PutLong(o + bb_pos, val); return true; } else { return false; } }
-  public ushort Count { get { int o = __offset(8); return o != 0 ? bb.GetUshort(o + bb_pos) : (ushort)0; } }
-  public bool MutateCount(ushort count) { int o = __offset(8); if (o != 0) { bb.PutUshort(o + bb_pos, count); return true; } else { return false; } }
+  public string Id { get { int o = __p.__offset(4); return o != 0 ? __p.__string(o + __p.bb_pos) : null; } }
+  public ArraySegment<byte>? GetIdBytes() { return __p.__vector_as_arraysegment(4); }
+  public long Val { get { int o = __p.__offset(6); return o != 0 ? __p.bb.GetLong(o + __p.bb_pos) : (long)0; } }
+  public bool MutateVal(long val) { int o = __p.__offset(6); if (o != 0) { __p.bb.PutLong(o + __p.bb_pos, val); return true; } else { return false; } }
+  public ushort Count { get { int o = __p.__offset(8); return o != 0 ? __p.bb.GetUshort(o + __p.bb_pos) : (ushort)0; } }
+  public bool MutateCount(ushort count) { int o = __p.__offset(8); if (o != 0) { __p.bb.PutUshort(o + __p.bb_pos, count); return true; } else { return false; } }
 
   public static Offset<Stat> CreateStat(FlatBufferBuilder builder,
       StringOffset idOffset = default(StringOffset),

--- a/tests/MyGame/Example/Stat.java
+++ b/tests/MyGame/Example/Stat.java
@@ -10,8 +10,9 @@ import com.google.flatbuffers.*;
 @SuppressWarnings("unused")
 public final class Stat extends Table {
   public static Stat getRootAsStat(ByteBuffer _bb) { return getRootAsStat(_bb, new Stat()); }
-  public static Stat getRootAsStat(ByteBuffer _bb, Stat obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__init(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
-  public Stat __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static Stat getRootAsStat(ByteBuffer _bb, Stat obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public Stat __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
   public String id() { int o = __offset(4); return o != 0 ? __string(o + bb_pos) : null; }
   public ByteBuffer idAsByteBuffer() { return __vector_as_bytebuffer(4, 1); }

--- a/tests/MyGame/Example/Test.cs
+++ b/tests/MyGame/Example/Test.cs
@@ -6,13 +6,16 @@ namespace MyGame.Example
 using System;
 using FlatBuffers;
 
-public sealed class Test : Struct {
-  public Test __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+public struct Test : IFlatbufferObject
+{
+  private Struct __p;
+  public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
+  public Test __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public short A { get { return bb.GetShort(bb_pos + 0); } }
-  public void MutateA(short a) { bb.PutShort(bb_pos + 0, a); }
-  public sbyte B { get { return bb.GetSbyte(bb_pos + 2); } }
-  public void MutateB(sbyte b) { bb.PutSbyte(bb_pos + 2, b); }
+  public short A { get { return __p.bb.GetShort(__p.bb_pos + 0); } }
+  public void MutateA(short a) { __p.bb.PutShort(__p.bb_pos + 0, a); }
+  public sbyte B { get { return __p.bb.GetSbyte(__p.bb_pos + 2); } }
+  public void MutateB(sbyte b) { __p.bb.PutSbyte(__p.bb_pos + 2, b); }
 
   public static Offset<Test> CreateTest(FlatBufferBuilder builder, short A, sbyte B) {
     builder.Prep(2, 4);

--- a/tests/MyGame/Example/Test.java
+++ b/tests/MyGame/Example/Test.java
@@ -9,7 +9,8 @@ import com.google.flatbuffers.*;
 
 @SuppressWarnings("unused")
 public final class Test extends Struct {
-  public Test __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public Test __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
   public short a() { return bb.getShort(bb_pos + 0); }
   public void mutateA(short a) { bb.putShort(bb_pos + 0, a); }

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.cs
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.cs
@@ -6,13 +6,16 @@ namespace MyGame.Example
 using System;
 using FlatBuffers;
 
-public partial class TestSimpleTableWithEnum : Table {
+public partial struct TestSimpleTableWithEnum : IFlatbufferObject
+{
+  private Table __p;
   public static TestSimpleTableWithEnum GetRootAsTestSimpleTableWithEnum(ByteBuffer _bb) { return GetRootAsTestSimpleTableWithEnum(_bb, new TestSimpleTableWithEnum()); }
-  public static TestSimpleTableWithEnum GetRootAsTestSimpleTableWithEnum(ByteBuffer _bb, TestSimpleTableWithEnum obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
-  public TestSimpleTableWithEnum __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static TestSimpleTableWithEnum GetRootAsTestSimpleTableWithEnum(ByteBuffer _bb, TestSimpleTableWithEnum obj) { return (obj.__assign(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
+  public TestSimpleTableWithEnum __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public Color Color { get { int o = __offset(4); return o != 0 ? (Color)bb.GetSbyte(o + bb_pos) : Color.Green; } }
-  public bool MutateColor(Color color) { int o = __offset(4); if (o != 0) { bb.PutSbyte(o + bb_pos, (sbyte)color); return true; } else { return false; } }
+  public Color Color { get { int o = __p.__offset(4); return o != 0 ? (Color)__p.bb.GetSbyte(o + __p.bb_pos) : Color.Green; } }
+  public bool MutateColor(Color color) { int o = __p.__offset(4); if (o != 0) { __p.bb.PutSbyte(o + __p.bb_pos, (sbyte)color); return true; } else { return false; } }
 
   public static Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnum(FlatBufferBuilder builder,
       Color color = Color.Green) {

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.java
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.java
@@ -10,8 +10,9 @@ import com.google.flatbuffers.*;
 @SuppressWarnings("unused")
 public final class TestSimpleTableWithEnum extends Table {
   public static TestSimpleTableWithEnum getRootAsTestSimpleTableWithEnum(ByteBuffer _bb) { return getRootAsTestSimpleTableWithEnum(_bb, new TestSimpleTableWithEnum()); }
-  public static TestSimpleTableWithEnum getRootAsTestSimpleTableWithEnum(ByteBuffer _bb, TestSimpleTableWithEnum obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__init(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
-  public TestSimpleTableWithEnum __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static TestSimpleTableWithEnum getRootAsTestSimpleTableWithEnum(ByteBuffer _bb, TestSimpleTableWithEnum obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public TestSimpleTableWithEnum __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
   public byte color() { int o = __offset(4); return o != 0 ? bb.get(o + bb_pos) : 2; }
   public boolean mutateColor(byte color) { int o = __offset(4); if (o != 0) { bb.put(o + bb_pos, color); return true; } else { return false; } }

--- a/tests/MyGame/Example/Vec3.cs
+++ b/tests/MyGame/Example/Vec3.cs
@@ -6,21 +6,23 @@ namespace MyGame.Example
 using System;
 using FlatBuffers;
 
-public sealed class Vec3 : Struct {
-  public Vec3 __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+public struct Vec3 : IFlatbufferObject
+{
+  private Struct __p;
+  public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
+  public Vec3 __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public float X { get { return bb.GetFloat(bb_pos + 0); } }
-  public void MutateX(float x) { bb.PutFloat(bb_pos + 0, x); }
-  public float Y { get { return bb.GetFloat(bb_pos + 4); } }
-  public void MutateY(float y) { bb.PutFloat(bb_pos + 4, y); }
-  public float Z { get { return bb.GetFloat(bb_pos + 8); } }
-  public void MutateZ(float z) { bb.PutFloat(bb_pos + 8, z); }
-  public double Test1 { get { return bb.GetDouble(bb_pos + 16); } }
-  public void MutateTest1(double test1) { bb.PutDouble(bb_pos + 16, test1); }
-  public Color Test2 { get { return (Color)bb.GetSbyte(bb_pos + 24); } }
-  public void MutateTest2(Color test2) { bb.PutSbyte(bb_pos + 24, (sbyte)test2); }
-  public Test Test3 { get { return GetTest3(new Test()); } }
-  public Test GetTest3(Test obj) { return obj.__init(bb_pos + 26, bb); }
+  public float X { get { return __p.bb.GetFloat(__p.bb_pos + 0); } }
+  public void MutateX(float x) { __p.bb.PutFloat(__p.bb_pos + 0, x); }
+  public float Y { get { return __p.bb.GetFloat(__p.bb_pos + 4); } }
+  public void MutateY(float y) { __p.bb.PutFloat(__p.bb_pos + 4, y); }
+  public float Z { get { return __p.bb.GetFloat(__p.bb_pos + 8); } }
+  public void MutateZ(float z) { __p.bb.PutFloat(__p.bb_pos + 8, z); }
+  public double Test1 { get { return __p.bb.GetDouble(__p.bb_pos + 16); } }
+  public void MutateTest1(double test1) { __p.bb.PutDouble(__p.bb_pos + 16, test1); }
+  public Color Test2 { get { return (Color)__p.bb.GetSbyte(__p.bb_pos + 24); } }
+  public void MutateTest2(Color test2) { __p.bb.PutSbyte(__p.bb_pos + 24, (sbyte)test2); }
+  public Test Test3 { get { return (new Test()).__assign(__p.bb_pos + 26, __p.bb); } }
 
   public static Offset<Vec3> CreateVec3(FlatBufferBuilder builder, float X, float Y, float Z, double Test1, Color Test2, short test3_A, sbyte test3_B) {
     builder.Prep(16, 32);

--- a/tests/MyGame/Example/Vec3.java
+++ b/tests/MyGame/Example/Vec3.java
@@ -9,7 +9,8 @@ import com.google.flatbuffers.*;
 
 @SuppressWarnings("unused")
 public final class Vec3 extends Struct {
-  public Vec3 __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public Vec3 __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
   public float x() { return bb.getFloat(bb_pos + 0); }
   public void mutateX(float x) { bb.putFloat(bb_pos + 0, x); }
@@ -22,7 +23,7 @@ public final class Vec3 extends Struct {
   public byte test2() { return bb.get(bb_pos + 24); }
   public void mutateTest2(byte test2) { bb.put(bb_pos + 24, test2); }
   public Test test3() { return test3(new Test()); }
-  public Test test3(Test obj) { return obj.__init(bb_pos + 26, bb); }
+  public Test test3(Test obj) { return obj.__assign(bb_pos + 26, bb); }
 
   public static int createVec3(FlatBufferBuilder builder, float x, float y, float z, double test1, byte test2, short test3_a, byte test3_b) {
     builder.prep(16, 32);

--- a/tests/MyGame/Example2/Monster.cs
+++ b/tests/MyGame/Example2/Monster.cs
@@ -6,10 +6,13 @@ namespace MyGame.Example2
 using System;
 using FlatBuffers;
 
-public sealed class Monster : Table {
+public struct Monster : IFlatbufferObject
+{
+  private Table __p;
   public static Monster GetRootAsMonster(ByteBuffer _bb) { return GetRootAsMonster(_bb, new Monster()); }
-  public static Monster GetRootAsMonster(ByteBuffer _bb, Monster obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
-  public Monster __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static Monster GetRootAsMonster(ByteBuffer _bb, Monster obj) { return (obj.__assign(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
+  public Monster __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
 
   public static void StartMonster(FlatBufferBuilder builder) { builder.StartObject(0); }

--- a/tests/MyGame/Example2/Monster.java
+++ b/tests/MyGame/Example2/Monster.java
@@ -10,8 +10,9 @@ import com.google.flatbuffers.*;
 @SuppressWarnings("unused")
 public final class Monster extends Table {
   public static Monster getRootAsMonster(ByteBuffer _bb) { return getRootAsMonster(_bb, new Monster()); }
-  public static Monster getRootAsMonster(ByteBuffer _bb, Monster obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__init(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
-  public Monster __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static Monster getRootAsMonster(ByteBuffer _bb, Monster obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public Monster __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
 
   public static void startMonster(FlatBufferBuilder builder) { builder.startObject(0); }

--- a/tests/generate_code.bat
+++ b/tests/generate_code.bat
@@ -12,6 +12,9 @@
 :: See the License for the specific language governing permissions and
 :: limitations under the License.
 
-..\flatc.exe --cpp --java --csharp --go --binary --python --js --php --grpc --gen-mutable --gen-object-api --no-includes monster_test.fbs monsterdata_test.json
-..\flatc.exe --cpp --java --csharp --go --binary --python --js --php --gen-mutable -o namespace_test namespace_test\namespace_test1.fbs namespace_test\namespace_test2.fbs
-..\flatc.exe --binary --schema monster_test.fbs
+set buildtype=Release
+if "%1"=="-b" set buildtype=%2
+
+..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --js --php --grpc --gen-mutable --gen-object-api --no-includes monster_test.fbs monsterdata_test.json
+..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --js --php --gen-mutable -o namespace_test namespace_test\namespace_test1.fbs namespace_test\namespace_test2.fbs
+..\%buildtype%\flatc.exe --binary --schema monster_test.fbs

--- a/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.cs
+++ b/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.cs
@@ -6,13 +6,16 @@ namespace NamespaceA.NamespaceB
 using System;
 using FlatBuffers;
 
-public sealed class StructInNestedNS : Struct {
-  public StructInNestedNS __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+public struct StructInNestedNS : IFlatbufferObject
+{
+  private Struct __p;
+  public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
+  public StructInNestedNS __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public int A { get { return bb.GetInt(bb_pos + 0); } }
-  public void MutateA(int a) { bb.PutInt(bb_pos + 0, a); }
-  public int B { get { return bb.GetInt(bb_pos + 4); } }
-  public void MutateB(int b) { bb.PutInt(bb_pos + 4, b); }
+  public int A { get { return __p.bb.GetInt(__p.bb_pos + 0); } }
+  public void MutateA(int a) { __p.bb.PutInt(__p.bb_pos + 0, a); }
+  public int B { get { return __p.bb.GetInt(__p.bb_pos + 4); } }
+  public void MutateB(int b) { __p.bb.PutInt(__p.bb_pos + 4, b); }
 
   public static Offset<StructInNestedNS> CreateStructInNestedNS(FlatBufferBuilder builder, int A, int B) {
     builder.Prep(4, 8);

--- a/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.java
+++ b/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.java
@@ -9,7 +9,8 @@ import com.google.flatbuffers.*;
 
 @SuppressWarnings("unused")
 public final class StructInNestedNS extends Struct {
-  public StructInNestedNS __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public StructInNestedNS __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
   public int a() { return bb.getInt(bb_pos + 0); }
   public void mutateA(int a) { bb.putInt(bb_pos + 0, a); }

--- a/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.cs
+++ b/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.cs
@@ -6,13 +6,16 @@ namespace NamespaceA.NamespaceB
 using System;
 using FlatBuffers;
 
-public sealed class TableInNestedNS : Table {
+public struct TableInNestedNS : IFlatbufferObject
+{
+  private Table __p;
   public static TableInNestedNS GetRootAsTableInNestedNS(ByteBuffer _bb) { return GetRootAsTableInNestedNS(_bb, new TableInNestedNS()); }
-  public static TableInNestedNS GetRootAsTableInNestedNS(ByteBuffer _bb, TableInNestedNS obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
-  public TableInNestedNS __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static TableInNestedNS GetRootAsTableInNestedNS(ByteBuffer _bb, TableInNestedNS obj) { return (obj.__assign(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
+  public TableInNestedNS __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public int Foo { get { int o = __offset(4); return o != 0 ? bb.GetInt(o + bb_pos) : (int)0; } }
-  public bool MutateFoo(int foo) { int o = __offset(4); if (o != 0) { bb.PutInt(o + bb_pos, foo); return true; } else { return false; } }
+  public int Foo { get { int o = __p.__offset(4); return o != 0 ? __p.bb.GetInt(o + __p.bb_pos) : (int)0; } }
+  public bool MutateFoo(int foo) { int o = __p.__offset(4); if (o != 0) { __p.bb.PutInt(o + __p.bb_pos, foo); return true; } else { return false; } }
 
   public static Offset<TableInNestedNS> CreateTableInNestedNS(FlatBufferBuilder builder,
       int foo = 0) {

--- a/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.java
+++ b/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.java
@@ -10,8 +10,9 @@ import com.google.flatbuffers.*;
 @SuppressWarnings("unused")
 public final class TableInNestedNS extends Table {
   public static TableInNestedNS getRootAsTableInNestedNS(ByteBuffer _bb) { return getRootAsTableInNestedNS(_bb, new TableInNestedNS()); }
-  public static TableInNestedNS getRootAsTableInNestedNS(ByteBuffer _bb, TableInNestedNS obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__init(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
-  public TableInNestedNS __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static TableInNestedNS getRootAsTableInNestedNS(ByteBuffer _bb, TableInNestedNS obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public TableInNestedNS __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
   public int foo() { int o = __offset(4); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
   public boolean mutateFoo(int foo) { int o = __offset(4); if (o != 0) { bb.putInt(o + bb_pos, foo); return true; } else { return false; } }

--- a/tests/namespace_test/NamespaceA/SecondTableInA.cs
+++ b/tests/namespace_test/NamespaceA/SecondTableInA.cs
@@ -6,13 +6,15 @@ namespace NamespaceA
 using System;
 using FlatBuffers;
 
-public sealed class SecondTableInA : Table {
+public struct SecondTableInA : IFlatbufferObject
+{
+  private Table __p;
   public static SecondTableInA GetRootAsSecondTableInA(ByteBuffer _bb) { return GetRootAsSecondTableInA(_bb, new SecondTableInA()); }
-  public static SecondTableInA GetRootAsSecondTableInA(ByteBuffer _bb, SecondTableInA obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
-  public SecondTableInA __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static SecondTableInA GetRootAsSecondTableInA(ByteBuffer _bb, SecondTableInA obj) { return (obj.__assign(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
+  public SecondTableInA __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public NamespaceC.TableInC ReferToC { get { return GetReferToC(new NamespaceC.TableInC()); } }
-  public NamespaceC.TableInC GetReferToC(NamespaceC.TableInC obj) { int o = __offset(4); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
+  public NamespaceC.TableInC? ReferToC { get { int o = __p.__offset(4); return o != 0 ? (NamespaceC.TableInC?)(new NamespaceC.TableInC()).__assign(__p.__indirect(o + __p.bb_pos), __p.bb) : null; } }
 
   public static Offset<SecondTableInA> CreateSecondTableInA(FlatBufferBuilder builder,
       Offset<NamespaceC.TableInC> refer_to_cOffset = default(Offset<NamespaceC.TableInC>)) {

--- a/tests/namespace_test/NamespaceA/SecondTableInA.java
+++ b/tests/namespace_test/NamespaceA/SecondTableInA.java
@@ -10,11 +10,12 @@ import com.google.flatbuffers.*;
 @SuppressWarnings("unused")
 public final class SecondTableInA extends Table {
   public static SecondTableInA getRootAsSecondTableInA(ByteBuffer _bb) { return getRootAsSecondTableInA(_bb, new SecondTableInA()); }
-  public static SecondTableInA getRootAsSecondTableInA(ByteBuffer _bb, SecondTableInA obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__init(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
-  public SecondTableInA __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static SecondTableInA getRootAsSecondTableInA(ByteBuffer _bb, SecondTableInA obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public SecondTableInA __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
   public NamespaceC.TableInC referToC() { return referToC(new NamespaceC.TableInC()); }
-  public NamespaceC.TableInC referToC(NamespaceC.TableInC obj) { int o = __offset(4); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
+  public NamespaceC.TableInC referToC(NamespaceC.TableInC obj) { int o = __offset(4); return o != 0 ? obj.__assign(__indirect(o + bb_pos), bb) : null; }
 
   public static int createSecondTableInA(FlatBufferBuilder builder,
       int refer_to_cOffset) {

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.cs
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.cs
@@ -6,17 +6,18 @@ namespace NamespaceA
 using System;
 using FlatBuffers;
 
-public sealed class TableInFirstNS : Table {
+public struct TableInFirstNS : IFlatbufferObject
+{
+  private Table __p;
   public static TableInFirstNS GetRootAsTableInFirstNS(ByteBuffer _bb) { return GetRootAsTableInFirstNS(_bb, new TableInFirstNS()); }
-  public static TableInFirstNS GetRootAsTableInFirstNS(ByteBuffer _bb, TableInFirstNS obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
-  public TableInFirstNS __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static TableInFirstNS GetRootAsTableInFirstNS(ByteBuffer _bb, TableInFirstNS obj) { return (obj.__assign(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
+  public TableInFirstNS __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public NamespaceA.NamespaceB.TableInNestedNS FooTable { get { return GetFooTable(new NamespaceA.NamespaceB.TableInNestedNS()); } }
-  public NamespaceA.NamespaceB.TableInNestedNS GetFooTable(NamespaceA.NamespaceB.TableInNestedNS obj) { int o = __offset(4); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
-  public NamespaceA.NamespaceB.EnumInNestedNS FooEnum { get { int o = __offset(6); return o != 0 ? (NamespaceA.NamespaceB.EnumInNestedNS)bb.GetSbyte(o + bb_pos) : NamespaceA.NamespaceB.EnumInNestedNS.A; } }
-  public bool MutateFooEnum(NamespaceA.NamespaceB.EnumInNestedNS foo_enum) { int o = __offset(6); if (o != 0) { bb.PutSbyte(o + bb_pos, (sbyte)foo_enum); return true; } else { return false; } }
-  public NamespaceA.NamespaceB.StructInNestedNS FooStruct { get { return GetFooStruct(new NamespaceA.NamespaceB.StructInNestedNS()); } }
-  public NamespaceA.NamespaceB.StructInNestedNS GetFooStruct(NamespaceA.NamespaceB.StructInNestedNS obj) { int o = __offset(8); return o != 0 ? obj.__init(o + bb_pos, bb) : null; }
+  public NamespaceA.NamespaceB.TableInNestedNS? FooTable { get { int o = __p.__offset(4); return o != 0 ? (NamespaceA.NamespaceB.TableInNestedNS?)(new NamespaceA.NamespaceB.TableInNestedNS()).__assign(__p.__indirect(o + __p.bb_pos), __p.bb) : null; } }
+  public NamespaceA.NamespaceB.EnumInNestedNS FooEnum { get { int o = __p.__offset(6); return o != 0 ? (NamespaceA.NamespaceB.EnumInNestedNS)__p.bb.GetSbyte(o + __p.bb_pos) : NamespaceA.NamespaceB.EnumInNestedNS.A; } }
+  public bool MutateFooEnum(NamespaceA.NamespaceB.EnumInNestedNS foo_enum) { int o = __p.__offset(6); if (o != 0) { __p.bb.PutSbyte(o + __p.bb_pos, (sbyte)foo_enum); return true; } else { return false; } }
+  public NamespaceA.NamespaceB.StructInNestedNS? FooStruct { get { int o = __p.__offset(8); return o != 0 ? (NamespaceA.NamespaceB.StructInNestedNS?)(new NamespaceA.NamespaceB.StructInNestedNS()).__assign(o + __p.bb_pos, __p.bb) : null; } }
 
   public static void StartTableInFirstNS(FlatBufferBuilder builder) { builder.StartObject(3); }
   public static void AddFooTable(FlatBufferBuilder builder, Offset<NamespaceA.NamespaceB.TableInNestedNS> fooTableOffset) { builder.AddOffset(0, fooTableOffset.Value, 0); }

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.java
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.java
@@ -10,15 +10,16 @@ import com.google.flatbuffers.*;
 @SuppressWarnings("unused")
 public final class TableInFirstNS extends Table {
   public static TableInFirstNS getRootAsTableInFirstNS(ByteBuffer _bb) { return getRootAsTableInFirstNS(_bb, new TableInFirstNS()); }
-  public static TableInFirstNS getRootAsTableInFirstNS(ByteBuffer _bb, TableInFirstNS obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__init(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
-  public TableInFirstNS __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static TableInFirstNS getRootAsTableInFirstNS(ByteBuffer _bb, TableInFirstNS obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public TableInFirstNS __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
   public NamespaceA.NamespaceB.TableInNestedNS fooTable() { return fooTable(new NamespaceA.NamespaceB.TableInNestedNS()); }
-  public NamespaceA.NamespaceB.TableInNestedNS fooTable(NamespaceA.NamespaceB.TableInNestedNS obj) { int o = __offset(4); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
+  public NamespaceA.NamespaceB.TableInNestedNS fooTable(NamespaceA.NamespaceB.TableInNestedNS obj) { int o = __offset(4); return o != 0 ? obj.__assign(__indirect(o + bb_pos), bb) : null; }
   public byte fooEnum() { int o = __offset(6); return o != 0 ? bb.get(o + bb_pos) : 0; }
   public boolean mutateFooEnum(byte foo_enum) { int o = __offset(6); if (o != 0) { bb.put(o + bb_pos, foo_enum); return true; } else { return false; } }
   public NamespaceA.NamespaceB.StructInNestedNS fooStruct() { return fooStruct(new NamespaceA.NamespaceB.StructInNestedNS()); }
-  public NamespaceA.NamespaceB.StructInNestedNS fooStruct(NamespaceA.NamespaceB.StructInNestedNS obj) { int o = __offset(8); return o != 0 ? obj.__init(o + bb_pos, bb) : null; }
+  public NamespaceA.NamespaceB.StructInNestedNS fooStruct(NamespaceA.NamespaceB.StructInNestedNS obj) { int o = __offset(8); return o != 0 ? obj.__assign(o + bb_pos, bb) : null; }
 
   public static void startTableInFirstNS(FlatBufferBuilder builder) { builder.startObject(3); }
   public static void addFooTable(FlatBufferBuilder builder, int fooTableOffset) { builder.addOffset(0, fooTableOffset, 0); }

--- a/tests/namespace_test/NamespaceC/TableInC.cs
+++ b/tests/namespace_test/NamespaceC/TableInC.cs
@@ -6,15 +6,16 @@ namespace NamespaceC
 using System;
 using FlatBuffers;
 
-public sealed class TableInC : Table {
+public struct TableInC : IFlatbufferObject
+{
+  private Table __p;
   public static TableInC GetRootAsTableInC(ByteBuffer _bb) { return GetRootAsTableInC(_bb, new TableInC()); }
-  public static TableInC GetRootAsTableInC(ByteBuffer _bb, TableInC obj) { return (obj.__init(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
-  public TableInC __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static TableInC GetRootAsTableInC(ByteBuffer _bb, TableInC obj) { return (obj.__assign(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
+  public TableInC __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public NamespaceA.TableInFirstNS ReferToA1 { get { return GetReferToA1(new NamespaceA.TableInFirstNS()); } }
-  public NamespaceA.TableInFirstNS GetReferToA1(NamespaceA.TableInFirstNS obj) { int o = __offset(4); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
-  public SecondTableInA ReferToA2 { get { return GetReferToA2(new SecondTableInA()); } }
-  public SecondTableInA GetReferToA2(SecondTableInA obj) { int o = __offset(6); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
+  public NamespaceA.TableInFirstNS? ReferToA1 { get { int o = __p.__offset(4); return o != 0 ? (NamespaceA.TableInFirstNS?)(new NamespaceA.TableInFirstNS()).__assign(__p.__indirect(o + __p.bb_pos), __p.bb) : null; } }
+  public SecondTableInA? ReferToA2 { get { int o = __p.__offset(6); return o != 0 ? (SecondTableInA?)(new SecondTableInA()).__assign(__p.__indirect(o + __p.bb_pos), __p.bb) : null; } }
 
   public static Offset<NamespaceC.TableInC> CreateTableInC(FlatBufferBuilder builder,
       Offset<NamespaceA.TableInFirstNS> refer_to_a1Offset = default(Offset<NamespaceA.TableInFirstNS>),

--- a/tests/namespace_test/NamespaceC/TableInC.java
+++ b/tests/namespace_test/NamespaceC/TableInC.java
@@ -10,13 +10,14 @@ import com.google.flatbuffers.*;
 @SuppressWarnings("unused")
 public final class TableInC extends Table {
   public static TableInC getRootAsTableInC(ByteBuffer _bb) { return getRootAsTableInC(_bb, new TableInC()); }
-  public static TableInC getRootAsTableInC(ByteBuffer _bb, TableInC obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__init(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
-  public TableInC __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; return this; }
+  public static TableInC getRootAsTableInC(ByteBuffer _bb, TableInC obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public TableInC __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
   public NamespaceA.TableInFirstNS referToA1() { return referToA1(new NamespaceA.TableInFirstNS()); }
-  public NamespaceA.TableInFirstNS referToA1(NamespaceA.TableInFirstNS obj) { int o = __offset(4); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
+  public NamespaceA.TableInFirstNS referToA1(NamespaceA.TableInFirstNS obj) { int o = __offset(4); return o != 0 ? obj.__assign(__indirect(o + bb_pos), bb) : null; }
   public SecondTableInA referToA2() { return referToA2(new SecondTableInA()); }
-  public SecondTableInA referToA2(SecondTableInA obj) { int o = __offset(6); return o != 0 ? obj.__init(__indirect(o + bb_pos), bb) : null; }
+  public SecondTableInA referToA2(SecondTableInA obj) { int o = __offset(6); return o != 0 ? obj.__assign(__indirect(o + bb_pos), bb) : null; }
 
   public static int createTableInC(FlatBufferBuilder builder,
       int refer_to_a1Offset,


### PR DESCRIPTION
This changes the accessor object in C# generated code from a class to a struct, allowing it to generate much less garbage, and not requiring manual object reuse.

To be precise, this returns a Nullable accessor type, since fields are optional.

This subtly BREAKS the API in places. I tried to stay as close to the old API as possible, and quite a bit of code should work as-is, but it is unavoidable that code will need to be adapted.

We just released FlatBuffers 1.4.0, so this will only affect those that follow the bleeding edge of FlatBuffers, so I think this is acceptable, as the efficiency and API gains are worth having.