### PR TITLE
Comment update for ForceDefaults.

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -838,7 +838,8 @@ class FlatBufferBuilder {
 
   /// @brief In order to save space, fields that are set to their default value
   /// don't get serialized into the buffer.
-  /// @param[in] bool fd When set to `true`, always serializes default values.
+  /// @param[in] bool fd When set to `true`, always serializes default values that are set.
+  /// Optional fields which are not set explicitly, will still not be serialized.
   void ForceDefaults(bool fd) { force_defaults_ = fd; }
 
   /// @brief By default vtables are deduped in order to save space.


### PR DESCRIPTION
Current comment is a bit ambiguous. Default values can be read either if field is not written (like in table), or if they are written explicitly by client but not serialized due to optimization. Impression from current comment is that all the default values which are coming during read are from binaries when we turn-on Force-Defaults. However, that will be a wrong interpretation.

Force_Defaults = true ensures to turn OFF later optimization. In case a field is not written, during read we will get default values but they will still not be serialized.

