### PR TITLE
Add @maxw's faster byte array retrieval method to generator.

### DIFF
--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -403,6 +403,8 @@ class Builder(object):
             x = s.encode(encoding, errors)
         elif isinstance(s, compat.binary_types):
             x = s
+        elif isinstance(s, bytearray):
+            x = s
         else:
             raise TypeError("non-string passed to CreateString")
 

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -274,6 +274,22 @@ static void GetMemberOfVectorOfNonStruct(const StructDef &struct_def,
   code += "\n";
 }
 
+// Get the value of a vector's non-struct as a bytearray.
+static void GetMemberOfVectorOfNonStructBytes(const StructDef &struct_def,
+                                         const FieldDef &field,
+                                         std::string *code_ptr) {
+  std::string &code = *code_ptr;
+
+  GenReceiver(struct_def, code_ptr);
+  code += MakeCamel(field.name);
+  code += "Bytes";
+  code += "(self):";
+  code += OffsetPrefix(field);
+  code += Indent + Indent + Indent + "return self._tab.String(o + self._tab.Pos)\n";
+  code += Indent + Indent + "return \"\"\n";
+  code += "\n";
+}
+
 // Begin the creator function signature.
 static void BeginBuilderArgs(const StructDef &struct_def,
                              std::string *code_ptr) {
@@ -440,6 +456,7 @@ static void GenStructAccessor(const StructDef &struct_def,
           GetMemberOfVectorOfStruct(struct_def, field, code_ptr);
         } else {
           GetMemberOfVectorOfNonStruct(struct_def, field, code_ptr);
+          GetMemberOfVectorOfNonStructBytes(struct_def, field, code_ptr);
         }
         break;
       }


### PR DESCRIPTION
I looked into other possible solutions for this, but ended up just making it so the code you initially quickly hacked in would work the next time we ran the generator. It generated the same code as the handwritten one when I ran it with these changes.

Here's the commit message:
This adds a an additional getter method for vectors with a 'Bytes' suffix.

So if you have:
 table Foo {
   data:[ubyte];
 }

it will generate two accessors:
 def Data(self, j):
 def DataBytes(self):

The second one which grabs the whole vector so you don't have to loop
through them to build it.