### PR TITLE
Reword comment so that code editors can mark deprecation correctly

### DIFF
--- a/go/table.go
+++ b/go/table.go
@@ -10,7 +10,7 @@ type Table struct {
 
 // Offset provides access into the Table's vtable.
 //
-// Deprecated fields are ignored by checking against the vtable's length.
+// Fields which are deprecated are ignored by checking against the vtable's length.
 func (t *Table) Offset(vtableOffset VOffsetT) VOffsetT {
 	vtable := UOffsetT(SOffsetT(t.Pos) - t.GetSOffsetT(t.Pos))
 	if vtableOffset < t.GetVOffsetT(vtable) {


### PR DESCRIPTION
Hi,


Following the conversation here: https://groups.google.com/forum/#!topic/golang-dev/ya5vE0G62Z4 editors would incorrectly flag this as deprecated which could throw off users.
As such, I propose renaming this comment to something similar that would preserve the meaning but not interfere with code editors and other tooling.