### PR TITLE
Track included files in PATH-agnostic way.

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -610,7 +610,7 @@ private:
   std::string file_identifier_;
   std::string file_extension_;
 
-  std::map<std::string, bool> included_files_;
+  std::map<std::string, std::string> included_files_;
   std::map<std::string, std::set<std::string>> files_included_per_file_;
   std::vector<std::string> native_included_files_;
 

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -72,7 +72,7 @@ class CppGenerator : public BaseGenerator {
     }
     for (auto it = parser_.included_files_.begin();
          it != parser_.included_files_.end(); ++it) {
-      auto noext = flatbuffers::StripExtension(it->first);
+      auto noext = flatbuffers::StripExtension(it->second);
       auto basename = flatbuffers::StripPath(noext);
       if (basename != file_name_) {
         code_ += "#include \"" + parser_.opts.include_prefix +

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -72,14 +72,15 @@ class CppGenerator : public BaseGenerator {
     }
     for (auto it = parser_.included_files_.begin();
          it != parser_.included_files_.end(); ++it) {
+      if (it->second.empty())
+        continue;
       auto noext = flatbuffers::StripExtension(it->second);
       auto basename = flatbuffers::StripPath(noext);
-      if (basename != file_name_) {
-        code_ += "#include \"" + parser_.opts.include_prefix +
-                 (parser_.opts.keep_include_path ? noext : basename) +
-                 "_generated.h\"";
-        num_includes++;
-      }
+
+      code_ += "#include \"" + parser_.opts.include_prefix +
+               (parser_.opts.keep_include_path ? noext : basename) +
+               "_generated.h\"";
+      num_includes++;
     }
     if (num_includes) code_ += "";
   }

--- a/src/idl_gen_fbs.cpp
+++ b/src/idl_gen_fbs.cpp
@@ -72,12 +72,12 @@ std::string GenerateFBS(const Parser &parser, const std::string &file_name) {
     int num_includes = 0;
     for (auto it = parser.included_files_.begin();
          it != parser.included_files_.end(); ++it) {
+      if (it->second.empty())
+        continue;
       auto basename = flatbuffers::StripPath(
-                        flatbuffers::StripExtension(it->first));
-      if (basename != file_name) {
-        schema += "include \"" + basename + ".fbs\";\n";
-        num_includes++;
-      }
+                        flatbuffers::StripExtension(it->second));
+      schema += "include \"" + basename + ".fbs\";\n";
+      num_includes++;
     }
     if (num_includes) schema += "\n";
     #endif

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1917,8 +1917,9 @@ CheckedError Parser::SkipJsonString() {
 
 bool Parser::Parse(const char *source, const char **include_paths,
                    const char *source_filename) {
+  const auto source_basename = flatbuffers::StripPath(source_filename);
   return !DoParse(source, include_paths, source_filename,
-                  source_filename).Check();
+                  source_basename.c_str()).Check();
 }
 
 CheckedError Parser::DoParse(const char *source, const char **include_paths,
@@ -1926,8 +1927,8 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
                              const char *include_filename) {
   file_being_parsed_ = source_filename ? source_filename : "";
   if (source_filename &&
-      included_files_.find(include_filename) == included_files_.end()) {
-    included_files_[include_filename] = true;
+      included_files_.find(source_filename) == included_files_.end()) {
+    included_files_[source_filename] = include_filename;
     files_included_per_file_[source_filename] = std::set<std::string>();
   }
   if (!include_paths) {
@@ -1976,7 +1977,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
         return Error("unable to locate include file: " + name);
       if (source_filename)
         files_included_per_file_[source_filename].insert(filepath);
-      if (included_files_.find(name) == included_files_.end()) {
+      if (included_files_.find(filepath) == included_files_.end()) {
         // We found an include file that we have not parsed yet.
         // Load it and parse it.
         std::string contents;

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1917,9 +1917,7 @@ CheckedError Parser::SkipJsonString() {
 
 bool Parser::Parse(const char *source, const char **include_paths,
                    const char *source_filename) {
-  const auto source_basename = flatbuffers::StripPath(source_filename);
-  return !DoParse(source, include_paths, source_filename,
-                  source_basename.c_str()).Check();
+  return !DoParse(source, include_paths, source_filename, nullptr).Check();
 }
 
 CheckedError Parser::DoParse(const char *source, const char **include_paths,
@@ -1928,7 +1926,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
   file_being_parsed_ = source_filename ? source_filename : "";
   if (source_filename &&
       included_files_.find(source_filename) == included_files_.end()) {
-    included_files_[source_filename] = include_filename;
+    included_files_[source_filename] = include_filename ? include_filename : "";
     files_included_per_file_[source_filename] = std::set<std::string>();
   }
   if (!include_paths) {


### PR DESCRIPTION
Use full paths as keys in the map of included files. Store logical include path
as a value, and use it for code generation.

This fixes the issue when a schema file supplied to flatc by a relative path
tries to include itself using a path relative to one of the -I paths.

For example, suppose the buffer.fbs file includes itself as "my/buffer.fbs",
and gets compiled as follows:
  `flatc -c -I ../schema ../schema/my/buffer.fbs`
The buffer.fbs file will be parsed twice because it is recorded as
"../schema/my/buffer.fbs" and "my/buffer.fbs".

Moreover, other issues are possible. For example, if one file can be included
using multiple path prefixes (because one of the -I paths is a subfolder of
another), then potentially it can be scanned twice as well. Using PATH-agnostic
paths guarantees that it won't happen.