### PR TITLE
Add licenses to BUILD

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])
+
 package(
     default_visibility = ["//visibility:public"],
     features = [


### PR DESCRIPTION
This allows to build flatbuffers from third_party directory.