### PR TITLE
Optimize CreateVector for types > 1 byte on little endian

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1110,14 +1110,26 @@ class FlatBufferBuilder
   /// where the vector is stored.
   template<typename T> Offset<Vector<T>> CreateVector(const T *v, size_t len) {
     StartVector(len, sizeof(T));
-    if (sizeof(T) == 1) {
-      PushBytes(reinterpret_cast<const uint8_t *>(v), len);
-    } else {
-      for (auto i = len; i > 0; ) {
-        PushElement(v[--i]);
+    #if FLATBUFFERS_LITTLEENDIAN
+      PushBytes(reinterpret_cast<const uint8_t *>(v), len * sizeof(T));
+    #else
+      if (sizeof(T) == 1) {
+        PushBytes(reinterpret_cast<const uint8_t *>(v), len);
+      } else {
+        for (auto i = len; i > 0; ) {
+          PushElement(v[--i]);
+        }
       }
-    }
+    #endif
     return Offset<Vector<T>>(EndVector(len));
+  }
+
+  template<typename T> Offset<Vector<Offset<T>>> CreateVector(const Offset<T> *v, size_t len) {
+    StartVector(len, sizeof(Offset<T>));
+    for (auto i = len; i > 0; ) {
+      PushElement(v[--i]);
+    }
+    return Offset<Vector<Offset<T>>>(EndVector(len));
   }
 
   /// @brief Serialize a `std::vector` into a FlatBuffer `vector`.


### PR DESCRIPTION
This gives a 10x speed up in my test, when creating a Vector of floats

