### PR TITLE
Attach header directory information to the "flatbuffers" library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,10 @@ include_directories(include)
 include_directories(grpc)
 
 if(FLATBUFFERS_BUILD_FLATLIB)
-add_library(flatbuffers STATIC ${FlatBuffers_Library_SRCS})
+  add_library(flatbuffers STATIC ${FlatBuffers_Library_SRCS})
+  # CMake > 2.8.11: Attach header directory for when build via add_subdirectory().
+  target_include_directories(flatbuffers INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 endif()
 
 if(FLATBUFFERS_BUILD_FLATC)
@@ -256,18 +259,6 @@ if(FLATBUFFERS_BUILD_GRPCTEST)
   endif()
   add_executable(grpctest ${FlatBuffers_GRPCTest_SRCS})
   target_link_libraries(grpctest grpc++_unsecure grpc_unsecure gpr pthread dl)
-endif()
-
-# If the CMake version supports it, attach header directory information
-# to the targets for when we are part of a parent build (via add_subdirectory()).
-if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "3.0.2")
-  if(TARGET flatbuffers)
-    target_include_directories(
-      flatbuffers SYSTEM INTERFACE
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>  
-      $<INSTALL_INTERFACE:include>
-    )
-  endif()
 endif()
 
 include(CMake/Version.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,18 @@ if(FLATBUFFERS_BUILD_GRPCTEST)
   target_link_libraries(grpctest grpc++_unsecure grpc_unsecure gpr pthread dl)
 endif()
 
+# If the CMake version supports it, attach header directory information
+# to the targets for when we are part of a parent build (via add_subdirectory()).
+if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "3.0.2")
+  if(TARGET flatbuffers)
+    target_include_directories(
+      flatbuffers SYSTEM INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>  
+      $<INSTALL_INTERFACE:include>
+    )
+  endif()
+endif()
+
 include(CMake/Version.cmake)
 
 if(FLATBUFFERS_INSTALL)

--- a/docs/source/Building.md
+++ b/docs/source/Building.md
@@ -41,7 +41,7 @@ running the `android_sample.sh` script. Optionally, you may go to the
 `flatbuffers/samples/android` folder and build the sample with the
 `build_apk.sh` script or `ndk_build` / `adb` etc.
 
-## Using FlatBuffers in your own projects.
+## Using FlatBuffers in your own projects
 
 For C++, there is usually no runtime to compile, as the code consists of a
 single header, `include/flatbuffers/flatbuffers.h`. You should add the
@@ -54,6 +54,31 @@ also want to be able convert binary to text).
 To see how to include FlatBuffers in any of our supported languages, please
 view the [Tutorial](@ref flatbuffers_guide_tutorial) and select your appropriate
 language using the radio buttons.
+
+### Using in CMake-based projects
+If you want to use FlatBuffers in a project which already uses CMake, then a more
+robust and flexible approach is to build FlatBuffers as part of that project directly.
+This is done by making the FlatBuffers source code available to the main build
+and adding it using CMake's `add_subdirectory()` command. This has the
+significant advantage that the same compiler and linker settings are used
+between FlatBuffers and the rest of your project, so issues associated with using
+incompatible libraries (eg debug/release), etc. are avoided. This is
+particularly useful on Windows.
+
+Suppose you put FlatBuffers source code in directory `${FLATBUFFERS_SRC_DIR}`.
+To build it as part of your project, add following code to your `CMakeLists.txt` file:
+```cmake
+# Add FlatBuffers directly to our build. This defines the `flatbuffers` target.
+add_subdirectory(${FLATBUFFERS_SRC_DIR}
+                 ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers-build
+                 EXCLUDE_FROM_ALL)
+
+# Now simply link against flatbuffers as needed to your already declared target.
+# The flatbuffers target carry header search path automatically if CMake > 2.8.11.
+target_link_libraries(own_project_target PRIVATE flatbuffers)
+```
+When build your project the `flatbuffers` library will be compiled and linked 
+to a target as part of your project.
 
 #### For Google Play apps
 


### PR DESCRIPTION
Attach header directory information to the targets for when flatbuffers library is part of a parent build via `add_subdirectory()`, if the CMake version supports it.

This PR makes unnecessary `target_include_directories` command for flatbuffers linking:
```
add_subdirectory(${FLATBUFFERS_SRC_DIR}
                 ${CMAKE_BINARY_DIR}/flatbuffers-build
                 EXCLUDE_FROM_ALL)
target_link_libraries(user_app_target PRIVATE flatbuffers)

# The next line will be unnecessary.
target_include_directories(user_app_target PRIVATE ${FLATBUFFERS_SRC_DIR}/include)
```

