### PR TITLE
Restore the ''import "unsafe'' removed in 36daedf35fd0cc2ad0e5e24d187…

### DIFF
--- a/go/sizes.go
+++ b/go/sizes.go
@@ -1,5 +1,9 @@
 package flatbuffers
 
+import (
+        "unsafe"
+)
+
 const (
 	// See http://golang.org/ref/spec#Numeric_types
 


### PR DESCRIPTION
…b25613c13660e.

This was causing build failures with tools dependent on Flatbuffers in Go.
E.g.
go/src/github.com/google/flatbuffers/go/sizes.go:50: undefined: unsafe in unsafe.Pointer