### PR TITLE
Add a builder option to enable/disable vtables deduplication.

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -720,7 +720,7 @@ FLATBUFFERS_FINAL_CLASS
   /// @param[in] bool fd When set to `true`, always serializes default values.
   void ForceDefaults(bool fd) { force_defaults_ = fd; }
 
-  /// @brief Vtables are deduped in order to save space.
+  /// @brief By default vtables are deduped in order to save space.
   /// @param[in] bool dedup When set to `true`, dedup vtables.
   void DedupVtables(bool dedup) { dedup_vtables_ = dedup; }
 
@@ -1269,7 +1269,7 @@ FLATBUFFERS_FINAL_CLASS
 
   bool force_defaults_;  // Serialize values equal to their defaults anyway.
 
-  bool dedup_vtables_;  // Dedup vtables.
+  bool dedup_vtables_;
 
   struct StringOffsetCompare {
     StringOffsetCompare(const vector_downward &buf) : buf_(&buf) {}


### PR DESCRIPTION
FlatBuffers (FBS) supports random field access by tracking field indices called "vtable" in FBS terms. vtable is a fix length buffer (per message type) that stores field offsets into the data buffer.

Each FBS Table (like Proto Message) has a vtable offset indicating the location of the actual vtable data. In order to reduce the wire format size, FBS dedups the vtables. When a vtable of a new table is the same with a previous one, the vtable offset will just point to the existing.

However, this size optimization turns out to be expensive as shown by cpu profile. It's costly to locate the existing vtable with the same data. It is unnecessary in certain use cases where the wire format size is not a concern (e.g., rpc communication).

This CL adds an option to the FBS framework to enable/disable the deduping.

It shows ~15% improvement of the coding throughput for certain benchmark. The wire format size increases 50%. So turn it on when size is not a concern (e.g. rpc communication where network bandwidth is not a bottleneck.)