### PR TITLE
Add missing public header `minireflect.h` to bazel build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -43,6 +43,7 @@ filegroup(
         "include/flatbuffers/flexbuffers.h",
         "include/flatbuffers/hash.h",
         "include/flatbuffers/idl.h",
+        "include/flatbuffers/minireflect.h",
         "include/flatbuffers/reflection.h",
         "include/flatbuffers/reflection_generated.h",
         "include/flatbuffers/stl_emulation.h",


### PR DESCRIPTION
Hello there! When trying to use `flatbuffers::FlatBufferToString` I noticed that `flatbuffers/minireflect.h` wasn't included as a public header in the bazel `BUILD` file. Here's the fix so this can be included. Hope that helps!
