### PR TITLE
Changing the the Java generator to use 'char' instead of 'short' for …

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -47,7 +47,7 @@ namespace flatbuffers {
   TD(CHAR,   "byte",   int8_t,   byte,   int8,    sbyte,  int8) \
   TD(UCHAR,  "ubyte",  uint8_t,  byte,   byte,    byte,   uint8) \
   TD(SHORT,  "short",  int16_t,  short,  int16,   short,  int16) \
-  TD(USHORT, "ushort", uint16_t, short,  uint16,  ushort, uint16) \
+  TD(USHORT, "ushort", uint16_t, char,   uint16,  ushort, uint16) \
   TD(INT,    "int",    int32_t,  int,    int32,   int,    int32) \
   TD(UINT,   "uint",   uint32_t, int,    uint32,  uint,   uint32) \
   TD(LONG,   "long",   int64_t,  long,   int64,   long,   int64) \

--- a/java/com/google/flatbuffers/Constants.java
+++ b/java/com/google/flatbuffers/Constants.java
@@ -27,6 +27,8 @@ public class Constants {
     static final int SIZEOF_BYTE = 1;
     /** The number of bytes in a `short`. */
     static final int SIZEOF_SHORT = 2;
+    /** The number of bytes in a `char`. */
+    static final int SIZEOF_CHAR = 2;
     /** The number of bytes in an `int`. */
     static final int SIZEOF_INT = 4;
     /** The number of bytes in an `float`. */

--- a/java/com/google/flatbuffers/FlatBufferBuilder.java
+++ b/java/com/google/flatbuffers/FlatBufferBuilder.java
@@ -272,6 +272,14 @@ public class FlatBufferBuilder {
     public void putShort  (short   x) { bb.putShort (space -= Constants.SIZEOF_SHORT, x); }
 
     /**
+     * Add a `char` to the buffer, backwards from the current location. Doesn't align nor
+     * check for space.
+     *
+     * @param x A `char` to put into the buffer.
+     */
+    public void putChar   (char   x) { bb.putChar (space -= Constants.SIZEOF_CHAR, x); }
+
+    /**
      * Add an `int` to the buffer, backwards from the current location. Doesn't align nor
      * check for space.
      *
@@ -324,6 +332,13 @@ public class FlatBufferBuilder {
      * @param x A `short` to put into the buffer.
      */
     public void addShort  (short   x) { prep(Constants.SIZEOF_SHORT, 0); putShort  (x); }
+
+    /**
+     * Add a `char` to the buffer, properly aligned, and grows the buffer (if necessary).
+     *
+     * @param x A `char` to put into the buffer.
+     */
+    public void addChar   (char   x) { prep(Constants.SIZEOF_CHAR, 0); putChar  (x); }
 
     /**
      * Add an `int` to the buffer, properly aligned, and grows the buffer (if necessary).
@@ -652,6 +667,17 @@ public class FlatBufferBuilder {
      * @param d A `short` default value to compare against when `force_defaults` is `false`.
      */
     public void addShort  (int o, short   x, int     d) { if(force_defaults || x != d) { addShort  (x); slot(o); } }
+
+    /**
+     * Add a `char` to a table at `o` into its vtable, with value `x` and default `d`.
+     *
+     * @param o The index into the vtable.
+     * @param x A `char` to put into the buffer, depending on how defaults are handled. If
+     * `force_defaults` is `false`, compare `x` against the default value `d`. If `x` contains the
+     * default value, it can be skipped.
+     * @param d A `char` default value to compare against when `force_defaults` is `false`.
+     */
+    public void addChar   (int o, char   x, char     d) { if(force_defaults || x != d) { addChar  (x); slot(o); } }
 
     /**
      * Add an `int` to a table at `o` into its vtable, with value `x` and default `d`.

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -399,7 +399,7 @@ class GeneralGenerator : public BaseGenerator {
             if (type.base_type == BASE_TYPE_UINT)
               return "(int)";
             else if (type.base_type == BASE_TYPE_USHORT)
-              return "(short)";
+              return "(char)";
             else if (type.base_type == BASE_TYPE_UCHAR)
               return "(byte)";
           }


### PR DESCRIPTION
…the ushort data type.

It was mentioned [here](https://github.com/google/flatbuffers/issues/4703) that a `java_type` hint could be added.  How would that be done?