### PR TITLE
cleaning up JavaTest.sh - quote paths, and less error-prone deletion [Java, Linux, master]

### DIFF
--- a/tests/JavaTest.sh
+++ b/tests/JavaTest.sh
@@ -14,31 +14,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+
 echo Compile then run the Java test.
 
 java -version
 
-testdir=$(readlink -fn `dirname $0`)
-thisdir=$(readlink -fn `pwd`)
+testdir="$(readlink -fn "$(dirname "$0")")"
 
-targetdir=${testdir}/target
-
-if [[ "$testdir" != "$thisdir" ]]; then
-	echo error: must be run from inside the ${testdir} directory
-	echo you ran it from ${thisdir}
-	exit 1
-fi
-
-find .. -type f -name "*.class" -exec rm  {} \;
+targetdir="${testdir}/target"
 
 if [[ -e "${targetdir}" ]]; then
-    echo "clean target"
-    rm -rf ${targetdir}
+    echo "cleaning target"
+    rm -rf "${targetdir}"
 fi
 
-mkdir ${targetdir}
+mkdir -v "${targetdir}"
 
-javac -d ${targetdir} -classpath ${testdir}/../java:${testdir}:${testdir}/namespace_test JavaTest.java
-java -classpath ${targetdir} JavaTest
+if ! find "${testdir}/../java" -type f -name "*.class" -delete; then
+    echo "failed to clean .class files from java directory" >&2
+    exit 1
+fi
 
-rm -rf ${targetdir}
+javac -d "${targetdir}" -classpath "${testdir}/../java:${testdir}:${testdir}/namespace_test" "${testdir}/JavaTest.java"
+
+(cd "${testdir}" && java -classpath "${targetdir}" JavaTest )
+
+rm -rf "${targetdir}"


### PR DESCRIPTION
JavaTest.sh is the only file edited, regarding #4300 

I avoided changing the java code, which consequently involved opening a subshell on line 41. This is not an uncommon pattern.