### PR TITLE
Add move constructor to generated union class.

### DIFF
--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -74,6 +74,8 @@ struct EquipmentUnion {
   flatbuffers::NativeTable *table;
 
   EquipmentUnion() : type(Equipment_NONE), table(nullptr) {}
+  EquipmentUnion(EquipmentUnion&& u):
+    type(std::move(u.type)), table(std::move(u.table)) {}
   EquipmentUnion(const EquipmentUnion &);
   EquipmentUnion &operator=(const EquipmentUnion &);
   ~EquipmentUnion() { Reset(); }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -650,7 +650,8 @@ class CppGenerator : public BaseGenerator {
       code_ += "  flatbuffers::NativeTable *table;";
       code_ += "";
       code_ += "  {{NAME}}Union() : type({{NONE}}), table(nullptr) {}";
-      code_ += "  {{NAME}}Union({{NAME}}Union &&) = default;";
+      code_ += "  {{NAME}}Union({{NAME}}Union&& u):";
+      code_ += "    type(std::move(u.type)), table(std::move(u.table)) {}";
       code_ += "  {{NAME}}Union(const {{NAME}}Union &);";
       code_ += "  {{NAME}}Union &operator=(const {{NAME}}Union &);";
       code_ += "  ~{{NAME}}Union() { Reset(); }";

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -650,6 +650,7 @@ class CppGenerator : public BaseGenerator {
       code_ += "  flatbuffers::NativeTable *table;";
       code_ += "";
       code_ += "  {{NAME}}Union() : type({{NONE}}), table(nullptr) {}";
+      code_ += "  {{NAME}}Union({{NAME}}Union &&) = default;";
       code_ += "  {{NAME}}Union(const {{NAME}}Union &);";
       code_ += "  {{NAME}}Union &operator=(const {{NAME}}Union &);";
       code_ += "  ~{{NAME}}Union() { Reset(); }";

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -103,6 +103,8 @@ struct AnyUnion {
   flatbuffers::NativeTable *table;
 
   AnyUnion() : type(Any_NONE), table(nullptr) {}
+  AnyUnion(AnyUnion&& u):
+    type(std::move(u.type)), table(std::move(u.table)) {}
   AnyUnion(const AnyUnion &);
   AnyUnion &operator=(const AnyUnion &);
   ~AnyUnion() { Reset(); }


### PR DESCRIPTION
Hi, I am developing with Flatbuffers in C++.
I understand that there is no CopyConstructor, but is there any reason why there is no Move?
I added Move Constructor as a proposal.
Thank you