### PR TITLE
add String::str() function

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -218,7 +218,8 @@ class String : public Sized {
 
   size_t length() const { return size(); }
   const char *c_str() const { return reinterpret_cast<const char *>(data_); }
-
+  std::string str() const { return c_str(); }
+    
   static String EmptyString() {
     static const uint8_t empty_string[] = { 0/*len*/, 0/*terminator*/ };
     return String(empty_string + 1, 1);


### PR DESCRIPTION
I inserted a line of code for convenience.

`...`
`std::cout << str.AsString().c_str() << std::endl;`
` std::cout << str.AsString().str() << std::endl;`

result is equal.