### PR TITLE
fixed flag for javascript

### DIFF
--- a/docs/source/Compiler.md
+++ b/docs/source/Compiler.md
@@ -29,7 +29,7 @@ For any schema input files, one or more generators can be specified:
 
 -   `--python`, `-p`: Generate Python code.
 
--   `--javascript`, `-s`: Generate JavaScript code.
+-   `--js`, `-s`: Generate JavaScript code.
 
 -   `--php`: Generate PHP code.
 


### PR DESCRIPTION
--javascript flag does not work in the 1.6 flatc.exe, changed to --js

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
