### PR TITLE
Correctly generate identifier for enums.

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -991,7 +991,7 @@ class CppGenerator : public BaseGenerator {
       for (auto it = enum_def.vals.vec.begin(); it != enum_def.vals.vec.end();
            ++it) {
         const auto &ev = **it;
-        code_ += "    case {{ENUM_NAME}}_" + Name(ev) + ": return \"" +
+        code_ += "    case " + GetEnumValUse(enum_def, ev) + ": return \"" +
                  Name(ev) + "\";";
       }
 


### PR DESCRIPTION
This should allow the EnumName* function to work with enums generated
using the --scoped-enum flag.

Thank you for submitting a PR!

--This should only affect C++ code gen.