### PR TITLE
Changed how vector_data works.

### DIFF
--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -41,12 +41,14 @@ inline char string_back(const std::string &value) {
 // Helper method that retrieves ::data() from a vector in a way that is
 // compatible with pre C++11 STLs (e.g stlport).
 template <typename T> inline T *vector_data(std::vector<T> &vector) {
-  return &(vector[0]);
+  // In some debug environments, operator[] does bounds checking, so &vector[0]
+  // can't be used.
+  return &(*vector.begin());
 }
 
 template <typename T> inline const T *vector_data(
     const std::vector<T> &vector) {
-  return &(vector[0]);
+  return &(*vector.begin());
 }
 
 template <typename T, typename V>


### PR DESCRIPTION
In some debug environments using vector[i] does bounds checking even
though the standard specifies that it should not. Using
*(vector.begin()) sidesteps this though, giving the same result without
the bounds checking.

This resolves issue #4466