### PR TITLE
Remove using namespace std from java_generator.h

### DIFF
--- a/grpc/src/compiler/java_generator.h
+++ b/grpc/src/compiler/java_generator.h
@@ -65,8 +65,6 @@ class LogHelper {
 // Abort the program after logging the mesage.
 #define GRPC_CODEGEN_FAIL GRPC_CODEGEN_CHECK(false)
 
-using namespace std;
-
 namespace grpc_java_generator {
 struct Parameters {
   //        //Defines the custom parameter types for methods


### PR DESCRIPTION
This declaration doesn't appear to be needed, and Chromium builds [Wheader-hygiene](https://clang.llvm.org/docs/DiagnosticsReference.html#wheader-hygiene).