### PR TITLE
Fix Visual Studio 2017 new warning (C4244: 'argument': conversion fro…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,9 +145,8 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
 
 elseif(MSVC)
   # Visual Studio pedantic build settings
-  # warning C4244: 'conversion' conversion from 'type1' to 'type2', possible loss of data
   # warning C4512: assignment operator could not be generated
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX /wd4244 /wd4512")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX /wd4512")
 endif()
 
 if(FLATBUFFERS_CODE_COVERAGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,8 +145,9 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
 
 elseif(MSVC)
   # Visual Studio pedantic build settings
+  # warning C4244: 'conversion' conversion from 'type1' to 'type2', possible loss of data
   # warning C4512: assignment operator could not be generated
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX /wd4512")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX /wd4244 /wd4512")
 endif()
 
 if(FLATBUFFERS_CODE_COVERAGE)

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -114,6 +114,11 @@ inline uint64_t StringToUInt(const char *str, char **endptr = nullptr,
   #endif
 }
 
+// Pedantic warning free version of toupper().
+inline char ToUpper(char c) {
+  return static_cast<char>(::toupper(c));
+}
+
 typedef bool (*LoadFileFunction)(const char *filename, bool binary,
                                  std::string *dest);
 typedef bool (*FileExistsFunction)(const char *filename);

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -28,6 +28,10 @@ static std::string GeneratedFileName(const std::string &path,
   return path + file_name + "_generated.h";
 }
 
+char ToUpper(char c) {
+  return static_cast<char>(::toupper(c));
+}
+
 namespace cpp {
 class CppGenerator : public BaseGenerator {
  public:
@@ -54,7 +58,7 @@ class CppGenerator : public BaseGenerator {
       guard += *it + "_";
     }
     guard += "H_";
-    std::transform(guard.begin(), guard.end(), guard.begin(), ::toupper);
+    std::transform(guard.begin(), guard.end(), guard.begin(), ToUpper);
     return guard;
   }
 
@@ -852,7 +856,7 @@ class CppGenerator : public BaseGenerator {
 
   std::string GenFieldOffsetName(const FieldDef &field) {
     std::string uname = field.name;
-    std::transform(uname.begin(), uname.end(), uname.begin(), ::toupper);
+    std::transform(uname.begin(), uname.end(), uname.begin(), ToUpper);
     return "VT_" + uname;
   }
 

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -28,10 +28,6 @@ static std::string GeneratedFileName(const std::string &path,
   return path + file_name + "_generated.h";
 }
 
-char ToUpper(char c) {
-  return static_cast<char>(::toupper(c));
-}
-
 namespace cpp {
 class CppGenerator : public BaseGenerator {
  public:

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -262,8 +262,8 @@ void AccessFlatBufferTest(const uint8_t *flatbuf, size_t length,
   auto vecofstructs = monster->testarrayofsortedstruct();
   if (vecofstructs) {  // not filled in monster_test.bfbs
     for (size_t i = 0; i < vecofstructs->size()-1; i++) {
-      auto left = vecofstructs->Get(i);
-      auto right = vecofstructs->Get(i+1);
+      auto left = vecofstructs->Get(static_cast<flatbuffers::uoffset_t>(i));
+      auto right = vecofstructs->Get(static_cast<flatbuffers::uoffset_t>(i+1));
       TEST_EQ(true, (left->KeyCompareLessThan(right)));
     }
     TEST_NOTNULL(vecofstructs->LookupByKey(3));

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -261,9 +261,9 @@ void AccessFlatBufferTest(const uint8_t *flatbuf, size_t length,
   // Test accessing a vector of sorted structs
   auto vecofstructs = monster->testarrayofsortedstruct();
   if (vecofstructs) {  // not filled in monster_test.bfbs
-    for (size_t i = 0; i < vecofstructs->size()-1; i++) {
-      auto left = vecofstructs->Get(static_cast<flatbuffers::uoffset_t>(i));
-      auto right = vecofstructs->Get(static_cast<flatbuffers::uoffset_t>(i+1));
+    for (flatbuffers::uoffset_t i = 0; i < vecofstructs->size()-1; i++) {
+      auto left = vecofstructs->Get(i);
+      auto right = vecofstructs->Get(i+1);
       TEST_EQ(true, (left->KeyCompareLessThan(right)));
     }
     TEST_NOTNULL(vecofstructs->LookupByKey(3));


### PR DESCRIPTION
…m 'int' to 'const char', possible loss of data)

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
