### PR TITLE
Addition of Go FinishWithFileIdentifier

### DIFF
--- a/go/builder.go
+++ b/go/builder.go
@@ -1,7 +1,5 @@
 package flatbuffers
 
-import "fmt"
-
 // Builder is a state machine for creating FlatBuffer objects.
 // Use a Builder to construct object(s) starting from leaf nodes.
 //
@@ -549,8 +547,7 @@ func (b *Builder) Slot(slotnum int) {
 // as well as applys a file identifier
 func (b *Builder) FinishWithFileIdentifier(rootTable UOffsetT, fid []byte) {
 	if fid == nil || len(fid) != fileIdentifierLength {
-		panic(fmt.Sprintf(
-			"file identifier must be length %d", fileIdentifierLength))
+		panic("incorrect file identifier length")
 	}
 	// In order to add a file identifier to the flatbuffer message, we need
 	// to prepare an alignment and file identifier length

--- a/go/builder.go
+++ b/go/builder.go
@@ -551,7 +551,7 @@ func (b *Builder) FinishWithFileIdentifier(rootTable UOffsetT, fid []byte) {
 	}
 	// In order to add a file identifier to the flatbuffer message, we need
 	// to prepare an alignment and file identifier length
-	b.Prep(SizeInt32+fileIdentifierLength, 0)
+	b.Prep(b.minalign, SizeInt32+fileIdentifierLength)
 	for i := fileIdentifierLength - 1; i >= 0; i-- {
 		// place the file identifier
 		b.PlaceByte(fid[i])

--- a/go/builder.go
+++ b/go/builder.go
@@ -1,5 +1,7 @@
 package flatbuffers
 
+import "fmt"
+
 // Builder is a state machine for creating FlatBuffer objects.
 // Use a Builder to construct object(s) starting from leaf nodes.
 //
@@ -546,16 +548,16 @@ func (b *Builder) Slot(slotnum int) {
 // FinishWithFileIdentifier finalizes a buffer, pointing to the given `rootTable`.
 // as well as applys a file identifier
 func (b *Builder) FinishWithFileIdentifier(rootTable UOffsetT, fid []byte) {
-	if fid != nil && len(fid) == fileIdentifierLength {
-		// In order to add a file identifier to the flatbuffer message, we need
-		// to prepare an alignment and file identifier length
-		b.Prep(b.minalign, SizeInt32+fileIdentifierLength)
-		// zero out for alignment
-		b.PlaceInt32(0)
-		for i := fileIdentifierLength - 1; i >= 0; i-- {
-			// place the file identifier
-			b.PlaceByte(fid[i])
-		}
+	if fid == nil || len(fid) != fileIdentifierLength {
+		panic(fmt.Sprintf(
+			"file identifier must be length %d", fileIdentifierLength))
+	}
+	// In order to add a file identifier to the flatbuffer message, we need
+	// to prepare an alignment and file identifier length
+	b.Prep(SizeInt32+fileIdentifierLength, 0)
+	for i := fileIdentifierLength - 1; i >= 0; i-- {
+		// place the file identifier
+		b.PlaceByte(fid[i])
 	}
 	// finish
 	b.Finish(rootTable)


### PR DESCRIPTION
Needed the ability to include a file identifier in the flatbuffer output.  These changes will allow the Go implementation to perform that, without changing current functionality.
