### PR TITLE
Adding endianess support for s390x

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -77,7 +77,7 @@
 // the common platforms).
 #if !defined(FLATBUFFERS_LITTLEENDIAN)
   #if defined(__GNUC__) || defined(__clang__)
-    #if defined(__BIG_ENDIAN__) || defined(__BIG_ENDIAN)
+    #if defined(__BIG_ENDIAN__) || (defined(__s390x__) && defined(__BIG_ENDIAN))
       #define FLATBUFFERS_LITTLEENDIAN 0
     #else
       #define FLATBUFFERS_LITTLEENDIAN 1

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -77,7 +77,7 @@
 // the common platforms).
 #if !defined(FLATBUFFERS_LITTLEENDIAN)
   #if defined(__GNUC__) || defined(__clang__)
-    #ifdef __BIG_ENDIAN__
+    #if defined(__BIG_ENDIAN__) || defined(__BIG_ENDIAN)
       #define FLATBUFFERS_LITTLEENDIAN 0
     #else
       #define FLATBUFFERS_LITTLEENDIAN 1


### PR DESCRIPTION
Added endianess support for s390x architecture in flatbuffers.h file. 
s390x is an big endian  platform.

Can someone review the changes done?