### PR TITLE
Makes JavaTest depends on TableInC to detect compilation error

### DIFF
--- a/tests/JavaTest.java
+++ b/tests/JavaTest.java
@@ -271,6 +271,8 @@ class JavaTest {
         TableInFirstNS.startTableInFirstNS(fbb);      
         TableInFirstNS.addFooTable(fbb, nestedTableOff);
         int off = TableInFirstNS.endTableInFirstNS(fbb);
+
+        TableInC.startTableInC(fbb);
     }
     
     static void TestNestedFlatBuffer() {

--- a/tests/JavaTest.java
+++ b/tests/JavaTest.java
@@ -270,9 +270,11 @@ class JavaTest {
         
         TableInFirstNS.startTableInFirstNS(fbb);      
         TableInFirstNS.addFooTable(fbb, nestedTableOff);
-        int off = TableInFirstNS.endTableInFirstNS(fbb);
+        int offTableInFirstNS = TableInFirstNS.endTableInFirstNS(fbb);
 
-        TableInC.startTableInC(fbb);
+        FlatBufferBuilder fbb2 = new FlatBufferBuilder(1);
+        TableInC.startTableInC(fbb2);
+        int offTableInC = TableInC.endTableInC(fbb2);
     }
     
     static void TestNestedFlatBuffer() {


### PR DESCRIPTION
This adds a dependency of JavaTest on TableInC class to ensure TableInC.java get compiled and compilation errors are reported. With no dependency, javac just ignored that class causing Java code generation bugs to remain undetected.

Notes that as a recent commit has broken Java code generation for TableInC, JavaTest will fail (has would be expected).
