### PR TITLE
Dart: Add missing imports

### DIFF
--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -78,6 +78,10 @@ class DartGenerator : public BaseGenerator {
       code += "import 'package:flat_buffers/flat_buffers.dart' as " + _kFb +
               ";\n\n";
 
+      if (parser_.opts.include_dependence_headers) {
+        GenIncludeDependencies(&code, kv->first);
+      }
+
       for (auto kv2 = namespace_code.begin(); kv2 != namespace_code.end();
            ++kv2) {
         if (kv2->first != kv->first) {
@@ -130,6 +134,19 @@ class DartGenerator : public BaseGenerator {
     // std::transform(ret.begin(), ret.end(), ret.begin(), ::tolower);
     return ret;
   }
+
+  void GenIncludeDependencies(std::string* code, const std::string& the_namespace) {
+    for (auto it = parser_.included_files_.begin();
+         it != parser_.included_files_.end(); ++it) {
+      if (it->second.empty()) continue;
+
+      auto noext = flatbuffers::StripExtension(it->second);
+      auto basename = flatbuffers::StripPath(noext);
+
+      *code += "import '" + GeneratedFileName("", basename + "_" + the_namespace) + "';\n";
+    }
+  }
+
   static std::string EscapeKeyword(const std::string &name) {
     for (size_t i = 0; i < sizeof(keywords) / sizeof(keywords[0]); i++) {
       if (name == keywords[i]) { return MakeCamel(name + "_", false); }


### PR DESCRIPTION
So, there are 2 schema files where we define tables Foo and Bar, and note that foo.fbs is included in bar.fbs:

foo.fbs
```
namespace com.company.fbs;

table Foo {
   // ...
}
```

bar.fbs
```
include "foo.fbs";

namespace com.company.fbs;

table Bar {
   // ...
}
```

Currently, the import of foo.dart is missing from the generated bar_com.company.fbs_generated.dart, which is added by this commit.

Note that this commit doesn't handle cases when there are multiple namespaces.