### PR TITLE
JS: add package.json to publish the npm pacakge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "flatbuffers",
+  "version": "<version>",
+  "description": "Memory Efficient Serialization Library",
+  "files": ["js/flatbuffers.js"],
+  "main": "js/flatbuffers.js",
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "tests/JavaScriptTest.sh"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/google/flatbuffers.git"
+  },
+  "keywords": [
+    "flatbuffers"
+  ],
+  "author": "<author>",
+  "license": "SEE LICENSE IN LICENSE.txt",
+  "bugs": {
+    "url": "https://github.com/google/flatbuffers/issues"
+  },
+  "homepage": "https://google.github.io/flatbuffers/"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flatbuffers",
-  "version": "<version>",
+  "version": "1.5.0",
   "description": "Memory Efficient Serialization Library",
   "files": ["js/flatbuffers.js"],
   "main": "js/flatbuffers.js",
@@ -18,7 +18,7 @@
   "keywords": [
     "flatbuffers"
   ],
-  "author": "<author>",
+  "author": "The FlatBuffers project",
   "license": "SEE LICENSE IN LICENSE.txt",
   "bugs": {
     "url": "https://github.com/google/flatbuffers/issues"


### PR DESCRIPTION
## GOAL
The goal of this PR is to make it easier to use flatbuffers with `npm install flatbuffers`.

## ISSUES

- [x] We cannot use global `flatbuffers` package name. It is already used. (https://github.com/google/flatbuffers/issues/3786#issuecomment-234733060)
- [x] I don't know what value is better for `version`.
- [x] I don't know what value is better for `author`.

## Test

If you want to test the package, you can try it with `npm i @dictav/flatbuffers`
