### PR TITLE
Go: Fix gRPC generated code format based on gofmt spec

### DIFF
--- a/grpc/src/compiler/go_generator.cc
+++ b/grpc/src/compiler/go_generator.cc
@@ -70,12 +70,11 @@ void GenerateImports(grpc_generator::File *file, grpc_generator::Printer *printe
 	printer->Print("//If you make any local changes, they will be lost\n");
 	printer->Print(vars, "//source: $filename$\n\n");
 	printer->Print(vars, "package $Package$\n\n");
-	if (file->additional_imports() != "") {
-		printer->Print(file->additional_imports().c_str());
-		printer->Print("\n\n");
-	}
 	printer->Print("import (\n");
 	printer->Indent();
+	if (file->additional_imports() != "") {
+		printer->Print(file->additional_imports().c_str());
+	}
 	printer->Print(vars, "$context$ \"golang.org/x/net/context\"\n");
 	printer->Print(vars, "$grpc$ \"google.golang.org/grpc\"\n");
 	printer->Outdent();

--- a/src/idl_gen_grpc.cpp
+++ b/src/idl_gen_grpc.cpp
@@ -175,7 +175,7 @@ class FlatBufFile : public grpc_generator::File {
   }
 
   std::string additional_imports() const {
-    return "import \"github.com/google/flatbuffers/go\"";
+    return "flatbuffers \"github.com/google/flatbuffers/go\"\n";
   }
 
   int service_count() const {

--- a/tests/GoTest.sh
+++ b/tests/GoTest.sh
@@ -20,7 +20,7 @@ go_path=${test_dir}/go_gen
 go_src=${go_path}/src
 
 # Emit Go code for the example schema in the test dir:
-../flatc -g monster_test.fbs
+../flatc -g --grpc monster_test.fbs
 
 # Go requires a particular layout of files in order to link multiple packages.
 # Copy flatbuffer Go files to their own package directories to compile the
@@ -40,6 +40,7 @@ cp -a ./go_test.go ./go_gen/src/flatbuffers_test/
 # Developers may also wish to run benchmarks, which may be achieved with the
 # flag -test.bench and the wildcard regexp ".":
 #   go -test -test.bench=. ...
+GOPATH=${go_path} go get golang.org/x/net/context google.golang.org/grpc
 GOPATH=${go_path} go test flatbuffers_test \
                      --test.coverpkg=github.com/google/flatbuffers/go \
                      --cpp_data=${test_dir}/monsterdata_test.mon \


### PR DESCRIPTION
Fix Go gRPC generated code format based on gofmt spec.

Thanks for support gRPC for Go!
I tried to use it immediately, but there was a part that does not conform to the specification of `gofmt`. so fixed it.
A typical Go project runs `gofmt` in CI, I thought that it would be ideal to follow specifications.
There are a lot of fixes. See commit message for details.

However, I noticed the hard-coded in the 2 whitespace indent on https://github.com/google/flatbuffers/blob/master/src/idl_gen_grpc.cpp#L123.

Go does not allow space indent (compile would be possible), Also if implementing support the gRPC for Python, it is 4 spaces. I think it should be changeable by each language.
But it affects the `idl_gen_cpp.cpp` side, and since I didn't know the implementation plan of the flatbuffers team, So I have not fixed it yet.
I would appreciate it if you would give me some advice.

Now `gofmt -d MyGame/Example/MonsterStorage_grpc.go` suggested below. It was a bit complicated so I have not fixed it yet too.
Note that with temporary change to `str_->insert(str_->end(), indent_ * 1, '	');` (`'	'` is `\t`)
```diff
diff MyGame/Example/MonsterStorage_grpc.go gofmt/MyGame/Example/MonsterStorage_grpc.go
@@ -101,6 +101,5 @@
 			Handler:    _MonsterStorage_Retrieve_Handler,
 		},
 	},
-	Streams: []grpc.StreamDesc{
-	},
+	Streams: []grpc.StreamDesc{},
 }
```
And, adding `const bool is_func` to `GenerateClientMethodSignature` args might be not good. I want to advise too.

Finally, the `GoTest.sh` script did not work because it supported grpc. Changed to fetch dependency packages. and test passed.
What do you think about this change?