### PR TITLE
forwarding IDLOptions.strict_json to flexbuffers .ToString()

### DIFF
--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -178,7 +178,7 @@ static bool GenFieldOffset(const FieldDef &fd, const Table *table, bool fixed,
   } else if (fd.flexbuffer) {
     auto vec = table->GetPointer<const Vector<uint8_t> *>(fd.value.offset);
     auto root = flexbuffers::GetRoot(vec->data(), vec->size());
-    root.ToString(true, false, *_text);
+    root.ToString(true, opts.strict_json, *_text);
     return true;
   } else {
     val = IsStruct(fd.value.type)


### PR DESCRIPTION
Hi,

the IDLOption for strict_json was not set correctly when serializing flexbuffers to JSON, resulting in non-strict JSON output.
This fixes it.

Regards.