### PR TITLE
JS: make flatbuffers.js into a UMD module

### DIFF
--- a/js/flatbuffers.js
+++ b/js/flatbuffers.js
@@ -3,18 +3,14 @@
 /// @{
 /// @cond FLATBUFFERS_INTERNAL
 
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = { flatbuffers: factory() } :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(global.flatbuffers = factory());
+}(this, (function () { 'use strict';
 /**
- * @fileoverview
- *
- * Need to suppress 'global this' error so the Node.js export line doesn't cause
- * closure compile to error out.
- * @suppress {globalThis}
- */
-
-/**
- * @const
- * @namespace
- */
+* @exports flatbuffers
+*/
 var flatbuffers = {};
 
 /**
@@ -1152,8 +1148,9 @@ flatbuffers.ByteBuffer.prototype.createLong = function(low, high) {
   return flatbuffers.Long.create(low, high);
 };
 
-// Exports for Node.js and RequireJS
-this.flatbuffers = flatbuffers;
+return flatbuffers;
+
+})));
 
 /// @endcond
 /// @}


### PR DESCRIPTION
While working fine in browsers and Nodejs directly, assigning to `this` on root scope requires some gymnastics when using flatbuffers with a build system like `rollup`.

As a solution this PR adds a UMD header to flatbuffers.js.

Browsers will still have a global flatbuffers object but in CJS space it will become a default export:
```js
const flatbuffers = require('flatbuffers').flatbuffers;
// becomes
const flatbuffers = require('flatbuffers');
```
While the fix is trivial, this change will break every single NodeJS project depending on flatbuffers out there.
If deprecation is required we could add a reference to itself to the flatbuffers object so `require('flatbuffers').flatbuffers` continues to work.
The fact that this workaround will disapear in a few releases' time should be added to the release notes in that case.

This PR will also allow AMD users to `require` flatbuffers.