### PR TITLE
Update FLATBUFFERS_HAS_STRING_VIEW __cplusplus checks

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -158,14 +158,14 @@
   // to detect a header that provides an implementation
   #if defined(__has_include)
     // Check for std::string_view (in c++17)
-    #if __has_include(<string_view>) && (__cplusplus > 201402)
+    #if __has_include(<string_view>) && (__cplusplus >= 201606)
       #include <string_view>
       namespace flatbuffers {
         typedef std::string_view string_view;
       }
       #define FLATBUFFERS_HAS_STRING_VIEW 1
     // Check for std::experimental::string_view (in c++14, compiler-dependent)
-    #elif __has_include(<experimental/string_view>) && (__cplusplus > 201103)
+    #elif __has_include(<experimental/string_view>) && (__cplusplus >= 201411)
       #include <experimental/string_view>
       namespace flatbuffers {
         typedef std::experimental::string_view string_view;


### PR DESCRIPTION
Update `FLATBUFFERS_HAS_STRING_VIEW` `__cplusplus` checks to the versions provided by the standard feature test macros.

Use the table of feature_testing_macros provided by C++ reference:
https://en.cppreference.com/w/User:D41D8CD98F/feature_testing_macros

Compare using >= equality to clarify the first version supporting the feature (not the previous behaviour of the version after the last version NOT supporting the feature).