### PR TITLE
Isolate the complied Java classes into a target folder.

### DIFF
--- a/tests/JavaTest.sh
+++ b/tests/JavaTest.sh
@@ -19,11 +19,20 @@ echo Compile then run the Java test.
 testdir=$(readlink -fn `dirname $0`)
 thisdir=$(readlink -fn `pwd`)
 
+targetdir=${testdir}/target
+
 if [[ "$testdir" != "$thisdir" ]]; then
 	echo error: must be run from inside the ${testdir} directory
 	echo you ran it from ${thisdir}
 	exit 1
 fi
 
-javac -classpath ${testdir}/../java:${testdir}:${testdir}/namespace_test JavaTest.java
-java -classpath ${testdir}/../java:${testdir}:${testdir}/namespace_test JavaTest
+if [ -e "${targetdir}" ]; then
+    echo "clean target"
+    rm -fr ${targetdir}
+fi
+
+mkdir ${targetdir}
+
+javac -d ${targetdir} -classpath ${testdir}/../java:${testdir}:${testdir}/namespace_test JavaTest.java
+java -classpath ${targetdir} JavaTest


### PR DESCRIPTION
It is a common practice to put all the compiled classes into a
dedicated folder in order to:
 - avoid to mix the code and the complied classes
 - to allow a simple way to remove the complied classes