### PR TITLE
python: do not clobber minalign when we create objects

### DIFF
--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -160,7 +160,6 @@ class Builder(object):
         # use 32-bit offsets so that arithmetic doesn't overflow.
         self.current_vtable = [0 for _ in range_func(numfields)]
         self.objectEnd = self.Offset()
-        self.minalign = 1
         self.nested = True
 
     def WriteVtable(self):


### PR DESCRIPTION
As pointed out by @gwvo, we should not clobber minalign once we've started tracking it.
