### PR TITLE
Flatbuffers JSON parsing should properly deal with unexpected null values

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1758,6 +1758,9 @@ CheckedError Parser::SkipAnyJsonValue() {
     case kTokenFloatConstant:
       EXPECT(kTokenFloatConstant);
       break;
+    case kTokenNull:
+      EXPECT(kTokenNull);
+      break;
     default:
       return Error(std::string("Unexpected token:") + std::string(1, static_cast<char>(token_)));
   }


### PR DESCRIPTION
Flatbuffers JSON parsing should properly deal with unexpected null values in objects that it is skipping, when --unknown-json is enabled.