### PR TITLE
Provide a way to check if the builder has finished

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -730,6 +730,11 @@ FLATBUFFERS_FINAL_CLASS
   }
   /// @endcond
 
+  // @brief check if the builder has been finished
+  bool isFinished() const {
+      return finished;
+  }
+
   /// @brief In order to save space, fields that are set to their default value
   /// don't get serialized into the buffer.
   /// @param[in] bool fd When set to `true`, always serializes default values.


### PR DESCRIPTION
Add a public accessor to determine if the builder's `Finish()` has been called yet or not.

This only affects the C++ code.
