### PR TITLE
Update for Dart 2.x constants

### DIFF
--- a/dart/lib/flat_buffers.dart
+++ b/dart/lib/flat_buffers.dart
@@ -44,30 +44,30 @@ class BufferContext {
       _buffer.buffer.asUint8List(_buffer.offsetInBytes + offset, length);
 
   double _getFloat64(int offset) =>
-      _buffer.getFloat64(offset, Endianness.LITTLE_ENDIAN);
+      _buffer.getFloat64(offset, Endian.little);
 
   double _getFloat32(int offset) =>
-      _buffer.getFloat32(offset, Endianness.LITTLE_ENDIAN);
+      _buffer.getFloat32(offset, Endian.little);
 
   int _getInt64(int offset) =>
-      _buffer.getInt64(offset, Endianness.LITTLE_ENDIAN);
+      _buffer.getInt64(offset, Endian.little);
 
   int _getInt32(int offset) =>
-      _buffer.getInt32(offset, Endianness.LITTLE_ENDIAN);
+      _buffer.getInt32(offset, Endian.little);
 
   int _getInt16(int offset) =>
-      _buffer.getInt16(offset, Endianness.LITTLE_ENDIAN);
+      _buffer.getInt16(offset, Endian.little);
 
   int _getInt8(int offset) => _buffer.getInt8(offset);
 
   int _getUint64(int offset) =>
-      _buffer.getUint64(offset, Endianness.LITTLE_ENDIAN);
+      _buffer.getUint64(offset, Endian.little);
 
   int _getUint32(int offset) =>
-      _buffer.getUint32(offset, Endianness.LITTLE_ENDIAN);
+      _buffer.getUint32(offset, Endian.little);
 
   int _getUint16(int offset) =>
-      _buffer.getUint16(offset, Endianness.LITTLE_ENDIAN);
+      _buffer.getUint16(offset, Endian.little);
 
   int _getUint8(int offset) => _buffer.getUint8(offset);
 
@@ -306,7 +306,7 @@ class Builder {
       for (int i = _vTables.length - 1; i >= 0; i--) {
         final int vt2Offset = _vTables[i];
         final int vt2Start = _buf.lengthInBytes - vt2Offset;
-        final int vt2Size = _buf.getUint16(vt2Start, Endianness.LITTLE_ENDIAN);
+        final int vt2Size = _buf.getUint16(vt2Start, Endian.little);
 
         if (_currentVTable._vTableSize == vt2Size &&
             _currentVTable._offsetsMatch(vt2Start, _buf)) {
@@ -660,7 +660,7 @@ class Builder {
 
   int _writeString(String value) {
     // TODO(scheglov) optimize for ASCII strings
-    List<int> bytes = UTF8.encode(value);
+    List<int> bytes = utf8.encode(value);
     int length = bytes.length;
     _prepare(4, 1, additionalBytes: length);
     final int result = _tail;
@@ -733,35 +733,35 @@ class Builder {
   }
 
   static void _setFloat64AtTail(ByteData _buf, int tail, double x) {
-    _buf.setFloat64(_buf.lengthInBytes - tail, x, Endianness.LITTLE_ENDIAN);
+    _buf.setFloat64(_buf.lengthInBytes - tail, x, Endian.little);
   }
 
   static void _setFloat32AtTail(ByteData _buf, int tail, double x) {
-    _buf.setFloat32(_buf.lengthInBytes - tail, x, Endianness.LITTLE_ENDIAN);
+    _buf.setFloat32(_buf.lengthInBytes - tail, x, Endian.little);
   }
 
   static void _setUint64AtTail(ByteData _buf, int tail, int x) {
-    _buf.setUint64(_buf.lengthInBytes - tail, x, Endianness.LITTLE_ENDIAN);
+    _buf.setUint64(_buf.lengthInBytes - tail, x, Endian.little);
   }
 
   static void _setInt64AtTail(ByteData _buf, int tail, int x) {
-    _buf.setInt64(_buf.lengthInBytes - tail, x, Endianness.LITTLE_ENDIAN);
+    _buf.setInt64(_buf.lengthInBytes - tail, x, Endian.little);
   }
 
   static void _setInt32AtTail(ByteData _buf, int tail, int x) {
-    _buf.setInt32(_buf.lengthInBytes - tail, x, Endianness.LITTLE_ENDIAN);
+    _buf.setInt32(_buf.lengthInBytes - tail, x, Endian.little);
   }
 
   static void _setUint32AtTail(ByteData _buf, int tail, int x) {
-    _buf.setUint32(_buf.lengthInBytes - tail, x, Endianness.LITTLE_ENDIAN);
+    _buf.setUint32(_buf.lengthInBytes - tail, x, Endian.little);
   }
 
   static void _setInt16AtTail(ByteData _buf, int tail, int x) {
-    _buf.setInt16(_buf.lengthInBytes - tail, x, Endianness.LITTLE_ENDIAN);
+    _buf.setInt16(_buf.lengthInBytes - tail, x, Endian.little);
   }
 
   static void _setUint16AtTail(ByteData _buf, int tail, int x) {
-    _buf.setUint16(_buf.lengthInBytes - tail, x, Endianness.LITTLE_ENDIAN);
+    _buf.setUint16(_buf.lengthInBytes - tail, x, Endian.little);
   }
 
   static void _setInt8AtTail(ByteData _buf, int tail, int x) {
@@ -943,7 +943,7 @@ class StringReader extends Reader<String> {
     if (_isLatin(bytes)) {
       return new String.fromCharCodes(bytes);
     }
-    return UTF8.decode(bytes);
+    return utf8.decode(bytes);
   }
 
   static bool _isLatin(Uint8List bytes) {
@@ -1207,7 +1207,7 @@ class _VTable {
     for (int i = 0; i < fieldOffsets.length; i++) {
       if (fieldOffsets[i] !=
           buf.getUint16(
-              vt2Start + _metadataLength + (2 * i), Endianness.LITTLE_ENDIAN)) {
+              vt2Start + _metadataLength + (2 * i), Endian.little)) {
         return false;
       }
     }
@@ -1227,14 +1227,14 @@ class _VTable {
   /// and have at least [numOfUint16] 16-bit words available.
   void output(ByteData buf, int bufOffset) {
     // VTable size.
-    buf.setUint16(bufOffset, numOfUint16 * 2, Endianness.LITTLE_ENDIAN);
+    buf.setUint16(bufOffset, numOfUint16 * 2, Endian.little);
     bufOffset += 2;
     // Table size.
-    buf.setUint16(bufOffset, tableSize, Endianness.LITTLE_ENDIAN);
+    buf.setUint16(bufOffset, tableSize, Endian.little);
     bufOffset += 2;
     // Field offsets.
     for (int fieldOffset in fieldOffsets) {
-      buf.setUint16(bufOffset, fieldOffset, Endianness.LITTLE_ENDIAN);
+      buf.setUint16(bufOffset, fieldOffset, Endian.little);
       bufOffset += 2;
     }
   }

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flat_buffers
-version: 1.9.0
+version: 1.9.1
 description: >
   FlatBuffers reading and writing library for Dart.  Use the flatc compiler to
   generate Dart classes for a FlatBuffers schema, and this library to assist with
@@ -16,3 +16,5 @@ dev_dependencies:
   test: ^0.12.33
   test_reflective_loader: ^0.1.4
   path: ^1.5.1
+environment:
+  sdk: '>=2.0.0-dev.28.0 <3.0.0'

--- a/dart/test/flat_buffers_test.dart
+++ b/dart/test/flat_buffers_test.dart
@@ -160,7 +160,7 @@ class BuilderTest {
     // Convert byteList to a ByteData so that we can read data from it.
     ByteData byteData = byteList.buffer.asByteData(byteList.offsetInBytes);
     // First 4 bytes are an offset to the table data.
-    int tableDataLoc = byteData.getUint32(0, Endianness.LITTLE_ENDIAN);
+    int tableDataLoc = byteData.getUint32(0, Endian.little);
     // Next 4 bytes are the file identifier.
     expect(byteData.getUint8(4), 65); // 'a'
     expect(byteData.getUint8(5), 122); // 'z'
@@ -168,13 +168,13 @@ class BuilderTest {
     expect(byteData.getUint8(7), 255); // 'ÿ'
     // First 4 bytes of the table data are a backwards offset to the vtable.
     int vTableLoc = tableDataLoc -
-        byteData.getInt32(tableDataLoc, Endianness.LITTLE_ENDIAN);
+        byteData.getInt32(tableDataLoc, Endian.little);
     // First 2 bytes of the vtable are the size of the vtable in bytes, which
     // should be 4.
-    expect(byteData.getUint16(vTableLoc, Endianness.LITTLE_ENDIAN), 4);
+    expect(byteData.getUint16(vTableLoc, Endian.little), 4);
     // Next 2 bytes are the size of the object in bytes (including the vtable
     // pointer), which should be 4.
-    expect(byteData.getUint16(vTableLoc + 2, Endianness.LITTLE_ENDIAN), 4);
+    expect(byteData.getUint16(vTableLoc + 2, Endian.little), 4);
   }
 
   void test_low() {
@@ -229,22 +229,22 @@ class BuilderTest {
     // Convert byteList to a ByteData so that we can read data from it.
     ByteData byteData = byteList.buffer.asByteData(byteList.offsetInBytes);
     // First 4 bytes are an offset to the table data.
-    int tableDataLoc = byteData.getUint32(0, Endianness.LITTLE_ENDIAN);
+    int tableDataLoc = byteData.getUint32(0, Endian.little);
     // First 4 bytes of the table data are a backwards offset to the vtable.
     int vTableLoc = tableDataLoc -
-        byteData.getInt32(tableDataLoc, Endianness.LITTLE_ENDIAN);
+        byteData.getInt32(tableDataLoc, Endian.little);
     // First 2 bytes of the vtable are the size of the vtable in bytes, which
     // should be 10.
-    expect(byteData.getUint16(vTableLoc, Endianness.LITTLE_ENDIAN), 10);
+    expect(byteData.getUint16(vTableLoc, Endian.little), 10);
     // Next 2 bytes are the size of the object in bytes (including the vtable
     // pointer), which should be 16.
-    expect(byteData.getUint16(vTableLoc + 2, Endianness.LITTLE_ENDIAN), 16);
+    expect(byteData.getUint16(vTableLoc + 2, Endian.little), 16);
     // Remaining 6 bytes are the offsets within the object where the ints are
     // located.
     for (int i = 0; i < 3; i++) {
       int offset =
-          byteData.getUint16(vTableLoc + 4 + 2 * i, Endianness.LITTLE_ENDIAN);
-      expect(byteData.getInt32(tableDataLoc + offset, Endianness.LITTLE_ENDIAN),
+          byteData.getUint16(vTableLoc + 4 + 2 * i, Endian.little);
+      expect(byteData.getInt32(tableDataLoc + offset, Endian.little),
           10 + 10 * i);
     }
   }


### PR DESCRIPTION
Dart 2.x has removed support for some deprecated constants (`Endianness` and `UTF8` in particular) that are used by this package.  

This change will allow people to use latest/cutting edge releases of Dart, but removes support for 1.x

Users of Dart 1.x would have to use the previous version of this patch, and will not benefit from continued updates.

Fixes #4836 (more discussion there as well)