### PR TITLE
Python: Add numpy array accessors for vectors [WIP]

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -345,6 +345,7 @@ struct IDLOptions {
   bool include_dependence_headers;
   bool mutable_buffer;
   bool one_file;
+  bool generate_numpy_accessors;
   bool proto_mode;
   bool generate_all;
   bool skip_unexpected_fields_in_json;

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -83,6 +83,7 @@ std::string FlatCompiler::GetUsageString(const char* program_name) const {
       "  --gen-mutable      Generate accessors that can mutate buffers in-place.\n"
       "  --gen-onefile      Generate single output file for C#.\n"
       "  --gen-name-strings Generate type name functions for C++.\n"
+      "  --gen-numpy        Generate numpy array accessors for Python.\n"
       "  --escape-proto-ids Disable appending '_' in namespaces names.\n"
       "  --gen-object-api   Generate an additional object-based API.\n"
       "  --cpp-ptr-type T   Set object API pointer type (default std::unique_ptr)\n"
@@ -176,6 +177,8 @@ int FlatCompiler::Compile(int argc, const char** argv) {
         opts.include_dependence_headers = false;
       } else if (arg == "--gen-onefile") {
         opts.one_file = true;
+      } else if (arg == "--gen-numpy") {
+        opts.generate_numpy_accessors = true;
       } else if (arg == "--raw-binary") {
         raw_binary = true;
       } else if(arg == "--") {  // Separator between text and binary inputs.


### PR DESCRIPTION
This has been discussed in #4090 and #4144. @rw and @maxw: I'd love your opinions on this!

This adds a `--gen-numpy` option to `flatc`, which enables generation of `_as_numpy_array`-suffixed vector accessors in the Python code generation.

This implementation does work as advertised, but I expect there to be much more discussion around what the API for things like this should look like, both from a Python API perspective (what code is being generated) and from the code generation implementation (how it's being generated). As such, I've marked this WIP, and expect to (probably) rewrite it completely :)

The way I plumbed the parser options through to the individual functions in the Python code generator felt pretty hackish. Is there a better way to pass them through than what I did?

Also, When writing this, it occurred to me that there could be a `flatbuffers.VectorAccessor` class that implements indexed lookups and iterators, as well as having an `as_numpy_array` method on it. The generated vector accessors could then just return a properly initialized `flatbuffers.VectorAccessor` object.