### PR TITLE
Remove libc++ and c++abi requirement on Linux with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,9 +126,14 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
 
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
   set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -std=c++0x -stdlib=libc++ -Wall -pedantic -Werror \
+      "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -pedantic -Werror \
                           -Wextra")
-  if(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
+  if(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+    set(CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+  endif()
+  if(NOT ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD" OR
+          "${CMAKE_SYSTEM_NAME}" MATCHES "Linux"))
     set(CMAKE_EXE_LINKER_FLAGS
         "${CMAKE_EXE_LINKER_FLAGS} -lc++abi")
   endif()


### PR DESCRIPTION
Fixes https://github.com/google/flatbuffers/issues/4188