### PR TITLE
Add string view [C++]

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -156,12 +156,12 @@
 #ifndef FLATBUFFERS_STRING_VIEW
   // Only provide string_view features if __has_include can be used to detect it
   #if defined(__has_include)
-    // Check for std::string_view
+    // Check for std::string_view (in c++17)
     #if __has_include(<string_view>) && (__cplusplus > 201402)
       #include <string_view>
       #define FLATBUFFERS_STRING_VIEW std::string_view
-    // Check for std::experimental::string_view
-    #elif __has_include(<experimental/string_view>)
+    // Check for std::experimental::string_view (in c++14, compiler-dependent)
+    #elif __has_include(<experimental/string_view>) && (__cplusplus > 201103)
       #include <experimental/string_view>
       #define FLATBUFFERS_STRING_VIEW std::experimental::string_view
     #endif

--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -153,6 +153,21 @@
   #pragma warning(disable: 4127) // C4127: conditional expression is constant
 #endif
 
+#ifndef FLATBUFFERS_STRING_VIEW
+  // Only provide string_view features if __has_include can be used to detect it
+  #if defined(__has_include)
+    // Check for std::string_view
+    #if __has_include(<string_view>) && (__cplusplus > 201402)
+      #include <string_view>
+      #define FLATBUFFERS_STRING_VIEW std::string_view
+    // Check for std::experimental::string_view
+    #elif __has_include(<experimental/string_view>)
+      #include <experimental/string_view>
+      #define FLATBUFFERS_STRING_VIEW std::experimental::string_view
+    #endif
+  #endif // __has_include
+#endif // !FLATBUFFERS_STRING_VIEW
+
 /// @endcond
 
 /// @file

--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -153,20 +153,27 @@
   #pragma warning(disable: 4127) // C4127: conditional expression is constant
 #endif
 
-#ifndef FLATBUFFERS_STRING_VIEW
-  // Only provide string_view features if __has_include can be used to detect it
+#ifndef FLATBUFFERS_HAS_STRING_VIEW
+  // Only provide flatbuffers::string_view if __has_include can be used
+  // to detect a header that provides an implementation
   #if defined(__has_include)
     // Check for std::string_view (in c++17)
     #if __has_include(<string_view>) && (__cplusplus > 201402)
       #include <string_view>
-      #define FLATBUFFERS_STRING_VIEW std::string_view
+      namespace flatbuffers {
+        typedef std::string_view string_view;
+      }
+      #define FLATBUFFERS_HAS_STRING_VIEW 1
     // Check for std::experimental::string_view (in c++14, compiler-dependent)
     #elif __has_include(<experimental/string_view>) && (__cplusplus > 201103)
       #include <experimental/string_view>
-      #define FLATBUFFERS_STRING_VIEW std::experimental::string_view
+      namespace flatbuffers {
+        typedef std::experimental::string_view string_view;
+      }
+      #define FLATBUFFERS_HAS_STRING_VIEW 1
     #endif
   #endif // __has_include
