### PR TITLE
optimization of FlatBufferBuilder::CreateVector()

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1057,8 +1057,12 @@ FLATBUFFERS_FINAL_CLASS
   /// where the vector is stored.
   template<typename T> Offset<Vector<T>> CreateVector(const T *v, size_t len) {
     StartVector(len, sizeof(T));
-    for (auto i = len; i > 0; ) {
-      PushElement(v[--i]);
+    if (sizeof(T) == 1) {
+      PushBytes(reinterpret_cast<const uint8_t *>(v), len);
+    } else {
+      for (auto i = len; i > 0; ) {
+        PushElement(v[--i]);
+      }
     }
     return Offset<Vector<T>>(EndVector(len));
   }


### PR DESCRIPTION
optimization of FlatBufferBuilder::CreateVector()
1. optimization of FlatBufferBuilder::CreateVector() for "1 == sizeof(T)" ( such as [byte], [ubyte]).
2. For my project, it was about 10x improvement on flatbuffers serialization.
3. why not "string": "string, which may only hold UTF-8 or 7-bit ASCII. For other text encodings or general binary data use vectors ([byte] or [ubyte]) instead."
