### PR TITLE
Fixed build error in Visual Studio 2017

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -587,7 +587,7 @@ class vector_downward {
     return static_cast<uoffset_t>(reserved_ - (cur_ - buf_));
   }
 
-  uoffset_t capacity() const {
+  size_t capacity() const {
     return reserved_;
   }
 


### PR DESCRIPTION
flatbuffers.h(591): error C2220: warning treated as error - no 'object' file generated
flatbuffers.h(591): warning C4267: 'return': conversion from 'size_t' to 'flatbuffers::uoffset_t', possible loss of data

Updates  #4347