### PR TITLE
Remove extra semicolon

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -255,7 +255,7 @@ struct VectorIterator
 
 public:
   VectorIterator(const uint8_t *data, uoffset_t i) :
-      data_(data + IndirectHelper<T>::element_stride * i) {};
+      data_(data + IndirectHelper<T>::element_stride * i) {}
   VectorIterator(const VectorIterator &other) : data_(other.data_) {}
   #ifndef FLATBUFFERS_CPP98_STL
   VectorIterator(VectorIterator &&other) : data_(std::move(other.data_)) {}


### PR DESCRIPTION
Hello, I get the following warning when compiling with Clang and `-Wextra-semi` compiler option:

```
flatbuffers/flatbuffers.h:258:61: warning: extra ';' after member function definition [-Wextra-semi]
      data_(data + IndirectHelper<T>::element_stride * i) {};
                                                            ^
```

This pull request gets rid of the semicolon at the end of a constructor definition and fixes the warning.

Thanks!