### PR TITLE
C++: mini_reflect: Add DefaultTypeTable

### DIFF
--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -191,7 +191,7 @@ struct MonsterT : public flatbuffers::NativeTable {
 
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MonsterT NativeTableType;
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return MonsterTypeTable();
   }
   enum {
@@ -393,7 +393,7 @@ struct WeaponT : public flatbuffers::NativeTable {
 
 struct Weapon FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef WeaponT NativeTableType;
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return WeaponTypeTable();
   }
   enum {

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -17,6 +17,12 @@ struct MonsterT;
 struct Weapon;
 struct WeaponT;
 
+inline flatbuffers::TypeTable *Vec3TypeTable();
+
+inline flatbuffers::TypeTable *MonsterTypeTable();
+
+inline flatbuffers::TypeTable *WeaponTypeTable();
+
 enum Color {
   Color_Red = 0,
   Color_Green = 1,
@@ -185,7 +191,7 @@ struct MonsterT : public flatbuffers::NativeTable {
 
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MonsterT NativeTableType;
-  static MonsterTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return MonsterTypeTable();
   }
   enum {
@@ -387,7 +393,7 @@ struct WeaponT : public flatbuffers::NativeTable {
 
 struct Weapon FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef WeaponT NativeTableType;
-  static WeaponTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return WeaponTypeTable();
   }
   enum {
@@ -608,12 +614,6 @@ inline void EquipmentUnion::Reset() {
   value = nullptr;
   type = Equipment_NONE;
 }
-
-inline flatbuffers::TypeTable *Vec3TypeTable();
-
-inline flatbuffers::TypeTable *MonsterTypeTable();
-
-inline flatbuffers::TypeTable *WeaponTypeTable();
 
 inline flatbuffers::TypeTable *ColorTypeTable() {
   static flatbuffers::TypeCode type_codes[] = {

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -185,6 +185,9 @@ struct MonsterT : public flatbuffers::NativeTable {
 
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MonsterT NativeTableType;
+  static MonsterTypeTable DefaultTypeTable() {
+    return MonsterTypeTable();
+  }
   enum {
     VT_POS = 4,
     VT_MANA = 6,
@@ -384,6 +387,9 @@ struct WeaponT : public flatbuffers::NativeTable {
 
 struct Weapon FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef WeaponT NativeTableType;
+  static WeaponTypeTable DefaultTypeTable() {
+    return WeaponTypeTable();
+  }
   enum {
     VT_NAME = 4,
     VT_DAMAGE = 6

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -1503,6 +1503,12 @@ class CppGenerator : public BaseGenerator {
     if (parser_.opts.generate_object_based_api) {
       code_ += "  typedef {{NATIVE_NAME}} NativeTableType;";
     }
+    if (parser_.opts.mini_reflect) {
+      code_ += "  static flatbuffers::TypeTable* DefaultTypeTable() {";
+      code_ += "    return {{STRUCT_NAME}}TypeTable();";
+      code_ += "  }";
+    }
+
 
     GenFullyQualifiedNameGetter(struct_def, Name(struct_def));
 

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -1507,7 +1507,7 @@ class CppGenerator : public BaseGenerator {
       code_ += "  typedef {{NATIVE_NAME}} NativeTableType;";
     }
     if (parser_.opts.mini_reflect != IDLOptions::kNone) {
-      code_ += "  static flatbuffers::TypeTable* DefaultTypeTable() {";
+      code_ += "  static flatbuffers::TypeTable *MiniReflectTypeTable() {";
       code_ += "    return {{STRUCT_NAME}}TypeTable();";
       code_ += "  }";
     }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -1503,7 +1503,7 @@ class CppGenerator : public BaseGenerator {
     if (parser_.opts.generate_object_based_api) {
       code_ += "  typedef {{NATIVE_NAME}} NativeTableType;";
     }
-    if (parser_.opts.mini_reflect) {
+    if (parser_.opts.mini_reflect != IDLOptions::kTypesAndNames) {
       code_ += "  static flatbuffers::TypeTable* DefaultTypeTable() {";
       code_ += "    return {{STRUCT_NAME}}TypeTable();";
       code_ += "  }";

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -358,7 +358,7 @@ struct InParentNamespaceT : public flatbuffers::NativeTable {
 
 struct InParentNamespace FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef InParentNamespaceT NativeTableType;
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return InParentNamespaceTypeTable();
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
@@ -403,7 +403,7 @@ struct MonsterT : public flatbuffers::NativeTable {
 
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MonsterT NativeTableType;
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return MonsterTypeTable();
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
@@ -452,7 +452,7 @@ struct TestSimpleTableWithEnumT : public flatbuffers::NativeTable {
 
 struct TestSimpleTableWithEnum FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TestSimpleTableWithEnumT NativeTableType;
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TestSimpleTableWithEnumTypeTable();
   }
   enum {
@@ -515,7 +515,7 @@ struct StatT : public flatbuffers::NativeTable {
 
 struct Stat FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef StatT NativeTableType;
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return StatTypeTable();
   }
   enum {
@@ -661,7 +661,7 @@ struct MonsterT : public flatbuffers::NativeTable {
 /// an example documentation comment: monster object
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MonsterT NativeTableType;
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return MonsterTypeTable();
   }
   enum {
@@ -1302,7 +1302,7 @@ struct TypeAliasesT : public flatbuffers::NativeTable {
 
 struct TypeAliases FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TypeAliasesT NativeTableType;
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TypeAliasesTypeTable();
   }
   enum {

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -332,6 +332,9 @@ struct InParentNamespaceT : public flatbuffers::NativeTable {
 
 struct InParentNamespace FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef InParentNamespaceT NativeTableType;
+  static InParentNamespaceTypeTable DefaultTypeTable() {
+    return InParentNamespaceTypeTable();
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -374,6 +377,9 @@ struct MonsterT : public flatbuffers::NativeTable {
 
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MonsterT NativeTableType;
+  static MonsterTypeTable DefaultTypeTable() {
+    return MonsterTypeTable();
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -420,6 +426,9 @@ struct TestSimpleTableWithEnumT : public flatbuffers::NativeTable {
 
 struct TestSimpleTableWithEnum FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TestSimpleTableWithEnumT NativeTableType;
+  static TestSimpleTableWithEnumTypeTable DefaultTypeTable() {
+    return TestSimpleTableWithEnumTypeTable();
+  }
   enum {
     VT_COLOR = 4
   };
@@ -480,6 +489,9 @@ struct StatT : public flatbuffers::NativeTable {
 
 struct Stat FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef StatT NativeTableType;
+  static StatTypeTable DefaultTypeTable() {
+    return StatTypeTable();
+  }
   enum {
     VT_ID = 4,
     VT_VAL = 6,
@@ -623,6 +635,9 @@ struct MonsterT : public flatbuffers::NativeTable {
 /// an example documentation comment: monster object
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MonsterT NativeTableType;
+  static MonsterTypeTable DefaultTypeTable() {
+    return MonsterTypeTable();
+  }
   enum {
     VT_POS = 4,
     VT_MANA = 6,
@@ -1261,6 +1276,9 @@ struct TypeAliasesT : public flatbuffers::NativeTable {
 
 struct TypeAliases FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TypeAliasesT NativeTableType;
+  static TypeAliasesTypeTable DefaultTypeTable() {
+    return TypeAliasesTypeTable();
+  }
   enum {
     VT_I8 = 4,
     VT_U8 = 6,

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -39,6 +39,32 @@ struct MonsterT;
 struct TypeAliases;
 struct TypeAliasesT;
 
+}  // namespace Example
+
+inline flatbuffers::TypeTable *InParentNamespaceTypeTable();
+
+namespace Example2 {
+
+inline flatbuffers::TypeTable *MonsterTypeTable();
+
+}  // namespace Example2
+
+namespace Example {
+
+inline flatbuffers::TypeTable *TestTypeTable();
+
+inline flatbuffers::TypeTable *TestSimpleTableWithEnumTypeTable();
+
+inline flatbuffers::TypeTable *Vec3TypeTable();
+
+inline flatbuffers::TypeTable *AbilityTypeTable();
+
+inline flatbuffers::TypeTable *StatTypeTable();
+
+inline flatbuffers::TypeTable *MonsterTypeTable();
+
+inline flatbuffers::TypeTable *TypeAliasesTypeTable();
+
 enum Color {
   Color_Red = 1,
   Color_Green = 2,
@@ -332,7 +358,7 @@ struct InParentNamespaceT : public flatbuffers::NativeTable {
 
 struct InParentNamespace FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef InParentNamespaceT NativeTableType;
-  static InParentNamespaceTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return InParentNamespaceTypeTable();
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
@@ -377,7 +403,7 @@ struct MonsterT : public flatbuffers::NativeTable {
 
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MonsterT NativeTableType;
-  static MonsterTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return MonsterTypeTable();
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
@@ -426,7 +452,7 @@ struct TestSimpleTableWithEnumT : public flatbuffers::NativeTable {
 
 struct TestSimpleTableWithEnum FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TestSimpleTableWithEnumT NativeTableType;
-  static TestSimpleTableWithEnumTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return TestSimpleTableWithEnumTypeTable();
   }
   enum {
@@ -489,7 +515,7 @@ struct StatT : public flatbuffers::NativeTable {
 
 struct Stat FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef StatT NativeTableType;
-  static StatTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return StatTypeTable();
   }
   enum {
@@ -635,7 +661,7 @@ struct MonsterT : public flatbuffers::NativeTable {
 /// an example documentation comment: monster object
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MonsterT NativeTableType;
-  static MonsterTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return MonsterTypeTable();
   }
   enum {
@@ -1276,7 +1302,7 @@ struct TypeAliasesT : public flatbuffers::NativeTable {
 
 struct TypeAliases FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TypeAliasesT NativeTableType;
-  static TypeAliasesTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return TypeAliasesTypeTable();
   }
   enum {
@@ -1907,32 +1933,6 @@ inline void AnyUnion::Reset() {
   value = nullptr;
   type = Any_NONE;
 }
-
-}  // namespace Example
-
-inline flatbuffers::TypeTable *InParentNamespaceTypeTable();
-
-namespace Example2 {
-
-inline flatbuffers::TypeTable *MonsterTypeTable();
-
-}  // namespace Example2
-
-namespace Example {
-
-inline flatbuffers::TypeTable *TestTypeTable();
-
-inline flatbuffers::TypeTable *TestSimpleTableWithEnumTypeTable();
-
-inline flatbuffers::TypeTable *Vec3TypeTable();
-
-inline flatbuffers::TypeTable *AbilityTypeTable();
-
-inline flatbuffers::TypeTable *StatTypeTable();
-
-inline flatbuffers::TypeTable *MonsterTypeTable();
-
-inline flatbuffers::TypeTable *TypeAliasesTypeTable();
 
 inline flatbuffers::TypeTable *ColorTypeTable() {
   static flatbuffers::TypeCode type_codes[] = {

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -13,6 +13,10 @@ struct TableInNestedNS;
 
 struct StructInNestedNS;
 
+inline flatbuffers::TypeTable *TableInNestedNSTypeTable();
+
+inline flatbuffers::TypeTable *StructInNestedNSTypeTable();
+
 enum EnumInNestedNS {
   EnumInNestedNS_A = 0,
   EnumInNestedNS_B = 1,
@@ -74,7 +78,7 @@ MANUALLY_ALIGNED_STRUCT(4) StructInNestedNS FLATBUFFERS_FINAL_CLASS {
 STRUCT_END(StructInNestedNS, 8);
 
 struct TableInNestedNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  static TableInNestedNSTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return TableInNestedNSTypeTable();
   }
   enum {
@@ -118,10 +122,6 @@ inline flatbuffers::Offset<TableInNestedNS> CreateTableInNestedNS(
   builder_.add_foo(foo);
   return builder_.Finish();
 }
-
-inline flatbuffers::TypeTable *TableInNestedNSTypeTable();
-
-inline flatbuffers::TypeTable *StructInNestedNSTypeTable();
 
 inline flatbuffers::TypeTable *EnumInNestedNSTypeTable() {
   static flatbuffers::TypeCode type_codes[] = {

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -78,7 +78,7 @@ MANUALLY_ALIGNED_STRUCT(4) StructInNestedNS FLATBUFFERS_FINAL_CLASS {
 STRUCT_END(StructInNestedNS, 8);
 
 struct TableInNestedNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInNestedNSTypeTable();
   }
   enum {

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -74,6 +74,9 @@ MANUALLY_ALIGNED_STRUCT(4) StructInNestedNS FLATBUFFERS_FINAL_CLASS {
 STRUCT_END(StructInNestedNS, 8);
 
 struct TableInNestedNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  static TableInNestedNSTypeTable DefaultTypeTable() {
+    return TableInNestedNSTypeTable();
+  }
   enum {
     VT_FOO = 4
   };

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -39,7 +39,7 @@ namespace NamespaceA {
 inline flatbuffers::TypeTable *SecondTableInATypeTable();
 
 struct TableInFirstNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInFirstNSTypeTable();
   }
   enum {
@@ -116,7 +116,7 @@ inline flatbuffers::Offset<TableInFirstNS> CreateTableInFirstNS(
 namespace NamespaceC {
 
 struct TableInC FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInCTypeTable();
   }
   enum {
@@ -181,7 +181,7 @@ inline flatbuffers::Offset<TableInC> CreateTableInC(
 namespace NamespaceA {
 
 struct SecondTableInA FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return SecondTableInATypeTable();
   }
   enum {

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -24,8 +24,22 @@ namespace NamespaceA {
 
 struct SecondTableInA;
 
+inline flatbuffers::TypeTable *TableInFirstNSTypeTable();
+
+}  // namespace NamespaceA
+
+namespace NamespaceC {
+
+inline flatbuffers::TypeTable *TableInCTypeTable();
+
+}  // namespace NamespaceC
+
+namespace NamespaceA {
+
+inline flatbuffers::TypeTable *SecondTableInATypeTable();
+
 struct TableInFirstNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  static TableInFirstNSTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return TableInFirstNSTypeTable();
   }
   enum {
@@ -102,7 +116,7 @@ inline flatbuffers::Offset<TableInFirstNS> CreateTableInFirstNS(
 namespace NamespaceC {
 
 struct TableInC FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  static TableInCTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return TableInCTypeTable();
   }
   enum {
@@ -167,7 +181,7 @@ inline flatbuffers::Offset<TableInC> CreateTableInC(
 namespace NamespaceA {
 
 struct SecondTableInA FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  static SecondTableInATypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return SecondTableInATypeTable();
   }
   enum {
@@ -220,20 +234,6 @@ namespace NamespaceC {
 }  // namespace NamespaceC
 
 namespace NamespaceA {
-
-inline flatbuffers::TypeTable *TableInFirstNSTypeTable();
-
-}  // namespace NamespaceA
-
-namespace NamespaceC {
-
-inline flatbuffers::TypeTable *TableInCTypeTable();
-
-}  // namespace NamespaceC
-
-namespace NamespaceA {
-
-inline flatbuffers::TypeTable *SecondTableInATypeTable();
 
 inline flatbuffers::TypeTable *TableInFirstNSTypeTable() {
   static flatbuffers::TypeCode type_codes[] = {

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -25,6 +25,9 @@ namespace NamespaceA {
 struct SecondTableInA;
 
 struct TableInFirstNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  static TableInFirstNSTypeTable DefaultTypeTable() {
+    return TableInFirstNSTypeTable();
+  }
   enum {
     VT_FOO_TABLE = 4,
     VT_FOO_ENUM = 6,
@@ -99,6 +102,9 @@ inline flatbuffers::Offset<TableInFirstNS> CreateTableInFirstNS(
 namespace NamespaceC {
 
 struct TableInC FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  static TableInCTypeTable DefaultTypeTable() {
+    return TableInCTypeTable();
+  }
   enum {
     VT_REFER_TO_A1 = 4,
     VT_REFER_TO_A2 = 6
@@ -161,6 +167,9 @@ inline flatbuffers::Offset<TableInC> CreateTableInC(
 namespace NamespaceA {
 
 struct SecondTableInA FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  static SecondTableInATypeTable DefaultTypeTable() {
+    return SecondTableInATypeTable();
+  }
   enum {
     VT_REFER_TO_C = 4
   };

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -819,7 +819,7 @@ void ReflectionTest(uint8_t *flatbuf, size_t length) {
 }
 
 void MiniReflectFlatBuffersTest(uint8_t *flatbuf) {
-  auto s = flatbuffers::FlatBufferToString(flatbuf, Monster::DefaultTypeTable());
+  auto s = flatbuffers::FlatBufferToString(flatbuf, Monster::MiniReflectTypeTable());
   TEST_EQ_STR(
       s.c_str(),
       "{ "

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -819,7 +819,7 @@ void ReflectionTest(uint8_t *flatbuf, size_t length) {
 }
 
 void MiniReflectFlatBuffersTest(uint8_t *flatbuf) {
-  auto s = flatbuffers::FlatBufferToString(flatbuf, MonsterTypeTable());
+  auto s = flatbuffers::FlatBufferToString(flatbuf, Monster::DefaultTypeTable());
   TEST_EQ_STR(
       s.c_str(),
       "{ "

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -191,7 +191,7 @@ struct AttackerT : public flatbuffers::NativeTable {
 
 struct Attacker FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef AttackerT NativeTableType;
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return AttackerTypeTable();
   }
   enum {
@@ -251,7 +251,7 @@ struct MovieT : public flatbuffers::NativeTable {
 
 struct Movie FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MovieT NativeTableType;
-  static flatbuffers::TypeTable* DefaultTypeTable() {
+  static flatbuffers::TypeTable *MiniReflectTypeTable() {
     return MovieTypeTable();
   }
   enum {

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -183,6 +183,9 @@ struct AttackerT : public flatbuffers::NativeTable {
 
 struct Attacker FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef AttackerT NativeTableType;
+  static AttackerTypeTable DefaultTypeTable() {
+    return AttackerTypeTable();
+  }
   enum {
     VT_SWORD_ATTACK_DAMAGE = 4
   };
@@ -240,6 +243,9 @@ struct MovieT : public flatbuffers::NativeTable {
 
 struct Movie FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MovieT NativeTableType;
+  static MovieTypeTable DefaultTypeTable() {
+    return MovieTypeTable();
+  }
   enum {
     VT_MAIN_CHARACTER_TYPE = 4,
     VT_MAIN_CHARACTER = 6,

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -16,6 +16,14 @@ struct BookReader;
 struct Movie;
 struct MovieT;
 
+inline flatbuffers::TypeTable *AttackerTypeTable();
+
+inline flatbuffers::TypeTable *RapunzelTypeTable();
+
+inline flatbuffers::TypeTable *BookReaderTypeTable();
+
+inline flatbuffers::TypeTable *MovieTypeTable();
+
 enum Character {
   Character_NONE = 0,
   Character_MuLan = 1,
@@ -183,7 +191,7 @@ struct AttackerT : public flatbuffers::NativeTable {
 
 struct Attacker FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef AttackerT NativeTableType;
-  static AttackerTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return AttackerTypeTable();
   }
   enum {
@@ -243,7 +251,7 @@ struct MovieT : public flatbuffers::NativeTable {
 
 struct Movie FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MovieT NativeTableType;
-  static MovieTypeTable DefaultTypeTable() {
+  static flatbuffers::TypeTable* DefaultTypeTable() {
     return MovieTypeTable();
   }
   enum {
@@ -600,14 +608,6 @@ inline void CharacterUnion::Reset() {
   value = nullptr;
   type = Character_NONE;
 }
-
-inline flatbuffers::TypeTable *AttackerTypeTable();
-
-inline flatbuffers::TypeTable *RapunzelTypeTable();
-
-inline flatbuffers::TypeTable *BookReaderTypeTable();
-
-inline flatbuffers::TypeTable *MovieTypeTable();
 
 inline flatbuffers::TypeTable *CharacterTypeTable() {
   static flatbuffers::TypeCode type_codes[] = {


### PR DESCRIPTION
Currently it's very easy to make a mistake when it comes to
instantiating the TypeTable to print a buffer because it is not type
safe.

This will allow us to write safer cpp code:

flatbuffers::FlatBufferToString(reinterpret_cast<const uint8_t *>(&t),
                                decltype(t)::DefaultTypeTable());