### PR TITLE
[C++] Remove std::iterator usage (#4340)

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -19,6 +19,7 @@
 #include <vector>
 #include <set>
 #include <algorithm>
+#include <iterator>
 #include <memory>
 
 #ifdef _STLPORT_VERSION

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -122,8 +122,8 @@ struct VectorIterator {
   typedef std::random_access_iterator_tag iterator_category;
   typedef IT value_type;
   typedef uoffset_t difference_type;
-  typedef IT * pointer;
-  typedef IT& reference;
+  typedef IT *pointer;
+  typedef IT &reference;
 
   VectorIterator(const uint8_t *data, uoffset_t i) :
       data_(data + IndirectHelper<T>::element_stride * i) {}

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -118,12 +118,13 @@ template<typename T> struct IndirectHelper<const T *> {
 // An STL compatible iterator implementation for Vector below, effectively
 // calling Get() for every element.
 template<typename T, typename IT>
-struct VectorIterator
-    : public std::iterator<std::random_access_iterator_tag, IT, uoffset_t> {
+struct VectorIterator {
+  typedef std::random_access_iterator_tag iterator_category;
+  typedef IT value_type;
+  typedef uoffset_t difference_type;
+  typedef IT * pointer;
+  typedef IT& reference;
 
-  typedef std::iterator<std::random_access_iterator_tag, IT, uoffset_t> super_type;
-
-public:
   VectorIterator(const uint8_t *data, uoffset_t i) :
       data_(data + IndirectHelper<T>::element_stride * i) {}
   VectorIterator(const VectorIterator &other) : data_(other.data_) {}
@@ -154,11 +155,11 @@ public:
     return (data_ - other.data_) / IndirectHelper<T>::element_stride;
   }
 
-  typename super_type::value_type operator *() const {
+  IT operator *() const {
     return IndirectHelper<T>::Read(data_, 0);
   }
 
-  typename super_type::value_type operator->() const {
+  IT operator->() const {
     return IndirectHelper<T>::Read(data_, 0);
   }
 


### PR DESCRIPTION
Inheriting from `std::iterator` has never been required, and it's deprecated in C++17. It can be replaced by directly providing typedefs. (This is compatible with C++98.)

Include `<iterator>` for `std::random_access_iterator_tag`.

Note that structs default to public access control.