### PR TITLE
Tweak fallthrough comments to get recognized by gcc7

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -301,7 +301,7 @@ Type DestinationType(const Type &type, bool vectorelem) {
     case BASE_TYPE_VECTOR:
       if (vectorelem)
         return DestinationType(type.VectorType(), vectorelem);
-      // else fall thru:
+      // else fall thru
     default: return type;
   }
 }
@@ -348,7 +348,7 @@ std::string DestinationMask(const Type &type, bool vectorelem) {
     case BASE_TYPE_VECTOR:
       if (vectorelem)
         return DestinationMask(type.VectorType(), vectorelem);
-      // else fall thru:
+      // else fall thru
     default: return "";
   }
 }

--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -420,8 +420,8 @@ Offset<const Table *> CopyTable(FlatBufferBuilder &fbb,
               offset = fbb.CreateVector(elements).o;
               break;
             }
-            // FALL-THRU:
           }
+          // FALL-THRU
           default: {  // Scalars and structs.
             auto element_size = GetTypeSize(element_base_type);
             if (elemobjectdef && elemobjectdef->is_struct())
@@ -458,8 +458,8 @@ Offset<const Table *> CopyTable(FlatBufferBuilder &fbb,
                      subobjectdef.bytesize());
           break;
         }
-        // else: FALL-THRU:
       }
+      // ELSE FALL-THRU
       case reflection::Union:
       case reflection::String:
       case reflection::Vector:


### PR DESCRIPTION
GCC gained a new warning, -Wimplicit-fallthrough, which warns about
implicitly falling through a case statement. The regular expressions
used at the default level (-Wimplicit-fallthrough=3) don't match with
a colon at the end. The comment also needs to be followed (after
optional whitespace and other comments) by a 'case' or 'default'
keyword, i.e. it will not be recognized with a '}' between the comment
and the keyword.

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
