### PR TITLE
Typescript support (alternative)

### DIFF
--- a/include/flatbuffers/code_generators.h
+++ b/include/flatbuffers/code_generators.h
@@ -113,6 +113,7 @@ class BaseGenerator {
                               const std::string &name) const;
 
   std::string WrapInNameSpace(const Definition &def) const;
+
   const Parser &parser_;
   const std::string &path_;
   const std::string &file_name_;

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -651,19 +651,13 @@ extern bool GenerateCPP(const Parser &parser,
                         const std::string &path,
                         const std::string &file_name);
 
-// Generate JavaScript code from the definitions in the Parser object.
+// Generate JavaScript or TypeScript code from the definitions in
+// the Parser object.
 // See idl_gen_js.
 extern std::string GenerateJS(const Parser &parser);
 extern bool GenerateJS(const Parser &parser,
                        const std::string &path,
                        const std::string &file_name);
-
-// Generate TypeScript code from the definitions in the Parser object.
-// See idl_gen_js.
-extern std::string GenerateTS(const Parser &parser);
-extern bool GenerateTS(const Parser &parser,
-	                   const std::string &path,
-	                   const std::string &file_name);
 
 // Generate Go files from the definitions in the Parser object.
 // See idl_gen_go.cpp.
@@ -709,16 +703,11 @@ extern bool GenerateFBS(const Parser &parser,
                         const std::string &path,
                         const std::string &file_name);
 
-// Generate a make rule for the generated JavaScript code.
+// Generate a make rule for the generated JavaScript or TypeScript code.
 // See idl_gen_js.cpp.
 extern std::string JSMakeRule(const Parser &parser,
                               const std::string &path,
                               const std::string &file_name);
-// Generate a make rule for the generated TypeScript code.
-// See idl_gen_js.cpp.
-extern std::string TSMakeRule(const Parser &parser,
-	                          const std::string &path,
-	                          const std::string &file_name);
 
 // Generate a make rule for the generated C++ header.
 // See idl_gen_cpp.cpp.

--- a/src/flatc_main.cpp
+++ b/src/flatc_main.cpp
@@ -91,11 +91,11 @@ int main(int argc, const char *argv[]) {
       flatbuffers::IDLOptions::kPhp,
       "Generate PHP files for tables/structs",
       flatbuffers::GeneralMakeRule },
-    { flatbuffers::GenerateTS,       nullptr, "--ts", "TypeScript",
+    { flatbuffers::GenerateJS,       nullptr, "--ts", "TypeScript",
       nullptr,
       flatbuffers::IDLOptions::kTs,
       "Generate TypeScript code for tables/structs",
-      flatbuffers::TSMakeRule },
+      flatbuffers::JSMakeRule },
     };
 
   flatbuffers::FlatCompiler::InitParams params;

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -23,16 +23,6 @@
 
 namespace flatbuffers {
 
-static std::string GeneratedFileName(const std::string &path,
-                                     const std::string &file_name) {
-  return path + file_name + "_generated.js";
-}
-
-static std::string GeneratedTsFileName(const std::string &path,
-                                     const std::string &file_name) {
-  return path + file_name + "_generated.ts";
-}
-
 struct JsLanguageParameters {
   IDLOptions::Language language;
   std::string file_extension;
@@ -56,6 +46,12 @@ const JsLanguageParameters& GetJsLangParams(IDLOptions::Language lang) {
     assert(lang == IDLOptions::kTs);
     return js_language_parameters[1];
   }
+}
+
+static std::string GeneratedFileName(const std::string &path,
+                                     const std::string &file_name,
+                                     const JsLanguageParameters &lang) {
+  return path + file_name + "_generated" + lang.file_extension;
 }
 
 namespace js {
@@ -93,14 +89,7 @@ class JsGenerator : public BaseGenerator {
       code += exports_code;
     }
 
-    std::string filename = "";
-    if (ts) {
-      filename = GeneratedTsFileName(path_, file_name_);
-    }
-    else {
-      filename = GeneratedFileName(path_, file_name_);
-    }
-    return SaveFile(filename.c_str(), code, false);
+    return SaveFile(GeneratedFileName(path_, file_name_, lang_).c_str(), code, false);
   }
 
  private:
@@ -998,7 +987,7 @@ std::string JSMakeRule(const Parser &parser,
 
   std::string filebase = flatbuffers::StripPath(
       flatbuffers::StripExtension(file_name));
-  std::string make_rule = path + filebase + "_generated" + lang.file_extension + ": ";
+  std::string make_rule = GeneratedFileName(path, filebase, lang) + ": ";
 
   auto included_files = parser.GetIncludedFilesRecursive(file_name);
   for (auto it = included_files.begin();


### PR DESCRIPTION
I've started cleaning up #4065 as TypeScript being supported by upstream flatbuffers is something I'd really like, but then I noticed someone was also doing that, in #4232.

I believe #4232 should eventually be the one that gets merged, mostly because it has some import / namespacing logic that neither mine nor the original have, but some of the changes I made are, I believe, good examples of how to fit better into the rest of the flatbuffers codebase / are more in line with the review comments made by @gwvo in #4065.

In particular:

  * booleans (the ts_ field) make for unclear callsites: the difference between `new Generator(true)` and `new Generator(false)` isn't obvious to the reader - enums are a better choice, even when there's only two options. The `IDL::Options::k{language}` enum does just fine, and is in fact already passed to JsGenerator's constructor
  * the main issue with #4065 (besides formatting) was "switching on type" - I believe #4232 is still very much affected by that. I've followed `idl_gen_general`'s convention and started making an array of structs containing characteristics and code snippets to be used when generating either JavaScript or TypeScript code.
  * this PR deduplicates the `JsGenerate` and `JsMakeRule` functions, and removes `GetNameSpace`, whose job was already adequately done by `FullNamespace`

I believe this PR looks more like what the flatbuffers maintainers would've written if they had written TypeScript support themselves, that it fits better in the codebase, however, I haven't finished cleaning it, since it lacks other things in #4232, such as:

  * Importing included files
  * A `--no-fb-import` option to disable that behavior
  * Generating .ts files in tests
  * Various fixes to problems I hadn't even encountered (my use case only has one .fbs file, no includes)

I'm submitting the PR so that I can sign the CLA and release my initial work to the flatbuffers project, in the hopes that @krojew can leverage it to polish #4232 to the point where it gets merged and everybody wins!

*TL;DR: want typescript, found old PR, researched conventions, started making changes, noticed more feature-rich PR, this PR is destined to serve as a reference (possibly of what not to do, it hasn't been reviewed yet) and to be closed when #4232 is merged.*