### PR TITLE
Add #ifndef FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT blocks [C++]

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -321,7 +321,7 @@ inline void EnsureDirExists(const std::string &filepath) {
 // Returns the input path if the absolute path couldn't be resolved.
 inline std::string AbsolutePath(const std::string &filepath) {
   // clang-format off
-  #ifdef FLATBUFFERS_NO_ABSOLUTE_PATH_RESOLUTION
+  #if defined(FLATBUFFERS_NO_ABSOLUTE_PATH_RESOLUTION) || defined(FLATBUFFERS_NO_FILE_SUPPORT)
     return filepath;
   #else
     #ifdef _WIN32

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -92,7 +92,11 @@ std::string MakeCamel(const std::string &in, bool first) {
 }
 
 void Parser::Message(const std::string &msg) {
+#ifndef FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
   error_ = file_being_parsed_.length() ? AbsolutePath(file_being_parsed_) : "";
+#else // FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
+  error_ = file_being_parsed_.length() ? file_being_parsed_ : "";
+#endif // FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
   // clang-format off
   #ifdef _WIN32
     error_ += "(" + NumToString(line_) + ")";  // MSVC alike
@@ -2382,6 +2386,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
     } else if (IsIdent("include") || (opts.proto_mode && IsIdent("import"))) {
       NEXT();
       if (opts.proto_mode && attribute_ == "public") NEXT();
+#ifndef FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
       auto name = flatbuffers::PosixPath(attribute_.c_str());
       EXPECT(kTokenStringConstant);
       // Look for the file in include_paths.
@@ -2420,6 +2425,10 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
                        include_filename);
       }
       EXPECT(';');
+#else // FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
+      auto name = attribute_;
+      return Error("unable to load include file: " + name);
+#endif // FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
     } else {
       break;
     }

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -92,11 +92,7 @@ std::string MakeCamel(const std::string &in, bool first) {
 }
 
 void Parser::Message(const std::string &msg) {
-#ifndef FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
   error_ = file_being_parsed_.length() ? AbsolutePath(file_being_parsed_) : "";
-#else // FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
-  error_ = file_being_parsed_.length() ? file_being_parsed_ : "";
-#endif // FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
   // clang-format off
   #ifdef _WIN32
     error_ += "(" + NumToString(line_) + ")";  // MSVC alike

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2382,7 +2382,11 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
     } else if (IsIdent("include") || (opts.proto_mode && IsIdent("import"))) {
       NEXT();
       if (opts.proto_mode && attribute_ == "public") NEXT();
-#ifndef FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
+#ifdef FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
+      auto name = attribute_;
+      // Early return if platform has no file support
+      return Error("unable to load include file: " + name);
+#endif  // FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
       auto name = flatbuffers::PosixPath(attribute_.c_str());
       EXPECT(kTokenStringConstant);
       // Look for the file in include_paths.
@@ -2421,10 +2425,6 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
                        include_filename);
       }
       EXPECT(';');
-#else // FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
-      auto name = attribute_;
-      return Error("unable to load include file: " + name);
-#endif // FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT
     } else {
       break;
     }


### PR DESCRIPTION
To avoid using path related functions if the target platform has no file system.

Should only have effect if `FLATBUFFERS_PLATFORM_NO_FILE_SUPPORT` is defined manually.