### PR TITLE
Add --root-type option to flatc [C++, parser, JSON]

### DIFF
--- a/docs/source/Compiler.md
+++ b/docs/source/Compiler.md
@@ -128,5 +128,7 @@ Additional options:
 -   `--reflect-types` : Add minimal type reflection to code generation.
 -   `--reflect-names` : Add minimal type/name reflection.
 
+-   `--root-type T` : Select or override the default root_type.
+
 NOTE: short-form options for generators are deprecated, use the long form
 whenever possible.

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -390,6 +390,7 @@ struct IDLOptions {
   bool reexport_ts_modules;
   bool protobuf_ascii_alike;
   bool size_prefixed;
+  std::string root_type;
 
   // Possible options for the more general generator below.
   enum Language {

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2432,9 +2432,12 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
       auto root_type = attribute_;
       EXPECT(kTokenIdentifier);
       ECHECK(ParseNamespacing(&root_type, nullptr));
-      if (!SetRootType(root_type.c_str()))
-        return Error("unknown root type: " + root_type);
-      if (root_struct_def_->fixed) return Error("root type must be a table");
+      if (opts.root_type.empty()) {
+        if (!SetRootType(root_type.c_str()))
+          return Error("unknown root type: " + root_type);
+        if (root_struct_def_->fixed)
+          return Error("root type must be a table");
+      }
       EXPECT(';');
     } else if (IsIdent("file_identifier")) {
       NEXT();


### PR DESCRIPTION
This allows to select or override a `root_type` that may or may not be present in the schema.