### PR TITLE
Added missing EndTable() call to VerifyObject()

### DIFF
--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -700,6 +700,9 @@ bool VerifyObject(flatbuffers::Verifier &v,
     }
   }
 
+  if (!v.EndTable())
+    return false;
+  
   return true;
 }
 


### PR DESCRIPTION
VerifyObject called VerifyTableStart() but not EndTable(). This made Verifier::VerifyComplexity() increase depth_ with each table, not with the depth of tables.

https://groups.google.com/forum/#!topic/flatbuffers/OpxtW5UFAdg
