### PR TITLE
flatbuffer force-empty option

### DIFF
--- a/docs/source/Compiler.md
+++ b/docs/source/Compiler.md
@@ -138,5 +138,8 @@ Additional options:
 
 -   `--force-defaults` : Emit default values in binary output from JSON.
 
+-   `--force-empty` : When serializing from object API representation, force
+     strings and vectors to empty rather than null.
+
 NOTE: short-form options for generators are deprecated, use the long form
 whenever possible.

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -422,6 +422,10 @@ struct IDLOptions {
   // for code generation.
   unsigned long lang_to_generate;
 
+  // If set (default behavior), empty string and vector fields will be set to
+  // nullptr to make the flatbuffer more compact.
+  bool set_empty_to_null;
+
   IDLOptions()
       : strict_json(false),
         skip_js_exports(false),
@@ -457,7 +461,8 @@ struct IDLOptions {
         force_defaults(false),
         lang(IDLOptions::kJava),
         mini_reflect(IDLOptions::kNone),
-        lang_to_generate(0) {}
+        lang_to_generate(0),
+        set_empty_to_null(true) {}
 };
 
 // This encapsulates where the parser is in the current source file.

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -123,6 +123,8 @@ std::string FlatCompiler::GetUsageString(const char *program_name) const {
     "  --reflect-names    Add minimal type/name reflection.\n"
     "  --root-type T      Select or override the default root_type\n"
     "  --force-defaults   Emit default values in binary output from JSON\n"
+    "  --force-empty      When serializing from object API representation, "
+    "                     force strings and vectors to empty rather than null.\n"
     "FILEs may be schemas (must end in .fbs), or JSON files (conforming to preceding\n"
     "schema). FILEs after the -- must be binary flatbuffer format files.\n"
     "Output files are named using the base file name of the input,\n"
@@ -280,6 +282,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.root_type = argv[argi];
       } else if (arg == "--force-defaults") {
         opts.force_defaults = true;
+      } else if (arg == "--force-empty") {
+        opts.set_empty_to_null = false;
       } else {
         for (size_t i = 0; i < params_.num_generators; ++i) {
           if (arg == params_.generators[i].generator_opt_long ||


### PR DESCRIPTION
Adds --no-empty option to flatbuffer C++ code generator to enable users
to opt in for empty strings and vectors instead of nullptrs when creating flatbuffers with object API.