### PR TITLE
made HashFnv functions constexpr

### DIFF
--- a/include/flatbuffers/hash.h
+++ b/include/flatbuffers/hash.h
@@ -43,7 +43,7 @@ struct FnvTraits<uint64_t> {
 };
 
 template <typename T>
-T HashFnv1(const char *input) {
+constexpr T HashFnv1(const char *input) {
   T hash = FnvTraits<T>::kOffsetBasis;
   for (const char *c = input; *c; ++c) {
     hash *= FnvTraits<T>::kFnvPrime;
@@ -53,7 +53,7 @@ T HashFnv1(const char *input) {
 }
 
 template <typename T>
-T HashFnv1a(const char *input) {
+constexpr T HashFnv1a(const char *input) {
   T hash = FnvTraits<T>::kOffsetBasis;
   for (const char *c = input; *c; ++c) {
     hash ^= static_cast<unsigned char>(*c);


### PR DESCRIPTION
Hello,

I changed the declaration of the 2 HashFnv template functions to be constexpr.
This allows the function to be callable at compile time on a string literal.

My use case was to have compile-time-static hashes to look for.

Regards.