### PR TITLE
Makes VectorIterator compatible with STL iterators.

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -91,7 +91,7 @@ template<typename T> struct IndirectHelper<const T *> {
 template<typename T, typename IT> struct VectorIterator {
   typedef std::random_access_iterator_tag iterator_category;
   typedef IT value_type;
-  typedef uoffset_t difference_type;
+  typedef ptrdiff_t difference_type;
   typedef IT *pointer;
   typedef IT &reference;
 
@@ -121,7 +121,7 @@ template<typename T, typename IT> struct VectorIterator {
     return data_ != other.data_;
   }
 
-  ptrdiff_t operator-(const VectorIterator &other) const {
+  difference_type operator-(const VectorIterator &other) const {
     return (data_ - other.data_) / IndirectHelper<T>::element_stride;
   }
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -273,8 +273,13 @@ void AccessFlatBufferTest(const uint8_t *flatbuf, size_t length,
   TEST_EQ(VectorLength(inventory), 10UL);  // Works even if inventory is null.
   TEST_NOTNULL(inventory);
   unsigned char inv_data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-  for (auto it = inventory->begin(); it != inventory->end(); ++it)
-    TEST_EQ(*it, inv_data[it - inventory->begin()]);
+  // Check compatibilty of iterators with STL.
+  std::vector<unsigned char> inv_vec(inventory->begin(), inventory->end());
+  for (auto it = inventory->begin(); it != inventory->end(); ++it) {
+    auto indx = it - inventory->begin();
+    TEST_EQ(*it, inv_vec.at(indx));  // Use bounds-check.
+    TEST_EQ(*it, inv_data[indx]);
+  }
 
   TEST_EQ(monster->color(), Color_Blue);
 


### PR DESCRIPTION
Issue #4767.
`VectorIterator::difference_type` changed to `ptrdiff_t`.
Fix compatibility problem with STL  constructor `template< class InputIt > vector( InputIt first, InputIt last)`.