### PR TITLE
Fix vector_data failure under debug

### DIFF
--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -51,12 +51,12 @@ inline char string_back(const std::string &value) {
 template <typename T> inline T *vector_data(std::vector<T> &vector) {
   // In some debug environments, operator[] does bounds checking, so &vector[0]
   // can't be used.
-  return &(*vector.begin());
+  return vector.empty() ? nullptr : &vector[0];
 }
 
 template <typename T> inline const T *vector_data(
     const std::vector<T> &vector) {
-  return &(*vector.begin());
+  return vector.empty() ? nullptr : &vector[0];
 }
 
 template <typename T, typename V>


### PR DESCRIPTION
flatbuffers::vector_data for an empty vector failed under Debug (MSVC)
> std::vector<int> empty;
(void) flatbuffers::vector_data(empty);

This code terminated with "vector iterator not dereferencable".


