### PR TITLE
C++: Fix minor const correctness issue

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -327,7 +327,7 @@ public:
     return temp;
   }
 
-  VectorIterator operator+(const uoffset_t &offset) {
+  VectorIterator operator+(const uoffset_t &offset) const {
     return VectorIterator(data_ + offset * IndirectHelper<T>::element_stride, 0);
   }
 


### PR DESCRIPTION
`operator+` should not (and does not in this case) modify `this`