### PR TITLE
Added support for nested flatbuffers serializing to json

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -603,6 +603,9 @@ private:
   FLATBUFFERS_CHECKED_ERROR ParseVectorDelimiters(
       size_t &count, ParseVectorDelimitersBody body, void *state);
   FLATBUFFERS_CHECKED_ERROR ParseVector(const Type &type, uoffset_t *ovalue);
+  FLATBUFFERS_CHECKED_ERROR ParseNestedFlatbuffer(Value &val, FieldDef *field,
+                                                  size_t parent_fieldn,
+                                                  const StructDef *parent_struct_def);
   FLATBUFFERS_CHECKED_ERROR ParseMetaData(SymbolTable<Value> *attributes);
   FLATBUFFERS_CHECKED_ERROR TryTypedValue(int dtoken, bool check, Value &e,
                                           BaseType req, bool *destmatch);
@@ -641,6 +644,8 @@ private:
                                        StructDef *struct_def,
                                        const char *suffix,
                                        BaseType baseType);
+  void InitializeNestedFlatbufferParser(Parser& nestedParser, Value *const attribute);
+  void CleanupNestedFlatbufferParser(Parser&);
 
  public:
   SymbolTable<Type> types_;

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -232,7 +232,7 @@ struct Definition {
 
 struct FieldDef : public Definition {
   FieldDef() : deprecated(false), required(false), key(false),
-               flexbuffer(false), padding(0) {}
+               flexbuffer(false), nested_flatbuffer(false), padding(0) {}
 
   Offset<reflection::Field> Serialize(FlatBufferBuilder *builder, uint16_t id,
                                       const Parser &parser) const;
@@ -245,6 +245,7 @@ struct FieldDef : public Definition {
   bool native_inline;  // Field will be defined inline (instead of as a pointer)
                        // for native tables if field is a struct.
   bool flexbuffer; // This field contains FlexBuffer data.
+  bool nested_flatbuffer; // This field contains nested FlatBuffer data.
   size_t padding;  // Bytes to always pad after this field.
 };
 

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -245,7 +245,7 @@ struct FieldDef : public Definition {
   bool native_inline;  // Field will be defined inline (instead of as a pointer)
                        // for native tables if field is a struct.
   bool flexbuffer; // This field contains FlexBuffer data.
-  StructDef* nested_flatbuffer; // This field contains nested FlatBuffer data.
+  StructDef *nested_flatbuffer; // This field contains nested FlatBuffer data.
   size_t padding;  // Bytes to always pad after this field.
 };
 

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -232,7 +232,7 @@ struct Definition {
 
 struct FieldDef : public Definition {
   FieldDef() : deprecated(false), required(false), key(false),
-               flexbuffer(false), nested_flatbuffer(false), padding(0) {}
+               flexbuffer(false), nested_flatbuffer(NULL), padding(0) {}
 
   Offset<reflection::Field> Serialize(FlatBufferBuilder *builder, uint16_t id,
                                       const Parser &parser) const;
@@ -245,7 +245,7 @@ struct FieldDef : public Definition {
   bool native_inline;  // Field will be defined inline (instead of as a pointer)
                        // for native tables if field is a struct.
   bool flexbuffer; // This field contains FlexBuffer data.
-  bool nested_flatbuffer; // This field contains nested FlatBuffer data.
+  StructDef* nested_flatbuffer; // This field contains nested FlatBuffer data.
   size_t padding;  // Bytes to always pad after this field.
 };
 

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -644,8 +644,6 @@ private:
                                        StructDef *struct_def,
                                        const char *suffix,
                                        BaseType baseType);
-  void InitializeNestedFlatbufferParser(Parser& nestedParser, Value *const attribute);
-  void CleanupNestedFlatbufferParser(Parser&);
 
  public:
   SymbolTable<Type> types_;

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -1065,7 +1065,7 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
       }
     }
   // generate object accessors if is nested_flatbuffer
-  if (field.nested_flatbuffer) {
+  if (field.nested_flatbuffer != nullptr) {
   auto nested = field.attributes.Lookup("nested_flatbuffer");
 	auto nested_type = nested->type.struct_def;
     auto nested_type_name = WrapInNameSpace(*nested_type);

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -1067,22 +1067,22 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
   // generate object accessors if is nested_flatbuffer
   if (field.nested_flatbuffer) {
     auto nested_type_name = WrapInNameSpace(*field.nested_flatbuffer);
-    auto nestedMethodName = MakeCamel(field.name, lang_.first_camel_upper)
+    auto nested_method_name = MakeCamel(field.name, lang_.first_camel_upper)
       + "As" + nested_type_name;
-    auto getNestedMethodName = nestedMethodName;
+    auto get_nested_method_name = nested_method_name;
     if (lang_.language == IDLOptions::kCSharp) {
-      getNestedMethodName = "Get" + nestedMethodName;
+      get_nested_method_name = "Get" + nested_method_name;
       conditional_cast = "(" + nested_type_name + lang_.optional_suffix + ")";
     }
     if (lang_.language != IDLOptions::kCSharp) {
       code += "  public " + nested_type_name + lang_.optional_suffix + " ";
-      code += nestedMethodName + "() { return ";
-      code += getNestedMethodName + "(new " + nested_type_name + "()); }\n";
+      code += nested_method_name + "() { return ";
+      code += get_nested_method_name + "(new " + nested_type_name + "()); }\n";
     } else {
       obj = "(new " + nested_type_name + "())";
     }
     code += "  public " + nested_type_name + lang_.optional_suffix + " ";
-    code += getNestedMethodName + "(";
+    code += get_nested_method_name + "(";
     if (lang_.language != IDLOptions::kCSharp)
       code += nested_type_name + " obj";
     code += ") { int o = " + lang_.accessor_prefix + "__offset(";

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -1065,10 +1065,8 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
       }
     }
   // generate object accessors if is nested_flatbuffer
-  if (field.nested_flatbuffer != nullptr) {
-  auto nested = field.attributes.Lookup("nested_flatbuffer");
-	auto nested_type = nested->type.struct_def;
-    auto nested_type_name = WrapInNameSpace(*nested_type);
+  if (field.nested_flatbuffer) {
+    auto nested_type_name = WrapInNameSpace(*field.nested_flatbuffer);
     auto nestedMethodName = MakeCamel(field.name, lang_.first_camel_upper)
       + "As" + nested_type_name;
     auto getNestedMethodName = nestedMethodName;

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -1065,11 +1065,9 @@ void GenStruct(StructDef &struct_def, std::string *code_ptr) {
       }
     }
   // generate object accessors if is nested_flatbuffer
+  if (field.nested_flatbuffer) {
   auto nested = field.attributes.Lookup("nested_flatbuffer");
-  if (nested) {
-    auto nested_qualified_name =
-      parser_.namespaces_.back()->GetFullyQualifiedName(nested->constant);
-    auto nested_type = parser_.structs_.Lookup(nested_qualified_name);
+	auto nested_type = nested->type.struct_def;
     auto nested_type_name = WrapInNameSpace(*nested_type);
     auto nestedMethodName = MakeCamel(field.name, lang_.first_camel_upper)
       + "As" + nested_type_name;

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -187,8 +187,7 @@ static bool GenFieldOffset(const FieldDef &fd, const Table *table, bool fixed,
   } else if (fd.nested_flatbuffer) {
     auto vec = table->GetPointer<const Vector<uint8_t> *>(fd.value.offset);
     auto root = GetRoot<Table>(vec->data());
-    auto nested = fd.attributes.Lookup("nested_flatbuffer");
-    return GenStruct(*nested->type.struct_def, root, indent, opts, _text);
+    return GenStruct(*fd.nested_flatbuffer, root, indent, opts, _text);
   } else {
     val = IsStruct(fd.value.type)
       ? table->GetStruct<const void *>(fd.value.offset)

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -185,12 +185,10 @@ static bool GenFieldOffset(const FieldDef &fd, const Table *table, bool fixed,
     root.ToString(true, opts.strict_json, *_text);
     return true;
   } else if (fd.nested_flatbuffer) {
-	  auto vec = table->GetPointer<const Vector<uint8_t> *>(fd.value.offset);
-	  auto root = GetRoot<Table>(vec->data());
-	  auto nested = fd.attributes.Lookup("nested_flatbuffer");
-	  return GenStruct(*nested->type.struct_def,
-					   root,
-					   indent, opts, _text);
+    auto vec = table->GetPointer<const Vector<uint8_t> *>(fd.value.offset);
+    auto root = GetRoot<Table>(vec->data());
+    auto nested = fd.attributes.Lookup("nested_flatbuffer");
+    return GenStruct(*nested->type.struct_def, root, indent, opts, _text);
   } else {
     val = IsStruct(fd.value.type)
       ? table->GetStruct<const void *>(fd.value.offset)

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -165,6 +165,10 @@ template<typename T> static bool GenField(const FieldDef &fd,
                                             opts, _text);
 }
 
+static bool GenStruct(const StructDef &struct_def, const Table *table,
+						  int indent, const IDLOptions &opts,
+						  std::string *_text);
+
 // Generate text for non-scalar field.
 static bool GenFieldOffset(const FieldDef &fd, const Table *table, bool fixed,
                            int indent, Type *union_type,
@@ -180,6 +184,13 @@ static bool GenFieldOffset(const FieldDef &fd, const Table *table, bool fixed,
     auto root = flexbuffers::GetRoot(vec->data(), vec->size());
     root.ToString(true, opts.strict_json, *_text);
     return true;
+  } else if (fd.nested_flatbuffer) {
+	  auto vec = table->GetPointer<const Vector<uint8_t> *>(fd.value.offset);
+	  auto root = GetRoot<Table>(vec->data());
+	  auto nested = fd.attributes.Lookup("nested_flatbuffer");
+	  return GenStruct(*nested->type.struct_def,
+					   root,
+					   indent, opts, _text);
   } else {
     val = IsStruct(fd.value.type)
       ? table->GetStruct<const void *>(fd.value.offset)

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1140,14 +1140,8 @@ CheckedError Parser::ParseNestedFlatbuffer(Value &val, FieldDef *field,
     //create and initialize new parser
     Parser nested_parser;
     assert(field->nested_flatbuffer);
-    nested_parser.root_struct_def_ = field->nested_flatbuffer;  
-
-    nested_parser.types_ = types_;
-    nested_parser.structs_ = structs_;
+    nested_parser.root_struct_def_ = field->nested_flatbuffer;
     nested_parser.enums_ = enums_;
-    nested_parser.services_ = services_;
-    std::copy(namespaces_.begin(), namespaces_.end(), std::back_inserter(nested_parser.namespaces_));
-    std::copy(known_attributes_.begin(), known_attributes_.end(), std::insert_iterator<decltype(known_attributes_)>(nested_parser.known_attributes_, nested_parser.known_attributes_.end()));
     nested_parser.opts = opts;
     nested_parser.uses_flexbuffers_ = uses_flexbuffers_;
     //done initializing
@@ -1160,16 +1154,8 @@ CheckedError Parser::ParseNestedFlatbuffer(Value &val, FieldDef *field,
     val.constant = NumToString(off.o);
 
     //clean nested_parser before destruction to avoid deleting the elements in the SymbolTables
-    nested_parser.types_.dict.clear();
-    nested_parser.types_.vec.clear();
-    nested_parser.structs_.dict.clear();
-    nested_parser.structs_.vec.clear();
     nested_parser.enums_.dict.clear();
     nested_parser.enums_.vec.clear();
-    nested_parser.services_.dict.clear();
-    nested_parser.services_.vec.clear();
-    nested_parser.namespaces_.clear();
-    nested_parser.known_attributes_.clear();
   }
   return NoError();
 }

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1137,23 +1137,22 @@ CheckedError Parser::ParseNestedFlatbuffer(Value &val, FieldDef *field,
     ECHECK(SkipAnyJsonValue());
     std::string substring(cursor_at_value_begin -1 , cursor_ -1);
 
-    //create and initialize new parser
+    // Create and initialize new parser
     Parser nested_parser;
     assert(field->nested_flatbuffer);
     nested_parser.root_struct_def_ = field->nested_flatbuffer;
     nested_parser.enums_ = enums_;
     nested_parser.opts = opts;
     nested_parser.uses_flexbuffers_ = uses_flexbuffers_;
-    //done initializing
 
-    //parse JSON substring into new flatbuffer builder using nested_parser
+    // Parse JSON substring into new flatbuffer builder using nested_parser
     if (!nested_parser.Parse(substring.c_str(), nullptr, nullptr)) {
       ECHECK(Error(nested_parser.error_));
     }
     auto off = builder_.CreateVector(nested_parser.builder_.GetBufferPointer(), nested_parser.builder_.GetSize());
     val.constant = NumToString(off.o);
 
-    //clean nested_parser before destruction to avoid deleting the elements in the SymbolTables
+    // Clean nested_parser before destruction to avoid deleting the elements in the SymbolTables
     nested_parser.enums_.dict.clear();
     nested_parser.enums_.vec.clear();
   }

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -713,6 +713,7 @@ CheckedError Parser::ParseField(StructDef &struct_def) {
 
   auto nested = field->attributes.Lookup("nested_flatbuffer");
   if (nested) {
+    field->nested_flatbuffer = true;
     if (nested->type.base_type != BASE_TYPE_STRING)
       return Error(
             "nested_flatbuffer attribute must be a string (the root type)");
@@ -722,7 +723,7 @@ CheckedError Parser::ParseField(StructDef &struct_def) {
             "nested_flatbuffer attribute may only apply to a vector of ubyte");
     // This will cause an error if the root type of the nested flatbuffer
     // wasn't defined elsewhere.
-    LookupCreateStruct(nested->constant);
+    nested->type.struct_def = LookupCreateStruct(nested->constant);
   }
 
   if (field->attributes.Lookup("flexbuffer")) {


### PR DESCRIPTION
Hello,

this is a patch that fixes the issues described in https://github.com/google/flatbuffers/issues/4375

added features:
- serializing nested flatbuffers as JSON structure instead of byte array
- deserializing nested flatbuffers from JSON structure instead of byte array
- support for 'legacy' byte arrays deserialization

Best regards.