### PR TITLE
Fix call to Verifier::VerifyBuffer from BufferRef

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1502,7 +1502,7 @@ template<typename T> struct BufferRef : BufferRefBase {
 
   bool Verify() {
     Verifier verifier(buf, len);
-    return verifier.VerifyBuffer<T>();
+    return verifier.VerifyBuffer<T>(nullptr);
   }
 
   uint8_t *buf;


### PR DESCRIPTION
3a1f776132cf9377e3a85a888e6ff2bc12c7248c added a required identifier parameter to Verifier::VerifyBuffer but did not update the templated call site in BufferRef. This causes errors like the following when trying to instantiate the call site by calling BufferRef::Verify():

```
include/flatbuffers/flatbuffers.h: In instantiation of ‘bool flatbuffers::BufferRef<T>::Verify() [with T = MyType]’:
MyApp.cpp:16:3:   required from here
include/flatbuffers/flatbuffers.h:1421:37: error: no matching function for call to ‘flatbuffers::Verifier::VerifyBuffer()’
     return verifier.VerifyBuffer<T>();
                                     ^
include/flatbuffers/flatbuffers.h:1421:37: note: candidate is:
include/flatbuffers/flatbuffers.h:1352:29: note: template<class T> bool flatbuffers::Verifier::VerifyBuffer(const char*)
   template<typename T> bool VerifyBuffer(const char *identifier) {
                             ^
include/flatbuffers/flatbuffers.h:1352:29: note:   template argument deduction/substitution failed:
include/flatbuffers/flatbuffers.h:1421:37: note:   candidate expects 1 argument, 0 provided
     return verifier.VerifyBuffer<T>();
                                     ^
```

This commit fixes the BufferRef call site by adding a nullptr argument.