### PR TITLE
Add char * overload for FlatBufferBuilder::CreateString()

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1001,6 +1001,13 @@ class FlatBufferBuilder {
     return CreateString(str, strlen(str));
   }
 
+  /// @brief Store a string in the buffer, which is null-terminated.
+  /// @param[in] str A char pointer to a C-string to add to the buffer.
+  /// @return Returns the offset in the buffer where the string starts.
+  Offset<String> CreateString(char *str) {
+    return CreateString(str, strlen(str));
+  }
+
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const reference to a std::string to store in the buffer.
   /// @return Returns the offset in the buffer where the string starts.


### PR DESCRIPTION
Without this change, the compiler tries to select the following overload
when CreateString is passed a `char *`:

    template<typename T>
    Offset<String> CreateString(const T &str) {
      return CreateString(str.c_str(), str.length());
    }

which is not valid since char pointers don't have methods.

(Fixes #4579)