### PR TITLE
go: add back missing import of unsafe, fixes #4108

### DIFF
--- a/go/sizes.go
+++ b/go/sizes.go
@@ -1,5 +1,7 @@
 package flatbuffers
 
+import "unsafe"
+
 const (
 	// See http://golang.org/ref/spec#Numeric_types
 


### PR DESCRIPTION
I'm not sure why @ibloat did not open this PR. Opening on his behalf.