### PR TITLE
Add FinishSizePrefixed, GetSizePrefixedRootAs support for Python

### DIFF
--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -462,13 +462,31 @@ class Builder(object):
         self.current_vtable[slotnum] = self.Offset()
     ## @endcond
 
-    def Finish(self, rootTable):
+    def __Finish(self, rootTable, sizePrefix):
         """Finish finalizes a buffer, pointing to the given `rootTable`."""
         N.enforce_number(rootTable, N.UOffsetTFlags)
-        self.Prep(self.minalign, N.UOffsetTFlags.bytewidth)
+        prepSize = N.UOffsetTFlags.bytewidth
+        if sizePrefix:
+            prepSize += N.Int32Flags.bytewidth
+        self.Prep(self.minalign, prepSize)
         self.PrependUOffsetTRelative(rootTable)
+        if sizePrefix:
+            size = len(self.Bytes) - self.Head()
+            N.enforce_number(size, N.Int32Flags)
+            self.PrependInt32(size)
         self.finished = True
         return self.Head()
+
+    def Finish(self, rootTable):
+        """Finish finalizes a buffer, pointing to the given `rootTable`."""
+        return self.__Finish(rootTable, False)
+
+    def FinishSizePrefixed(self, rootTable):
+        """
+        Finish finalizes a buffer, pointing to the given `rootTable`,
+        with the size prefixed.
+        """
+        return self.__Finish(rootTable, True)
 
     ## @cond FLATBUFFERS_INTERNAL
     def Prepend(self, flags, off):

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -83,6 +83,7 @@ static void NewRootTypeFromBuffer(const StructDef &struct_def,
                                   std::string *code_ptr) {
   std::string &code = *code_ptr;
 
+  // without size prefixed
   code += Indent + "@classmethod\n";
   code += Indent + "def GetRootAs";
   code += struct_def.name;
@@ -94,6 +95,33 @@ static void NewRootTypeFromBuffer(const StructDef &struct_def,
   code += Indent + Indent + "x = " + struct_def.name + "()\n";
   code += Indent + Indent + "x.Init(buf, n + offset)\n";
   code += Indent + Indent + "return x\n";
+  code += "\n";
+
+  // with size prefixed
+  code += Indent + "@classmethod\n";
+  code += Indent + "def GetSizePrefixedRootAs";
+  code += struct_def.name;
+  code += "(cls, buf, offset):";
+  code += "\n";
+  code += Indent + Indent;
+  code += "return cls.GetRootAs";
+  code += struct_def.name;
+  code += "(buf, offset + ";
+  code += "flatbuffers.number_types.Int32Flags.bytewidth)\n";
+  code += "\n" ;
+}
+
+// Obtain the prefix size from a buffer
+static void SizePrefixFromBuffer(const StructDef &struct_def,
+                                 std::string *code_ptr) {
+  std::string &code = *code_ptr;
+
+  code += Indent + "@classmethod\n";
+  code += Indent + "def GetSizePrefix(cls, buf, offset):";
+  code += "\n";
+  code += Indent + Indent;
+  code += "return flatbuffers.encode.Get";
+  code += "(flatbuffers.packer.int32, buf, offset)\n";
   code += "\n";
 }
 
@@ -520,6 +548,9 @@ static void GenStruct(const StructDef &struct_def,
     // Generate a special accessor for the table that has been declared as
     // the root type.
     NewRootTypeFromBuffer(struct_def, code_ptr);
+
+    // Generate getter for the size prefix.
+    SizePrefixFromBuffer(struct_def, code_ptr);
   }
   // Generate the Init method that sets the field in a pre-existing
   // accessor object. This is to allow object reuse.

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -112,8 +112,7 @@ static void NewRootTypeFromBuffer(const StructDef &struct_def,
 }
 
 // Obtain the prefix size from a buffer
-static void SizePrefixFromBuffer(const StructDef &struct_def,
-                                 std::string *code_ptr) {
+static void SizePrefixFromBuffer(std::string *code_ptr) {
   std::string &code = *code_ptr;
 
   code += Indent + "@classmethod\n";
@@ -550,7 +549,7 @@ static void GenStruct(const StructDef &struct_def,
     NewRootTypeFromBuffer(struct_def, code_ptr);
 
     // Generate getter for the size prefix.
-    SizePrefixFromBuffer(struct_def, code_ptr);
+    SizePrefixFromBuffer(code_ptr);
   }
   // Generate the Init method that sets the field in a pre-existing
   // accessor object. This is to allow object reuse.

--- a/tests/MyGame/Example/Monster.py
+++ b/tests/MyGame/Example/Monster.py
@@ -15,6 +15,14 @@ class Monster(object):
         x.Init(buf, n + offset)
         return x
 
+    @classmethod
+    def GetSizePrefixedRootAsMonster(cls, buf, offset):
+        return cls.GetRootAsMonster(buf, offset + flatbuffers.number_types.Int32Flags.bytewidth)
+
+    @classmethod
+    def GetSizePrefix(cls, buf, offset):
+        return flatbuffers.encode.Get(flatbuffers.packer.int32, buf, offset)
+
     # Monster
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/MyGame/Example/Stat.py
+++ b/tests/MyGame/Example/Stat.py
@@ -14,6 +14,14 @@ class Stat(object):
         x.Init(buf, n + offset)
         return x
 
+    @classmethod
+    def GetSizePrefixedRootAsStat(cls, buf, offset):
+        return cls.GetRootAsStat(buf, offset + flatbuffers.number_types.Int32Flags.bytewidth)
+
+    @classmethod
+    def GetSizePrefix(cls, buf, offset):
+        return flatbuffers.encode.Get(flatbuffers.packer.int32, buf, offset)
+
     # Stat
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.py
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.py
@@ -14,6 +14,14 @@ class TestSimpleTableWithEnum(object):
         x.Init(buf, n + offset)
         return x
 
+    @classmethod
+    def GetSizePrefixedRootAsTestSimpleTableWithEnum(cls, buf, offset):
+        return cls.GetRootAsTestSimpleTableWithEnum(buf, offset + flatbuffers.number_types.Int32Flags.bytewidth)
+
+    @classmethod
+    def GetSizePrefix(cls, buf, offset):
+        return flatbuffers.encode.Get(flatbuffers.packer.int32, buf, offset)
+
     # TestSimpleTableWithEnum
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/MyGame/Example/TypeAliases.py
+++ b/tests/MyGame/Example/TypeAliases.py
@@ -14,6 +14,14 @@ class TypeAliases(object):
         x.Init(buf, n + offset)
         return x
 
+    @classmethod
+    def GetSizePrefixedRootAsTypeAliases(cls, buf, offset):
+        return cls.GetRootAsTypeAliases(buf, offset + flatbuffers.number_types.Int32Flags.bytewidth)
+
+    @classmethod
+    def GetSizePrefix(cls, buf, offset):
+        return flatbuffers.encode.Get(flatbuffers.packer.int32, buf, offset)
+
     # TypeAliases
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/MyGame/Example2/Monster.py
+++ b/tests/MyGame/Example2/Monster.py
@@ -14,6 +14,14 @@ class Monster(object):
         x.Init(buf, n + offset)
         return x
 
+    @classmethod
+    def GetSizePrefixedRootAsMonster(cls, buf, offset):
+        return cls.GetRootAsMonster(buf, offset + flatbuffers.number_types.Int32Flags.bytewidth)
+
+    @classmethod
+    def GetSizePrefix(cls, buf, offset):
+        return flatbuffers.encode.Get(flatbuffers.packer.int32, buf, offset)
+
     # Monster
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/MyGame/InParentNamespace.py
+++ b/tests/MyGame/InParentNamespace.py
@@ -14,6 +14,14 @@ class InParentNamespace(object):
         x.Init(buf, n + offset)
         return x
 
+    @classmethod
+    def GetSizePrefixedRootAsInParentNamespace(cls, buf, offset):
+        return cls.GetRootAsInParentNamespace(buf, offset + flatbuffers.number_types.Int32Flags.bytewidth)
+
+    @classmethod
+    def GetSizePrefix(cls, buf, offset):
+        return flatbuffers.encode.Get(flatbuffers.packer.int32, buf, offset)
+
     # InParentNamespace
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.py
+++ b/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.py
@@ -14,6 +14,14 @@ class TableInNestedNS(object):
         x.Init(buf, n + offset)
         return x
 
+    @classmethod
+    def GetSizePrefixedRootAsTableInNestedNS(cls, buf, offset):
+        return cls.GetRootAsTableInNestedNS(buf, offset + flatbuffers.number_types.Int32Flags.bytewidth)
+
+    @classmethod
+    def GetSizePrefix(cls, buf, offset):
+        return flatbuffers.encode.Get(flatbuffers.packer.int32, buf, offset)
+
     # TableInNestedNS
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/namespace_test/NamespaceA/SecondTableInA.py
+++ b/tests/namespace_test/NamespaceA/SecondTableInA.py
@@ -14,6 +14,14 @@ class SecondTableInA(object):
         x.Init(buf, n + offset)
         return x
 
+    @classmethod
+    def GetSizePrefixedRootAsSecondTableInA(cls, buf, offset):
+        return cls.GetRootAsSecondTableInA(buf, offset + flatbuffers.number_types.Int32Flags.bytewidth)
+
+    @classmethod
+    def GetSizePrefix(cls, buf, offset):
+        return flatbuffers.encode.Get(flatbuffers.packer.int32, buf, offset)
+
     # SecondTableInA
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.py
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.py
@@ -14,6 +14,14 @@ class TableInFirstNS(object):
         x.Init(buf, n + offset)
         return x
 
+    @classmethod
+    def GetSizePrefixedRootAsTableInFirstNS(cls, buf, offset):
+        return cls.GetRootAsTableInFirstNS(buf, offset + flatbuffers.number_types.Int32Flags.bytewidth)
+
+    @classmethod
+    def GetSizePrefix(cls, buf, offset):
+        return flatbuffers.encode.Get(flatbuffers.packer.int32, buf, offset)
+
     # TableInFirstNS
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/namespace_test/NamespaceC/TableInC.py
+++ b/tests/namespace_test/NamespaceC/TableInC.py
@@ -14,6 +14,14 @@ class TableInC(object):
         x.Init(buf, n + offset)
         return x
 
+    @classmethod
+    def GetSizePrefixedRootAsTableInC(cls, buf, offset):
+        return cls.GetRootAsTableInC(buf, offset + flatbuffers.number_types.Int32Flags.bytewidth)
+
+    @classmethod
+    def GetSizePrefix(cls, buf, offset):
+        return flatbuffers.encode.Get(flatbuffers.packer.int32, buf, offset)
+
     # TableInC
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/py_test.py
+++ b/tests/py_test.py
@@ -56,9 +56,11 @@ def assertRaises(test_case, fn, exception_class):
 class TestWireFormat(unittest.TestCase):
     def test_wire_format(self):
         # Verify that using the generated Python code builds a buffer without
-        # returning errors, and is interpreted correctly:
-        gen_buf, gen_off = make_monster_from_generated_code()
-        CheckReadBuffer(gen_buf, gen_off)
+        # returning errors, and is interpreted correctly, for size prefixed
+        # representation and regular:
+        for sizePrefix in [True, False]:
+            gen_buf, gen_off = make_monster_from_generated_code(sizePrefix = sizePrefix)
+            CheckReadBuffer(gen_buf, gen_off, sizePrefix = sizePrefix)
 
         # Verify that the canonical flatbuffer file is readable by the
         # generated Python code. Note that context managers are not part of
@@ -74,7 +76,7 @@ class TestWireFormat(unittest.TestCase):
         f.close()
 
 
-def CheckReadBuffer(buf, offset):
+def CheckReadBuffer(buf, offset, sizePrefix = False):
     ''' CheckReadBuffer checks that the given buffer is evaluated correctly
         as the example Monster. '''
 
@@ -83,7 +85,13 @@ def CheckReadBuffer(buf, offset):
         if not stmt:
             raise AssertionError('CheckReadBuffer case failed')
 
-    monster = MyGame.Example.Monster.Monster.GetRootAsMonster(buf, offset)
+    if sizePrefix:
+        size = MyGame.Example.Monster.Monster.GetSizePrefix(buf, offset)
+        # taken from the size of monsterdata_python_wire.mon, minus 4
+        asserter(size == 348)
+        monster = MyGame.Example.Monster.Monster.GetSizePrefixedRootAsMonster(buf, offset)
+    else:
+        monster = MyGame.Example.Monster.Monster.GetRootAsMonster(buf, offset)
 
     asserter(monster.Hp() == 80)
     asserter(monster.Mana() == 150)
@@ -799,7 +807,7 @@ class TestByteLayout(unittest.TestCase):
         ])
 
 
-def make_monster_from_generated_code():
+def make_monster_from_generated_code(sizePrefix = False):
     ''' Use generated code to build the example Monster. '''
 
     b = flatbuffers.Builder(0)
@@ -860,7 +868,10 @@ def make_monster_from_generated_code():
     MyGame.Example.Monster.MonsterAddVectorOfDoubles(b, VectorOfDoubles)
     mon = MyGame.Example.Monster.MonsterEnd(b)
 
-    b.Finish(mon)
+    if sizePrefix:
+        b.FinishSizePrefixed(mon)
+    else:
+        b.Finish(mon)
 
     return b.Bytes, b.Head()
 


### PR DESCRIPTION
Hi,

this PR adds the `FinishSizePrefixed`, `GetSizePrefixedRootAs` functionality for Python.
The extended tests succeeded on my platform (macOS), for all Python providers.
I'd greatly appreciate your opinions on this, and would be happy to adapt the code as a result of your review.
Many thanks in advance!

Cheers
Robert