### PR TITLE
C++: add String::str() function in flexbuffers.h

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -218,6 +218,7 @@ class String : public Sized {
 
   size_t length() const { return size(); }
   const char *c_str() const { return reinterpret_cast<const char *>(data_); }
+  std::string str() const { return std::string(c_str(), length()); }
 
   static String EmptyString() {
     static const uint8_t empty_string[] = { 0/*len*/, 0/*terminator*/ };


### PR DESCRIPTION
#4229 

add String::str() for convenience.