### PR TITLE
Link grpctest with libgrpc_unsecure explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ if(FLATBUFFERS_BUILD_GRPCTEST)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter -Wno-shadow")
   endif()
   add_executable(grpctest ${FlatBuffers_GRPCTest_SRCS})
-  target_link_libraries(grpctest grpc++_unsecure pthread dl)
+  target_link_libraries(grpctest grpc++_unsecure grpc_unsecure pthread dl)
 endif()
 
 if(FLATBUFFERS_INSTALL)


### PR DESCRIPTION
Link grpctest with libgrpc_unsecure explicitly. Not sure if this is a new grpc change or if this is an OSX thing, but it seems that it's necessary to be explicit about this library.