### PR TITLE
Make flatbuffers work with ArduinoSTL (#4357) [C++]

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -10,10 +10,10 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
-#ifndef ARDUINO
-#include <utility>
-#else
+#if defined(ARDUINO) && !defined(ARDUINOSTL_M_H)
 #include <utility.h>
+#else
+#include <utility>
 #endif
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
This fixes #4357 by conditionally including `utility` over `utility.h` for ArduinoSTL based upon the include guard of the library's header (no better way to check afaik on which lib is in use).

Legacy compatibility with StandardCplusplus lib (`utility.h`) is maintained.