### PR TITLE
Remove unnecessary const qualifier from cast

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -321,7 +321,7 @@ inline int FromUTF8(const char **in) {
       break;
     }
   }
-  if ((static_cast<const unsigned char>(**in) << len) & 0x80) return -1;  // Bit after leading 1's must be 0.
+  if ((static_cast<unsigned char>(**in) << len) & 0x80) return -1;  // Bit after leading 1's must be 0.
   if (!len) return *(*in)++;
   // UTF-8 encoded values with a length are between 2 and 4 bytes.
   if (len < 2 || len > 4) { return -1; }


### PR DESCRIPTION
Const does not make sense here, and compiler actually throws warning
(error with -Werror) when you would try to compile it.

    In file included from include/flatbuffers/flexbuffers.h:24,
                     from include/flatbuffers/idl.h:26,
                     from include/flatbuffers/code_generators.h:22,
                     from src/code_generators.cpp:17:
    include/flatbuffers/util.h: In function ‘int flatbuffers::FromUTF8(const char**)’:
    include/flatbuffers/util.h:325:44: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
       if ((static_cast<const unsigned char>(tmp) << len) & 0x80) return -1;  // Bit after leading 1's must be 0.
                                            ^
    cc1plus: all warnings being treated as errors

This warning caught by gcc8:

    $ g++ --version
    g++ (GCC) 8.0.1 20180222 (Red Hat 8.0.1-0.16)

The issue was introduced in https://github.com/google/flatbuffers/commit/60de37448671772201e156eae66d503bf70066bc.