### PR TITLE
[C++] Remove std::move around a raw pointer in flatbuffers.h

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -127,9 +127,6 @@ public:
   VectorIterator(const uint8_t *data, uoffset_t i) :
       data_(data + IndirectHelper<T>::element_stride * i) {}
   VectorIterator(const VectorIterator &other) : data_(other.data_) {}
-  #ifndef FLATBUFFERS_CPP98_STL
-  VectorIterator(VectorIterator &&other) : data_(other.data_) {}
-  #endif
 
   VectorIterator &operator=(const VectorIterator &other) {
     data_ = other.data_;

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -128,7 +128,7 @@ public:
       data_(data + IndirectHelper<T>::element_stride * i) {}
   VectorIterator(const VectorIterator &other) : data_(other.data_) {}
   #ifndef FLATBUFFERS_CPP98_STL
-  VectorIterator(VectorIterator &&other) : data_(std::move(other.data_)) {}
+  VectorIterator(VectorIterator &&other) : data_(other.data_) {}
   #endif
 
   VectorIterator &operator=(const VectorIterator &other) {


### PR DESCRIPTION
Calling std::move on a raw pointer has no advantage to just copying its value. Moreover, it is confusing, because it indicates that the argument is movable in some non-trivial way (e.g., is it actually meant to be a smart pointer?). More context in https://crbug.com/729393.

This change thus removes std::move from the VectorIterator move constructor in where it takes another VectorIterator's data_.