### PR TITLE
NoError was returning on DoParse method when file was empty

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1874,6 +1874,10 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
   namespaces_.push_back(new Namespace());
   ECHECK(SkipByteOrderMark());
   NEXT();
+
+  if (Is(kTokenEof))
+      return Error("json file is empty");
+
   // Includes must come before type declarations:
   for (;;) {
     // Parse pre-include proto statements if any:

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1876,7 +1876,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
   NEXT();
 
   if (Is(kTokenEof))
-      return Error("json file is empty");
+      return Error("input file is empty");
 
   // Includes must come before type declarations:
   for (;;) {


### PR DESCRIPTION
Fix for issue #4185.