### PR TITLE
Use flatbuffer unique_ptr instead of std's.

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -284,7 +284,7 @@ struct StructDef : public Definition {
   size_t minalign;  // What the whole object needs to be aligned to.
   size_t bytesize;  // Size if fixed.
 
-  std::unique_ptr<std::string> original_location;
+  flatbuffers::unique_ptr<std::string> original_location;
 };
 
 inline bool IsStruct(const Type &type) {

--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -170,7 +170,7 @@ inline void vector_emplace_back(std::vector<T> *vector, V &&data) {
       return *this;
     }
 
-    const T& operator*() const { return ptr_; }
+    const T& operator*() const { return *ptr_; }
     T* operator->() const { return ptr_; }
     T* get() const noexcept { return ptr_; }
     explicit operator bool() const { return ptr_ != nullptr; }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1661,7 +1661,7 @@ void FlexBuffersTest() {
       int ints[] = { 1, 2, 3 };
       slb2.Vector("bar", ints, 3);
       slb2.FixedTypedVector("bar3", ints, 3);
-      slb.Bool("bool", true);
+      slb2.Bool("bool", true);
       slb2.Double("foo", 100);
       slb2.Map("mymap", [](flexbuffers::Builder& slb3) {
         slb3.String("foo", "Fred");  // Testing key and string reuse.


### PR DESCRIPTION
Stlport does not have std unique_ptr, so using the one provided by
flatbuffers.
Also fixing a problem with the flatbuffer unique_ptr, and a test.

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
