### PR TITLE
Python: fix default bool value.

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -147,13 +147,13 @@ static void GetScalarFieldOfTable(const StructDef &struct_def,
     getter = "bool(" + getter + ")";
   }
   code += Indent + Indent + Indent + "return " + getter + "\n";
-  std::string defaultValue;
+  std::string default_value;
   if (is_bool) {
-    defaultValue = field.value.constant == "0" ? "False" : "True";
+    default_value = field.value.constant == "0" ? "False" : "True";
   } else {
-    defaultValue = field.value.constant;
+    default_value = field.value.constant;
   }
-  code += Indent + Indent + "return " + defaultValue + "\n\n";
+  code += Indent + Indent + "return " + default_value + "\n\n";
 }
 
 // Get a struct by initializing an existing struct.

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -147,7 +147,12 @@ static void GetScalarFieldOfTable(const StructDef &struct_def,
     getter = "bool(" + getter + ")";
   }
   code += Indent + Indent + Indent + "return " + getter + "\n";
-  auto defaultValue = (is_bool ? "False" : field.value.constant);
+  std::string defaultValue;
+  if (is_bool) {
+    defaultValue = field.value.constant == "0" ? "False" : "True";
+  } else {
+    defaultValue = field.value.constant;
+  }
   code += Indent + Indent + "return " + defaultValue + "\n\n";
 }
 


### PR DESCRIPTION
Fixes a regression caused by a previous PR (#4736). If a boolean field has the default value of 0, False will be returned in the default case, else True. This is consistent with Python in general (if you call bool(0), the result will be False, any other integer, True).
