### PR TITLE
made HashFnv functions constexpr

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -121,6 +121,13 @@
   #define FLATBUFFERS_CONSTEXPR
 #endif
 
+#if (defined(__cplusplus) && __cplusplus >= 201402L) || \
+    (defined(__cpp_constexpr) && __cpp_constexpr >= 201304)
+  #define FLATBUFFERS_CONSTEXPR_CPP14 FLATBUFFERS_CONSTEXPR
+#else
+  #define FLATBUFFERS_CONSTEXPR_CPP14
+#endif
+
 #if defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC__ * 10 + __GNUC_MINOR__ >= 46 || \
     defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026
   #define FLATBUFFERS_NOEXCEPT noexcept

--- a/include/flatbuffers/hash.h
+++ b/include/flatbuffers/hash.h
@@ -39,7 +39,7 @@ template<> struct FnvTraits<uint64_t> {
   static const uint64_t kOffsetBasis = 0xcbf29ce484222645ULL;
 };
 
-template<typename T> T HashFnv1(const char *input) {
+template<typename T> FLATBUFFERS_CONSTEXPR_CPP14 T HashFnv1(const char *input) {
   T hash = FnvTraits<T>::kOffsetBasis;
   for (const char *c = input; *c; ++c) {
     hash *= FnvTraits<T>::kFnvPrime;
@@ -48,7 +48,7 @@ template<typename T> T HashFnv1(const char *input) {
   return hash;
 }
 
-template<typename T> T HashFnv1a(const char *input) {
+template<typename T> FLATBUFFERS_CONSTEXPR_CPP14 T HashFnv1a(const char *input) {
   T hash = FnvTraits<T>::kOffsetBasis;
   for (const char *c = input; *c; ++c) {
     hash ^= static_cast<unsigned char>(*c);
@@ -57,12 +57,12 @@ template<typename T> T HashFnv1a(const char *input) {
   return hash;
 }
 
-template <> inline uint16_t HashFnv1<uint16_t>(const char *input) {
+template <> FLATBUFFERS_CONSTEXPR_CPP14 inline uint16_t HashFnv1<uint16_t>(const char *input) {
   uint32_t hash = HashFnv1<uint32_t>(input);
   return (hash >> 16) ^ (hash & 0xffff);
 }
 
-template <> inline uint16_t HashFnv1a<uint16_t>(const char *input) {
+template <> FLATBUFFERS_CONSTEXPR_CPP14 inline uint16_t HashFnv1a<uint16_t>(const char *input) {
   uint32_t hash = HashFnv1a<uint32_t>(input);
   return (hash >> 16) ^ (hash & 0xffff);
 }


### PR DESCRIPTION
Hello,

this change adds the define `FLATBUFFERS_CONSTEXPR_CPP14` as `constexpr` and sets it on the `HashFnv`* functions. This allows to hash a string a compile time, rather than at run time.
Rationale/use cases:
- creating reference ids from `constexpr char[]` at compile time
- creating reference hashes of strings at compile time for cheaper comparison (I'm using this to compare shaders, i.e. reference version compiled into engine VS updated version loaded from disc).

Regards.