### PR TITLE
Set Working Directory for flatc commands

### DIFF
--- a/CMake/BuildFlatBuffers.cmake
+++ b/CMake/BuildFlatBuffers.cmake
@@ -71,6 +71,8 @@ function(build_flatbuffers flatbuffers_schemas
       )
   endif()
 
+  set(working_dir "${CMAKE_CURRENT_SOURCE_DIR}")
+
   set(schema_glob "*.fbs")
   # Generate the include files parameters.
   set(include_params "")
@@ -97,7 +99,8 @@ function(build_flatbuffers flatbuffers_schemas
         -o ${generated_includes_dir}
         ${include_params}
         -c ${schema}
-        DEPENDS ${FLATC_TARGET} ${schema} ${additional_dependencies})
+        DEPENDS ${FLATC_TARGET} ${schema} ${additional_dependencies}
+        WORKING_DIRECTORY "${working_dir}")
       list(APPEND all_generated_files ${generated_include})
     endif()
 
@@ -109,7 +112,8 @@ function(build_flatbuffers flatbuffers_schemas
         -o ${binary_schemas_dir}
         ${include_params}
         ${schema}
-        DEPENDS ${FLATC_TARGET} ${schema} ${additional_dependencies})
+        DEPENDS ${FLATC_TARGET} ${schema} ${additional_dependencies}
+        WORKING_DIRECTORY "${working_dir}")
       list(APPEND all_generated_files ${binary_schema})
     endif()
 


### PR DESCRIPTION
There's currently a trivial bug in the BuildFlatbuffers.cmake module with how flatc is invoked. The bug is simply that a WORKING_DIRECTORY isn't supplied.

One might assume that add_custom_command will execute the command in the directory of the the current source code. But in reality, it's Generator dependent. While working with CLion which uses `CodeBlocks - Unix Makefiles`, it seems to work like the [XCode Generator](https://github.com/Kitware/CMake/blob/5099af044fc737fef6215ccacdce3bb4c9f3d957/Source/cmGlobalXCodeGenerator.cxx#L1696) which is to say that it seems to just run out of whatever directory the process currently happens to be in.

If any other `add_custom_*` command was run prior to calling `build_flatbuffers` that directory will be whatever is set as the `WORKING_DIRECTORY`.

This means that the current BuildFlatBuffers.cmake file is guaranteed to fail under the following circumstances:
* The fbs files were specified as relative paths to the current source dir (Almost always true for any "source" files in CMake)
* There was any other `add_custom_*` directive before build_flatbuffers at any point in the same cmake run with a WORKING_DIRECTORY *other* than the source directory where the build_flatbuffers command was executed.

