### PR TITLE
Dart: Fix default values

### DIFF
--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -518,9 +518,19 @@ class DartGenerator : public BaseGenerator {
           code += ".vTableGet(_bc, _bcOffset, " +
                   NumToString(field.value.offset) + ", ";
           if (!field.value.constant.empty() && field.value.constant != "0") {
-            code += field.value.constant;
+            if (IsBool(field.value.type.base_type)) {
+              code += "true";
+            } else {
+              code += field.value.constant;
+            }
           } else {
-            code += "null";
+            if (IsBool(field.value.type.base_type)) {
+              code += "false";
+            } else if (IsScalar(field.value.type.base_type)) {
+              code += "0";
+            } else {
+              code += "null";
+            }
           }
           code += ")";
         }


### PR DESCRIPTION
If a boolean field has the default value of 0, false will be returned.

If a scalar field (non boolean) has the default value of 0, 0 will be returned.

In all other cases, null will be returned if the field has the default value of 0.
