### PR TITLE
C++ fixed compile error C2678 with msvc when using std::find_if

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -296,6 +296,10 @@ public:
     return data_ == other.data_;
   }
 
+  bool operator<(const VectorIterator &other) const {
+    return data_ < other.data_;
+  }
+
   bool operator!=(const VectorIterator &other) const {
     return data_ != other.data_;
   }


### PR DESCRIPTION
on vectors

In Debug mode it is checked that iterator begin is less than end
therefore the operator< in class VectorIterator is needed

Example to reproduce:

Schema
```
namespace Schema;

table Item
{
	Counter : uint;
}

table Block{
	Content : [Item];
}

root_type Block;
```

Sample program
```
FlatBufferBuilder fbb;
Offset<Item> msg1 = CreateItem(fbb, 10);
Offset<Item> msg2 = CreateItem(fbb, 20);
Offset<Item> msg3 = CreateItem(fbb, 30);
vector<Offset<Item>> msgs = { msg1, msg2, msg3 };
Offset<Vector<Offset<Item>>> msgVect = fbb.CreateVector(msgs);
auto block = CreateBlock(fbb, msgVect);
FinishBlockBuffer(fbb, block);

auto blockDoc = GetBlock(fbb.GetBufferPointer());

auto content = blockDoc->Content();
auto m2 = std::find_if(content->begin(), content->end(), [](const Item *item) {return item->Counter() == 20;});
if (m2 != content->end()) {
	cout << m2->Counter();
}
```

Error without patch in debug (sorry for using the german error messages)

```
1>------ Erstellen gestartet: Projekt: CPP_Client, Konfiguration: Debug Win32 ------
1>CPP_Client.cpp
1>c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.10.25017\include\xutility(978): error C2678: Binärer Operator "<": Es konnte kein Operator gefunden werden, der einen linksseitigen Operanden vom Typ "flatbuffers::VectorIterator<T,const Schema::Item *>" akzeptiert (oder keine geeignete Konvertierung möglich)
1>        with
1>        [
1>            T=flatbuffers::Offset<Schema::Item>
1>        ]
1>c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.10.25017\include\system_error(433): note: kann "bool std::operator <(const std::error_condition &,const std::error_condition &) noexcept" sein
1>c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.10.25017\include\system_error(424): note: oder "bool std::operator <(const std::error_code &,const std::error_code &) noexcept"
1>c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.10.25017\include\xutility(978): note: bei Anpassung der Argumentliste "(flatbuffers::VectorIterator<T,const Schema::Item *>, flatbuffers::VectorIterator<T,const Schema::Item *>)"
1>        with
1>        [
1>            T=flatbuffers::Offset<Schema::Item>
1>        ]
1>c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.10.25017\include\xutility(988): note: Siehe Verweis auf die Instanziierung der gerade kompilierten Funktions-Vorlage "void std::_Debug_range2<_InIt>(_RanIt,_RanIt,std::_Dbfile_t,std::_Dbline_t,std::random_access_iterator_tag)".
1>        with
1>        [
1>            _InIt=flatbuffers::VectorIterator<flatbuffers::Offset<Schema::Item>,const Schema::Item *>,
1>            _RanIt=flatbuffers::VectorIterator<flatbuffers::Offset<Schema::Item>,const Schema::Item *>
1>        ]
1>c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.10.25017\include\algorithm(175): note: Siehe Verweis auf die Instanziierung der gerade kompilierten Funktions-Vorlage "void std::_Debug_range<_InIt>(_InIt,_InIt,std::_Dbfile_t,std::_Dbline_t)".
1>        with
1>        [
1>            _InIt=flatbuffers::VectorIterator<flatbuffers::Offset<Schema::Item>,const Schema::Item *>
1>        ]
1>c:\users\tobias\source\repos\flatbuffersdemo\cpp_client\cpp_client.cpp(27): note: Siehe Verweis auf die Instanziierung der gerade kompilierten Funktions-Vorlage "_InIt std::find_if<flatbuffers::VectorIterator<T,const Schema::Item *>,main::<lambda_8d6647f516b86ae978bb22e0124fe437>>(_InIt,_InIt,_Pr)".
1>        with
1>        [
1>            _InIt=flatbuffers::VectorIterator<flatbuffers::Offset<Schema::Item>,const Schema::Item *>,
1>            T=flatbuffers::Offset<Schema::Item>,
1>            _Pr=main::<lambda_8d6647f516b86ae978bb22e0124fe437>
1>        ]
1>Die Erstellung des Projekts "CPP_Client.vcxproj" ist abgeschlossen -- FEHLER.
========== Erstellen: 0 erfolgreich, 1 fehlerhaft, 1 aktuell, 0 übersprungen ==========

```
