### PR TITLE
fix for union Set (T&& val) when used with lvalues

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -940,7 +940,7 @@ class CppGenerator : public BaseGenerator {
         code_ += "    Reset();";
         code_ += "    type = {{NAME}}Traits<typename std::decay<T>::type::TableType>::enum_value;";
         code_ += "    if (type != {{NONE}}) {";
-        code_ += "      value = new std::decay<T>::type(std::forward<T>(val));";
+        code_ += "      value = new typename std::decay<T>::type(std::forward<T>(val));";
         code_ += "    }";
         code_ += "  }";
         code_ += "#endif  // FLATBUFFERS_CPP98_STL";

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -938,9 +938,9 @@ class CppGenerator : public BaseGenerator {
         code_ += "  template <typename T>";
         code_ += "  void Set(T&& val) {";
         code_ += "    Reset();";
-        code_ += "    type = {{NAME}}Traits<typename T::TableType>::enum_value;";
+        code_ += "    type = {{NAME}}Traits<typename std::decay_t<T>::TableType>::enum_value;";
         code_ += "    if (type != {{NONE}}) {";
-        code_ += "      value = new T(std::forward<T>(val));";
+        code_ += "      value = new std::decay_t<T>(std::forward<T>(val));";
         code_ += "    }";
         code_ += "  }";
         code_ += "#endif  // FLATBUFFERS_CPP98_STL";

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -938,9 +938,9 @@ class CppGenerator : public BaseGenerator {
         code_ += "  template <typename T>";
         code_ += "  void Set(T&& val) {";
         code_ += "    Reset();";
-        code_ += "    type = {{NAME}}Traits<typename std::decay_t<T>::TableType>::enum_value;";
+        code_ += "    type = {{NAME}}Traits<typename std::decay<T>::type::TableType>::enum_value;";
         code_ += "    if (type != {{NONE}}) {";
-        code_ += "      value = new std::decay_t<T>(std::forward<T>(val));";
+        code_ += "      value = new std::decay<T>::type(std::forward<T>(val));";
         code_ += "    }";
         code_ += "  }";
         code_ += "#endif  // FLATBUFFERS_CPP98_STL";


### PR DESCRIPTION
union `template <typename T> void Set(T&& val)` fails to compile when called with lvalue, as forwarding reference T&& is deduced as T&. 

Using visual studio 2017.