### PR TITLE
[JS]: Add support for node ESModules with --experimental-modules flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ android/build/
 samples/android/.externalNativeBuild/
 samples/android/.gradle/
 samples/android/build/
+js/flatbuffers.mjs

--- a/package.json
+++ b/package.json
@@ -2,14 +2,17 @@
   "name": "flatbuffers",
   "version": "1.8.0",
   "description": "Memory Efficient Serialization Library",
-  "files": ["js/flatbuffers.js"],
-  "main": "js/flatbuffers.js",
+  "files": ["js/flatbuffers.js", "js/flatbuffers.mjs"],
+  "main": "js/flatbuffers",
+  "module": "js/flatbuffers.mjs",
   "directories": {
     "doc": "docs",
     "test": "tests"
   },
   "scripts": {
-    "test": "tests/JavaScriptTest.sh"
+    "test": "tests/JavaScriptTest.sh",
+    "append-esm-export": "sed \"s/this.flatbuffers = flatbuffers;/export { flatbuffers };/\" js/flatbuffers.js >> js/flatbuffers.mjs",
+    "prepublishOnly": "npm run append-esm-export"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds support for using `flatbuffers` with node's new `--experimental-modules` flag which natively supports ESModules:

1. remove the `this.flatbuffers = flatbuffers;` line from the end of the source file
2. rename `js/flatbuffers.js` to `js/flatbuffers.src.js`, in order to maintain backwards-compatability
3. add an npm prepublishOnly script that creates two new (git-ignored) files:
    a. `js/flatbuffers.js` with `this.flatbuffers = flatbuffers;` appended to the end for CommonJS/RequireJS backwards-compat
    b. `js/flatbuffers.mjs` with `export { flatbuffers };` appended to the end for ESModules
4. Removes the extension from the `"main": "js/flatbuffers.js"` entry in package.json (so it is now just `"main": "js/flatbuffers"`)
5. Adds a second explicit `"module": "js/flatbuffers.mjs"` definition in the package.json, for compatibility with Closure Compiler
6. Updates the `"files"` entry in package.json to publish `["js/flatbuffers.js", "js/flatbuffers.mjs"]`

Items 2-4 are necessary because node will automatically select either the "js" or "mjs" file depending on whether it was run with the `--experimental-modules` flag, but only if the "main" entry doesn't explicitly specify a file extension.

If you attempt to import a CommonJS module as an ESModule (either by explicitly importing the "js" version, or if there's no explicit extension and no "mjs" file available), node will synthesize a default export from the "module.exports" object, leading to the following error condition:

```js
// $ node index.js
// works like a charm
const { flatbuffers } = require('flatbuffers');
```

```js
// $ node --experimental-modules index.mjs
// throws "SyntaxError: The requested module does not provide an export named 'flatbuffers'"
import { flatbuffers } from 'flatbuffers';
```

Item 5 is necessary support newer builds of Closure Compiler that support compiling ESModules with the `module_resolution: "NODE"` compiler flag:

```sh
closure-compiler --module_resolution=NODE \
  # select dep package.json "module" entries before "main"
  --package_json_entry_names=module,main \
  --js=node_modules/flatbuffers/package.json \
  --js=node_modules/flatbuffers/js/flatbuffers.mjs \
  --entry_point=index.js
```

For context: the [Apache Arrow](https://github.com/apache/arrow) project is based on flatbuffers, and we compile ES6 -> ES5 JS bundles with closure-compiler + advanced optimizations.

Recently closure-compiler's ESModules support has improved to the point where we can use it directly, instead of duplicating and maintaining dependency sources in our project. We also support importing Arrow as ESModules in node directly with the `--experimental-modules` flag.

The last step in this process is helping ensure our dependencies expose closure-compiler and node v8.6.0+ compatible ESModules. Please let me know if there's anything else I can do to help get this PR accepted, and a new version published soon. Thanks!