### PR TITLE
Add C#/Java generator behaviour for 'private' attribute

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -564,6 +564,7 @@ class Parser : public ParserState {
     known_attributes_["native_type"] = true;
     known_attributes_["native_default"] = true;
     known_attributes_["flexbuffer"] = true;
+    known_attributes_["private"] = true;
   }
 
   ~Parser() {

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -504,7 +504,16 @@ class GeneralGenerator : public BaseGenerator {
     // to map directly to how they're used in C/C++ and file formats.
     // That, and Java Enums are expensive, and not universally liked.
     GenComment(enum_def.doc_comment, code_ptr, &lang_.comment_config);
-    code += std::string("public ") + lang_.enum_decl + enum_def.name;
+    if (enum_def.attributes.Lookup("private")) {
+      // For Java, we leave the enum unmarked to indicate package-private
+      // For C# we mark the enum as internal
+      if (lang_.language == IDLOptions::kCSharp) {
+        code += "internal ";
+      }
+    } else {
+      code += "public ";
+    }
+    code += lang_.enum_decl + enum_def.name;
     if (lang_.language == IDLOptions::kCSharp) {
       code += lang_.inheritance_marker +
               GenTypeBasic(enum_def.underlying_type, false);
@@ -773,7 +782,15 @@ class GeneralGenerator : public BaseGenerator {
     //   int o = __offset(offset); return o != 0 ? bb.getType(o + i) : default;
     // }
     GenComment(struct_def.doc_comment, code_ptr, &lang_.comment_config);
-    code += "public ";
+    if (struct_def.attributes.Lookup("private")) {
+      // For Java, we leave the struct unmarked to indicate package-private
+      // For C# we mark the struct as internal
+      if (lang_.language == IDLOptions::kCSharp) {
+        code += "internal ";
+      }
+    } else {
+      code += "public ";
+    }
     if (lang_.language == IDLOptions::kCSharp &&
         struct_def.attributes.Lookup("csharp_partial")) {
       // generate a partial class for this C# struct/table

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.cs
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.cs
@@ -8,7 +8,7 @@ namespace MyGame.Example
 using global::System;
 using global::FlatBuffers;
 
-public partial struct TestSimpleTableWithEnum : IFlatbufferObject
+internal partial struct TestSimpleTableWithEnum : IFlatbufferObject
 {
   private Table __p;
   public ByteBuffer ByteBuffer { get { return __p.bb; } }

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.java
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.java
@@ -8,7 +8,7 @@ import java.util.*;
 import com.google.flatbuffers.*;
 
 @SuppressWarnings("unused")
-public final class TestSimpleTableWithEnum extends Table {
+final class TestSimpleTableWithEnum extends Table {
   public static TestSimpleTableWithEnum getRootAsTestSimpleTableWithEnum(ByteBuffer _bb) { return getRootAsTestSimpleTableWithEnum(_bb, new TestSimpleTableWithEnum()); }
   public static TestSimpleTableWithEnum getRootAsTestSimpleTableWithEnum(ByteBuffer _bb, TestSimpleTableWithEnum obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }

--- a/tests/monster_test.fbs
+++ b/tests/monster_test.fbs
@@ -20,7 +20,7 @@ union Any { Monster, TestSimpleTableWithEnum, MyGame.Example2.Monster }
 
 struct Test { a:short; b:byte; }
 
-table TestSimpleTableWithEnum (csharp_partial) {
+table TestSimpleTableWithEnum (csharp_partial, private) {
   color: Color = Green;
 }
 


### PR DESCRIPTION
This adds support for marking tables, structs and enums with a `private` attribute, restricting the visibility of the generated object. Discussion around this addition can be found in #4864.

- When generating C#, produces a struct/enum marked as `internal` rather than `public` - meaning it will only be visible to code built as part of the same assembly
- When generating Java, produces a class/enum with no visibility modifier - meaning it will only be visible to code in the same package (namespace)
- When generating any other languages, the attribute is ignored