### PR TITLE
Report a build failure when any Android build fails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ matrix:
         - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo ln -s -v -f $(which g++-$GCC_VERSION) /usr/bin/g++; fi
         - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo ln -s -v -f $(which gcc-$GCC_VERSION) /usr/bin/gcc; fi
       script:
-        - for build_gradle in $(git ls-files | grep build.gradle); do ( cd "$(dirname "${build_gradle}")" && ./gradlew build ); done
+        - failed=0; for build_gradle in $(git ls-files | grep build.gradle); do ( cd "$(dirname "${build_gradle}")" && ./gradlew build ) || failed=1; done; exit $((failed))

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1754,21 +1754,29 @@ void TypeAliasesTest()
 {
   flatbuffers::FlatBufferBuilder builder;
 
-  builder.Finish(CreateTypeAliases(builder,
-          INT8_MIN, UINT8_MAX, INT16_MIN, UINT16_MAX,
-          INT32_MIN, UINT32_MAX, INT64_MIN, UINT64_MAX, 2.3f, 2.3));
+  builder.Finish(CreateTypeAliases(
+      builder,
+      flatbuffers::numeric_limits<int8_t>::min(),
+      flatbuffers::numeric_limits<uint8_t>::max(),
+      flatbuffers::numeric_limits<int16_t>::min(),
+      flatbuffers::numeric_limits<uint16_t>::max(),
+      flatbuffers::numeric_limits<int32_t>::min(),
+      flatbuffers::numeric_limits<uint32_t>::max(),
+      flatbuffers::numeric_limits<int64_t>::min(),
+      flatbuffers::numeric_limits<uint64_t>::max(),
+      2.3f, 2.3));
 
   auto p = builder.GetBufferPointer();
   auto ta = flatbuffers::GetRoot<TypeAliases>(p);
 
-  TEST_EQ(ta->i8(), INT8_MIN);
-  TEST_EQ(ta->u8(), UINT8_MAX);
-  TEST_EQ(ta->i16(), INT16_MIN);
-  TEST_EQ(ta->u16(), UINT16_MAX);
-  TEST_EQ(ta->i32(), INT32_MIN);
-  TEST_EQ(ta->u32(), UINT32_MAX);
-  TEST_EQ(ta->i64(), INT64_MIN);
-  TEST_EQ(ta->u64(), UINT64_MAX);
+  TEST_EQ(ta->i8(), flatbuffers::numeric_limits<int8_t>::min());
+  TEST_EQ(ta->u8(), flatbuffers::numeric_limits<uint8_t>::max());
+  TEST_EQ(ta->i16(), flatbuffers::numeric_limits<int16_t>::min());
+  TEST_EQ(ta->u16(), flatbuffers::numeric_limits<uint16_t>::max());
+  TEST_EQ(ta->i32(), flatbuffers::numeric_limits<int32_t>::min());
+  TEST_EQ(ta->u32(), flatbuffers::numeric_limits<uint32_t>::max());
+  TEST_EQ(ta->i64(), flatbuffers::numeric_limits<int64_t>::min());
+  TEST_EQ(ta->u64(), flatbuffers::numeric_limits<uint64_t>::max());
   TEST_EQ(ta->f32(), 2.3f);
   TEST_EQ(ta->f64(), 2.3);
   TEST_EQ(sizeof(ta->i8()), 1);


### PR DESCRIPTION
The travis script was only failing if the last Android build fails.
This changes the script to report a failure if any of the Android
projects fail to build.

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
