### PR TITLE
release field_stack_ before parsing to fix memory leaking

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1836,6 +1836,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
   source_ = cursor_ = source;
   line_ = 1;
   error_.clear();
+  field_stack_.clear();
   builder_.Clear();
   // Start with a blank namespace just in case this file doesn't have one.
   namespaces_.push_back(new Namespace());

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1837,7 +1837,6 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
   line_ = 1;
   error_.clear();
   field_stack_.clear();
-  struct_stack_.clear();
   builder_.Clear();
   // Start with a blank namespace just in case this file doesn't have one.
   namespaces_.push_back(new Namespace());

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1837,6 +1837,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
   line_ = 1;
   error_.clear();
   field_stack_.clear();
+  struct_stack_.clear();
   builder_.Clear();
   // Start with a blank namespace just in case this file doesn't have one.
   namespaces_.push_back(new Namespace());


### PR DESCRIPTION
in ParseTable/ParseVector, values are pushed in field_stack_, and at the end of the fucntions, the field_stack_ will get pop up. but if there is any exception happen before, ECHECK, or EXPECT ,the function will get returned w/o pop up the stack, which cause values are always stay in field_stack_, it is a memory leaking issue when the Parser object are reused for a long time. 
the fix is to clear the stack everytime starting a new parse.