### PR TITLE
Building x64 with latest Visual Studio

### DIFF
--- a/docs/source/Building.md
+++ b/docs/source/Building.md
@@ -10,6 +10,7 @@ e.g.:
 
     cmake -G "Unix Makefiles"
     cmake -G "Visual Studio 10"
+    or cmake -G "Visual Studio 15 2017 Win64" -T host=x64
     cmake -G "Xcode"
 
 Then, build as normal for your platform. This should result in a `flatc`


### PR DESCRIPTION
It's a minor change to use the 64bit variant.
https://cmake.org/cmake/help/v3.8/generator/Visual%20Studio%2015%202017.html#toolset-selection
https://gitlab.kitware.com/cmake/cmake/issues/15622#note_180677
