### PR TITLE
[BREAKING CHANGE] Python: return None for missing strings.

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -194,7 +194,7 @@ static void GetStringField(const StructDef &struct_def, const FieldDef &field,
   code += OffsetPrefix(field);
   code += Indent + Indent + Indent + "return " + GenGetter(field.value.type);
   code += "o + self._tab.Pos)\n";
-  code += Indent + Indent + "return bytes()\n\n";
+  code += Indent + Indent + "return None\n\n";
 }
 
 // Get the value of a union from an object.

--- a/tests/MyGame/Example/Monster.py
+++ b/tests/MyGame/Example/Monster.py
@@ -49,7 +49,7 @@ class Monster(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             return self._tab.String(o + self._tab.Pos)
-        return bytes()
+        return None
 
     # Monster
     def Inventory(self, j):

--- a/tests/MyGame/Example/Stat.py
+++ b/tests/MyGame/Example/Stat.py
@@ -23,7 +23,7 @@ class Stat(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.String(o + self._tab.Pos)
-        return bytes()
+        return None
 
     # Stat
     def Val(self):

--- a/tests/py_test.py
+++ b/tests/py_test.py
@@ -917,7 +917,7 @@ class TestAllCodePathsOfExampleSchema(unittest.TestCase):
         self.assertEqual(100, self.mon.Hp())
 
     def test_default_monster_name(self):
-        self.assertEqual(b'', self.mon.Name())
+        self.assertEqual(None, self.mon.Name())
 
     def test_default_monster_inventory_item(self):
         self.assertEqual(0, self.mon.Inventory(0))


### PR DESCRIPTION
Here's a simple change: if a string is not provided, return None (the idiomatic Python sentinel for missing values) instead of an empty string.

I believe this is more aligned with what the docs have to say:

> Only scalar values can have defaults, non-scalar (string/vector/table) fields default to NULL when not present.

This lets us differentiate between a missing value (None) and a present empty string. It also makes the actual type agree with the type signature Optional[bytes].