### PR TITLE
idl_parser.cpp ignores $schema in input json

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -914,20 +914,12 @@ CheckedError Parser::ParseTable(const StructDef &struct_def, std::string *value,
   size_t fieldn = 0;
   auto err = ParseTableDelimiters(fieldn, &struct_def,
                                   [&](const std::string &name) -> CheckedError {
-  const char *schema_key = "$schema";
-  bool is_schema_key = true;
-  for (std::string::size_type i = 0; i < name.size(); ++i) {
-    if (tolower(name[i]) != tolower(schema_key[i])) {
-      is_schema_key = false;
-      break;
+    if (name == "$schema") {
+      NEXT(); // Ignore this field.
+      return NoError();
     }
-  }
-  if (is_schema_key) {
-    NEXT(); // Ignore this field.
-    return NoError();
-  }
-  auto field = struct_def.fields.Lookup(name);
-  if (!field) {
+    auto field = struct_def.fields.Lookup(name);
+    if (!field) {
       if (!opts.skip_unexpected_fields_in_json) {
         return Error("unknown field: " + name);
       } else {

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -914,8 +914,20 @@ CheckedError Parser::ParseTable(const StructDef &struct_def, std::string *value,
   size_t fieldn = 0;
   auto err = ParseTableDelimiters(fieldn, &struct_def,
                                   [&](const std::string &name) -> CheckedError {
-    auto field = struct_def.fields.Lookup(name);
-    if (!field) {
+  const char *schema_key = "$schema";
+  bool is_schema_key = true;
+  for (int i = 0; i < name.size(); ++i) {
+    if (tolower(name[i]) != tolower(schema_key[i])) {
+      is_schema_key = false;
+      break;
+    }
+  }
+  if (is_schema_key) {
+    NEXT(); // Ignore this field.
+    return NoError();
+  }
+  auto field = struct_def.fields.Lookup(name);
+  if (!field) {
       if (!opts.skip_unexpected_fields_in_json) {
         return Error("unknown field: " + name);
       } else {

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -916,7 +916,7 @@ CheckedError Parser::ParseTable(const StructDef &struct_def, std::string *value,
                                   [&](const std::string &name) -> CheckedError {
   const char *schema_key = "$schema";
   bool is_schema_key = true;
-  for (int i = 0; i < name.size(); ++i) {
+  for (std::string::size_type i = 0; i < name.size(); ++i) {
     if (tolower(name[i]) != tolower(schema_key[i])) {
       is_schema_key = false;
       break;

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -915,7 +915,7 @@ CheckedError Parser::ParseTable(const StructDef &struct_def, std::string *value,
   auto err = ParseTableDelimiters(fieldn, &struct_def,
                                   [&](const std::string &name) -> CheckedError {
     if (name == "$schema") {
-      NEXT(); // Ignore this field.
+      EXPECT(kTokenStringConstant);
       return NoError();
     }
     auto field = struct_def.fields.Lookup(name);


### PR DESCRIPTION
#4381
Ignores the json key $schema
