### PR TITLE
Javascript: Add suppport for ES6 style exports

### DIFF
--- a/docs/source/Compiler.md
+++ b/docs/source/Compiler.md
@@ -101,6 +101,10 @@ Additional options:
     instead of Node.js style exporting.  Needed for compatibility with the
     Google closure compiler (useful for JS).
 
+-   `--es6-js-export` : Generates ECMAScript v6 style export definitions
+    instead of Node.js style exporting. Useful when integrating flatbuffers
+    with modern Javascript projects.
+
 -   `--raw-binary` : Allow binaries without a file_indentifier to be read.
     This may crash flatc given a mismatched schema.
 

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -358,6 +358,7 @@ struct IDLOptions {
   bool strict_json;
   bool skip_js_exports;
   bool use_goog_js_export_format;
+  bool use_ES6_js_export_format;
   bool output_default_scalars_in_json;
   int indent_step;
   bool output_enum_identifiers;
@@ -423,6 +424,7 @@ struct IDLOptions {
       : strict_json(false),
         skip_js_exports(false),
         use_goog_js_export_format(false),
+        use_ES6_js_export_format(false),
         output_default_scalars_in_json(false),
         indent_step(2),
         output_enum_identifiers(true),

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -97,6 +97,7 @@ std::string FlatCompiler::GetUsageString(const char *program_name) const {
     "                     Default value is \"T\"\n"
     "  --no-js-exports    Removes Node.js style export lines in JS.\n"
     "  --goog-js-export   Uses goog.exports* for closure compiler exporting in JS.\n"
+    "  --es6-js-export    Uses ECMAScript 6 export style lines in JS.\n"
     "  --go-namespace     Generate the overrided namespace in Golang.\n"
     "  --go-import        Generate the overrided import for flatbuffers in Golang.\n"
     "                     (default is \"github.com/google/flatbuffers/go\")\n"
@@ -191,6 +192,10 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.skip_js_exports = true;
       } else if (arg == "--goog-js-export") {
         opts.use_goog_js_export_format = true;
+        opts.use_ES6_js_export_format = false;
+      } else if (arg == "--es6-js-export") {
+        opts.use_goog_js_export_format = false;
+        opts.use_ES6_js_export_format = true;
       } else if (arg == "--go-namespace") {
         if (++argi >= argc) Error("missing golang namespace" + arg, true);
         opts.go_namespace = argv[argi];

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -298,6 +298,8 @@ class JsGenerator : public BaseGenerator {
         if (parser_.opts.use_goog_js_export_format) {
           exports += "goog.exportSymbol('" + enum_def.name + "', " +
                      enum_def.name + ");\n";
+        } else if (parser_.opts.use_ES6_js_export_format) {
+          exports += "export {" + enum_def.name + "};\n";   
         } else {
           exports += "this." + enum_def.name + " = " + enum_def.name + ";\n";
         }
@@ -566,6 +568,8 @@ class JsGenerator : public BaseGenerator {
         if (parser_.opts.use_goog_js_export_format) {
           exports += "goog.exportSymbol('" + struct_def.name + "', " +
                      struct_def.name + ");\n";
+        } else if (parser_.opts.use_ES6_js_export_format) {
+          exports += "export {" + struct_def.name + "};\n";
         } else {
           exports +=
               "this." + struct_def.name + " = " + struct_def.name + ";\n";

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -103,7 +103,10 @@ class JsGenerator : public BaseGenerator {
 
     if (lang_.language == IDLOptions::kJs && !exports_code.empty() &&
         !parser_.opts.skip_js_exports) {
-      code += "// Exports for Node.js and RequireJS\n";
+        if( parser_.opts.use_ES6_js_export_format )
+            code += "// Exports for ECMAScript6 Modules\n";
+        else
+            code += "// Exports for Node.js and RequireJS\n";
       code += exports_code;
     }
 
@@ -223,6 +226,8 @@ class JsGenerator : public BaseGenerator {
           code += "var ";
           if (parser_.opts.use_goog_js_export_format) {
             exports += "goog.exportSymbol('" + *it + "', " + *it + ");\n";
+          } else if( parser_.opts.use_ES6_js_export_format){
+            exports += "export {" + *it + "};\n";
           } else {
             exports += "this." + *it + " = " + *it + ";\n";
           }


### PR DESCRIPTION
Adds support for ECMAScript 6 module exports during Javascript
generation. This is useful as many development projects are
switching to this new standard and away from custom module
solutions. By integrating support into flatbuffers, users
do not need to perform additional post-processing of generated
files in order to use flatbuffers output directly in their
codebases.

Reference to ECMAScript 6 modules:
https://www.ecma-international.org/ecma-262/6.0/#sec-exports

Changes:
* Added `--es6-js-export` option to cli parser tool
* Added conditional code to generate a ES6 style export
  line, replacing the normal NodeJS/RequireJS line.

[js_test_results.zip](https://github.com/google/flatbuffers/files/2020603/js_test_results.zip)
