### PR TITLE
Add a backwards-compatible overload of VerifyBuffer()

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1487,6 +1487,10 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
   }
 
   // Verify this whole buffer, starting with root type T.
+  template<typename T> bool VerifyBuffer() {
+    return VerifyBuffer<T>(nullptr);
+  }
+
   template<typename T> bool VerifyBuffer(const char *identifier) {
     return VerifyBufferFromStart<T>(identifier, buf_);
   }


### PR DESCRIPTION
3a1f776 broke the API for `VerifyBuffer()`. This adds an overload to fix it.

This affects C++.