### PR TITLE
Fixing bazel build by adding the missing lua file 

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -92,6 +92,7 @@ cc_binary(
         "src/idl_gen_grpc.cpp",
         "src/idl_gen_js.cpp",
         "src/idl_gen_json_schema.cpp",
+        "src/idl_gen_lua.cpp",
         "src/idl_gen_php.cpp",
         "src/idl_gen_python.cpp",
         "src/idl_gen_text.cpp",


### PR DESCRIPTION
I noticed this file was missing in the bazel build for `:flatc`. This fixes the build issue. 

Thanks for all the great work on this project!