### PR TITLE
JSON import/export: added base64 support for [ubyte] array and nested FBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(FlatBuffers_Library_SRCS
   src/idl_gen_text.cpp
   src/reflection.cpp
   src/util.cpp
+  src/util_base64.cpp
 )
 
 set(FlatBuffers_Compiler_SRCS

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -37,6 +37,7 @@ LOCAL_SRC_FILES := src/idl_parser.cpp \
                    src/idl_gen_text.cpp \
                    src/reflection.cpp \
                    src/util.cpp \
+                   src/util_base64.cpp \
                    src/code_generators.cpp
 LOCAL_STATIC_LIBRARIES := flatbuffers
 LOCAL_ARM_MODE := arm

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -543,6 +543,8 @@ class Parser : public ParserState {
     known_attributes_["native_type"] = true;
     known_attributes_["native_default"] = true;
     known_attributes_["flexbuffer"] = true;
+    known_attributes_["base64"] = true;
+    known_attributes_["base64url"] = true;
   }
 
   ~Parser() {
@@ -648,6 +650,8 @@ class Parser : public ParserState {
   FLATBUFFERS_CHECKED_ERROR ParseVectorDelimiters(
       size_t &count, ParseVectorDelimitersBody body, void *state);
   FLATBUFFERS_CHECKED_ERROR ParseVector(const Type &type, uoffset_t *ovalue);
+  FLATBUFFERS_CHECKED_ERROR ParseVectorBase64(const Type &type, int base64_mode,
+                                              uoffset_t *ovalue);
   FLATBUFFERS_CHECKED_ERROR ParseNestedFlatbuffer(Value &val, FieldDef *field,
                                                   size_t fieldn,
                                                   const StructDef *parent_struct_def);

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -652,8 +652,6 @@ class Parser : public ParserState {
   FLATBUFFERS_CHECKED_ERROR ParseVectorDelimiters(
       size_t &count, ParseVectorDelimitersBody body, void *state);
   FLATBUFFERS_CHECKED_ERROR ParseVector(const Type &type, uoffset_t *ovalue);
-  FLATBUFFERS_CHECKED_ERROR ParseVectorBase64(const Type &type, int base64_mode,
-                                              uoffset_t *ovalue);
   FLATBUFFERS_CHECKED_ERROR ParseNestedFlatbuffer(Value &val, FieldDef *field,
                                                   size_t fieldn,
                                                   const StructDef *parent_struct_def);

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -388,6 +388,7 @@ struct IDLOptions {
   bool reexport_ts_modules;
   bool protobuf_ascii_alike;
   bool size_prefixed;
+  bool base64_cancel_padding;
 
   // Possible options for the more general generator below.
   enum Language {
@@ -444,6 +445,7 @@ struct IDLOptions {
         reexport_ts_modules(true),
         protobuf_ascii_alike(false),
         size_prefixed(false),
+        base64_cancel_padding(false),
         lang(IDLOptions::kJava),
         mini_reflect(IDLOptions::kNone),
         lang_to_generate(0) {}

--- a/include/flatbuffers/util_base64.h
+++ b/include/flatbuffers/util_base64.h
@@ -1,0 +1,59 @@
+#ifndef FLATBUFFERS_UTIL_B64_H_
+#define FLATBUFFERS_UTIL_B64_H_
+
+namespace flatbuffers {
+// [BASE64]{https://tools.ietf.org/html/rfc4648}
+
+// a Field doesn't have base64 attribute
+static const int kBase64Undefined = 0;
+
+// attribute (base64): strict RFC4648
+// general base64 alphabet, padding mandatory both for encoder and decoder
+static const int kBase64Strict = 1;
+
+// attribute (base64url): RFC4648 with URL and Filename Safe Alphabet
+// URL safe alphabet, padding optional both for decoder and skipped at encoder
+static const int kBase64Url = 2;
+
+// Helper: FDT is <idl.h>::FieldDef type
+template<typename FDT> inline int field_base64_mode(const FDT *fd) {
+  auto mode = kBase64Undefined;
+  if (fd) {
+    if (fd->attributes.Lookup("base64")) {
+      mode = kBase64Strict;
+    } else if (fd->attributes.Lookup("base64url")) {
+      mode = kBase64Url;
+    }
+  }
+  return mode;
+}
+
+// calculate number of bytes required to save Decoded result
+// return zero if error.
+// error condition : (src_size != 0 && ret == 0)
+size_t Base64DecodedSize(int base64_mode, const char *src, size_t src_size,
+                         size_t *error_position = nullptr);
+
+// Decode input base64 sequence.
+// expects: dst_size >= Base64DecodedSize(mode, src, src_size)
+// return number of written bytes or zero
+// error condition : (src_size != 0 && ret == 0)
+size_t Base64Decode(int base64_mode, const char *src, size_t src_size,
+                    uint8_t *dst, size_t dst_size,
+                    size_t *error_position = nullptr);
+
+// calculate number of bytes required to save Encoded result
+// return zero if error.
+// error condition : (src_size != 0 && ret == 0)
+size_t Base64EncodedSize(int base64_mode, const uint8_t *src, size_t src_size);
+
+// encode input byte sequence to base64 sequence.
+// expects: dst_size >= Base64EncodedSize(mode, src, src_size)
+// return number of written bytes or zero.
+// error condition : (src_size != 0 && ret == 0)
+size_t Base64Encode(int base64_mode, const uint8_t *src, size_t src_size,
+                    char *dst, size_t dst_size);
+
+}  // namespace flatbuffers
+
+#endif  // FLATBUFFERS_UTIL_B64_H_

--- a/include/flatbuffers/util_base64.h
+++ b/include/flatbuffers/util_base64.h
@@ -1,63 +1,74 @@
 #ifndef FLATBUFFERS_UTIL_B64_H_
 #define FLATBUFFERS_UTIL_B64_H_
+#include "flatbuffers/idl.h"
 
 namespace flatbuffers {
 // [BASE64]{https://tools.ietf.org/html/rfc4648}
 
-// a Field doesn't have base64/base64url attribute
-static const int kBase64Undefined = 0;
+enum Base64Mode {
+  // a Field doesn't have base64/base64url attribute.
+  Base64ModeNotSet = 0,
 
-// attribute (base64): standard RFC4648 alphabet
-// decoder: padding is optional
-// encoder: with padding
-static const int kBase64Standard = 1;
+  // Attribute (base64): standard RFC4648 alphabet.
+  // Padding is optional for the decoder.
+  // Valid input strings:
+  //  {"/43+AergFA==", "/43+AergFA"}.
+  // The encoder output always with padding if required:
+  // [255, 141, 254, 1, 234, 224, 20] => "/43+AergFA==".
+  Base64ModeStandard = 1,
 
-// attribute (base64url): RFC4648 with URL and Filename Safe Alphabet
-// decoder: padding is optional
-// encoder: padding can be canceled using kBase64CancelPadding flag
-static const int kBase64UrlSafe = 2;
+  // Attribute (base64url): RFC4648 with URL and Filename Safe Alphabet.
+  // Padding is optional for the decoder.
+  // The decoder accepts both alphabets: UrlSafe and Standard.
+  // Valid input strings:
+  //  {"/43+AergFA==", "/43+AergFA", "_43-AergFA==", "_43-AergFA"}.
+  // The encoder output always with padding if required:
+  // [255, 141, 254, 1, 234, 224, 20] encoded to "_43-AergFA==".
+  Base64ModeUrlSafe = 2,
 
-// Cancel padding for Base64Url encoder
-static const int kBase64CancelPadding = 4;
+  // Extension of (base64url) attribute.
+  // The decoder is the same as for Base64ModeUrlSafe.
+  // The encoder omits a padding for output sequence.
+  // [255, 141, 254, 1, 234, 224, 20] encoded to "_43-AergFA".
+  Base64ModeUrlSafeWithoutPadding = (Base64ModeUrlSafe | 4)
+};
 
-// Helper: FDT is <idl.h>::FieldDef type
-template<typename FDT> inline int field_base64_mode(const FDT *fd) {
-  auto mode = kBase64Undefined;
+// Helper for Base64Mode enum.
+inline Base64Mode Base64CancelPadding(Base64Mode mode) {
+  return (Base64ModeUrlSafe == mode) ? Base64ModeUrlSafeWithoutPadding : mode;
+}
+
+// Helper for FieldDef attributes check.
+inline Base64Mode FieldGetBase64Mode(const FieldDef *fd) {
+  auto mode = Base64ModeNotSet;
   if (fd) {
     if (fd->attributes.Lookup("base64")) {
-      mode = kBase64Standard;
+      mode = Base64ModeStandard;
     } else if (fd->attributes.Lookup("base64url")) {
-      mode = kBase64UrlSafe;
+      mode = Base64ModeUrlSafe;
     }
   }
   return mode;
 }
 
-// calculate number of bytes required to save Decoded result
-// return zero if error.
-// error condition : (src_size != 0 && ret == 0)
-size_t Base64DecodedSize(int base64_mode, const char *src, size_t src_size,
-                         size_t *error_position = nullptr);
+// Returns the number of bytes, need to save a decoded result.
+// Return zero if an error or if src_size==0.
+// Error condition : (src_size != 0 && ret == 0).
+size_t Base64DecodedSize(Base64Mode base64_mode, const char *src,
+                         size_t src_size, size_t *error_position = nullptr);
 
-// Decode input base64 sequence.
-// expects: dst_size >= Base64DecodedSize(mode, src, src_size)
-// return number of written bytes or zero
-// error condition : (src_size != 0 && ret == 0)
-size_t Base64Decode(int base64_mode, const char *src, size_t src_size,
+// Decodes the input base64 string into the binary sequence of bytes.
+// Expects: dst_size >= Base64DecodedSize(mode, src, src_size).
+// On success, returns the number of bytes written to the destination memory.
+// Returned Zero indicates nothing was written.
+// Error condition : (src_size != 0 && ret == 0).
+size_t Base64Decode(Base64Mode base64_mode, const char *src, size_t src_size,
                     uint8_t *dst, size_t dst_size,
                     size_t *error_position = nullptr);
 
-// calculate number of bytes required to save Encoded result
-// return zero if error.
-// error condition : (src_size != 0 && ret == 0)
-size_t Base64EncodedSize(int base64_mode, const uint8_t *src, size_t src_size);
-
-// encode input byte sequence to base64 sequence.
-// expects: dst_size >= Base64EncodedSize(mode, src, src_size)
-// return number of written bytes or zero.
-// error condition : (src_size != 0 && ret == 0)
-size_t Base64Encode(int base64_mode, const uint8_t *src, size_t src_size,
-                    char *dst, size_t dst_size);
+// Encodes the input byte sequence into the base64 encoded string.
+void Base64Encode(Base64Mode base64_mode, const uint8_t *src, size_t src_size,
+                  std::string *_text);
 
 }  // namespace flatbuffers
 

--- a/include/flatbuffers/util_base64.h
+++ b/include/flatbuffers/util_base64.h
@@ -4,25 +4,30 @@
 namespace flatbuffers {
 // [BASE64]{https://tools.ietf.org/html/rfc4648}
 
-// a Field doesn't have base64 attribute
+// a Field doesn't have base64/base64url attribute
 static const int kBase64Undefined = 0;
 
-// attribute (base64): strict RFC4648
-// general base64 alphabet, padding mandatory both for encoder and decoder
-static const int kBase64Strict = 1;
+// attribute (base64): standard RFC4648 alphabet
+// decoder: padding is optional
+// encoder: with padding
+static const int kBase64Standard = 1;
 
 // attribute (base64url): RFC4648 with URL and Filename Safe Alphabet
-// URL safe alphabet, padding optional both for decoder and skipped at encoder
-static const int kBase64Url = 2;
+// decoder: padding is optional
+// encoder: padding can be canceled using kBase64CancelPadding flag
+static const int kBase64UrlSafe = 2;
+
+// Cancel padding for Base64Url encoder
+static const int kBase64CancelPadding = 4;
 
 // Helper: FDT is <idl.h>::FieldDef type
 template<typename FDT> inline int field_base64_mode(const FDT *fd) {
   auto mode = kBase64Undefined;
   if (fd) {
     if (fd->attributes.Lookup("base64")) {
-      mode = kBase64Strict;
+      mode = kBase64Standard;
     } else if (fd->attributes.Lookup("base64url")) {
-      mode = kBase64Url;
+      mode = kBase64UrlSafe;
     }
   }
   return mode;

--- a/include/flatbuffers/util_base64.h
+++ b/include/flatbuffers/util_base64.h
@@ -4,71 +4,66 @@
 
 namespace flatbuffers {
 // [BASE64]{https://tools.ietf.org/html/rfc4648}
+//
+// Field attribute (base64): accepts standard RFC4648 alphabet.
+// Padding is optional for the decoder.
+// Valid input strings: {"/43+AergFA==", "/43+AergFA"}.
+// The encoder output always with padding if required:
+// Vector [255, 141, 254, 1, 234, 224, 20] => "/43+AergFA==".
+//
+// Field attribute (base64url): RFC4648 with URL and Filename Safe Alphabet.
+// Padding is optional for the decoder.
+// The decoder accepts both alphabets: UrlSafe and Standard.
+// Valid input strings:
+//  {"/43+AergFA==", "/43+AergFA", "_43-AergFA==", "_43-AergFA"}.
+// The encoder output always with padding if required:
+// Vector [255, 141, 254, 1, 234, 224, 20] encoded to "_43-AergFA==".
+//
+// Print extension of (base64url) attribute:
+// If IDLOptions::base64_cancel_padding is true, then the encoder omits
+// a padding for the output sequence.
+// Vector [255, 141, 254, 1, 234, 224, 20] encoded to // "_43-AergFA".
 
-enum Base64Mode {
-  // a Field doesn't have base64/base64url attribute.
-  Base64ModeNotSet = 0,
+// Parse ubyte vector from a base64 string.
+// Return number of processed symbols from the string.
+// Return zero if any:
+//  1) type != BASE_TYPE_UCHAR,
+//  2) text.size() < 1,
+//  3) fd doesn't have (base64) or (base64url) attribute.
+// On succsess, returned value is equal to text.size().
+// If the text has non-base64 symbols return the location of the first one.
+size_t ParseBase64Vector(Type type, const IDLOptions &opts,
+                         const std::string &text, const FieldDef *fd,
+                         uoffset_t *ovalue, FlatBufferBuilder *_builder);
 
-  // Attribute (base64): standard RFC4648 alphabet.
-  // Padding is optional for the decoder.
-  // Valid input strings:
-  //  {"/43+AergFA==", "/43+AergFA"}.
-  // The encoder output always with padding if required:
-  // [255, 141, 254, 1, 234, 224, 20] => "/43+AergFA==".
-  Base64ModeStandard = 1,
-
-  // Attribute (base64url): RFC4648 with URL and Filename Safe Alphabet.
-  // Padding is optional for the decoder.
-  // The decoder accepts both alphabets: UrlSafe and Standard.
-  // Valid input strings:
-  //  {"/43+AergFA==", "/43+AergFA", "_43-AergFA==", "_43-AergFA"}.
-  // The encoder output always with padding if required:
-  // [255, 141, 254, 1, 234, 224, 20] encoded to "_43-AergFA==".
-  Base64ModeUrlSafe = 2,
-
-  // Extension of (base64url) attribute.
-  // The decoder is the same as for Base64ModeUrlSafe.
-  // The encoder omits a padding for output sequence.
-  // [255, 141, 254, 1, 234, 224, 20] encoded to "_43-AergFA".
-  Base64ModeUrlSafeWithoutPadding = (Base64ModeUrlSafe | 4)
-};
-
-// Helper for Base64Mode enum.
-inline Base64Mode Base64CancelPadding(Base64Mode mode) {
-  return (Base64ModeUrlSafe == mode) ? Base64ModeUrlSafeWithoutPadding : mode;
+// Print a Vector as a base64 encoded string.
+// Return False if any:
+//  1) type T is not the same as ubyte type,
+//  2) v.size() < 1,
+//  3) fd doesn't have (base64) or (base64url) attribute.
+// On succsess, append to the _text quoted base64 string.
+// Takes into account the "opts.base64_cancel_padding" option if a field has
+// (base64url) attribute and cancel trailing padding for the output string.
+template<typename T>
+static inline bool PrintBase64Vector(const Vector<T> &v, Type type, int indent,
+                                     const IDLOptions &opts, std::string *_text,
+                                     const FieldDef *fd) {
+  (void)v;
+  (void)type;
+  (void)indent;
+  (void)opts;
+  (void)_text;
+  (void)fd;
+  return false;
 }
 
-// Helper for FieldDef attributes check.
-inline Base64Mode FieldGetBase64Mode(const FieldDef *fd) {
-  auto mode = Base64ModeNotSet;
-  if (fd) {
-    if (fd->attributes.Lookup("base64")) {
-      mode = Base64ModeStandard;
-    } else if (fd->attributes.Lookup("base64url")) {
-      mode = Base64ModeUrlSafe;
-    }
-  }
-  return mode;
-}
+// Override (not specialisation) for Vector<uint8_t>
+bool PrintBase64Vector(const flatbuffers::Vector<uint8_t> &v, Type type,
+                       int indent, const IDLOptions &opts, std::string *_text,
+                       const FieldDef *fd);
 
-// Returns the number of bytes, need to save a decoded result.
-// Return zero if an error or if src_size==0.
-// Error condition : (src_size != 0 && ret == 0).
-size_t Base64DecodedSize(Base64Mode base64_mode, const char *src,
-                         size_t src_size, size_t *error_position = nullptr);
-
-// Decodes the input base64 string into the binary sequence of bytes.
-// Expects: dst_size >= Base64DecodedSize(mode, src, src_size).
-// On success, returns the number of bytes written to the destination memory.
-// Returned Zero indicates nothing was written.
-// Error condition : (src_size != 0 && ret == 0).
-size_t Base64Decode(Base64Mode base64_mode, const char *src, size_t src_size,
-                    uint8_t *dst, size_t dst_size,
-                    size_t *error_position = nullptr);
-
-// Encodes the input byte sequence into the base64 encoded string.
-void Base64Encode(Base64Mode base64_mode, const uint8_t *src, size_t src_size,
-                  std::string *_text);
+// Internal tests for decode/encode routines.
+int UtilBase64InerTest();
 
 }  // namespace flatbuffers
 

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -78,21 +78,10 @@ template<typename T>
 bool PrintVector(const Vector<T> &v, Type type, int indent,
                  const IDLOptions &opts, std::string *_text,
                  const FieldDef *fd = nullptr) {
+  // Try to print an array as base64 string.
+  if (PrintBase64Vector(v, type, indent, opts, _text, fd)) return true;
+
   std::string &text = *_text;
-
-  // Try to print UCHAR array as base64 string.
-  if (type.base_type == BASE_TYPE_UCHAR) {
-    auto b64mode = FieldGetBase64Mode(fd);
-    if (b64mode) {
-      text += "\"";
-      Base64Encode(
-          opts.base64_cancel_padding ? Base64CancelPadding(b64mode) : b64mode,
-          reinterpret_cast<const uint8_t *>(v.data()), v.size(), &text);
-      text += "\"";
-      return true;
-    }
-  }
-
   text += "[";
   text += NewLine(opts);
   for (uoffset_t i = 0; i < v.size(); i++) {

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -19,7 +19,9 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/flexbuffers.h"
 #include "flatbuffers/idl.h"
+#include "flatbuffers/stl_emulation.h"
 #include "flatbuffers/util.h"
+#include "flatbuffers/util_base64.h"
 
 namespace flatbuffers {
 
@@ -48,7 +50,9 @@ void OutputIdentifier(const std::string &name, const IDLOptions &opts,
 // The general case for scalars:
 template<typename T>
 bool Print(T val, Type type, int /*indent*/, Type * /*union_type*/,
-           const IDLOptions &opts, std::string *_text) {
+           const IDLOptions &opts, std::string *_text,
+           const FieldDef *fd = nullptr) {
+  (void)fd;
   std::string &text = *_text;
   if (type.enum_def && opts.output_enum_identifiers) {
     auto enum_val = type.enum_def->ReverseLookup(static_cast<int64_t>(val));
@@ -69,10 +73,43 @@ bool Print(T val, Type type, int /*indent*/, Type * /*union_type*/,
   return true;
 }
 
+// Print a vector as base64-encoded string
+template<typename T>
+bool PrintVectorBase64(const Vector<T> &v, Type type, int indent,
+                       const IDLOptions &opts, std::string *_text,
+                       int b64mode) {
+  (void)type;
+  (void)indent;
+  (void)opts;
+  // Print a sequence of [uint8_t] as base64-encoded string
+  // only byte array supported
+  if (type.base_type != BASE_TYPE_UCHAR) return false;
+  // type T can by any, not only uint8_t
+  const auto *src = reinterpret_cast<const uint8_t *>(v.data());
+  const auto src_size = v.size();
+  const auto req_size = Base64EncodedSize(b64mode, src, src_size);
+  if ((0 == req_size) && (src_size > 0)) return false;
+  std::vector<char> buf(req_size);  // temporary buffer
+  auto b64_len = Base64Encode(b64mode, src, src_size,
+                              flatbuffers::vector_data(buf), buf.size());
+  if ((0 == b64_len) && (src_size > 0)) return false;
+  // copy data from temporary to the string
+  std::string &text = *_text;
+  text += "\"";
+  text.append(flatbuffers::vector_data(buf), buf.size());
+  text += "\"";
+  return true;
+}
+
 // Print a vector a sequence of JSON values, comma separated, wrapped in "[]".
 template<typename T>
 bool PrintVector(const Vector<T> &v, Type type, int indent,
-                 const IDLOptions &opts, std::string *_text) {
+                 const IDLOptions &opts, std::string *_text,
+                 const FieldDef *fd = nullptr) {
+  auto b64mode = field_base64_mode(fd);
+  if (b64mode && PrintVectorBase64<T>(v, type, indent, opts, _text, b64mode))
+    return true;
+
   std::string &text = *_text;
   text += "[";
   text += NewLine(opts);
@@ -103,7 +140,7 @@ bool PrintVector(const Vector<T> &v, Type type, int indent,
 template<>
 bool Print<const void *>(const void *val, Type type, int indent,
                          Type *union_type, const IDLOptions &opts,
-                         std::string *_text) {
+                         std::string *_text, const FieldDef *fd) {
   switch (type.base_type) {
     case BASE_TYPE_UNION:
       // If this assert hits, you have an corrupt buffer, a union type field
@@ -134,7 +171,7 @@ bool Print<const void *>(const void *val, Type type, int indent,
           case BASE_TYPE_ ## ENUM: \
             if (!PrintVector<CTYPE>( \
                   *reinterpret_cast<const Vector<CTYPE> *>(val), \
-                  type, indent, opts, _text)) { \
+                  type, indent, opts, _text, fd)) { \
               return false; \
             } \
             break;
@@ -190,7 +227,7 @@ static bool GenFieldOffset(const FieldDef &fd, const Table *table, bool fixed,
               ? table->GetStruct<const void *>(fd.value.offset)
               : table->GetPointer<const void *>(fd.value.offset);
   }
-  return Print(val, fd.value.type, indent, union_type, opts, _text);
+  return Print(val, fd.value.type, indent, union_type, opts, _text, &fd);
 }
 
 // Generate text for a struct or table, values separated by commas, indented,

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -896,10 +896,10 @@ CheckedError Parser::ParseAnyValue(Value &val, FieldDef *field,
       break;
     }
     case BASE_TYPE_VECTOR: {
-      if ((token_ == kTokenStringConstant) && field_base64_mode(field)) {
+      if ((token_ == kTokenStringConstant) && FieldGetBase64Mode(field)) {
         uoffset_t off;
         ECHECK(ParseVectorBase64(val.type.VectorType(),
-                                 field_base64_mode(field), &off));
+                                 FieldGetBase64Mode(field), &off));
         val.constant = NumToString(off);
       } else if (Is('[')) {
         uoffset_t off;
@@ -1203,14 +1203,15 @@ CheckedError Parser::ParseVectorBase64(const Type &type, const int base64_mode,
   const auto src_data = attribute_.c_str();
   const auto src_size = attribute_.size();
   size_t err_pos = 0;
-  // calculate number of required bytes
+  Base64Mode b64mode = static_cast<Base64Mode>(base64_mode);
+  // Calculate a number of required bytes.
   auto decoded_size =
-      Base64DecodedSize(base64_mode, src_data, src_size, &err_pos);
+      Base64DecodedSize(b64mode, src_data, src_size, &err_pos);
   if (decoded_size > 0) {
     uint8_t *dst = nullptr;
     *ovalue = builder_.CreateUninitializedVector(decoded_size, 1, &dst);
-    // Base64Decode return number of written bytes or zero if error detected
-    decoded_size = Base64Decode(base64_mode, src_data, src_size, dst,
+    // Base64Decode return number of written bytes or zero if error detected.
+    decoded_size = Base64Decode(b64mode, src_data, src_size, dst,
                                 decoded_size, &err_pos);
   }
   if ((0 == decoded_size) && (src_size > 0)) {

--- a/src/util_base64.cpp
+++ b/src/util_base64.cpp
@@ -1,0 +1,236 @@
+#include "flatbuffers/base.h"
+
+#include "flatbuffers/util_base64.h"
+
+// BASE64 - https://tools.ietf.org/html/rfc4648
+
+namespace flatbuffers {
+
+static inline bool Base64ModeIsStrict(int base64_mode) {
+  return 0 == (base64_mode & kBase64Url);
+}
+
+// return number of written bytes if success or zero if an error.
+// error condition: (src_size!=0 && ret==0)
+// return number of bytes requred for decoding if condition:
+// ((nullptr == dst) && (0 == dst_size))
+// <error_position> MUST be not-null
+static size_t decode_b64(const int mode, const char *const src,
+                         const size_t src_size, uint8_t *const dst,
+                         const size_t dst_size, size_t *const error_position) {
+  // strict base64 table (RFC 4648)
+  static const uint8_t strict_table[256] = {
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 62, 64, 64, 64, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+    61, 64, 64, 64, 64, 64, 64, 64, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64,
+    64, 64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+    43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64
+  };
+
+  // Base 64 Encoding with URL and Filename Safe Alphabet, allow "+/-_"
+  static const uint8_t url_table[256] = {
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 62, 64, 62, 64, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+    61, 64, 64, 64, 64, 64, 64, 64, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64,
+    63, 64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+    43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64
+  };
+  if (error_position) *error_position = 0;
+  const auto b64_tbl = Base64ModeIsStrict(mode) ? strict_table : url_table;
+  // padding mandatory for strict base64, and optional for base64url
+  const auto padding_mandatory = Base64ModeIsStrict(mode);
+  // base64 decode transform 4 encoded charaters to 3 data bytes
+  if (0 == src_size) return 0;
+  // decode prepare stage
+  // number of perfect char[4] blocks
+  auto C4full = src_size / 4;
+  // number of remained characters in the last char[4] block
+  auto C4rem = src_size % 4;
+  // if C4rem==0, then move the last char[4] block to remainder
+  if (C4rem == 0) {
+    C4full = C4full - 1;
+    C4rem = 4;
+  }
+  // the C4rem is strictly positive value from: {1,2,3,4}
+  // build char[4] perfect block for the remainder
+  // if padding is mandatory, sets incomplete characters as invalid symbols
+  // if it is optional, sets to zero symbol ('A')
+  char last_enc4[4];
+  uint8_t last_dec3[3];
+  memset(&last_enc4[0], padding_mandatory ? '#' : 'A', 4);
+  // copy available bytes
+  memcpy(&last_enc4[0], &src[C4full * 4], C4rem);
+  // guest for size of last decoded block, can be 1,2 or 3
+  auto last_dec_len = C4rem - 1;
+  // encoded sequence can has padding '=' symbols at the last char[4] block
+  // in this case are allowed only two variants: {x,y,=,=} or {x,y,z,=}
+  // replace '=' by 'zeros' and recalculate decoded size of the last block
+  if (last_enc4[3] == '=') {
+    last_dec_len = 2;
+    last_enc4[3] = 'A';
+    if (last_enc4[2] == '=') {
+      last_dec_len = 1;
+      last_enc4[2] = 'A';
+    }
+  }
+  // calculate size of decoded sequence if it has no errors
+  const auto decoded_len = (C4full * 3 + last_dec_len);
+  // if requested the only number of required bytes for decoding, return it
+  if ((nullptr == dst) && (0 == dst_size)) return decoded_len;
+  // insufficient memory test
+  if (dst_size < decoded_len) return 0;
+  // decode loop:
+  // at first iteration decode the last block
+  auto dst_ = &last_dec3[0];
+  const char *src_ = &last_enc4[0];
+  // loop counter: the last block plus all perfect blocks
+  auto loop_cnt = (1 + C4full);
+  // error mask can take only two states: (0)-ok and (1)-fail
+  // type of <err_mask> must match with unsigned <loop_cnt>
+  auto err_mask = loop_cnt * 0;
+  // use (err_mask - 1) = {0,~0} as conditional gate for the loop_cnt
+  for (size_t k = 0; loop_cnt & (err_mask - 1); loop_cnt--, k++) {
+    const auto a0 = b64_tbl[static_cast<uint8_t>(src_[0])];
+    const auto a1 = b64_tbl[static_cast<uint8_t>(src_[1])];
+    const auto a2 = b64_tbl[static_cast<uint8_t>(src_[2])];
+    const auto a3 = b64_tbl[static_cast<uint8_t>(src_[3])];
+    // decode by RFC 4648 alghorithm
+    dst_[0] = ((a0 << 2) | (a1 >> 4)) & 0xff;
+    dst_[1] = ((a1 << 4) | (a2 >> 2)) & 0xff;
+    dst_[2] = ((a2 << 6) | (a3 >> 0)) & 0xff;
+    // extract 0x40 bit from all decoded bytes and transform to {0,1}
+    err_mask = ((a0 | a1 | a2 | a3) >> 6);
+    src_ = src + (k * 4);
+    dst_ = dst + (k * 3);
+  }
+  const auto done = (0 == err_mask);
+  if (done) {
+    // copy the last decoded block to destanation
+    memcpy(&dst[C4full * 3], &last_dec3[0], last_dec_len);
+    *error_position = (src_size + 1);
+  } else {
+    // number of blocks processed and written to [src] memory
+    auto indx = C4full - loop_cnt;
+    // reject writen data
+    memset(dst, 0, indx * 3);
+    // seve position of corrupted characters
+    *error_position = 4 * (indx ? (indx - 1) : C4full);
+  }
+  return done ? decoded_len : 0;
+}
+
+// return number of written bytes or zero if error.
+// return number of bytes requred for decoding if:
+// ((nullptr == dst) && (0 == dst_size))
+static size_t encode_b64(const int mode, const uint8_t *const src,
+                         const size_t src_size, char *const dst,
+                         const size_t dst_size) {
+  static const char strict_table[64] = {
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+  };
+
+  static const char url_table[64] = {
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'
+  };
+
+  const auto tbl64 = Base64ModeIsStrict(mode) ? strict_table : url_table;
+  // padding mandatory for strict base64, and skipped for base64url
+  const auto force_padding = Base64ModeIsStrict(mode);
+  // base64 encode transform 3 data bytes to 4 encoded charaters
+  if (0 == src_size) return 0;
+  // number of complete blocks
+  auto B3full = src_size / 3;
+  // incomplete remainder
+  auto B3rem = src_size % 3;
+  // if B3rem, then move the last comlete block to remainder
+  if (B3rem == 0) {
+    B3full = B3full - 1;
+    B3rem = 3;
+  }
+  // if pad is mandatory, the remainder shall be encoded to the complete char[4]
+  const auto last_enc_len = force_padding ? 4 : (B3rem + 1);
+  const auto encoded_len = (B3full * 4) + last_enc_len;
+  // if requested the only number of required bytes for encoding, return it
+  if ((nullptr == dst) && (0 == dst_size)) return encoded_len;
+  // insufficient memory test
+  if (dst_size < encoded_len) return 0;
+  // encode loop
+  char last_enc4[4];
+  uint8_t last_bin3[3] = { 0, 0, 0 };
+  memcpy(&last_bin3[0], &src[B3full * 3], B3rem);
+  // complemented remainder encoded first
+  const uint8_t *src_ = &last_bin3[0];
+  auto dst_ = &last_enc4[0];
+  for (size_t k = 0; k < B3full + 1; k++) {
+    dst_[0] = tbl64[src_[0] >> 2];
+    dst_[1] = tbl64[(0x3f & (src_[0] << 4)) | (src_[1] >> 4)];
+    dst_[2] = tbl64[(0x3f & (src_[1] << 2)) | (src_[2] >> 6)];
+    dst_[3] = tbl64[0x3f & src_[2]];
+    src_ = src + (k * 3);
+    dst_ = dst + (k * 4);
+  }
+  // set padding ({a,_,_}=>{'x','y','=','='}, {a,b,_}=>{'x','y','z','='})
+  if (B3rem < 3) last_enc4[3] = '=';
+  if (B3rem < 2) last_enc4[2] = '=';
+  // copy remainder
+  memcpy(&dst[B3full * 4], &last_enc4[0], last_enc_len);
+  return encoded_len;
+}
+
+size_t Base64DecodedSize(int base64_mode, const char *src, size_t src_size,
+                         size_t *error_position) {
+  size_t err_pos = 0;
+  auto rc = decode_b64(base64_mode, src, src_size, nullptr, 0, &err_pos);
+  if (error_position) *error_position = err_pos;
+  return rc;
+}
+
+size_t Base64Decode(int base64_mode, const char *src, size_t src_size,
+                    uint8_t *dst, size_t dst_size, size_t *error_position) {
+  size_t err_pos = 0;
+  size_t rc = 0;
+  // if 0==dst_size && nullptr==src function decode_b64 return required size
+  // avoid this by check dst_size>0
+  if (dst_size > 0) {
+    rc = decode_b64(base64_mode, src, src_size, dst, dst_size, &err_pos);
+  }
+  if (error_position) *error_position = err_pos;
+  return rc;
+}
+
+size_t Base64EncodedSize(int base64_mode, const uint8_t *src, size_t src_size) {
+  return encode_b64(base64_mode, src, src_size, nullptr, 0);
+}
+
+size_t Base64Encode(int base64_mode, const uint8_t *src, size_t src_size,
+                    char *dst, size_t dst_size) {
+  if (0 == dst_size) return 0;
+  return encode_b64(base64_mode, src, src_size, dst, dst_size);
+}
+}  // namespace flatbuffers

--- a/src/util_base64.cpp
+++ b/src/util_base64.cpp
@@ -4,6 +4,34 @@
 
 namespace flatbuffers {
 
+enum Base64Mode {
+  // a Field doesn't have base64/base64url attribute.
+  Base64ModeNotSet = 0,
+
+  // Attribute (base64): standard RFC4648 alphabet.
+  // Padding is optional for the decoder.
+  // Valid input strings:
+  //  {"/43+AergFA==", "/43+AergFA"}.
+  // The encoder output always with padding if required:
+  // [255, 141, 254, 1, 234, 224, 20] => "/43+AergFA==".
+  Base64ModeStandard = 1,
+
+  // Attribute (base64url): RFC4648 with URL and Filename Safe Alphabet.
+  // Padding is optional for the decoder.
+  // The decoder accepts both alphabets: UrlSafe and Standard.
+  // Valid input strings:
+  //  {"/43+AergFA==", "/43+AergFA", "_43-AergFA==", "_43-AergFA"}.
+  // The encoder output always with padding if required:
+  // [255, 141, 254, 1, 234, 224, 20] encoded to "_43-AergFA==".
+  Base64ModeUrlSafe = 2,
+
+  // Extension of (base64url) attribute.
+  // The decoder is the same as for Base64ModeUrlSafe.
+  // The encoder omits a padding for output sequence.
+  // [255, 141, 254, 1, 234, 224, 20] encoded to "_43-AergFA".
+  Base64ModeUrlSafeWithoutPadding = 3
+};
+
 // Base64 Decoder implementaton.
 // 1) If condition ((nullptr == dst) && (0 == dst_size)) is satisfied,
 // returns the number of bytes, need to save a decoded result.
@@ -121,15 +149,15 @@ static size_t B64DecodeImpl(const int mode, const char *const src,
   if (done) {
     // Copy the decoded remainder to the destination.
     memcpy(&dst[C4full * 3], &last_dec3[0], last_dec_len);
-    *error_position = (src_size + 1);
+    *error_position = src_size;
   } else {
     // If an error detected:
     // Number of blocks processed and written to [src] memory:
     const auto indx = C4full - loop_cnt;
     // Reject written data.
     memset(dst, 0, indx * 3);
-    // Save a position of corrupted character.
-    *error_position = 4 * (indx ? (indx - 1) : C4full);
+    // Save the position of corrupted character as left closed boundary
+    *error_position = 4 * (indx ? (indx - 1) : C4full) + 3;
   }
   return done ? decoded_len : 0;
 }
@@ -205,20 +233,29 @@ static size_t B64EncodeImpl(const int mode, const uint8_t *const src,
   return encoded_len;
 }
 
-size_t Base64DecodedSize(Base64Mode base64_mode, const char *src,
-                         size_t src_size, size_t *error_position) {
+// Returns the number of bytes, need to save a decoded result.
+// Return zero if an error or if src_size==0.
+// Error condition : (src_size != 0 && ret == 0).
+static size_t Base64DecodedSize(Base64Mode base64_mode, const char *src,
+                                size_t src_size, size_t *error_position) {
   size_t err_pos = 0;
   auto rc = B64DecodeImpl(base64_mode, src, src_size, nullptr, 0, &err_pos);
   if (error_position) *error_position = err_pos;
   return rc;
 }
 
-size_t Base64Decode(Base64Mode base64_mode, const char *src, size_t src_size,
-                    uint8_t *dst, size_t dst_size, size_t *error_position) {
+// Decodes the input base64 string into the binary sequence of bytes.
+// Expects: dst_size >= Base64DecodedSize(mode, src, src_size).
+// On success, returns the number of bytes written to the destination memory.
+// Returned Zero indicates nothing was written.
+// Error condition : (src_size != 0 && ret == 0).
+static size_t Base64Decode(Base64Mode base64_mode, const char *src,
+                           size_t src_size, uint8_t *dst, size_t dst_size,
+                           size_t *error_position) {
   size_t err_pos = 0;
   size_t rc = 0;
-  // If (0==dst_size) && (nullptr==src) then decode_b64 return the required size.
-  // Avoid this by check (dst_size>0).
+  // If (0==dst_size) && (nullptr==src) then decode_b64 return the required
+  // size. Avoid this by check (dst_size>0).
   if (dst_size > 0) {
     rc = B64DecodeImpl(base64_mode, src, src_size, dst, dst_size, &err_pos);
   }
@@ -226,8 +263,9 @@ size_t Base64Decode(Base64Mode base64_mode, const char *src, size_t src_size,
   return rc;
 }
 
-void Base64Encode(Base64Mode base64_mode, const uint8_t *src, size_t src_size,
-                  std::string *_text) {
+// Encodes the input byte sequence into the base64 encoded string.
+static void Base64Encode(Base64Mode base64_mode, const uint8_t *src,
+                         size_t src_size, std::string *_text) {
   const auto req_size = B64EncodeImpl(base64_mode, src, src_size, nullptr, 0);
   if (req_size > 0) {
     // std::string is a contiguous memory container since C++11.
@@ -235,7 +273,6 @@ void Base64Encode(Base64Mode base64_mode, const uint8_t *src, size_t src_size,
     // http://en.cppreference.com/w/cpp/string/basic_string/data
     // http://en.cppreference.com/w/cpp/string/basic_string/operator_at
     // https://stackoverflow.com/questions/39200665/directly-write-into-char-buffer-of-stdstring
-
     // Allocate memory for a result.
     std::string &text = *_text;
     const auto text_pos = text.size();
@@ -243,6 +280,210 @@ void Base64Encode(Base64Mode base64_mode, const uint8_t *src, size_t src_size,
     text.append(req_size, '#');
     B64EncodeImpl(base64_mode, src, src_size, &text[text_pos], req_size);
   }
+}
+
+// Helper for FieldDef attributes check.
+static Base64Mode FieldGetBase64Mode(const FieldDef *fd) {
+  auto mode = Base64ModeNotSet;
+  if (fd) {
+    if (fd->attributes.Lookup("base64")) {
+      mode = Base64ModeStandard;
+    } else if (fd->attributes.Lookup("base64url")) {
+      mode = Base64ModeUrlSafe;
+    }
+  }
+  return mode;
+}
+
+// On success, returns true.
+bool PrintBase64Vector(const flatbuffers::Vector<uint8_t> &v, Type type,
+                       int indent, const IDLOptions &opts, std::string *_text,
+                       const FieldDef *fd) {
+  (void)type;
+  (void)indent;
+
+  // An empty vector can't be present as true base64 string.
+  if (0 == v.size()) return false;
+
+  auto b64mode = FieldGetBase64Mode(fd);
+  if (!b64mode) return false;
+
+  auto b64m = ((Base64ModeUrlSafe == b64mode) && opts.base64_cancel_padding)
+                  ? Base64ModeUrlSafeWithoutPadding
+                  : b64mode;
+
+  std::string &text = *_text;
+  text += '\"';
+  Base64Encode(b64m, v.data(), v.size(), &text);
+  text += '\"';
+  return true;
+}
+
+// Returns number of Decoded charaters from the text string until error.
+// Returns zero if string is empty or has not base64 attribute.
+// On success, returns text.size().
+size_t ParseBase64Vector(Type type, const IDLOptions &opts,
+                         const std::string &text, const FieldDef *fd,
+                         uoffset_t *ovalue, FlatBufferBuilder *_builder) {
+  (void)opts;
+  // Only UCHAR supported.
+  if ((type.base_type != BASE_TYPE_UCHAR) || text.empty()) return 0;
+  // Leave if string has not base64 attribute.
+  auto b64mode = FieldGetBase64Mode(fd);
+  if (!b64mode) return 0;
+
+  const auto src_data = text.c_str();
+  const auto src_size = text.size();
+  size_t decode_pos = 0;
+  // Calculate the number of required bytes.
+  auto dec_size = Base64DecodedSize(b64mode, src_data, src_size, &decode_pos);
+  if (dec_size > 0) {
+    // Allocate memory.
+    uint8_t *dst = nullptr;
+    *ovalue = _builder->CreateUninitializedVector(dec_size, 1, &dst);
+    // Decode the string to the memory.
+    Base64Decode(b64mode, src_data, src_size, dst, dec_size, &decode_pos);
+  }
+  return decode_pos;
+}
+
+// Public interface of util_base64 very hard for testing.
+int UtilBase64InerTest() {
+  // Use internal test for coverage.
+  struct _B64T {
+    static std::vector<uint8_t> Decode(const std::string &base64,
+                                       const Base64Mode b64m,
+                                       size_t *const err_pos = nullptr) {
+      if (err_pos) *err_pos = 0;
+      std::vector<uint8_t> out;
+      const auto indat = base64.c_str();
+      const auto inlen = base64.size();
+      // DecodeSize can fail if the input sequence is bad.
+      const auto req_size = Base64DecodedSize(b64m, indat, inlen, err_pos);
+      if (req_size > 0) {
+        // Allocate memory for a result.
+        out.resize(req_size);
+        const auto out_data = vector_data(out);
+        const auto out_size = out.size();
+        // Insufficient memory test must return zero.
+        if (Base64Decode(b64m, indat, inlen, out_data, req_size - 1, err_pos)) {
+          return std::vector<uint8_t>();
+        }
+        // Decode can fail if the input sequence is bad.
+        const auto rc =
+            Base64Decode(b64m, indat, inlen, out_data, out_size, err_pos);
+        // Reset the result if decode failed.
+        if (rc != req_size) { return std::vector<uint8_t>(); }
+      }
+      return out;
+    }
+
+    static bool DecEncTest(const Base64Mode dec_mode, const Base64Mode enc_mode,
+                           size_t *const err_pos, const std::string &input,
+                           const std::string &expected) {
+      auto decoded = Decode(input, dec_mode, err_pos);
+      std::string encoded("");
+      if (false == decoded.empty())
+        Base64Encode(enc_mode, vector_data(decoded), decoded.size(), &encoded);
+      return expected == encoded;
+    }
+
+    static bool EncDecTest(const Base64Mode enc_mode, const Base64Mode dec_mode,
+                           const std::vector<uint8_t> &input) {
+      std::string encoded;
+      Base64Encode(enc_mode, vector_data(input), input.size(), &encoded);
+      return input == Decode(encoded, dec_mode);
+    }
+  };
+
+  static const size_t B64ModeNum = 2;
+  const Base64Mode BaseSet[B64ModeNum] = { Base64ModeStandard,
+                                           Base64ModeUrlSafe };
+  // clang-format off
+  // The padding is optional both for Standard and UrlSafe decoders.
+  // Standard decoder can't decode a UrlSafe string.
+  const bool expects[B64ModeNum * B64ModeNum] = {
+    true,  true, // encoder: Standard
+    false, true, // encoder: UrlSafe
+                 //    |     |_______decoder: UrlSafe
+                 //    |_____________decoder: Standard
+  };
+  // clang-format on
+
+  // Auto-generated encode-decode loop:
+  for (size_t enc_index = 0; enc_index < B64ModeNum; enc_index++) {
+    const auto enc_mode = BaseSet[enc_index];
+    for (size_t dec_index = 0; dec_index < B64ModeNum; dec_index++) {
+      const auto match_expects = expects[enc_index * B64ModeNum + dec_index];
+      const auto dec_mode = BaseSet[dec_index];
+      const size_t B = 128;
+      const auto N = 2 * B + 1;
+      size_t k = 0;
+      for (k = 0; k < N; k++) {
+        const auto M = (k % (B - 1));
+        // Generate a binary data.
+        std::vector<uint8_t> bin(M);
+        for (size_t j = 0; j < M; j++) {
+          bin[j] = static_cast<uint8_t>(((k + j) % B) % 0x100);
+        }
+        // Check: Binary->Encode->Decode->Compare.
+        if (false == _B64T::EncDecTest(enc_mode, dec_mode, bin)) break;
+      }
+      if ((N == k) != match_expects) return __LINE__;
+    }
+  }
+
+  // Test of error position detector.
+  size_t epos = 0;
+  for (size_t mode_ind = 0; mode_ind < B64ModeNum; mode_ind++) {
+    const auto mode = BaseSet[mode_ind];
+    const std::string ref = "IARXA18BIg==";
+    for (size_t k = 0; k < ref.size(); k++) {
+      auto t = ref;
+      t[k] = '#';
+      if (!_B64T::DecEncTest(mode, mode, &epos, t, "")) return __LINE__;
+      // the position of error is in half-open range [k, ref.size())
+      if (!(epos >= k && epos < ref.size())) return __LINE__;
+    }
+  }
+
+  // Input is a standard RFC4648 sequence.
+  if (!_B64T::DecEncTest(Base64ModeStandard, Base64ModeStandard, &epos,
+                         "/43+AergFA==", "/43+AergFA==") ||
+      (epos != 12))
+    return __LINE__;
+
+  // Input is RFC4648 sequence without padding.
+  if (!_B64T::DecEncTest(Base64ModeStandard, Base64ModeStandard, &epos,
+                         "/43+AergFA", "/43+AergFA==") ||
+      (epos != 10))
+    return __LINE__;
+
+  // Test with the standard decoder and url-safe encoder.
+  if (!_B64T::DecEncTest(Base64ModeStandard, Base64ModeUrlSafe, &epos,
+                         "/43+AergFA==", "_43-AergFA==") ||
+      (epos != 12))
+    return __LINE__;
+
+  // Test with url-safe decoder and encoder.
+  if (!_B64T::DecEncTest(Base64ModeUrlSafe, Base64ModeUrlSafe, &epos,
+                         "_43-AergFA==", "_43-AergFA==") ||
+      (epos != 12))
+    return __LINE__;
+
+  // Test using base64 string without padding symbols.
+  if (!_B64T::DecEncTest(Base64ModeUrlSafe, Base64ModeUrlSafe, &epos,
+                         "_43-AergFA", "_43-AergFA==") ||
+      (epos != 10))
+    return __LINE__;
+
+  // Cancel output padding for Base64Url encoder.
+  if (!_B64T::DecEncTest(Base64ModeUrlSafe, Base64ModeUrlSafeWithoutPadding,
+                         &epos, "_43-AergFA==", "_43-AergFA") ||
+      (epos != 12))
+    return __LINE__;
+  // done
+  return 0;
 }
 
 }  // namespace flatbuffers

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1946,7 +1946,7 @@ void Base64InerTest() {
         // allocate memory for result
         out.resize(req_size);
         // Android doesn't support data() for std::vector/std::string
-        const auto out_data = out.empty() ? nullptr : &out[0];
+        const auto out_data = flatbuffers::vector_data(out);
         const auto out_size = out.size();
         // check violation of memory boundary, must return zero
         TEST_EQ(
@@ -1975,7 +1975,7 @@ void Base64InerTest() {
       TEST_EQ(req_size > 0, inlen > 0);
       // check size estimator
       std::vector<char> out(req_size);
-      const auto out_data = out.empty() ? nullptr : &out[0];
+      const auto out_data = flatbuffers::vector_data(out);
       const auto out_size = out.size();
       // check violation of memory boundary, must return zero
       TEST_EQ(flatbuffers::Base64Encode(base64_mode, indat, inlen, out_data,


### PR DESCRIPTION
Issue #4393 
Supported strict RFC4648 Base64 and Base64 with URL and Filename Safe Alphabet.
Added two new attributes (base64) and (base64url).
Added new option IDLOptions.output_base64_cancel_padding.
The Monster schema extended and regenerated for testing purposes.

Problem:
I don't know what to do with Base64SelftTest function.
https://github.com/vglavnyy/flatbuffers/blob/base64-PR/src/util_base64.cpp#L337-L448

This is the test of internal implementations of base64 encoder and decoder.
I can remove it from PR.

@mikkelfj can you review this PR for compatibility with flatcc?
