### PR TITLE
Proposing use of C++ header files and functions

### DIFF
--- a/docs/source/CppUsage.md
+++ b/docs/source/CppUsage.md
@@ -59,15 +59,18 @@ a `char *` array, which you pass to `GetMonster()`.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
     #include "flatbuffers/flatbuffers.h"
     #include "monster_test_generate.h"
-    #include <cstdio> // For printing and file access.
+    #include <iostream> // C++ header file for printing
+    #include <fstream> // C++ header file for file access
 
-    FILE* file = fopen("monsterdata_test.mon", "rb");
-    fseek(file, 0L, SEEK_END);
-    int length = ftell(file);
-    fseek(file, 0L, SEEK_SET);
+
+    std::ifstream infile;
+    infile.open("monsterdata_test.mon", std::ios::binary | std::ios::in);
+    infile.seekg(0,std::ios::end);
+    int length = infile.tellg();
+    infile.seekg(0,std::ios::beg);
     char *data = new char[length];
-    fread(data, sizeof(char), length, file);
-    fclose(file);
+    infile.read(data, sizeof(data));
+    infile.close();
 
     auto monster = GetMonster(data);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -78,9 +81,9 @@ If you look in your generated header, you'll see it has
 convenient accessors for all fields, e.g. `hp()`, `mana()`, etc:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-    printf("%d\n", monster->hp());            // `80`
-    printf("%d\n", monster->mana());          // default value of `150`
-    printf("%s\n", monster->name()->c_str()); // "MyMonster"
+    std::cout << "hp : " << monster->hp() << std::endl;            // `80`
+    std::cout << "mana : " << monster->mana() << std::endl;        // default value of `150`
+    std::cout << "name : " << monster->name() << std::endl;        // "MyMonster"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 *Note: That we never stored a `mana` value, so it will return the default.*

--- a/docs/source/CppUsage.md
+++ b/docs/source/CppUsage.md
@@ -69,7 +69,7 @@ a `char *` array, which you pass to `GetMonster()`.
     int length = infile.tellg();
     infile.seekg(0,std::ios::beg);
     char *data = new char[length];
-    infile.read(data, sizeof(data));
+    infile.read(data, length);
     infile.close();
 
     auto monster = GetMonster(data);
@@ -83,7 +83,7 @@ convenient accessors for all fields, e.g. `hp()`, `mana()`, etc:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
     std::cout << "hp : " << monster->hp() << std::endl;            // `80`
     std::cout << "mana : " << monster->mana() << std::endl;        // default value of `150`
-    std::cout << "name : " << monster->name() << std::endl;        // "MyMonster"
+    std::cout << "name : " << monster->name()->c_str() << std::endl;        // "MyMonster"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 *Note: That we never stored a `mana` value, so it will return the default.*


### PR DESCRIPTION
Proposing use of C++ header files and functions instead of C header file and functions. 
Here are few examples for comparison : 

C                            C++
<cstdio>                <iostream> & <fstream>
printf()                     cout 
fopen()                    ifstream
etc ...

Please let me know if there are any comments.

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
