### PR TITLE
Add support for Python lib continuous deployment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
         skip_cleanup: true
         on:
           tags: true
+          # all_branches must be set with tags: true. See below post:
+          # https://stackoverflow.com/a/27775257/1076585
+          all_branches: true
       deploy:
         # Produce a new build for the cutting edge when master changes.
         provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,28 @@ env:
     - GCC_VERSION="4.9"
 matrix:
   include:
+    - language: python
+      python: "2.7"
+      install:
+        - "pip install wheel twine"
+      script:
+        - "cd python/"
+        - 'VERSION="$TRAVIS_TAG" python setup.py sdist bdist_wheel'
+        - "cd ../"
+      deploy:
+        # Checkpointed release builds.
+        provider: script
+        script: .travis/deploy-python.sh
+        skip_cleanup: true
+        on:
+          tags: true
+      deploy:
+        # Produce a new build for the cutting edge when master changes.
+        provider: script
+        script: .travis/deploy-python.sh
+        skip_cleanup: true
+        on:
+          branch: master
     - language: cpp
       os:
       - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,21 +14,20 @@ matrix:
         - "cd ../"
       deploy:
         # Checkpointed release builds.
-        provider: script
-        script: .travis/deploy-python.sh
-        skip_cleanup: true
-        on:
-          tags: true
-          # all_branches must be set with tags: true. See below post:
-          # https://stackoverflow.com/a/27775257/1076585
-          all_branches: true
-      deploy:
+        - provider: script
+          script: .travis/deploy-python.sh
+          skip_cleanup: true
+          on:
+            tags: true
+            # all_branches must be set with tags: true. See below post:
+            # https://stackoverflow.com/a/27775257/1076585
+            all_branches: true
         # Produce a new build for the cutting edge when master changes.
-        provider: script
-        script: .travis/deploy-python.sh
-        skip_cleanup: true
-        on:
-          branch: master
+        - provider: script
+          script: .travis/deploy-python.sh
+          skip_cleanup: true
+          on:
+            branch: master
     - language: cpp
       os:
       - linux

--- a/.travis/deploy-python.sh
+++ b/.travis/deploy-python.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROD_REPOSITORY="https://upload.pypi.org/legacy"
+TEST_REPOSITORY="https://test.pypi.org/legacy/"
+
+twine upload \
+    --username mikeholler \
+    --password "$PYPI_PASSWORD" \
+    --repository-url "$PROD_REPOSITORY" \
+    "$DIR/../python/dist/"*
+

--- a/.travis/deploy-python.sh
+++ b/.travis/deploy-python.sh
@@ -5,7 +5,7 @@ PROD_REPOSITORY="https://upload.pypi.org/legacy/"
 TEST_REPOSITORY="https://test.pypi.org/legacy/"
 
 twine upload \
-    --username mikeholler \
+    --username "$PYPI_USERNAME" \
     --password "$PYPI_PASSWORD" \
     --repository-url "$PROD_REPOSITORY" \
     "$DIR/../python/dist/"*

--- a/.travis/deploy-python.sh
+++ b/.travis/deploy-python.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-PROD_REPOSITORY="https://upload.pypi.org/legacy"
+PROD_REPOSITORY="https://upload.pypi.org/legacy/"
 TEST_REPOSITORY="https://test.pypi.org/legacy/"
 
 twine upload \

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,2 @@
+/dist/
+/*.egg-info/

--- a/python/setup.py
+++ b/python/setup.py
@@ -12,11 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from datetime import datetime
 from setuptools import setup
+
+
+def version():
+    version = os.getenv('VERSION', None)
+    if version:
+        # Most git tags are prefixed with 'v' (example: v1.2.3) this is
+        # never desirable for artifact repositories, so we strip the
+        # leading 'v' if it's present.
+        return version[1:] if version.startswith('v') else version
+    else:
+        # Default version is an ISO8601 compiliant datetime. PyPI doesn't allow
+        # the colon ':' character in its versions, and time is required to allow
+        # for multiple publications to master in one day. This datetime string
+        # uses the "basic" ISO8601 format for both its date and time components
+        # to avoid issues with the colon character (ISO requires that date and
+        # time components of a date-time string must be uniformly basic or
+        # extended, which is why the date component does not have dashes.
+        #
+        # Publications using datetime versions should only be made from master
+        # to represent the HEAD moving forward.
+        version = datetime.utcnow().strftime('%Y%m%d%H%M%S')
+        print("VERSION environment variable not set, using datetime instead: {}"
+              .format(version))
+
+    return version
 
 setup(
     name='flatbuffers',
-    version='2015.05.14.0',
+    version=version(),
     license='Apache 2.0',
     author='FlatBuffers Contributors',
     author_email='me@rwinslow.com',


### PR DESCRIPTION
Use a combination of travis and twine to publish to PyPI. New
publications will be made:

* When `master` is updated. This will trigger the publication of a
  the Python artifact versioned an iso-compliant build datetime. In this
  way, the cutting edge version will always be available via PyPI.
* When a new git tag is pushed. Tag pushes trigger the publication of
  a python artifact with the same version as the git tag, with the
  leading `v` stripped if present (`v1.2.3` becomes `1.2.3`).

Publications rely on Travis having a PYPI_PASSWORD environment set in
the project settings. See the Travis CI documentation for information on
[setting environment variables which containing sensitive data][1]. Make
extra sure the "Display value in build log" switch is OFF.

In addition to setting the previously mentioned `PYPI_PASSWORD`
environment variable, the owner of the PyPI `flatbuffers` repository
should, after merging this commit into master, add his own commit to
change `mikeholler` in `.travis/deploy-python.sh` to his username. It's
also recommended that the owner of `flatbuffers` use a separate account
in the unlikely event that the environment variable somehow becomes
compromised. Again, this is very unlikely, since the environment
variable is only set for "safe" builds approved by maintainers (not on
random pull requests).

[1]: https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings