### PR TITLE
go: fix unknown field 'UOffset' to 'Pos'

### DIFF
--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -1251,9 +1251,9 @@ func CheckVtableDeduplication(fail func(string, ...interface{})) {
 			len(want), want, len(got), got)
 	}
 
-	table0 := &flatbuffers.Table{Bytes: b.Bytes, UOffset: flatbuffers.UOffsetT(len(b.Bytes)) - obj0}
-	table1 := &flatbuffers.Table{Bytes: b.Bytes, UOffset: flatbuffers.UOffsetT(len(b.Bytes)) - obj1}
-	table2 := &flatbuffers.Table{Bytes: b.Bytes, UOffset: flatbuffers.UOffsetT(len(b.Bytes)) - obj2}
+	table0 := &flatbuffers.Table{Bytes: b.Bytes, Pos: flatbuffers.UOffsetT(len(b.Bytes)) - obj0}
+	table1 := &flatbuffers.Table{Bytes: b.Bytes, Pos: flatbuffers.UOffsetT(len(b.Bytes)) - obj1}
+	table2 := &flatbuffers.Table{Bytes: b.Bytes, Pos: flatbuffers.UOffsetT(len(b.Bytes)) - obj2}
 
 	testTable := func(tab *flatbuffers.Table, a flatbuffers.VOffsetT, b, c, d byte) {
 		// vtable size


### PR DESCRIPTION
Currently, can't passes Go test because
```sh
# flatbuffers_test
go_gen/src/flatbuffers_test/go_test.go:1254: unknown field 'UOffset' in struct literal of type flatbuffers.Table
```

Fixes b55f18649a86c699118ed29e5470afbde421883c