### PR TITLE
Remove c++ stdlib related flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set(FlatBuffers_GRPCTest_SRCS
 # source_group(Tests FILES ${FlatBuffers_Tests_SRCS})
 
 if(APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror -Wextra")
 elseif(CMAKE_COMPILER_IS_GNUCXX)
   if(CYGWIN)
@@ -121,12 +121,8 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
 
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -std=c++0x -stdlib=libc++ -Wall -pedantic -Werror \
+      "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -pedantic -Werror \
                           -Wextra")
-  if(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
-    set(CMAKE_EXE_LINKER_FLAGS
-        "${CMAKE_EXE_LINKER_FLAGS} -lc++abi")
-  endif()
 
   # Certain platforms such as ARM do not use signed chars by default
   # which causes issues with certain bounds checks.


### PR DESCRIPTION
A toolchain file is responsible to choose a c++ stdlib through CMAKE_CXX_STANDARD_LIBRARIES_INIT. And it is common to link against gnustl even when the compiler is clang.
