### PR TITLE
Added bytes type to C++

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -58,7 +58,8 @@ namespace flatbuffers {
   TD(STRING, "string", Offset<void>, int, int, StringOffset, int) \
   TD(VECTOR, "",       Offset<void>, int, int, VectorOffset, int) \
   TD(STRUCT, "",       Offset<void>, int, int, int, int) \
-  TD(UNION,  "",       Offset<void>, int, int, int, int)
+  TD(UNION,  "",       Offset<void>, int, int, int, int) \
+  TD(BYTES,  "bytes",  Offset<void>, int, int, StringOffset, int) \
 
 // The fields are:
 // - enum

--- a/include/flatbuffers/reflection_generated.h
+++ b/include/flatbuffers/reflection_generated.h
@@ -43,10 +43,11 @@ enum BaseType {
   String = 13,
   Vector = 14,
   Obj = 15,
-  Union = 16
+  Union = 16,
+  Bytes = 17
 };
 
-inline const BaseType (&EnumValuesBaseType())[17] {
+inline const BaseType (&EnumValuesBaseType())[18] {
   static const BaseType values[] = {
     None,
     UType,
@@ -64,7 +65,8 @@ inline const BaseType (&EnumValuesBaseType())[17] {
     String,
     Vector,
     Obj,
-    Union
+    Union,
+    Bytes
   };
   return values;
 }
@@ -88,6 +90,7 @@ inline const char * const *EnumNamesBaseType() {
     "Vector",
     "Obj",
     "Union",
+    "Bytes",
     nullptr
   };
   return names;

--- a/reflection/reflection.fbs
+++ b/reflection/reflection.fbs
@@ -23,7 +23,8 @@ enum BaseType : byte {
     String,
     Vector,
     Obj,     // Used for tables & structs.
-    Union
+    Union,
+    Bytes
 }
 
 table Type {

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -50,7 +50,7 @@ const char kTypeSizes[] = {
 
 // The enums in the reflection schema should match the ones we use internally.
 // Compare the last element to check if these go out of sync.
-static_assert(BASE_TYPE_UNION == static_cast<BaseType>(reflection::Union),
+static_assert(BASE_TYPE_BYTES == static_cast<BaseType>(reflection::Bytes),
               "enums don't match");
 
 // Any parsing calls have to be wrapped in this macro, which automates
@@ -576,6 +576,9 @@ CheckedError Parser::ParseType(Type &type) {
       NEXT();
     } else if (IsIdent("string")) {
       type.base_type = BASE_TYPE_STRING;
+      NEXT();
+    } else if (IsIdent("bytes")) {
+      type.base_type = BASE_TYPE_BYTES;
       NEXT();
     } else {
       ECHECK(ParseTypeIdent(type));


### PR DESCRIPTION
Supports provided buffer as well as pre-allocated buffer.
This allows large blobs in existing buffers to be inserted into the flatbuffer easily.
Also allows third-party libraries to write large blobs directly to the flatbuffer without any intermediary buffers.

Examples using a Test.fbs with a single `foo:bytes;`:
```c++
// Packing Test with supplied data buffer
TestT test;
test.foo.set(data, data_size);
_fbb.Finish(Test::Pack(_fbb, &test));

// Packing Test with pre-allocated bytes
TestT test;
flatbuffers::BytesAlloc space;
_fbb.CreateBytesAlloc(data_size, space);
memcpy(space.ptr(), data, data_size);
// finished modifying, convert to bytes
test.foo.set(space);
_fbb.Finish(Test::Pack(_fbb, &test));

// Unpacking Test
TestT test;
flatbuffers::GetRoot<Test>(_fbb.GetBufferPointer())->UnPackTo(&test);
ASSERT_FALSE(test.foo.empty());
ASSERT_EQ(0, memcmp(test.foo.ptr(), data, data_size));
```
