### PR TITLE
[C++] Template Alias Preprocessor Check

### DIFF
--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -33,6 +33,16 @@
   #include <cctype>
 #endif  // defined(FLATBUFFERS_CPP98_STL)
 
+// Check if we can use template aliases
+// Not possible if Microsoft Compiler before 2012
+// Possible is the language feature __cpp_alias_templates is defined well
+// Or possible if the C++ std is C+11 or newer
+#if !(defined(_MSC_VER) && _MSC_VER <= 1700 /* MSVC2012 */) \
+  && ((defined(__cpp_alias_templates) && __cpp_alias_templates >= 200704) \
+    || (defined(__cplusplus) && __cplusplus >= 201103L))
+  #define FLATBUFFERS_TEMPLATES_ALIASES
+#endif
+
 // This header provides backwards compatibility for C++98 STLs like stlport.
 namespace flatbuffers {
 
@@ -69,13 +79,13 @@ inline void vector_emplace_back(std::vector<T> *vector, V &&data) {
 }
 
 #ifndef FLATBUFFERS_CPP98_STL
-  #if !(defined(_MSC_VER) && _MSC_VER <= 1700 /* MSVC2012 */)
+  #if defined(FLATBUFFERS_TEMPLATES_ALIASES)
     template <typename T>
     using numeric_limits = std::numeric_limits<T>;
   #else
     template <typename T> class numeric_limits :
       public std::numeric_limits<T> {};
-  #endif  // !(defined(_MSC_VER) && _MSC_VER <= 1700 /* MSVC2012 */)
+  #endif  // defined(FLATBUFFERS_TEMPLATES_ALIASES)
 #else
   template <typename T> class numeric_limits :
       public std::numeric_limits<T> {};
@@ -98,7 +108,7 @@ inline void vector_emplace_back(std::vector<T> *vector, V &&data) {
   };
 #endif  // FLATBUFFERS_CPP98_STL
 
-#if !(defined(_MSC_VER) && _MSC_VER <= 1700 /* MSVC2012 */)
+#if defined(FLATBUFFERS_TEMPLATES_ALIASES)
   #ifndef FLATBUFFERS_CPP98_STL
     template <typename T> using is_scalar = std::is_scalar<T>;
     template <typename T, typename U> using is_same = std::is_same<T,U>;
@@ -119,10 +129,10 @@ inline void vector_emplace_back(std::vector<T> *vector, V &&data) {
   template <typename T> struct is_floating_point :
         public std::is_floating_point<T> {};
   template <typename T> struct is_unsigned : public std::is_unsigned<T> {};
-#endif  // !(defined(_MSC_VER) && _MSC_VER <= 1700 /* MSVC2012 */)
+#endif  // defined(FLATBUFFERS_TEMPLATES_ALIASES)
 
 #ifndef FLATBUFFERS_CPP98_STL
-  #if !(defined(_MSC_VER) && _MSC_VER <= 1700 /* MSVC2012 */)
+  #if defined(FLATBUFFERS_TEMPLATES_ALIASES)
     template <class T> using unique_ptr = std::unique_ptr<T>;
   #else
     // MSVC 2010 doesn't support C++11 aliases.
@@ -148,7 +158,7 @@ inline void vector_emplace_back(std::vector<T> *vector, V &&data) {
         return std::unique_ptr<T>::operator=(p);
       }
     };
-  #endif  // !(defined(_MSC_VER) && _MSC_VER <= 1700 /* MSVC2012 */)
+  #endif  // defined(FLATBUFFERS_TEMPLATES_ALIASES)
 #else
   // Very limited implementation of unique_ptr.
   // This is provided simply to allow the C++ code generated from the default


### PR DESCRIPTION
References #4837.

I updated the check to see if the language feature flag is set appropriately OR if the C++ standard is C++11. This should cover most cases, as those compilers that don't set the __cplusplus flag correctly more than likely don't have template aliases support built in. Even if they do, the code should still compile with the alternative implementation.

