### PR TITLE
(C++) Swapped the order of two conditions in an assert.

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -1274,7 +1274,7 @@ class Builder FLATBUFFERS_FINAL_CLASS {
 
   void WriteOffset(uint64_t o, uint8_t byte_width) {
     auto reloff = buf_.size() - o;
-    assert(reloff < 1ULL << (byte_width * 8) || byte_width == 8);
+    assert(byte_width == 8 || reloff < 1ULL << (byte_width * 8));
     Write(reloff, byte_width);
   }
 


### PR DESCRIPTION
An assert in flexbuffers was bit-shifting a 64-bit number by
64 bits, which throws up warnings in some automated tools.

The same assert also checks to see if the number of bytes
being shifted is 8. Swapped the order, so that the bitshift
only occurs if the number of bits being shifted is not 64.

Should be the same behavior, but plays nicer with diagnostic
tools.