### PR TITLE
C++: Portable range check for *cursor_ value.

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -280,7 +280,7 @@ CheckedError Parser::Next() {
         int unicode_high_surrogate = -1;
 
         while (*cursor_ != c) {
-          if (*cursor_ < ' ' && *cursor_ >= 0)
+          if (*cursor_ < ' ' && static_cast<signed char>(*cursor_) >= 0)
             return Error("illegal character in string constant");
           if (*cursor_ == '\\') {
             cursor_++;


### PR DESCRIPTION
Avoids the following compile error when char is unsigned:

```error: comparison of unsigned expression >= 0 is always true [-Werror,-Wtautological-unsigned-zero-compare]```