### PR TITLE
Use string_view if _HAS_CXX17 is true

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -158,7 +158,7 @@
   // to detect a header that provides an implementation
   #if defined(__has_include)
     // Check for std::string_view (in c++17)
-    #if __has_include(<string_view>) && (__cplusplus >= 201606)
+    #if __has_include(<string_view>) && (__cplusplus >= 201606 || _HAS_CXX17)
       #include <string_view>
       namespace flatbuffers {
         typedef std::string_view string_view;


### PR DESCRIPTION
Current version of VC2017 is not setting __cplusplus to correct value, instead they use _MSC_VER, _MSVC_LANG and _HAS_CXX17 macros.