### PR TITLE
When Java raises a CharacterCodingException, the catch block rethrows…

### DIFF
--- a/java/com/google/flatbuffers/Table.java
+++ b/java/com/google/flatbuffers/Table.java
@@ -122,7 +122,7 @@ public class Table {
         cr.throwException();
       }
     } catch (CharacterCodingException x) {
-      throw new Error(x);
+      throw new RuntimeException(x);
     }
 
     return dst.flip().toString();


### PR DESCRIPTION
https://github.com/google/flatbuffers/issues/4629

When Java raises a CharacterCodingException, the catch block rethrows this exception as a java.lang.Error. Per the docs https://docs.oracle.com/javase/8/docs/api/java/lang/Error.html an Error is a serious problem that applications should not attempt to catch such as ThreadDeath. In this case, it is reasonable for a consumer to try to catch this error as it likely indicates a problem with the underlying data.

As Error does not inherit from Exception, a generic catch(Exception ex) will not catch this error.

A simple change from Error to Exception is not sufficient as an Exception is checked by the compiler, so in order to keep this issue unchecked, I am proposing raising a RuntimeException which is not checked, but is still a subclass of Exception.