-#endif // !FLATBUFFERS_STRING_VIEW
+#endif // !FLATBUFFERS_HAS_STRING_VIEW
 
 /// @endcond
 

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -343,11 +343,11 @@ template<typename T> static inline size_t VectorLength(const Vector<T> *v) {
 struct String : public Vector<char> {
   const char *c_str() const { return reinterpret_cast<const char *>(Data()); }
   std::string str() const { return std::string(c_str(), Length()); }
-  #ifdef FLATBUFFERS_STRING_VIEW
-  FLATBUFFERS_STRING_VIEW string_view() const {
-    return FLATBUFFERS_STRING_VIEW(c_str(), Length());
+  #ifdef FLATBUFFERS_HAS_STRING_VIEW
+  string_view string_view() const {
+    return flatbuffers::string_view(c_str(), Length());
   }
-  #endif // FLATBUFFERS_STRING_VIEW
+  #endif // FLATBUFFERS_HAS_STRING_VIEW
 
   bool operator<(const String &o) const {
     return strcmp(c_str(), o.c_str()) < 0;
@@ -1082,14 +1082,14 @@ class FlatBufferBuilder {
     return CreateString(str.c_str(), str.length());
   }
 
-  #ifdef FLATBUFFERS_STRING_VIEW
+  #ifdef FLATBUFFERS_HAS_STRING_VIEW
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const string_view to copy in to the buffer.
   /// @return Returns the offset in the buffer where the string starts.
-  Offset<String> CreateString(FLATBUFFERS_STRING_VIEW str) {
+  Offset<String> CreateString(string_view str) {
     return CreateString(str.data(), str.size());
   }
-  #endif // FLATBUFFERS_STRING_VIEW
+  #endif // FLATBUFFERS_HAS_STRING_VIEW
 
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const pointer to a `String` struct to add to the buffer.

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -340,18 +340,6 @@ template<typename T> static inline size_t VectorLength(const Vector<T> *v) {
   return v ? v->Length() : 0;
 }
 
-#ifndef FLATBUFFERS_STRING_VIEW
-  #if defined(__has_include)
-    #if __has_include(<string_view>) && (__cplusplus > 201402)
-      #include <string_view>
-      #define FLATBUFFERS_STRING_VIEW std::string_view
-    #elif __has_include(<experimental/string_view>)
-      #include <experimental/string_view>
-      #define FLATBUFFERS_STRING_VIEW std::experimental::string_view
-    #endif
-  #endif // __has_include
-#endif // !FLATBUFFERS_STRING_VIEW
-
 struct String : public Vector<char> {
   const char *c_str() const { return reinterpret_cast<const char *>(Data()); }
   std::string str() const { return std::string(c_str(), Length()); }
@@ -1098,7 +1086,7 @@ class FlatBufferBuilder {
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const string_view to copy in to the buffer.
   /// @return Returns the offset in the buffer where the string starts.
-  Offset<String> CreateString(const string_view &str) {
+  Offset<String> CreateString(FLATBUFFERS_STRING_VIEW str) {
     return CreateString(str.data(), str.size());
   }
 #endif // FLATBUFFERS_STRING_VIEW

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -343,11 +343,11 @@ template<typename T> static inline size_t VectorLength(const Vector<T> *v) {
 struct String : public Vector<char> {
   const char *c_str() const { return reinterpret_cast<const char *>(Data()); }
   std::string str() const { return std::string(c_str(), Length()); }
-#ifdef FLATBUFFERS_STRING_VIEW
+  #ifdef FLATBUFFERS_STRING_VIEW
   FLATBUFFERS_STRING_VIEW string_view() const {
     return FLATBUFFERS_STRING_VIEW(c_str(), Length());
   }
-#endif // FLATBUFFERS_STRING_VIEW
+  #endif // FLATBUFFERS_STRING_VIEW
 
   bool operator<(const String &o) const {
     return strcmp(c_str(), o.c_str()) < 0;
@@ -1082,14 +1082,14 @@ class FlatBufferBuilder {
     return CreateString(str.c_str(), str.length());
   }
 
-#ifdef FLATBUFFERS_STRING_VIEW
+  #ifdef FLATBUFFERS_STRING_VIEW
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const string_view to copy in to the buffer.
   /// @return Returns the offset in the buffer where the string starts.
   Offset<String> CreateString(FLATBUFFERS_STRING_VIEW str) {
     return CreateString(str.data(), str.size());
   }
-#endif // FLATBUFFERS_STRING_VIEW
+  #endif // FLATBUFFERS_STRING_VIEW
 
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const pointer to a `String` struct to add to the buffer.

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -344,7 +344,7 @@ struct String : public Vector<char> {
   const char *c_str() const { return reinterpret_cast<const char *>(Data()); }
   std::string str() const { return std::string(c_str(), Length()); }
   #ifdef FLATBUFFERS_HAS_STRING_VIEW
-  string_view string_view() const {
+  flatbuffers::string_view string_view() const {
     return flatbuffers::string_view(c_str(), Length());
   }
   #endif // FLATBUFFERS_HAS_STRING_VIEW
@@ -1086,7 +1086,7 @@ class FlatBufferBuilder {
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const string_view to copy in to the buffer.
   /// @return Returns the offset in the buffer where the string starts.
-  Offset<String> CreateString(string_view str) {
+  Offset<String> CreateString(flatbuffers::string_view str) {
     return CreateString(str.data(), str.size());
   }
   #endif // FLATBUFFERS_HAS_STRING_VIEW

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -343,11 +343,14 @@ template<typename T> static inline size_t VectorLength(const Vector<T> *v) {
 struct String : public Vector<char> {
   const char *c_str() const { return reinterpret_cast<const char *>(Data()); }
   std::string str() const { return std::string(c_str(), Length()); }
+
+  // clang-format off
   #ifdef FLATBUFFERS_HAS_STRING_VIEW
   flatbuffers::string_view string_view() const {
     return flatbuffers::string_view(c_str(), Length());
   }
   #endif // FLATBUFFERS_HAS_STRING_VIEW
+  // clang-format on
 
   bool operator<(const String &o) const {
     return strcmp(c_str(), o.c_str()) < 0;
@@ -1082,6 +1085,7 @@ class FlatBufferBuilder {
     return CreateString(str.c_str(), str.length());
   }
 
+  // clang-format off
   #ifdef FLATBUFFERS_HAS_STRING_VIEW
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const string_view to copy in to the buffer.
@@ -1090,6 +1094,7 @@ class FlatBufferBuilder {
     return CreateString(str.data(), str.size());
   }
   #endif // FLATBUFFERS_HAS_STRING_VIEW
+  // clang-format on
 
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const pointer to a `String` struct to add to the buffer.

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -344,8 +344,8 @@ struct String : public Vector<char> {
   const char *c_str() const { return reinterpret_cast<const char *>(Data()); }
   std::string str() const { return std::string(c_str(), Length()); }
 #ifdef FLATBUFFERS_STRING_VIEW
-  FLATBUFFERS_STRING_VIEW view() const {
-    return FLATBUFFERS_STRING_VIEW(Data(), Length());
+  FLATBUFFERS_STRING_VIEW string_view() const {
+    return FLATBUFFERS_STRING_VIEW(c_str(), Length());
   }
 #endif // FLATBUFFERS_STRING_VIEW
 


### PR DESCRIPTION
This adds a `String::string_view()` method to `flatbuffers::String` (re-using the existing `c_str()` method for the data pointer).

The `string_view()` method is only added if `string_view` support can be detected via `__has_include`.