### PR TITLE
Add define/ifdef blocks, alternate sprintf implementation via FLATBUFFERS_PREFER_PRINTF [C++]

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -66,7 +66,7 @@ template<typename T> size_t IntToDigitCount(T t) {
 
   // Count digits until fractional part
   T eps = std::numeric_limits<float>::epsilon();
-  while (t <= (-1.0 + eps) || (1.0 - eps) <= t) {
+  while (t <= (-1 + eps) || (1 - eps) <= t) {
     t /= 10;
     digit_count++;
   }

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -53,33 +53,23 @@ namespace flatbuffers {
 #ifdef FLATBUFFERS_PREFER_PRINTF
 template<typename T> size_t IntToDigitCount(T t) {
   size_t digit_count = 0;
-
   // Count the sign for negative numbers
-  if (t < 0) {
-    digit_count++;
-  }
-
+  if (t < 0) digit_count++;
   // Count a single 0 left of the dot for fractional numbers
-  if (-1 < t && t < 1) {
-    digit_count++;
-  }
-
+  if (-1 < t && t < 1) digit_count++;
   // Count digits until fractional part
   T eps = std::numeric_limits<float>::epsilon();
   while (t <= (-1 + eps) || (1 - eps) <= t) {
     t /= 10;
     digit_count++;
   }
-
   return digit_count;
 }
 
 template<typename T> size_t NumToStringWidth(T t, int precision = 0) {
   size_t string_width = IntToDigitCount(t);
-  if (precision) {
-    string_width += (precision + 1); // Count the dot for floating point numbers
-  }
-
+  // Count the dot for floating point numbers
+  if (precision) string_width += (precision + 1);
   return string_width;
 }
 
@@ -87,9 +77,7 @@ template<typename T> std::string NumToStringImplWrapper(T t, const char* fmt,
                                                         int precision = 0) {
   size_t string_width = NumToStringWidth(t, precision);
   std::string s(string_width, 0x00);
-
   snprintf(const_cast<char*>(s.data()), s.size(), fmt, precision, t);
-
   return s;
 }
 #endif // FLATBUFFERS_PREFER_PRINTF

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -86,10 +86,9 @@ template<typename T> size_t NumToStringWidth(T t, int precision = 0) {
 template<typename T> std::string NumToStringImplWrapper(T t, const char* fmt,
                                                         int precision = 0) {
   size_t string_width = NumToStringWidth(t, precision);
-  std::string s(string_width+1, 0x00); // Allocate an extra null byte
+  std::string s(string_width, 0x00);
 
   snprintf(const_cast<char*>(s.data()), s.size(), fmt, precision, t);
-  s.resize(string_width); // Remove the null byte
 
   return s;
 }

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -23,10 +23,10 @@
 #include <fstream>
 #include <iomanip>
 #ifndef FLATBUFFERS_PREFER_PRINTF
-#include <sstream>
+#  include <sstream>
 #else // FLATBUFFERS_PREFER_PRINTF
-#include <float.h>
-#include <stdio.h>
+#  include <float.h>
+#  include <stdio.h>
 #endif // FLATBUFFERS_PREFER_PRINTF
 #include <string>
 #ifdef _WIN32
@@ -98,14 +98,16 @@ template<typename T> std::string NumToStringImplWrapper(T t, const char* fmt,
 // In contrast to std::stringstream, "char" values are
 // converted to a string of digits, and we don't use scientific notation.
 template<typename T> std::string NumToString(T t) {
-#ifndef FLATBUFFERS_PREFER_PRINTF
-  std::stringstream ss;
-  ss << t;
-  return ss.str();
-#else // FLATBUFFERS_PREFER_PRINTF
-  auto v = static_cast<long long>(t);
-  return NumToStringImplWrapper(v, "%.*lld");
-#endif // FLATBUFFERS_PREFER_PRINTF
+  // clang-format off
+  #ifndef FLATBUFFERS_PREFER_PRINTF
+    std::stringstream ss;
+    ss << t;
+    return ss.str();
+  #else // FLATBUFFERS_PREFER_PRINTF
+    auto v = static_cast<long long>(t);
+    return NumToStringImplWrapper(v, "%.*lld");
+  #endif // FLATBUFFERS_PREFER_PRINTF
+  // clang-format on
 }
 // Avoid char types used as character data.
 template<> inline std::string NumToString<signed char>(signed char t) {
@@ -131,20 +133,22 @@ inline std::string NumToString<unsigned long long>(unsigned long long t) {
 
 // Special versions for floats/doubles.
 template<typename T> std::string FloatToString(T t, int precision) {
-#ifndef FLATBUFFERS_PREFER_PRINTF
-  // to_string() prints different numbers of digits for floats depending on
-  // platform and isn't available on Android, so we use stringstream
-  std::stringstream ss;
-  // Use std::fixed to suppress scientific notation.
-  ss << std::fixed;
-  // Default precision is 6, we want that to be higher for doubles.
-  ss << std::setprecision(precision);
-  ss << t;
-  auto s = ss.str();
-#else // FLATBUFFERS_PREFER_PRINTF
-  auto v = static_cast<double>(t);
-  auto s = NumToStringImplWrapper(v, "%0.*f", precision);
-#endif // FLATBUFFERS_PREFER_PRINTF
+  // clang-format off
+  #ifndef FLATBUFFERS_PREFER_PRINTF
+    // to_string() prints different numbers of digits for floats depending on
+    // platform and isn't available on Android, so we use stringstream
+    std::stringstream ss;
+    // Use std::fixed to suppress scientific notation.
+    ss << std::fixed;
+    // Default precision is 6, we want that to be higher for doubles.
+    ss << std::setprecision(precision);
+    ss << t;
+    auto s = ss.str();
+  #else // FLATBUFFERS_PREFER_PRINTF
+    auto v = static_cast<double>(t);
+    auto s = NumToStringImplWrapper(v, "%0.*f", precision);
+  #endif // FLATBUFFERS_PREFER_PRINTF
+  // clang-format on
   // Sadly, std::fixed turns "1" into "1.00000", so here we undo that.
   auto p = s.find_last_not_of('0');
   if (p != std::string::npos) {
@@ -165,14 +169,16 @@ template<> inline std::string NumToString<float>(float t) {
 // The returned string length is always xdigits long, prefixed by 0 digits.
 // For example, IntToStringHex(0x23, 8) returns the string "00000023".
 inline std::string IntToStringHex(int i, int xdigits) {
-#ifndef FLATBUFFERS_PREFER_PRINTF
-  std::stringstream ss;
-  ss << std::setw(xdigits) << std::setfill('0') << std::hex << std::uppercase
-     << i;
-  return ss.str();
-#else // FLATBUFFERS_PREFER_PRINTF
-  return NumToStringImplWrapper(i, "%.*X", xdigits);
-#endif // FLATBUFFERS_PREFER_PRINTF
+  // clang-format off
+  #ifndef FLATBUFFERS_PREFER_PRINTF
+    std::stringstream ss;
+    ss << std::setw(xdigits) << std::setfill('0') << std::hex << std::uppercase
+       << i;
+    return ss.str();
+  #else // FLATBUFFERS_PREFER_PRINTF
+    return NumToStringImplWrapper(i, "%.*X", xdigits);
+  #endif // FLATBUFFERS_PREFER_PRINTF
+  // clang-format on
 }
 
 // Portable implementation of strtoll().

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -77,7 +77,7 @@ template<typename T> std::string NumToString(T t) {
   }
   auto s = std::string(char_count+1, 0x00); // Allocate an extra null byte
   //TODO: handle floating point specially
-  snprintf(const_cast<char*>(s.data()), char_count, "%0.*f", precision, (double)t);
+  snprintf(const_cast<char*>(s.data()), s.size(), "%0.*f", precision, (double)t);
   s.resize(char_count); // Remove the null byte
   return s;
 #endif // FLATBUFFERS_PREFER_PRINTF
@@ -123,7 +123,7 @@ template<typename T> std::string FloatToString(T t, int precision) {
   }
   auto s = std::string(char_count+1, 0x00); // Allocate an extra null byte
   //TODO: handle floating point specially
-  snprintf(const_cast<char*>(s.data()), precision, "%0.*f", precision, (double)t);
+  snprintf(const_cast<char*>(s.data()), s.size(), "%0.*f", precision, (double)t);
   s.resize(char_count); // Remove the null byte
 #endif // FLATBUFFERS_PREFER_PRINTF
   // Sadly, std::fixed turns "1" into "1.00000", so here we undo that.
@@ -153,7 +153,7 @@ inline std::string IntToStringHex(int i, int xdigits) {
   return ss.str();
 #else // FLATBUFFERS_PREFER_PRINTF
   std::string s(xdigits+1, 0x00); // Allocate an extra null byte
-  snprintf(const_cast<char*>(s.data()), xdigits, "%.*X", xdigits, i);
+  snprintf(const_cast<char*>(s.data()), s.size(), "%.*X", xdigits, i);
   s.resize(xdigits); // Remove the null byte
   return s;
 #endif // FLATBUFFERS_PREFER_PRINTF

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -76,7 +76,6 @@ template<typename T> size_t IntToDigitCount(T t) {
 
 template<typename T> size_t NumToStringWidth(T t, int precision = 0) {
   size_t string_width = IntToDigitCount(t);
-
   if (precision) {
     string_width += (precision + 1); // Count the dot for floating point numbers
   }
@@ -106,8 +105,7 @@ template<typename T> std::string NumToString(T t) {
   return ss.str();
 #else // FLATBUFFERS_PREFER_PRINTF
   auto v = static_cast<long long>(t);
-  auto s = NumToStringImplWrapper(v, "%.*lld");
-  return s;
+  return NumToStringImplWrapper(v, "%.*lld");
 #endif // FLATBUFFERS_PREFER_PRINTF
 }
 // Avoid char types used as character data.
@@ -174,8 +172,7 @@ inline std::string IntToStringHex(int i, int xdigits) {
      << i;
   return ss.str();
 #else // FLATBUFFERS_PREFER_PRINTF
-  auto s = NumToStringImplWrapper(i, "%.*X", xdigits);
-  return s;
+  return NumToStringImplWrapper(i, "%.*X", xdigits);
 #endif // FLATBUFFERS_PREFER_PRINTF
 }
 

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -77,7 +77,8 @@ template<typename T> std::string NumToStringImplWrapper(T t, const char* fmt,
                                                         int precision = 0) {
   size_t string_width = NumToStringWidth(t, precision);
   std::string s(string_width, 0x00);
-  snprintf(const_cast<char*>(s.data()), s.size(), fmt, precision, t);
+  // Allow snprintf to use std::string trailing null to detect buffer overflow
+  snprintf(const_cast<char*>(s.data()), (s.size()+1), fmt, precision, t);
   return s;
 }
 #endif // FLATBUFFERS_PREFER_PRINTF

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -15,12 +15,8 @@
  */
 
 #include <algorithm>
-#ifndef FLATBUFFERS_PREFER_PRINTF
-#include <iostream>
-#else // FLATBUFFERS_PREFER_PRINTF
-#include <string>
-#endif // FLATBUFFERS_PREFER_PRINTF
 #include <list>
+#include <string>
 
 #include <math.h>
 

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -183,7 +183,7 @@ std::string Namespace::GetFullyQualifiedName(const std::string &name,
   if (components.empty() || !max_components) { return name; }
   std::string stream_str;
   for (size_t i = 0; i < std::min(components.size(), max_components); i++) {
-    if (i) { stream_str += "."; }
+    if (i) { stream_str += '.'; }
     stream_str += std::string(components[i]);
   }
   if (name.length()) {

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -181,15 +181,6 @@ std::string Namespace::GetFullyQualifiedName(const std::string &name,
                                              size_t max_components) const {
   // Early exit if we don't have a defined namespace.
   if (components.empty() || !max_components) { return name; }
-#ifndef FLATBUFFERS_PREFER_PRINTF
-  std::stringstream stream;
-  for (size_t i = 0; i < std::min(components.size(), max_components); i++) {
-    if (i) { stream << "."; }
-    stream << components[i];
-  }
-  if (name.length()) stream << "." << name;
-  return stream.str();
-#else // FLATBUFFERS_PREFER_PRINTF
   std::string stream_str;
   for (size_t i = 0; i < std::min(components.size(), max_components); i++) {
     if (i) { stream_str += "."; }
@@ -197,7 +188,6 @@ std::string Namespace::GetFullyQualifiedName(const std::string &name,
   }
   if (name.length()) { stream_str += name; }
   return stream_str;
-#endif // FLATBUFFERS_PREFER_PRINTF
 }
 
 // Declare tokens we'll use. Single character tokens are represented by their

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -15,7 +15,11 @@
  */
 
 #include <algorithm>
+#ifndef FLATBUFFERS_PREFER_PRINTF
 #include <iostream>
+#else // FLATBUFFERS_PREFER_PRINTF
+#include <string>
+#endif // FLATBUFFERS_PREFER_PRINTF
 #include <list>
 
 #include <math.h>
@@ -177,6 +181,7 @@ std::string Namespace::GetFullyQualifiedName(const std::string &name,
                                              size_t max_components) const {
   // Early exit if we don't have a defined namespace.
   if (components.empty() || !max_components) { return name; }
+#ifndef FLATBUFFERS_PREFER_PRINTF
   std::stringstream stream;
   for (size_t i = 0; i < std::min(components.size(), max_components); i++) {
     if (i) { stream << "."; }
@@ -184,6 +189,15 @@ std::string Namespace::GetFullyQualifiedName(const std::string &name,
   }
   if (name.length()) stream << "." << name;
   return stream.str();
+#else // FLATBUFFERS_PREFER_PRINTF
+  std::string stream_str;
+  for (size_t i = 0; i < std::min(components.size(), max_components); i++) {
+    if (i) { stream_str += "."; }
+    stream_str += std::string{components[i]};
+  }
+  if (name.length()) stream_str += std::string{"."} + name;
+  return stream_str;
+#endif // FLATBUFFERS_PREFER_PRINTF
 }
 
 // Declare tokens we'll use. Single character tokens are represented by their

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -186,7 +186,10 @@ std::string Namespace::GetFullyQualifiedName(const std::string &name,
     if (i) { stream_str += "."; }
     stream_str += std::string(components[i]);
   }
-  if (name.length()) { stream_str += name; }
+  if (name.length()) {
+    stream_str += '.';
+    stream_str += name;
+  }
   return stream_str;
 }
 

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -193,9 +193,9 @@ std::string Namespace::GetFullyQualifiedName(const std::string &name,
   std::string stream_str;
   for (size_t i = 0; i < std::min(components.size(), max_components); i++) {
     if (i) { stream_str += "."; }
-    stream_str += std::string{components[i]};
+    stream_str += std::string(components[i]);
   }
-  if (name.length()) stream_str += std::string{"."} + name;
+  if (name.length()) { stream_str += name; }
   return stream_str;
 #endif // FLATBUFFERS_PREFER_PRINTF
 }


### PR DESCRIPTION
I use this preliminary code to avoid bringing in C++ IOStreams, which is an extra 200K in flash size for my embedded platform. (s)printf is available already in my libc, so use that for number formatting in the idl_parser.

This works for me but I'm not sure if it is suitable for inclusion here (I did try to wrap my changes with an `#ifdef` guard.) Probably some better names could be chosen, as well as template specialization for floating-point vs integer.