### PR TITLE
Ignore rehasher resolver unused

### DIFF
--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -266,6 +266,9 @@ inline flatbuffers::Offset<Weapon> CreateWeaponDirect(flatbuffers::FlatBufferBui
 inline flatbuffers::Offset<Weapon> CreateWeapon(flatbuffers::FlatBufferBuilder &_fbb, const WeaponT *_o, const flatbuffers::rehasher_function_t *rehasher = nullptr);
 
 inline std::unique_ptr<MonsterT> Monster::UnPack(const flatbuffers::resolver_function_t *resolver) const {
+  #ifdef __GNUC__
+    (void)resolver;
+  #endif
   auto _o = new MonsterT();
   { auto _e = pos(); if (_e) _o->pos = std::unique_ptr<Vec3>(new Vec3(*_e)); };
   { auto _e = mana(); _o->mana = _e; };
@@ -280,6 +283,9 @@ inline std::unique_ptr<MonsterT> Monster::UnPack(const flatbuffers::resolver_fun
 }
 
 inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o, const flatbuffers::rehasher_function_t *rehasher) {
+  #ifdef __GNUC__
+    (void)rehasher;
+  #endif
   return CreateMonster(_fbb,
     _o->pos ? _o->pos.get() : 0,
     _o->mana,
@@ -293,6 +299,9 @@ inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder
 }
 
 inline std::unique_ptr<WeaponT> Weapon::UnPack(const flatbuffers::resolver_function_t *resolver) const {
+  #ifdef __GNUC__
+    (void)resolver;
+  #endif
   auto _o = new WeaponT();
   { auto _e = name(); if (_e) _o->name = _e->str(); };
   { auto _e = damage(); _o->damage = _e; };
@@ -300,6 +309,9 @@ inline std::unique_ptr<WeaponT> Weapon::UnPack(const flatbuffers::resolver_funct
 }
 
 inline flatbuffers::Offset<Weapon> CreateWeapon(flatbuffers::FlatBufferBuilder &_fbb, const WeaponT *_o, const flatbuffers::rehasher_function_t *rehasher) {
+  #ifdef __GNUC__
+    (void)rehasher;
+  #endif
   return CreateWeapon(_fbb,
     _o->name.size() ? _fbb.CreateString(_o->name) : 0,
     _o->damage);

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -982,6 +982,8 @@ class CppGenerator : public BaseGenerator {
     if (parser_.opts.generate_object_based_api) {
       // Generate the UnPack() method.
       code += "inline " + TableUnPackSignature(struct_def, false) + " {\n";
+      // TODO
+      code += "  #ifdef __GNUC__\n    (void)resolver;\n  #endif\n";
       code += "  auto _o = new " + NativeName(struct_def.name) + "();\n";
       for (auto it = struct_def.fields.vec.begin();
            it != struct_def.fields.vec.end(); ++it) {
@@ -1067,6 +1069,8 @@ class CppGenerator : public BaseGenerator {
       // Generate a CreateX method that works with an unpacked C++ object.
       code += TableCreateSignature(struct_def, false) + " {\n";
       auto before_return_statement = code.size();
+      //TODO
+      code += "  #ifdef __GNUC__\n    (void)rehasher;\n  #endif\n";
       code += "  return Create";
       code += struct_def.name + "(_fbb";
       bool any_fields = false;

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -597,12 +597,18 @@ inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder
 namespace Example2 {
 
 inline std::unique_ptr<MonsterT> Monster::UnPack(const flatbuffers::resolver_function_t *resolver) const {
+  #ifdef __GNUC__
+    (void)resolver;
+  #endif
   auto _o = new MonsterT();
   return std::unique_ptr<MonsterT>(_o);
 }
 
 inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o, const flatbuffers::rehasher_function_t *rehasher) {
   (void)_o;
+  #ifdef __GNUC__
+    (void)rehasher;
+  #endif
   return CreateMonster(_fbb);
 }
 
@@ -611,17 +617,26 @@ inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder
 namespace Example {
 
 inline std::unique_ptr<TestSimpleTableWithEnumT> TestSimpleTableWithEnum::UnPack(const flatbuffers::resolver_function_t *resolver) const {
+  #ifdef __GNUC__
+    (void)resolver;
+  #endif
   auto _o = new TestSimpleTableWithEnumT();
   { auto _e = color(); _o->color = _e; };
   return std::unique_ptr<TestSimpleTableWithEnumT>(_o);
 }
 
 inline flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnum(flatbuffers::FlatBufferBuilder &_fbb, const TestSimpleTableWithEnumT *_o, const flatbuffers::rehasher_function_t *rehasher) {
+  #ifdef __GNUC__
+    (void)rehasher;
+  #endif
   return CreateTestSimpleTableWithEnum(_fbb,
     _o->color);
 }
 
 inline std::unique_ptr<StatT> Stat::UnPack(const flatbuffers::resolver_function_t *resolver) const {
+  #ifdef __GNUC__
+    (void)resolver;
+  #endif
   auto _o = new StatT();
   { auto _e = id(); if (_e) _o->id = _e->str(); };
   { auto _e = val(); _o->val = _e; };
@@ -630,6 +645,9 @@ inline std::unique_ptr<StatT> Stat::UnPack(const flatbuffers::resolver_function_
 }
 
 inline flatbuffers::Offset<Stat> CreateStat(flatbuffers::FlatBufferBuilder &_fbb, const StatT *_o, const flatbuffers::rehasher_function_t *rehasher) {
+  #ifdef __GNUC__
+    (void)rehasher;
+  #endif
   return CreateStat(_fbb,
     _o->id.size() ? _fbb.CreateString(_o->id) : 0,
     _o->val,
@@ -637,6 +655,9 @@ inline flatbuffers::Offset<Stat> CreateStat(flatbuffers::FlatBufferBuilder &_fbb
 }
 
 inline std::unique_ptr<MonsterT> Monster::UnPack(const flatbuffers::resolver_function_t *resolver) const {
+  #ifdef __GNUC__
+    (void)resolver;
+  #endif
   auto _o = new MonsterT();
   { auto _e = pos(); if (_e) _o->pos = std::unique_ptr<Vec3>(new Vec3(*_e)); };
   { auto _e = mana(); _o->mana = _e; };
@@ -670,6 +691,9 @@ inline std::unique_ptr<MonsterT> Monster::UnPack(const flatbuffers::resolver_fun
 }
 
 inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o, const flatbuffers::rehasher_function_t *rehasher) {
+  #ifdef __GNUC__
+    (void)rehasher;
+  #endif
   return CreateMonster(_fbb,
     _o->pos ? _o->pos.get() : 0,
     _o->mana,

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -320,8 +320,17 @@ void ObjectFlatBuffersTest(uint8_t *flatbuf) {
   auto resolver = flatbuffers::resolver_function_t([](void **pointer_adr,
                                                flatbuffers::hash_value_t hash) {
     // Don't actually do anything, leave variable null.
+    // keep gcc quite about unused params
+    #ifdef __GNUC__
+      (void)pointer_adr;
+      (void)hash;
+    #endif
   });
   auto rehasher = flatbuffers::rehasher_function_t([](void *pointer) {
+    // keep gcc quite about unused params
+    #ifdef __GNUC__
+      (void)pointer;
+    #endif
     return 0;
   });
 


### PR DESCRIPTION
A bit of a quick fix to get Travis builds to pass.

I haven't used flatbuffers and was trying them for the first time today, so I didn't have time to review your code and find a nicer fix.

- I created two commits because from the in-line comment I in test.cpp I take it the params can be safely ignored
- The second commit adds TODOs and could be fixed and squashed or ignored an fixed later. @gwvo, you can do whatever is easier. 

The issues can be seen in the past 3 Travis builds [975](https://travis-ci.org/google/flatbuffers/builds/167189633), [976](https://travis-ci.org/google/flatbuffers/builds/167191843) & [977](https://travis-ci.org/google/flatbuffers/builds/167215416)


