### PR TITLE
Add constant accessors to C++ unions

### DIFF
--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -121,6 +121,10 @@ struct EquipmentUnion {
     return type == Equipment_Weapon ?
       reinterpret_cast<WeaponT *>(value) : nullptr;
   }
+  const WeaponT * AsWeapon() const {
+    return type == Equipment_Weapon ?
+      reinterpret_cast<const WeaponT *>(value) : nullptr;
+  }
 };
 
 bool VerifyEquipment(flatbuffers::Verifier &verifier, const void *obj, Equipment type);

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -121,7 +121,7 @@ struct EquipmentUnion {
     return type == Equipment_Weapon ?
       reinterpret_cast<WeaponT *>(value) : nullptr;
   }
-  const WeaponT * AsWeapon() const {
+  const WeaponT *AsWeapon() const {
     return type == Equipment_Weapon ?
       reinterpret_cast<const WeaponT *>(value) : nullptr;
   }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -760,9 +760,9 @@ class CppGenerator : public BaseGenerator {
         code_ += "      reinterpret_cast<{{NATIVE_TYPE}} *>(value) : nullptr;";
         code_ += "  }";
 
-        code_ += "  const {{NATIVE_TYPE}} * const As{{NATIVE_NAME}}() const {";
+        code_ += "  const {{NATIVE_TYPE}} * As{{NATIVE_NAME}}() const {";
         code_ += "    return type == {{NATIVE_ID}} ?";
-        code_ += "      reinterpret_cast<const {{NATIVE_TYPE}} * const>(value) : nullptr;";
+        code_ += "      reinterpret_cast<const {{NATIVE_TYPE}} *>(value) : nullptr;";
         code_ += "  }";
       }
       code_ += "};";

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -759,6 +759,11 @@ class CppGenerator : public BaseGenerator {
         code_ += "    return type == {{NATIVE_ID}} ?";
         code_ += "      reinterpret_cast<{{NATIVE_TYPE}} *>(value) : nullptr;";
         code_ += "  }";
+
+        code_ += "  const {{NATIVE_TYPE}} * const As{{NATIVE_NAME}}() const {";
+        code_ += "    return type == {{NATIVE_ID}} ?";
+        code_ += "      reinterpret_cast<const {{NATIVE_TYPE}} * const>(value) : nullptr;";
+        code_ += "  }";
       }
       code_ += "};";
       code_ += "";

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -760,7 +760,7 @@ class CppGenerator : public BaseGenerator {
         code_ += "      reinterpret_cast<{{NATIVE_TYPE}} *>(value) : nullptr;";
         code_ += "  }";
 
-        code_ += "  const {{NATIVE_TYPE}} * As{{NATIVE_NAME}}() const {";
+        code_ += "  const {{NATIVE_TYPE}} *As{{NATIVE_NAME}}() const {";
         code_ += "    return type == {{NATIVE_ID}} ?";
         code_ += "      reinterpret_cast<const {{NATIVE_TYPE}} *>(value) : nullptr;";
         code_ += "  }";

--- a/tests/generate_code.bat
+++ b/tests/generate_code.bat
@@ -23,3 +23,5 @@ if "%1"=="-b" set buildtype=%2
 cd ../samples
 ..\%buildtype%\flatc.exe --cpp --gen-mutable --gen-object-api --cpp-ptr-type flatbuffers::unique_ptr monster.fbs
 cd ../reflection
+
+cd ../tests

--- a/tests/generate_code.bat
+++ b/tests/generate_code.bat
@@ -15,7 +15,11 @@
 set buildtype=Release
 if "%1"=="-b" set buildtype=%2
 
-..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --js --php --grpc --gen-mutable --gen-object-api --no-includes -I include_test monster_test.fbs monsterdata_test.json
-..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --js --php --gen-mutable -o namespace_test namespace_test\namespace_test1.fbs namespace_test\namespace_test2.fbs
-..\%buildtype%\flatc.exe --binary --schema -I include_test monster_test.fbs
+..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --js --ts --php --grpc --gen-mutable --gen-object-api --no-includes --cpp-ptr-type flatbuffers::unique_ptr --no-fb-import -I include_test monster_test.fbs monsterdata_test.json
+..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --js --ts --php --gen-mutable --no-fb-import --cpp-ptr-type flatbuffers::unique_ptr  -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs
+..\%buildtype%\flatc.exe --cpp --js --ts --php --gen-mutable --gen-object-api --cpp-ptr-type flatbuffers::unique_ptr -o union_vector ./union_vector/union_vector.fbs
+..\%buildtype%\flatc.exe -b --schema --bfbs-comments -I include_test monster_test.fbs
 ..\%buildtype%\flatc.exe --jsonschema --schema -I include_test monster_test.fbs
+cd ../samples
+..\%buildtype%\flatc.exe --cpp --gen-mutable --gen-object-api --cpp-ptr-type flatbuffers::unique_ptr monster.fbs
+cd ../reflection

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -162,13 +162,25 @@ struct AnyUnion {
     return type == Any_Monster ?
       reinterpret_cast<MonsterT *>(value) : nullptr;
   }
+  const MonsterT * AsMonster() const {
+    return type == Any_Monster ?
+      reinterpret_cast<const MonsterT *>(value) : nullptr;
+  }
   TestSimpleTableWithEnumT *AsTestSimpleTableWithEnum() {
     return type == Any_TestSimpleTableWithEnum ?
       reinterpret_cast<TestSimpleTableWithEnumT *>(value) : nullptr;
   }
+  const TestSimpleTableWithEnumT * AsTestSimpleTableWithEnum() const {
+    return type == Any_TestSimpleTableWithEnum ?
+      reinterpret_cast<const TestSimpleTableWithEnumT *>(value) : nullptr;
+  }
   MyGame::Example2::MonsterT *AsMyGame_Example2_Monster() {
     return type == Any_MyGame_Example2_Monster ?
       reinterpret_cast<MyGame::Example2::MonsterT *>(value) : nullptr;
+  }
+  const MyGame::Example2::MonsterT * AsMyGame_Example2_Monster() const {
+    return type == Any_MyGame_Example2_Monster ?
+      reinterpret_cast<const MyGame::Example2::MonsterT *>(value) : nullptr;
   }
 };
 

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -162,7 +162,7 @@ struct AnyUnion {
     return type == Any_Monster ?
       reinterpret_cast<MonsterT *>(value) : nullptr;
   }
-  const MonsterT * AsMonster() const {
+  const MonsterT *AsMonster() const {
     return type == Any_Monster ?
       reinterpret_cast<const MonsterT *>(value) : nullptr;
   }
@@ -170,7 +170,7 @@ struct AnyUnion {
     return type == Any_TestSimpleTableWithEnum ?
       reinterpret_cast<TestSimpleTableWithEnumT *>(value) : nullptr;
   }
-  const TestSimpleTableWithEnumT * AsTestSimpleTableWithEnum() const {
+  const TestSimpleTableWithEnumT *AsTestSimpleTableWithEnum() const {
     return type == Any_TestSimpleTableWithEnum ?
       reinterpret_cast<const TestSimpleTableWithEnumT *>(value) : nullptr;
   }
@@ -178,7 +178,7 @@ struct AnyUnion {
     return type == Any_MyGame_Example2_Monster ?
       reinterpret_cast<MyGame::Example2::MonsterT *>(value) : nullptr;
   }
-  const MyGame::Example2::MonsterT * AsMyGame_Example2_Monster() const {
+  const MyGame::Example2::MonsterT *AsMyGame_Example2_Monster() const {
     return type == Any_MyGame_Example2_Monster ?
       reinterpret_cast<const MyGame::Example2::MonsterT *>(value) : nullptr;
   }

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -84,7 +84,7 @@ struct CharacterUnion {
     return type == Character_MuLan ?
       reinterpret_cast<AttackerT *>(value) : nullptr;
   }
-  const AttackerT * AsMuLan() const {
+  const AttackerT *AsMuLan() const {
     return type == Character_MuLan ?
       reinterpret_cast<const AttackerT *>(value) : nullptr;
   }
@@ -92,7 +92,7 @@ struct CharacterUnion {
     return type == Character_Rapunzel ?
       reinterpret_cast<Rapunzel *>(value) : nullptr;
   }
-  const Rapunzel * AsRapunzel() const {
+  const Rapunzel *AsRapunzel() const {
     return type == Character_Rapunzel ?
       reinterpret_cast<const Rapunzel *>(value) : nullptr;
   }
@@ -100,7 +100,7 @@ struct CharacterUnion {
     return type == Character_Belle ?
       reinterpret_cast<BookReader *>(value) : nullptr;
   }
-  const BookReader * AsBelle() const {
+  const BookReader *AsBelle() const {
     return type == Character_Belle ?
       reinterpret_cast<const BookReader *>(value) : nullptr;
   }
@@ -108,7 +108,7 @@ struct CharacterUnion {
     return type == Character_BookFan ?
       reinterpret_cast<BookReader *>(value) : nullptr;
   }
-  const BookReader * AsBookFan() const {
+  const BookReader *AsBookFan() const {
     return type == Character_BookFan ?
       reinterpret_cast<const BookReader *>(value) : nullptr;
   }
@@ -116,7 +116,7 @@ struct CharacterUnion {
     return type == Character_Other ?
       reinterpret_cast<std::string *>(value) : nullptr;
   }
-  const std::string * AsOther() const {
+  const std::string *AsOther() const {
     return type == Character_Other ?
       reinterpret_cast<const std::string *>(value) : nullptr;
   }
@@ -124,7 +124,7 @@ struct CharacterUnion {
     return type == Character_Unused ?
       reinterpret_cast<std::string *>(value) : nullptr;
   }
-  const std::string * AsUnused() const {
+  const std::string *AsUnused() const {
     return type == Character_Unused ?
       reinterpret_cast<const std::string *>(value) : nullptr;
   }

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -84,25 +84,49 @@ struct CharacterUnion {
     return type == Character_MuLan ?
       reinterpret_cast<AttackerT *>(value) : nullptr;
   }
+  const AttackerT * AsMuLan() const {
+    return type == Character_MuLan ?
+      reinterpret_cast<const AttackerT *>(value) : nullptr;
+  }
   Rapunzel *AsRapunzel() {
     return type == Character_Rapunzel ?
       reinterpret_cast<Rapunzel *>(value) : nullptr;
+  }
+  const Rapunzel * AsRapunzel() const {
+    return type == Character_Rapunzel ?
+      reinterpret_cast<const Rapunzel *>(value) : nullptr;
   }
   BookReader *AsBelle() {
     return type == Character_Belle ?
       reinterpret_cast<BookReader *>(value) : nullptr;
   }
+  const BookReader * AsBelle() const {
+    return type == Character_Belle ?
+      reinterpret_cast<const BookReader *>(value) : nullptr;
+  }
   BookReader *AsBookFan() {
     return type == Character_BookFan ?
       reinterpret_cast<BookReader *>(value) : nullptr;
+  }
+  const BookReader * AsBookFan() const {
+    return type == Character_BookFan ?
+      reinterpret_cast<const BookReader *>(value) : nullptr;
   }
   std::string *AsOther() {
     return type == Character_Other ?
       reinterpret_cast<std::string *>(value) : nullptr;
   }
+  const std::string * AsOther() const {
+    return type == Character_Other ?
+      reinterpret_cast<const std::string *>(value) : nullptr;
+  }
   std::string *AsUnused() {
     return type == Character_Unused ?
       reinterpret_cast<std::string *>(value) : nullptr;
+  }
+  const std::string * AsUnused() const {
+    return type == Character_Unused ?
+      reinterpret_cast<const std::string *>(value) : nullptr;
   }
 };
 


### PR DESCRIPTION
This is a simple modification to provide constant accessors to C++ native unions. Useful for this sort of thing:

```
bool Thingify(const SomeFlatbuffersTypeT & thing)
{
    // Access a union via the const reference...
    auto value = thing.someUnion.AsMagicalSuperType();
}
```