### PR TITLE
C++ Customise prefix/suffix of object API [Issue #4419]

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -366,6 +366,8 @@ struct IDLOptions {
   bool generate_object_based_api;
   std::string cpp_object_api_pointer_type;
   std::string cpp_object_api_string_type;
+  std::string object_prefix;
+  std::string object_suffix;
   bool union_value_namespacing;
   bool allow_non_utf8;
   std::string include_prefix;
@@ -415,6 +417,7 @@ struct IDLOptions {
       escape_proto_identifiers(false),
       generate_object_based_api(false),
       cpp_object_api_pointer_type("std::unique_ptr"),
+      object_suffix("T"),
       union_value_namespacing(true),
       allow_non_utf8(false),
       keep_include_path(false),

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -90,6 +90,8 @@ std::string FlatCompiler::GetUsageString(const char* program_name) const {
       "  --cpp-ptr-type T   Set object API pointer type (default std::unique_ptr)\n"
       "  --cpp-str-type T   Set object API string type (default std::string)\n"
       "                     T::c_str() and T::length() must be supported\n"
+      "  --object-prefix    Customise class prefix for C++ object-based API.\n"
+      "  --object-suffix    Customise class suffix for C++ object-based API. Default value is \"T\"\n"
       "  --no-js-exports    Removes Node.js style export lines in JS.\n"
       "  --goog-js-export   Uses goog.exports* for closure compiler exporting in JS.\n"
       "  --go-namespace     Generate the overrided namespace in Golang.\n"
@@ -201,6 +203,12 @@ int FlatCompiler::Compile(int argc, const char** argv) {
       } else if (arg == "--cpp-str-type") {
         if (++argi >= argc) Error("missing type following" + arg, true);
         opts.cpp_object_api_string_type = argv[argi];
+      } else if (arg == "--object-prefix") {
+        if (++argi >= argc) Error("missing type following" + arg, true);
+        opts.object_prefix = argv[argi];
+      } else if (arg == "--object-suffix") {
+        if (++argi >= argc) Error("missing type following" + arg, true);
+        opts.object_suffix = argv[argi];
       } else if(arg == "--gen-all") {
         opts.generate_all = true;
         opts.include_dependence_headers = false;

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -91,7 +91,8 @@ std::string FlatCompiler::GetUsageString(const char* program_name) const {
       "  --cpp-str-type T   Set object API string type (default std::string)\n"
       "                     T::c_str() and T::length() must be supported\n"
       "  --object-prefix    Customise class prefix for C++ object-based API.\n"
-      "  --object-suffix    Customise class suffix for C++ object-based API. Default value is \"T\"\n"
+      "  --object-suffix    Customise class suffix for C++ object-based API.\n"
+      "                     Default value is \"T\"\n"
       "  --no-js-exports    Removes Node.js style export lines in JS.\n"
       "  --goog-js-export   Uses goog.exports* for closure compiler exporting in JS.\n"
       "  --go-namespace     Generate the overrided namespace in Golang.\n"
@@ -204,10 +205,10 @@ int FlatCompiler::Compile(int argc, const char** argv) {
         if (++argi >= argc) Error("missing type following" + arg, true);
         opts.cpp_object_api_string_type = argv[argi];
       } else if (arg == "--object-prefix") {
-        if (++argi >= argc) Error("missing type following" + arg, true);
+        if (++argi >= argc) Error("missing prefix following" + arg, true);
         opts.object_prefix = argv[argi];
       } else if (arg == "--object-suffix") {
-        if (++argi >= argc) Error("missing type following" + arg, true);
+        if (++argi >= argc) Error("missing suffix following" + arg, true);
         opts.object_suffix = argv[argi];
       } else if(arg == "--gen-all") {
         opts.generate_all = true;


### PR DESCRIPTION
This is a simple modification to allow command-line configurability of the prefix/suffix applied to native C++ Objects.

Adds two new parameters: --object-prefix and --object-suffix. The latter has a default value of "T", to match previous behaviour. If no suffix is desired, an empty string can be provided at the command line. There is no default prefix.