### PR TITLE
flatc --defaults-json now prints enum names and true/false instead of numerical values for defaults

### DIFF
--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -257,7 +257,19 @@ static bool GenStruct(const StructDef &struct_def, const Table *table,
       }
       else
       {
-        text += fd.value.constant;
+        if (fd.value.type.enum_def && IsScalar(fd.value.type.base_type)) {
+          auto ev = fd.value.type.enum_def->ReverseLookup(
+              static_cast<int>(StringToInt(fd.value.constant.c_str())), false);
+          if (ev) {
+            OutputIdentifier(ev->name, opts, _text);
+          } else {
+            text += fd.value.constant;
+          }
+        } else if (fd.value.type.base_type == BASE_TYPE_BOOL) {
+          text += fd.value.constant == "0" ? "false" : "true";
+        } else {
+          text += fd.value.constant;
+        }
       }
     }
   }


### PR DESCRIPTION
This PR relates to #4509. I solved the issue in a different way to what was suggested primarily because this way I could mostly copy-paste code from `CppGenerator::GetDefaultScalarValue()` (I'm worried I'll unintentionally break something otherwise). It also prevents the need for a string to float to string conversion when printing default float values, which could potentially suffer from round-off error, and prevents an eager string to int/float conversion for the default when printing non-default values.

To clarify what this PR changes, given the following schema:
```
namespace Test;

enum Color: byte {
  Red,
  Green,
  Blue
}

table Test {
  red:   Color = Red;
  green: Color = Green;
  blue:  Color = Blue;
  true:  bool  = true;
  false: bool  = false;
  zero:  ubyte = 0;
  one:   ubyte = 1;
}

root_type Test;
```
`flatc -t --defaults-json` currently returns the following for a flatbuffer with all values omitted (i.e. the defaults take effect):
```
{
  red: 0,
  green: 1,
  blue: 2,
  true: 1,
  false: 0,
  zero: 0,
  one: 1
}
```
With the suggested code, it returns the following:
```
{                                                                                                                                                       
  red: Red,                                                                                                                                             
  green: Green,                                                                                                                                         
  blue: Blue,                                                                                                                                           
  true: true,                                                                                                                                           
  false: false,                                                                                                                                         
  zero: 0,                                                                                                                                              
  one: 1                                                                                                                                                
}
```
With `--strict-json` enabled, the enum names get quoted, while true/false does not, conforming to the printing behavior for non-default values:
```
{                                                                                                                                                       
  "red": "Red",                                                                                                                                         
  "green": "Green",                                                                                                                                     
  "blue": "Blue",                                                                                                                                       
  "true": true,                                                                                                                                         
  "false": false,                                                                                                                                       
  "zero": 0,                                                                                                                                            
  "one": 1                                                                                                                                              
}
```