### PR TITLE
Fixing an assert in flexbuffers CreateVector

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -1443,7 +1443,7 @@ class Builder FLATBUFFERS_FINAL_CLASS {
     }
     // If you get this assert, your fixed types are not one of:
     // Int / UInt / Float / Key.
-    FLATBUFFERS_ASSERT(IsTypedVectorElementType(vector_type));
+    FLATBUFFERS_ASSERT(!fixed || IsTypedVectorElementType(vector_type));
     auto byte_width = Align(bit_width);
     // Write vector. First the keys width/offset if available, and size.
     if (keys) {


### PR DESCRIPTION
An assert was blocking the creation of typedvectors. It was wrongly checking for limited types even though vector was not of fixedTyped.

