### PR TITLE
Remove copy constructor to make flatbuffers struct trivially copyable…

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2284,11 +2284,6 @@ class CppGenerator : public BaseGenerator {
     code_ += "    memset(this, 0, sizeof({{STRUCT_NAME}}));";
     code_ += "  }";
 
-    // Generate a copy constructor.
-    code_ += "  {{STRUCT_NAME}}(const {{STRUCT_NAME}} &_o) {";
-    code_ += "    memcpy(this, &_o, sizeof({{STRUCT_NAME}}));";
-    code_ += "  }";
-
     // Generate a constructor that takes all fields as arguments.
     std::string arg_list;
     std::string init_list;

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -197,9 +197,6 @@ MANUALLY_ALIGNED_STRUCT(2) Test FLATBUFFERS_FINAL_CLASS {
   Test() {
     memset(this, 0, sizeof(Test));
   }
-  Test(const Test &_o) {
-    memcpy(this, &_o, sizeof(Test));
-  }
   Test(int16_t _a, int8_t _b)
       : a_(flatbuffers::EndianScalar(_a)),
         b_(flatbuffers::EndianScalar(_b)),
@@ -236,9 +233,6 @@ MANUALLY_ALIGNED_STRUCT(16) Vec3 FLATBUFFERS_FINAL_CLASS {
  public:
   Vec3() {
     memset(this, 0, sizeof(Vec3));
-  }
-  Vec3(const Vec3 &_o) {
-    memcpy(this, &_o, sizeof(Vec3));
   }
   Vec3(float _x, float _y, float _z, double _test1, Color _test2, const Test &_test3)
       : x_(flatbuffers::EndianScalar(_x)),
@@ -301,9 +295,6 @@ MANUALLY_ALIGNED_STRUCT(4) Ability FLATBUFFERS_FINAL_CLASS {
  public:
   Ability() {
     memset(this, 0, sizeof(Ability));
-  }
-  Ability(const Ability &_o) {
-    memcpy(this, &_o, sizeof(Ability));
   }
   Ability(uint32_t _id, uint32_t _distance)
       : id_(flatbuffers::EndianScalar(_id)),

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -526,7 +526,7 @@ void SizePrefixedTest() {
   TEST_EQ_STR(m->name()->c_str(), "bob");
 }
 
-#ifndef FLATBUFFERS_CPP98_STL
+#if __cplusplus >= 201103L
 void TriviallyCopyableTest() {
     TEST_EQ(std::is_trivially_copyable<Vec3>::value, true);
 }
@@ -1815,7 +1815,7 @@ int main(int /*argc*/, const char * /*argv*/[]) {
   #else
     auto &flatbuf = flatbuf1;
   #endif // !defined(FLATBUFFERS_CPP98_STL)
-#ifndef FLATBUFFERS_CPP98_STL
+#if __cplusplus >= 201103L
   TriviallyCopyableTest();
 #endif
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -526,11 +526,17 @@ void SizePrefixedTest() {
   TEST_EQ_STR(m->name()->c_str(), "bob");
 }
 
-#if __cplusplus >= 201103L
+
 void TriviallyCopyableTest() {
-    TEST_EQ(std::is_trivially_copyable<Vec3>::value, true);
+  #if __GNUG__ && __GNUC__ < 5
+    TEST_EQ(__has_trivial_copy(Vec3), true);
+  #else
+    #if __cplusplus >= 201103L
+      TEST_EQ(std::is_trivially_copyable<Vec3>::value, true);
+    #endif
+  #endif
 }
-#endif
+
 
 // example of parsing text straight into a buffer, and generating
 // text back from it:
@@ -1815,9 +1821,8 @@ int main(int /*argc*/, const char * /*argv*/[]) {
   #else
     auto &flatbuf = flatbuf1;
   #endif // !defined(FLATBUFFERS_CPP98_STL)
-#if __cplusplus >= 201103L
+
   TriviallyCopyableTest();
-#endif
 
   AccessFlatBufferTest(reinterpret_cast<const uint8_t *>(rawbuf.c_str()),
                        rawbuf.length());

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -526,6 +526,10 @@ void SizePrefixedTest() {
   TEST_EQ_STR(m->name()->c_str(), "bob");
 }
 
+void TriviallyCopyableTest() {
+    TEST_EQ(std::is_trivially_copyable<Vec3>::value, true);
+}
+
 // example of parsing text straight into a buffer, and generating
 // text back from it:
 void ParseAndGenerateTextTest() {
@@ -1809,6 +1813,8 @@ int main(int /*argc*/, const char * /*argv*/[]) {
   #else
     auto &flatbuf = flatbuf1;
   #endif // !defined(FLATBUFFERS_CPP98_STL)
+  TriviallyCopyableTest();
+
   AccessFlatBufferTest(reinterpret_cast<const uint8_t *>(rawbuf.c_str()),
                        rawbuf.length());
   AccessFlatBufferTest(flatbuf.data(), flatbuf.size());

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -526,9 +526,11 @@ void SizePrefixedTest() {
   TEST_EQ_STR(m->name()->c_str(), "bob");
 }
 
+#ifndef FLATBUFFERS_CPP98_STL
 void TriviallyCopyableTest() {
     TEST_EQ(std::is_trivially_copyable<Vec3>::value, true);
 }
+#endif
 
 // example of parsing text straight into a buffer, and generating
 // text back from it:
@@ -1813,7 +1815,9 @@ int main(int /*argc*/, const char * /*argv*/[]) {
   #else
     auto &flatbuf = flatbuf1;
   #endif // !defined(FLATBUFFERS_CPP98_STL)
+#ifndef FLATBUFFERS_CPP98_STL
   TriviallyCopyableTest();
+#endif
 
   AccessFlatBufferTest(reinterpret_cast<const uint8_t *>(rawbuf.c_str()),
                        rawbuf.length());


### PR DESCRIPTION
… + add tests.

PR for issue #4472 