### PR TITLE
C++: Make the brand new Message<T> class more convenient to use

### DIFF
--- a/include/flatbuffers/grpc.h
+++ b/include/flatbuffers/grpc.h
@@ -45,6 +45,7 @@ class Message {
   }
 
   Message &operator=(const Message &other) {
+    grpc_slice_unref(slice_);
     slice_ = grpc_slice_ref(other.slice_);
     return *this;
   }

--- a/include/flatbuffers/grpc.h
+++ b/include/flatbuffers/grpc.h
@@ -38,13 +38,16 @@ class Message {
   Message(grpc_slice slice, bool add_ref)
     : slice_(add_ref ? grpc_slice_ref(slice) : slice) {}
 
-  Message &operator=(const Message &other) = delete;
+  Message(const Message &other) : slice_(grpc_slice_ref(other.slice_)) {}
 
   Message(Message &&other) : slice_(other.slice_) {
     other.slice_ = grpc_empty_slice();
   }
 
-  Message(const Message &other) = delete;
+  Message &operator=(const Message &other) {
+    slice_ = grpc_slice_ref(other.slice_);
+    return *this;
+  }
 
   Message &operator=(Message &&other) {
     grpc_slice_unref(slice_);


### PR DESCRIPTION
@llchan: Great work with the revamped gRPC support! It works really well for me and has avoided the need of a bunch of painful glue code, while at the same time increasing speed (in theory, I haven't measured).

This PR has two commits that for me make it much more convenient to use Message<T> than it is today. They can be judged separately, but for best effect I think both should be merged.

The basic idea is that Message<T> is essentially an std::shared_ptr to a Flatbuffer buffer, and because of that it makes sense for it to behave like an std::shared_ptr, meaning: Make it copyable and add smart pointer operator overloads.

Yes, there is a risk that people start copying Message<T>s unnecessarily and start losing out on performance, but this is a C++ API. People need to know about copying anyway. If you actually do want a copy with the current code that is actually quite painful, and since the underlying storage is refcounted I don't think the performance argument is particularly strong.

With operator overloading, there is always the risk of overusing operator overloads. The Google Code Style says that operator overloading should be used "judiciously" and "only if their meaning is obvious, unsurprising, and consistent with the corresponding built-in operators". Given how precisely Message<T>'s semantics matches those of smart pointers, I think this is not surprising or weird (in fact, if anything I find it weird that they aren't there).
