### PR TITLE
C#: Fixed possible conflicts between usings and user-supplied namespace

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -128,7 +128,7 @@ const LanguageParameters& GetLangParams(IDLOptions::Language lang) {
       "__p.",
       "Table.",
       "?",
-      "using System;\nusing FlatBuffers;\n\n",
+      "using global::System;\nusing global::FlatBuffers;\n\n",
       {
         nullptr,
         "///",

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -3,8 +3,8 @@
 namespace MyGame.Example
 {
 
-using System;
-using FlatBuffers;
+using global::System;
+using global::FlatBuffers;
 
 /// an example documentation comment: monster object
 public struct Monster : IFlatbufferObject

--- a/tests/MyGame/Example/Stat.cs
+++ b/tests/MyGame/Example/Stat.cs
@@ -3,8 +3,8 @@
 namespace MyGame.Example
 {
 
-using System;
-using FlatBuffers;
+using global::System;
+using global::FlatBuffers;
 
 public struct Stat : IFlatbufferObject
 {

--- a/tests/MyGame/Example/Test.cs
+++ b/tests/MyGame/Example/Test.cs
@@ -3,8 +3,8 @@
 namespace MyGame.Example
 {
 
-using System;
-using FlatBuffers;
+using global::System;
+using global::FlatBuffers;
 
 public struct Test : IFlatbufferObject
 {

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.cs
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.cs
@@ -3,8 +3,8 @@
 namespace MyGame.Example
 {
 
-using System;
-using FlatBuffers;
+using global::System;
+using global::FlatBuffers;
 
 public partial struct TestSimpleTableWithEnum : IFlatbufferObject
 {

--- a/tests/MyGame/Example/Vec3.cs
+++ b/tests/MyGame/Example/Vec3.cs
@@ -3,8 +3,8 @@
 namespace MyGame.Example
 {
 
-using System;
-using FlatBuffers;
+using global::System;
+using global::FlatBuffers;
 
 public struct Vec3 : IFlatbufferObject
 {

--- a/tests/MyGame/Example2/Monster.cs
+++ b/tests/MyGame/Example2/Monster.cs
@@ -3,8 +3,8 @@
 namespace MyGame.Example2
 {
 
-using System;
-using FlatBuffers;
+using global::System;
+using global::FlatBuffers;
 
 public struct Monster : IFlatbufferObject
 {

--- a/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.cs
+++ b/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.cs
@@ -3,8 +3,8 @@
 namespace NamespaceA.NamespaceB
 {
 
-using System;
-using FlatBuffers;
+using global::System;
+using global::FlatBuffers;
 
 public struct StructInNestedNS : IFlatbufferObject
 {

--- a/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.cs
+++ b/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.cs
@@ -3,8 +3,8 @@
 namespace NamespaceA.NamespaceB
 {
 
-using System;
-using FlatBuffers;
+using global::System;
+using global::FlatBuffers;
 
 public struct TableInNestedNS : IFlatbufferObject
 {

--- a/tests/namespace_test/NamespaceA/SecondTableInA.cs
+++ b/tests/namespace_test/NamespaceA/SecondTableInA.cs
@@ -3,8 +3,8 @@
 namespace NamespaceA
 {
 
-using System;
-using FlatBuffers;
+using global::System;
+using global::FlatBuffers;
 
 public struct SecondTableInA : IFlatbufferObject
 {

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.cs
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.cs
@@ -3,8 +3,8 @@
 namespace NamespaceA
 {
 
-using System;
-using FlatBuffers;
+using global::System;
+using global::FlatBuffers;
 
 public struct TableInFirstNS : IFlatbufferObject
 {

--- a/tests/namespace_test/NamespaceC/TableInC.cs
+++ b/tests/namespace_test/NamespaceC/TableInC.cs
@@ -3,8 +3,8 @@
 namespace NamespaceC
 {
 
-using System;
-using FlatBuffers;
+using global::System;
+using global::FlatBuffers;
 
 public struct TableInC : IFlatbufferObject
 {


### PR DESCRIPTION
C#: Added the global qualifier to using directives to prevent possible conflicts with the user-supplied namespace. Also prevents unintentional type hiding. Resolves issue #4242.