### PR TITLE
Export json default named

### DIFF
--- a/tests/monsterdata_test.golden
+++ b/tests/monsterdata_test.golden
@@ -4,7 +4,7 @@
     y: 2.0,
     z: 3.0,
     test1: 3.0,
-    test2: Green,
+    test2: "Green",
     test3: {
       a: 10,
       b: 20
@@ -24,7 +24,7 @@
     8,
     9
   ],
-  test_type: Monster,
+  test_type: "Monster",
   test: {
     name: "Fred"
   },


### PR DESCRIPTION
Changes in idl_gen_text.cpp and tests.cpp
GenerateText:
Added generation of an enum identifier if **output_defaut_scalars_in_json** is TRUE.

Case conditions by AND:
1. Enum value is not present in table (doesn't set explicitly when building a table)
2. Option **output_enum_identifiers** set to TRUE
3. Option **output_default_scalars_in_json** set to TRUE

Before changes:
Numeric code of default value of an enum is exported.
After changes: 
GenerateText generate identifier of an enum.

I'm not familiar with git, and my pull request without "git rebase -i", as recommended at https://google.github.io/flatbuffers/contributing.html
