### PR TITLE
overloaded Parser::Parse() to take initializer_list of schemas to parse

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -21,6 +21,9 @@
 #include <stack>
 #include <memory>
 #include <functional>
+#include <initializer_list>
+#include <tuple>
+
 
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/hash.h"
@@ -510,6 +513,11 @@ class Parser : public ParserState {
   // supply its name in source_filename.
   bool Parse(const char *_source, const char **include_paths = nullptr,
              const char *source_filename = nullptr);
+
+  // Parse the schemas provided in the initializer list
+  // The tuple maps the filename to its content.
+  bool Parse(std::initializer_list<std::tuple<const char*, const char*>> filename_source,
+             const char **include_paths = nullptr);
 
   // Set the root type. May override the one set in the schema.
   bool SetRootType(const char *name);

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1893,6 +1893,14 @@ bool Parser::Parse(const char *source, const char **include_paths,
   return !DoParse(source, include_paths, source_filename).Check();
 }
 
+bool Parser::Parse(std::initializer_list<std::tuple<const char*, const char*>> filename_source,
+             const char **include_paths) {
+  return std::all_of(filename_source.begin(), filename_source.end(), [this, &include_paths](const std::tuple<const char*, const char*>& _file_source) {
+    return Parse(std::get<1>(_file_source), include_paths, std::get<0>(_file_source));
+  });
+}
+
+
 CheckedError Parser::DoParse(const char *source, const char **include_paths,
                              const char *source_filename) {
   file_being_parsed_ = source_filename ? source_filename : "";


### PR DESCRIPTION
Hello,

this PR is an overload to `Parser::Parse()` that takes an initializer_list of schema sources and their respective name as mentioned in https://github.com/google/flatbuffers/issues/4283

The overloaded `Parse()` simplifies the Parser initialization in case there are several dependent schemas to be parsed. The argument type of  `initializer_list<tuple<const char*, const char*>>` has been chosen to be in line with the original `Parse()` method while also being memory efficient.

The code has been tested to compile, link and run as expected inside my current work project.

Regards.