You can repro this by adding a trivial add_custom_target just before calling build_flatbuffers. i.e.
```cmake
find_package(FlatBuffers REQUIRED)
add_custom_target(force_dir_change
        COMMAND echo "Changing to ${CMAKE_CURRENT_BINARY_DIR}"
        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
)

build_flatbuffers("fbs/test.fbs" "" "fb" "" "${CMAKE_CURRENT_BINARY_DIR}" "" "")
```
```shell
[ 33%] Generating test_generated.h
/home/karagon/.conan/data/flatbuffers/1.7.1/kmaragon/testing/package/a4e78634fe2ab608bf047bed1747d0a24afc42c7/bin/flatc: error: unable to load file: fbs/test.fbs
Usage: /home/karagon/.conan/data/flatbuffers/1.7.1/kmaragon/testing/package/a4e78634fe2ab608bf047bed1747d0a24afc42c7/bin/flatc [OPTION]... FILE... [-- FILE...]
  --binary     -b    Generate wire format binaries for any data definitions.
  --json       -t    Generate text output for any data definitions.
  --cpp        -c    Generate C++ headers for tables/structs.
  --go         -g    Generate Go files for tables/structs.
  --java       -j    Generate Java classes for tables/structs.
  --js         -s    Generate JavaScript code for tables/structs.
  --ts         -T    Generate TypeScript code for tables/structs.
  --csharp     -n    Generate C# classes for tables/structs.
  --python     -p    Generate Python files for tables/structs.
  --php              Generate PHP files for tables/structs.
  -o PATH            Prefix PATH to all generated files.
  -I PATH            Search for includes in the specified path.
  -M                 Print make rules for generated files.
  --version          Print the version number of flatc and exit.
  --strict-json      Strict JSON: field names must be / will be quoted,
                     no trailing commas in tables/vectors.
  --allow-non-utf8   Pass non-UTF-8 input through parser and emit nonstandard
                     \x escapes in JSON. (Default is to raise parse error on
                     non-UTF-8 input.)
  --defaults-json    Output fields whose value is the default when
                     writing JSON
  --unknown-json     Allow fields in JSON that are not defined in the
                     schema. These fields will be discared when generating
                     binaries.
  --no-prefix        Don't prefix enum values with the enum type in C++.
  --scoped-enums     Use C++11 style scoped and strongly typed enums.
                     also implies --no-prefix.
  --gen-includes     (deprecated), this is the default behavior.
                     If the original behavior is required (no include
                     statements) use --no-includes.
  --no-includes      Don't generate include statements for included
                     schemas the generated file depends on (C++).
  --gen-mutable      Generate accessors that can mutate buffers in-place.
  --gen-onefile      Generate single output file for C#.
  --gen-name-strings Generate type name functions for C++.
  --escape-proto-ids Disable appending '_' in namespaces names.
  --gen-object-api   Generate an additional object-based API.
  --cpp-ptr-type T   Set object API pointer type (default std::unique_ptr)
  --cpp-str-type T   Set object API string type (default std::string)
                     T::c_str() and T::length() must be supported
  --no-js-exports    Removes Node.js style export lines in JS.
  --goog-js-export   Uses goog.exports* for closure compiler exporting in JS.
  --go-namespace     Generate the overrided namespace in Golang.
  --raw-binary       Allow binaries without file_indentifier to be read.
                     This may crash flatc given a mismatched schema.
  --proto            Input is a .proto, translate to .fbs.
  --grpc             Generate GRPC interfaces for the specified languages
  --schema           Serialize schemas instead of JSON (use with -b)
  --bfbs-comments    Add doc comments to the binary schema files.
  --conform FILE     Specify a schema the following schemas should be
                     an evolution of. Gives errors if not.
  --conform-includes Include path for the schema given with --conform
    PATH             
  --include-prefix   Prefix this path to any generated include statements.
    PATH
  --keep-prefix      Keep original prefix of schema include statement.
  --no-fb-import     Don't include flatbuffers import statement for TypeScript.
  --no-ts-reexport   Don't re-export imported dependencies for TypeScript.
FILEs may be schemas, or JSON files (conforming to preceding schema)
FILEs after the -- must be binary flatbuffer format files.
Output files are named using the base file name of the input,
and written to the current directory or the path given by -o.
example: /home/karagon/.conan/data/flatbuffers/1.7.1/kmaragon/testing/package/a4e78634fe2ab608bf047bed1747d0a24afc42c7/bin/flatc -c -b schema1.fbs schema2.fbs data.json
CMakeFiles/fb.dir/build.make:60: recipe for target 'test_generated.h' failed
make[2]: *** [test_generated.h] Error 1
CMakeFiles/Makefile2:136: recipe for target 'CMakeFiles/fb.dir/all' failed
make[1]: *** [CMakeFiles/fb.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
```

There may be a concern that setting a WORKING_DIRECTORY will break people who *depend* on the non-determinstic working directory. But the workings of CMake independent of the generator would cause them to break in other ways.

The same command, add_custom_command takes a parameter for `DEPENDS` (which is necessarily specified by the current module currently being shipped). This will always be evaluated relative to the current source directory unless an absolute path was given. So if the user was depending on the unreliable WORKING_DIRECTORY while running the flatc command, they wouldn't be able to get to the point where the command runs because cmake would fail unless they had a matching set of .fbs files in the same paths relative to the source dir as they have in whatever directory previous add_custom_* commands landed them in for each .fbs file specified.

I specified the working_dir variable so that it would be possible to customize later with user input. But that will require modifying how the `DEPENDS` value gets set and generated. I'm not sure how one might want to customize that beyond what's already available. But just in case.