### PR TITLE
go: do not clobber minalign when we create objects

### DIFF
--- a/go/builder.go
+++ b/go/builder.go
@@ -82,7 +82,6 @@ func (b *Builder) StartObject(numfields int) {
 	}
 
 	b.objectEnd = b.Offset()
-	b.minalign = 1
 }
 
 // WriteVtable serializes the vtable for the current object, if applicable.


### PR DESCRIPTION
As pointed out by @gwvo, we should not clobber minalign once we've started tracking it.