### PR TITLE
Dart: Generate the enum from 0 if value is null and fix inconsistent naming when generating object builder

### DIFF
--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -769,7 +769,7 @@ class DartGenerator : public BaseGenerator {
         }
         code += "\n        : null;\n";
       } else if (field.value.type.base_type == BASE_TYPE_STRING) {
-        code += " = fbBuilder.writeString(_" + field.name + ");\n";
+        code += " = fbBuilder.writeString(_" + MakeCamel(field.name, false) + ");\n";
       } else {
         code += " = _" + MakeCamel(field.name, false) +
                 "?.getOrCreateOffset(fbBuilder);\n";

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -210,7 +210,7 @@ class DartGenerator : public BaseGenerator {
     code += "  final int value;\n";
     code += "  const " + name + "._(this.value);\n\n";
     code += "  factory " + name + ".fromValue(int value) {\n";
-    code += "    if (value == null) return null;\n";
+    code += "    if (value == null) value = 0;\n";
 
     code += "    if (!values.containsKey(value)) {\n";
     code +=


### PR DESCRIPTION
This PR contains 2 fixes below:

1. The current dart generator returns a null if a value of an enum is 0. Modified so that it returns 0 as expected.

2. There a problem when there is a field with underscores in its name, for example:

   ```
   table Foo {
     first_second: string;
   }
   ```
   With the schema above, it generates a field named _firstSecond, but within the finish method, it writes the string using _first_second.