### PR TITLE
Author: Daniel Lin <danielin@umich.edu>

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -370,11 +370,23 @@ class Allocator {
                                        size_t in_use_front) {
     assert(new_size > old_size);  // vector_downward only grows
     uint8_t *new_p = allocate(new_size);
+    memcpy_downward(old_p, old_size, new_p, new_size, in_use_back,
+                    in_use_front);
+    deallocate(old_p, old_size);
+    return new_p;
+  }
+
+ protected:
+  // Called by `reallocate_downward` to copy memory from `old_p` of `old_size`
+  // to `new_p` of `new_size`. Only memory of size `in_use_front` and
+  // `in_use_back` will be copied from the front and back of the old memory
+  // allocation.
+  void memcpy_downward(uint8_t *old_p, size_t old_size,
+                       uint8_t *new_p, size_t new_size,
+                       size_t in_use_back, size_t in_use_front) {
     memcpy(new_p + new_size - in_use_back, old_p + old_size - in_use_back,
            in_use_back);
     memcpy(new_p, old_p, in_use_front);
-    deallocate(old_p, old_size);
-    return new_p;
   }
 };
 


### PR DESCRIPTION
Date:   Mon Jan 15 11:38:20 2018 -0200

Compilation failure with grpc.h

If cmake run with flag FLATBUFFERS_BUILD_GRPCTEST=ON
compilation fails.
Fix :
	-Fix argument list for overriden function in grpc.
	-Fix member function name called by FlatBufferBuilder from
	buf() to scratch_data()

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
