### PR TITLE
Remove line break of CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,8 +126,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
         "${CMAKE_CXX_FLAGS} -faligned-new")
     endif()
     set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -Wunused-result -Werror=unused-result \
-                          -Wunused-parameter -Werror=unused-parameter")
+      "${CMAKE_CXX_FLAGS} -Wunused-result -Werror=unused-result -Wunused-parameter -Werror=unused-parameter")
   endif()
 
   # Certain platforms such as ARM do not use signed chars by default


### PR DESCRIPTION
Fix #4650
See link: https://github.com/google/flatbuffers/issues/4650

I tried building flatc on ubuntu, and found this issue was not resolved yet.