### PR TITLE
Fix ambiguities while parsing numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ dart/.dart_tool/
 dart/build/
 dart/doc/api/
 Cargo.lock
+.corpus
+.seed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,21 @@ if(NOT FLATBUFFERS_BUILD_FLATC AND FLATBUFFERS_BUILD_TESTS)
     set(FLATBUFFERS_BUILD_TESTS OFF)
 endif()
 
+if(DEFINED FLATBUFFERS_FORCE_LOCALE_INDEPENDENT)
+  # Enable locale independent code and define locale for tests.
+  # -DFLATBUFFERS_FORCE_LOCALE_INDEPENDENT="" - enable, but test with default locale
+  # -DFLATBUFFERS_FORCE_LOCALE_INDEPENDENT="ru_RU.CP1251" - enable and test with ru_RU.CP1251
+  # Locale was installed before (Ubuntu):>sudo locale-gen ru_RU.CP1251
+  add_definitions(-DFLATBUFFERS_FORCE_LOCALE_INDEPENDENT=\"${FLATBUFFERS_FORCE_LOCALE_INDEPENDENT}\")
+  message(STATUS "FLATBUFFERS_FORCE_LOCALE_INDEPENDENTo: ${FLATBUFFERS_FORCE_LOCALE_INDEPENDENT}")
+endif()
+
+if(DEFINED FLATBUFFERS_MAX_PARSING_DEPTH)
+  # Override default recursion depth limit.
+  add_definitions(-DFLATBUFFERS_MAX_PARSING_DEPTH=${FLATBUFFERS_MAX_PARSING_DEPTH})
+  message(STATUS "FLATBUFFERS_MAX_PARSING_DEPTH: ${FLATBUFFERS_MAX_PARSING_DEPTH}")
+endif()
+
 set(FlatBuffers_Library_SRCS
   include/flatbuffers/code_generators.h
   include/flatbuffers/base.h

--- a/docs/source/Building.md
+++ b/docs/source/Building.md
@@ -80,6 +80,27 @@ target_link_libraries(own_project_target PRIVATE flatbuffers)
 When build your project the `flatbuffers` library will be compiled and linked 
 to a target as part of your project.
 
+#### Enforce locale-independent mode
+If an application use non ascii-based [locale](@ref flatbuffers_locale_cpp) 
+to enforce locale-independent mode of Flatbuffers library add this directive:
+```cmake
+set(FLATBUFFERS_FORCE_LOCALE_INDEPENDENT "")
+```
+or
+```cmake
+set(FLATBUFFERS_FORCE_LOCALE_INDEPENDENT "<test-locale>")
+```
+to `CMakeLists.txt` file before `add_subdirectory(${FLATBUFFERS_SRC_DIR})` line.
+
+#### Override the depth limit of nested objects
+To override the limit value of the built-in depth recursion 
+[limiter](@ref flatbuffers_guide_use_cpp) add this directive:
+```cmake
+set(FLATBUFFERS_MAX_PARSING_DEPTH 16)
+```
+to `CMakeLists.txt` file before `add_subdirectory(${FLATBUFFERS_SRC_DIR})` line.
+
+
 #### For Google Play apps
 
 For applications on Google Play that integrate this library, usage is tracked.

--- a/docs/source/CppUsage.md
+++ b/docs/source/CppUsage.md
@@ -495,4 +495,45 @@ needed to use unions.
 
 To use scalars, simply wrap them in a struct.
 
+## Dependence from C-locale {#flatbuffers_locale_cpp}
+Flatbuffers [grammar](@ref flatbuffers grammar) is based on ASCII
+character set for reserved words, identifiers and alpha-numeric literals.
+String constants can use utf-8 symbols inside string.
+
+Internal implementation of Flatbuffers depends from functions which depend 
+from C-locale, `strtod()` for example.
+The Standard C locale is a global resource: there is only one locale for the 
+entire application. This makes it hard to build an application that has to 
+handle several locales at a time.
+
+By default, it is assumed that Flatbuffers library compiled and used for 
+applications with C-locales which are compatible with ASCII character set.
+It is assumed that following conditions are true:
+
+- `LC_NUMERIC` use dot `.` symbol as decimal separator. It is used to 
+  separate the integer part from the fractional part of a float number. 
+
+If your application use C-locale which is incompatible with these conditions
+you should activate locale-independent mode while compile Flatbuffers library.
+By default this mode is inactive and activated with global scope define 
+`FLATBUFFERS_FORCE_LOCALE_INDEPENDENT`.
+This define activate locale-independent code and test routines for this mode.
+Test routines expect that `FLATBUFFERS_FORCE_LOCALE_INDEPENDENT` is string with 
+a locale name to test it, for example `"ru_RU.CP1251"`.
+If the locale-independent mode is activated then functions with ability 
+to specify a locale will be used rather than common functions which based on the 
+global or per-thread locale.
+For example, instead of `strtod` will be used `strtod_l` function:
+  - `strtod_l` is available in stdlib++ 2.2 or higher.
+  - `_strtod_l` is available in MSVC since VS2005.
+
+## Limit depth of nested objects and stack-overflow control
+The parser of Flatbuffers schema or json-files is kind of recursive parser.
+To avoid stack-overflow problem the parser has a built-in limiter of recursion depth.
+This mean that number of nested definitions in a schema or number of nested objects in 
+a json-file are hard-limited. By default, this depth limit set to `64`.
+It is possible to override this limit with `FLATBUFFERS_MAX_PARSING_DEPTH` definition.
+This definition can be helpful for testing purposes or embedded applications.
+For details see [build](@ref fflatbuffers_guide_building) of CMake-based projects.
+
 <br>

--- a/docs/source/Grammar.md
+++ b/docs/source/Grammar.md
@@ -49,11 +49,26 @@ file_extension_decl = `file_extension` string\_constant `;`
 
 file_identifier_decl = `file_identifier` string\_constant `;`
 
-integer\_constant = `-?[0-9]+` | `true` | `false`
-
-float\_constant = `-?[0-9]+.[0-9]+((e|E)(+|-)?[0-9]+)?`
-
 string\_constant = `\".*?\"`
 
 ident = `[a-zA-Z_][a-zA-Z0-9_]*`
 
+`[:digit:]` = `[0-9]`
+
+`[:xdigit:]` = `[0-9a-fA-F]`
+
+dec\_integer\_constant = `[-+]?[:digit:]+`
+
+hex\_integer\_constant = `[-+]?0[xX][:xdigit:]+`
+
+integer\_constant = dec\_integer\_constant | hex\_integer\_constant
+
+dec\_float\_constant = `[-+]?(([.][:digit:]+)|([:digit:]+[.][:digit:]*)|([:digit:]+))([eE][-+]?[:digit:]+)?`
+
+hex\_float\_constant = `[-+]?0[xX](([.][:xdigit:]+)|([:xdigit:]+[.][:xdigit:]*)|([:xdigit:]+))([pP][-+]?[:digit:]+)`
+
+special\_float\_constant = `[-+]?(nan|inf|infinity)`
+
+float\_constant = decimal\_float\_constant | hexadecimal\_float\_constant | special\_float\_constant
+
+boolean\_constant = `(true|false)` | (integer\_constant ? `true` : `false`)

--- a/docs/source/Schemas.md
+++ b/docs/source/Schemas.md
@@ -385,6 +385,31 @@ When parsing JSON, it recognizes the following escape codes in strings:
 It also generates these escape codes back again when generating JSON from a
 binary representation.
 
+When parsing numbers, the parser is more flexible than JSON.
+A format of numeric literals is more close to the C/C++.
+According to the [grammar](@ref flatbuffers_grammar), it accepts the following 
+numerical literals:
+
+-   An integer literal can have any number of leading zero `0` digits.
+    Unlike C/C++, the parser ignores a leading zero, not interpreting it as the 
+    beginning of the octal number.
+    The numbers `[081, -00094]` are equal to `[81, -94]`  decimal integers.
+-   The parser accepts unsigned and signed hexadecimal integer numbers.
+    For example: `[0x123, +0x45, -0x67]` are equal to `[291, 69, -103]` decimals.
+-   The format of float-point numbers is fully compatible with C/C++ format.
+    If a modern C++ compiler is used the parser accepts hexadecimal and special 
+    float-point literals as well:
+    `[-1.0, 2., .3e0, 3.e4, 0x21.34p-5, -inf, nan]`.
+    The exponent suffix of hexadecimal float-point number is mandatory.
+    
+    Extended float-point support was tested with:
+    - x64 Windows: `MSVC2015` and higher.
+    - x64 Linux: `LLVM 6.0`, `GCC 4.9` and higher.
+
+-   For compatibility with a JSON lint tool all numeric literals of scalar 
+    fields can be wrapped to quoted string:
+    `"1", "2.0", "0x48A", "0x0C.0Ep-1", "-inf", "true"`.
+
 ## Guidelines
 
 ### Efficiency

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -149,19 +149,23 @@ bool Print<const void *>(const void *val, Type type, int indent,
   return true;
 }
 
+template<typename T> static T GetFieldDefault(const FieldDef &fd) {
+  T val;
+  auto check = StringToNumber(fd.value.constant.c_str(), &val);
+  (void)check;
+  FLATBUFFERS_ASSERT(check);
+  return val;
+}
+
 // Generate text for a scalar field.
-template<typename T> static bool GenField(const FieldDef &fd,
-                                          const Table *table, bool fixed,
-                                          const IDLOptions &opts,
-                                          int indent,
-                                          std::string *_text) {
-  return Print(fixed ?
-    reinterpret_cast<const Struct *>(table)->GetField<T>(fd.value.offset) :
-    table->GetField<T>(fd.value.offset,
-    IsFloat(fd.value.type.base_type) ?
-    static_cast<T>(strtod(fd.value.constant.c_str(), nullptr)) :
-    static_cast<T>(StringToInt(fd.value.constant.c_str()))),
-    fd.value.type, indent, nullptr, opts, _text);
+template<typename T>
+static bool GenField(const FieldDef &fd, const Table *table, bool fixed,
+                     const IDLOptions &opts, int indent, std::string *_text) {
+  return Print(
+      fixed ? reinterpret_cast<const Struct *>(table)->GetField<T>(
+                  fd.value.offset)
+            : table->GetField<T>(fd.value.offset, GetFieldDefault<T>(fd)),
+      fd.value.type, indent, nullptr, opts, _text);
 }
 
 static bool GenStruct(const StructDef &struct_def, const Table *table,

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2014 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -94,11 +94,13 @@ std::string MakeCamel(const std::string &in, bool first) {
 void Parser::Message(const std::string &msg) {
   error_ = file_being_parsed_.length() ? AbsolutePath(file_being_parsed_) : "";
   // clang-format off
-  #ifdef _WIN32
-    error_ += "(" + NumToString(line_) + ")";  // MSVC alike
-  #else
+  #ifdef _WIN32 // MSVC alike
+    error_ += "(" + NumToString(line_) + ", " +
+              NumToString(static_cast<int>(cursor_ - line_start_)) + ")";
+  #else // gcc alike
     if (file_being_parsed_.length()) error_ += ":";
-    error_ += NumToString(line_) + ":0";  // gcc alike
+    error_ += NumToString(line_) + ": " +
+              NumToString(static_cast<int>(cursor_ - line_start_));
   #endif
   // clang-format on
   error_ += ": " + msg;
@@ -118,57 +120,22 @@ CheckedError Parser::RecurseError() {
                " reached");
 }
 
-inline std::string OutOfRangeErrorMsg(int64_t val, const std::string &op,
-                                      int64_t limit) {
-  const std::string cause = NumToString(val) + op + NumToString(limit);
-  return "constant does not fit (" + cause + ")";
+CheckedError Parser::InvalidNumber(const char *number, const std::string &msg) {
+  return Error("invalid number: \"" + std::string(number) + "\"" + msg);
 }
-
-// Ensure that integer values we parse fit inside the declared integer type.
-CheckedError Parser::CheckInRange(int64_t val, int64_t min, int64_t max) {
-  if (val < min)
-    return Error(OutOfRangeErrorMsg(val, " < ", min));
-  else if (val > max)
-    return Error(OutOfRangeErrorMsg(val, " > ", max));
-  else
-    return NoError();
-}
-
 // atot: templated version of atoi/atof: convert a string to an instance of T.
 template<typename T>
 inline CheckedError atot(const char *s, Parser &parser, T *val) {
-  int64_t i = StringToInt(s);
-  const int64_t min = flatbuffers::numeric_limits<T>::min();
-  const int64_t max = flatbuffers::numeric_limits<T>::max();
-  *val = (T)i;  // Assign this first to make ASAN happy.
-  return parser.CheckInRange(i, min, max);
-}
-template<>
-inline CheckedError atot<uint64_t>(const char *s, Parser &parser,
-                                   uint64_t *val) {
-  (void)parser;
-  *val = StringToUInt(s);
-  return NoError();
-}
-template<>
-inline CheckedError atot<bool>(const char *s, Parser &parser, bool *val) {
-  (void)parser;
-  *val = 0 != atoi(s);
-  return NoError();
-}
-template<>
-inline CheckedError atot<float>(const char *s, Parser &parser, float *val) {
-  (void)parser;
-  *val = static_cast<float>(strtod(s, nullptr));
-  return NoError();
-}
-template<>
-inline CheckedError atot<double>(const char *s, Parser &parser, double *val) {
-  (void)parser;
-  *val = strtod(s, nullptr);
-  return NoError();
-}
+  auto done = StringToNumber(s, val);
+  if (done) return NoError();
 
+  return parser.InvalidNumber(
+      s, (0 == *val)
+             ? ""
+             : (", constant does not fit [" +
+                NumToString(flatbuffers::numeric_limits<T>::lowest()) + "; " +
+                NumToString(flatbuffers::numeric_limits<T>::max()) + "]"));
+}
 template<>
 inline CheckedError atot<Offset<void>>(const char *s, Parser &parser,
                                        Offset<void> *val) {
@@ -260,13 +227,21 @@ CheckedError Parser::SkipByteOrderMark() {
   return NoError();
 }
 
-bool IsIdentifierStart(char c) {
-  return isalpha(static_cast<unsigned char>(c)) || c == '_';
+inline bool IsIdentifierStart(char c) {
+  // isalpha depends from the current C-locale.
+  return ((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z')) || (c == '_');
+}
+
+// Local short to check is a decimal or hexadecimal digit.
+static inline bool is_dechex(char c, bool hex = false) {
+  return !!(hex ? isxdigit(static_cast<unsigned char>(c))
+                : isdigit(static_cast<unsigned char>(c)));
 }
 
 CheckedError Parser::Next() {
   doc_comment_.clear();
   bool seen_newline = cursor_ == source_;
+  attr_is_escaped_str_ = false;
   attribute_.clear();
   for (;;) {
     char c = *cursor_++;
@@ -280,7 +255,7 @@ CheckedError Parser::Next() {
       case '\r':
       case '\t': break;
       case '\n':
-        line_++;
+        MarkNewLine();
         seen_newline = true;
         break;
       case '{':
@@ -293,10 +268,6 @@ CheckedError Parser::Next() {
       case ':':
       case ';':
       case '=': return NoError();
-      case '.':
-        if (!isdigit(static_cast<unsigned char>(*cursor_)))
-          return NoError();
-        return Error("floating point constant can\'t start with \".\"");
       case '\"':
       case '\'': {
         int unicode_high_surrogate = -1;
@@ -305,6 +276,7 @@ CheckedError Parser::Next() {
           if (*cursor_ < ' ' && static_cast<signed char>(*cursor_) >= 0)
             return Error("illegal character in string constant");
           if (*cursor_ == '\\') {
+            attr_is_escaped_str_ = true;  // string has escape sequence
             cursor_++;
             if (unicode_high_surrogate != -1 && *cursor_ != 'u') {
               return Error(
@@ -420,7 +392,7 @@ CheckedError Parser::Next() {
           cursor_++;
           // TODO: make nested.
           while (*cursor_ != '*' || cursor_[1] != '/') {
-            if (*cursor_ == '\n') line_++;
+            if (*cursor_ == '\n') MarkNewLine();
             if (!*cursor_) return Error("end of file in comment");
             cursor_++;
           }
@@ -429,51 +401,74 @@ CheckedError Parser::Next() {
         }
         // fall thru
       default:
-        if (IsIdentifierStart(c)) {
+        const auto has_sign = (c == '+') || (c == '-');
+        // '-'/'+' and following identifier - can be a predefined constant like:
+        // NAN, INF, PI, etc.
+        if (IsIdentifierStart(c) || (has_sign && IsIdentifierStart(*cursor_))) {
           // Collect all chars of an identifier:
           const char *start = cursor_ - 1;
-          while (isalnum(static_cast<unsigned char>(*cursor_)) || *cursor_ == '_')
+          while (IsIdentifierStart(*cursor_) ||
+                 isdigit(static_cast<unsigned char>(*cursor_)))
             cursor_++;
           attribute_.append(start, cursor_);
-          token_ = kTokenIdentifier;
+          token_ = has_sign ? kTokenStringConstant : kTokenIdentifier;
           return NoError();
-        } else if (isdigit(static_cast<unsigned char>(c)) || c == '-') {
-          const char *start = cursor_ - 1;
-          if (c == '-' && *cursor_ == '0' &&
-              (cursor_[1] == 'x' || cursor_[1] == 'X')) {
-            ++start;
-            ++cursor_;
-            attribute_.append(&c, &c + 1);
-            c = '0';
+        }
+
+        const auto dot = (c == '.');
+        if (dot && !is_dechex(*cursor_)) return NoError();
+        // Parser accepts hexadecimal-ﬂoating-literal (see C++ 5.13.4).
+        if (dot || has_sign || is_dechex(c)) {
+          auto is_float = dot;
+          const auto start = cursor_ - 1;
+          auto start_digits = is_dechex(c) ? start : cursor_;
+          if ((dot || has_sign) && is_dechex(*cursor_)) {
+            start_digits = cursor_;  // see digit in cursor_ position
+            c = *cursor_++;
           }
-          if (c == '0' && (*cursor_ == 'x' || *cursor_ == 'X')) {
+          // hex-float can't starts from dot
+          auto use_hex =
+              !dot && (c == '0' && (*cursor_ == 'x' || *cursor_ == 'X'));
+          if (use_hex) {
             cursor_++;
-            while (isxdigit(static_cast<unsigned char>(*cursor_))) cursor_++;
-            attribute_.append(start + 2, cursor_);
-            attribute_ = NumToString(static_cast<int64_t>(
-                StringToUInt(attribute_.c_str(), nullptr, 16)));
-            token_ = kTokenIntegerConstant;
-            return NoError();
+            start_digits = cursor_;  // '0x' is prefix only
           }
-          while (isdigit(static_cast<unsigned char>(*cursor_))) cursor_++;
-          if (*cursor_ == '.' || *cursor_ == 'e' || *cursor_ == 'E') {
+          while (is_dechex(*cursor_, use_hex)) cursor_++;
             if (*cursor_ == '.') {
+            if (dot) {
+              // raise the double-dot error
+              start_digits = cursor_;
+            } else {
               cursor_++;
-              while (isdigit(static_cast<unsigned char>(*cursor_))) cursor_++;
+              is_float = true;
+              while (is_dechex(*cursor_, use_hex)) cursor_++;
             }
-            // See if this float has a scientific notation suffix. Both JSON
-            // and C++ (through strtod() we use) have the same format:
-            if (*cursor_ == 'e' || *cursor_ == 'E') {
-              cursor_++;
-              if (*cursor_ == '+' || *cursor_ == '-') cursor_++;
-              while (isdigit(static_cast<unsigned char>(*cursor_))) cursor_++;
-            }
-            token_ = kTokenFloatConstant;
-          } else {
-            token_ = kTokenIntegerConstant;
           }
-          attribute_.append(start, cursor_);
-          return NoError();
+          if (cursor_ > start_digits) {
+            // The exponent suffix of hexadecimal float-point number is mandatory.
+            if (is_float && use_hex) start_digits = cursor_;
+            if ((*cursor_ == 'e' || *cursor_ == 'E') ||
+                (use_hex && (*cursor_ == 'p' || *cursor_ == 'P'))) {
+              cursor_++;
+              is_float = true;
+              if (*cursor_ == '+' || *cursor_ == '-') cursor_++;
+              start_digits = cursor_;  // the exponent-part has to have digits
+              while (is_dechex(*cursor_)) cursor_++;
+            }
+          }
+          // If see the dot after the number, treat it as part of number.
+          if (*cursor_ == '.') {
+            cursor_++;               // consume this dot
+            start_digits = cursor_;  // raise the double-dot error
+          }
+          // Finalize
+          if ((cursor_ > start_digits)) {
+            attribute_.append(start, cursor_);
+            token_ = is_float ? kTokenFloatConstant : kTokenIntegerConstant;
+            return NoError();
+          } else {
+            return Error("invalid number: " + std::string(start, cursor_));
+          }
         }
         std::string ch;
         ch = c;
@@ -673,7 +668,7 @@ CheckedError Parser::ParseField(StructDef &struct_def) {
         (struct_def.fixed && field->value.constant != "0"))
       return Error(
             "default values currently only supported for scalars in tables");
-    ECHECK(ParseSingleValue(&field->name, field->value));
+    ECHECK(ParseSingleValue(&field->name, field->value, true));
   }
   if (type.enum_def &&
       !type.enum_def->is_union &&
@@ -683,9 +678,17 @@ CheckedError Parser::ParseField(StructDef &struct_def) {
     return Error("default value of " + field->value.constant + " for field " +
                  name + " is not part of enum " + type.enum_def->name);
   }
+  // Append .0 if the value has not it (skip hex and scientific floats).
+  // This suffix needed for generated C++ code.
   if (IsFloat(type.base_type)) {
-    if (!strpbrk(field->value.constant.c_str(), ".eE"))
+    auto &text = field->value.constant;
+    FLATBUFFERS_ASSERT(false == text.empty());
+    // 1) A float constants (nan, inf, pi, etc) end with non-digit.
+    // 2) A hex-float doesn't require .0 at the end.
+    if (!!isdigit(static_cast<unsigned char>(text.back())) &&
+        (std::string::npos == field->value.constant.find_first_of(".eExX"))) {
       field->value.constant += ".0";
+    }
   }
 
   if (type.enum_def && IsScalar(type.base_type) && !struct_def.fixed &&
@@ -914,11 +917,13 @@ CheckedError Parser::ParseAnyValue(Value &val, FieldDef *field,
           (token_ == kTokenIdentifier || token_ == kTokenStringConstant)) {
         ECHECK(ParseHash(val, field));
       } else {
-        ECHECK(ParseSingleValue(field ? &field->name : nullptr, val));
+        ECHECK(ParseSingleValue(field ? &field->name : nullptr, val, false));
       }
       break;
     }
-    default: ECHECK(ParseSingleValue(field ? &field->name : nullptr, val)); break;
+    default:
+      ECHECK(ParseSingleValue(field ? &field->name : nullptr, val, false));
+      break;
   }
   return NoError();
 }
@@ -993,7 +998,8 @@ CheckedError Parser::ParseTable(const StructDef &struct_def, std::string *value,
             ECHECK(parser->SkipAnyJsonValue());
           }
         } else {
-          if (parser->IsIdent("null")) {
+          if (parser->IsIdent("null") &&
+              !IsScalar(field->value.type.base_type)) {
             ECHECK(parser->Next());  // Ignore this field.
           } else {
             Value val = field->value;
@@ -1251,7 +1257,7 @@ CheckedError Parser::ParseMetaData(SymbolTable<Value> *attributes) {
       attributes->Add(name, e);
       if (Is(':')) {
         NEXT();
-        ECHECK(ParseSingleValue(&name, *e));
+        ECHECK(ParseSingleValue(&name, *e, true));
       }
       if (Is(')')) {
         NEXT();
@@ -1263,23 +1269,40 @@ CheckedError Parser::ParseMetaData(SymbolTable<Value> *attributes) {
   return NoError();
 }
 
-CheckedError Parser::TryTypedValue(const std::string *name, int dtoken, bool check, Value &e,
-                                   BaseType req, bool *destmatch) {
+CheckedError Parser::TryTypedValue(const std::string *name, int dtoken,
+                                   bool check, Value &e, BaseType req,
+                                   bool *destmatch) {
   bool match = dtoken == token_;
   if (match) {
+    FLATBUFFERS_ASSERT(*destmatch == false);
     *destmatch = true;
     e.constant = attribute_;
+    // Check token match
     if (!check) {
       if (e.type.base_type == BASE_TYPE_NONE) {
         e.type.base_type = req;
       } else {
-        return Error(std::string("type mismatch: expecting: ") +
-                     kTypeNames[e.type.base_type] +
-                     ", found: " + kTypeNames[req] +
-                     ", name: " + (name ? *name : "") +
-                     ", value: " + e.constant);
+        return Error(
+            std::string("type mismatch: expecting: ") +
+            kTypeNames[e.type.base_type] + ", found: " + kTypeNames[req] +
+            ", name: " + (name ? *name : "") + ", value: " + e.constant);
       }
     }
+    // The exponent suffix of hexadecimal float-point number is mandatory.
+    // A hex-integer constant is forbidden as an initializer of float number.
+    if ((kTokenFloatConstant != dtoken) && IsFloat(e.type.base_type)) {
+      const auto &s = e.constant;
+      const auto k = s.find_first_of("0123456789.");
+      if ((std::string::npos != k) && (s.length() > (k + 1)) &&
+          (s.at(k) == '0' && (s.at(k + 1) == 'x' || s.at(k + 1) == 'X')) &&
+          (std::string::npos == s.find_first_of("pP", k + 2))) {
+        return Error(
+            "invalid number, the exponent suffix of hexadecimal "
+            "floating-point literals is mandatory: \"" +
+            s + "\"");
+      }
+    }
+
     NEXT();
   }
   return NoError();
@@ -1374,20 +1397,29 @@ CheckedError Parser::TokenError() {
   return Error("cannot parse value starting with: " + TokenToStringId(token_));
 }
 
-CheckedError Parser::ParseSingleValue(const std::string *name, Value &e) {
+CheckedError Parser::ParseSingleValue(const std::string *name, Value &e,
+                                      bool check_now) {
   // First see if this could be a conversion function:
   if (token_ == kTokenIdentifier && *cursor_ == '(') {
-    auto functionname = attribute_;
+    // todo: Extract processing of conversion functions to ParseFunction.
+    const auto functionname = attribute_;
+    if (!IsFloat(e.type.base_type)) {
+      return Error(functionname + ": type of argument mismatch, expecting: " +
+                   kTypeNames[BASE_TYPE_DOUBLE] +
+                   ", found: " + kTypeNames[e.type.base_type] +
+                   ", name: " + (name ? *name : "") + ", value: " + e.constant);
+    }
     NEXT();
     EXPECT('(');
-    ECHECK(ParseSingleValue(name, e));
+    ECHECK(Recurse([&]() { return ParseSingleValue(name, e, false); }));
     EXPECT(')');
+    // calculate with double precision
+    double x, y = 0.0;
+    ECHECK(atot(e.constant.c_str(), *this, &x));
+    auto func_match = false;
     // clang-format off
     #define FLATBUFFERS_FN_DOUBLE(name, op) \
-      if (functionname == name) { \
-        auto x = strtod(e.constant.c_str(), nullptr); \
-        e.constant = NumToString(op); \
-      }
+      if (!func_match && functionname == name) { y = op; func_match = true; }
     FLATBUFFERS_FN_DOUBLE("deg", x / kPi * 180);
     FLATBUFFERS_FN_DOUBLE("rad", x * kPi / 180);
     FLATBUFFERS_FN_DOUBLE("sin", sin(x));
@@ -1399,47 +1431,107 @@ CheckedError Parser::ParseSingleValue(const std::string *name, Value &e) {
     // TODO(wvo): add more useful conversion functions here.
     #undef FLATBUFFERS_FN_DOUBLE
     // clang-format on
-    // Then check if this could be a string/identifier enum value:
-  } else if (e.type.base_type != BASE_TYPE_STRING &&
-             e.type.base_type != BASE_TYPE_BOOL &&
-             e.type.base_type != BASE_TYPE_NONE &&
-             (token_ == kTokenIdentifier || token_ == kTokenStringConstant)) {
-    if (IsIdentifierStart(attribute_[0])) {  // Enum value.
+    if (true != func_match)
+      return Error(std::string("Unknown conversion function: ") + functionname +
+                   ", field name: " + (name ? *name : "") +
+                   ", value: " + e.constant);
+    e.constant = NumToString(y);
+    return NoError();
+  }
+
+  auto match = false;
+  // clang-format off
+  // ((void)0,force) - use comma operator to suppress warning C4127 (MSVC 2010)
+  #define TRY_ECHECK(force, dtoken, check, req) \
+    if (!match && ((check) || ((void)0,force))) \
+      ECHECK(TryTypedValue(name, dtoken, check, e, req, &match))
+  // clang-format on
+
+  if (token_ == kTokenStringConstant || token_ == kTokenIdentifier) {
+    const auto kTokenStringOrIdent = token_;
+    // The string type is a most probable type, check it first.
+    TRY_ECHECK(false, kTokenStringConstant,
+               e.type.base_type == BASE_TYPE_STRING, BASE_TYPE_STRING);
+
+    // If current token isn't a string, check escapes inside string.
+    if (attr_is_escaped_str_) {
+      return Error(
+          std::string("type mismatch or invalid value, escaped characters are "
+                      "forbidden for non-string data type: ") +
+          kTypeNames[e.type.base_type] + ", name: " + (name ? *name : "") +
+          ", value: " + attribute_);
+    }
+
+    // A boolean as true/false. Boolean as Integer check below.
+    if (!match && IsBool(e.type.base_type)) {
+      auto is_true = attribute_ == "true";
+      if (is_true || attribute_ == "false") {
+        attribute_ = is_true ? "1" : "0";
+        // accepts both kTokenStringConstant and kTokenIdentifier
+        TRY_ECHECK(false, kTokenStringOrIdent, IsBool(e.type.base_type),
+                   BASE_TYPE_BOOL);
+      }
+    }
+    // Check if this could be a string/identifier enum value.
+    // Enum can have only true integer base type.
+    if (!match && IsInteger(e.type.base_type) && !IsBool(e.type.base_type) &&
+        IsIdentifierStart(*attribute_.c_str())) {
       int64_t val;
       ECHECK(ParseEnumFromString(e.type, &val));
       e.constant = NumToString(val);
       NEXT();
-    } else {  // Numeric constant in string.
-      if (IsInteger(e.type.base_type)) {
-        char *end;
-        e.constant = NumToString(StringToInt(attribute_.c_str(), &end));
-        if (*end) return Error("invalid integer: " + attribute_);
-      } else if (IsFloat(e.type.base_type)) {
-        char *end;
-        e.constant = NumToString(strtod(attribute_.c_str(), &end));
-        if (*end) return Error("invalid float: " + attribute_);
-      } else {
-        FLATBUFFERS_ASSERT(0);  // Shouldn't happen, we covered all types.
-        e.constant = "0";
-      }
-      NEXT();
+      match = true;
     }
+    // float/integer number in string
+    if ((token_ == kTokenStringConstant) && IsScalar(e.type.base_type)) {
+      // remove trailing whitespaces from attribute_
+      auto last = attribute_.find_last_not_of(' ');
+      if (std::string::npos != last)  // has non-whitespace
+        attribute_.resize(last + 1);
+    }
+    // Float numbers or nan, inf, pi, etc.
+    TRY_ECHECK(false, kTokenStringOrIdent, IsFloat(e.type.base_type),
+               BASE_TYPE_FLOAT);
+    // An integer constant in string.
+    TRY_ECHECK(false, kTokenStringOrIdent, IsInteger(e.type.base_type),
+               BASE_TYPE_INT);
+    // Unknown tokens will be interpreted as string type.
+    TRY_ECHECK(true, kTokenStringConstant, e.type.base_type == BASE_TYPE_STRING,
+               BASE_TYPE_STRING);
   } else {
-    bool match = false;
-    ECHECK(TryTypedValue(name, kTokenIntegerConstant, IsScalar(e.type.base_type), e,
-                         BASE_TYPE_INT, &match));
-    ECHECK(TryTypedValue(name, kTokenFloatConstant, IsFloat(e.type.base_type), e,
-                         BASE_TYPE_FLOAT, &match));
-    ECHECK(TryTypedValue(name, kTokenStringConstant,
-                         e.type.base_type == BASE_TYPE_STRING, e,
-                         BASE_TYPE_STRING, &match));
-    auto istrue = IsIdent("true");
-    if (istrue || IsIdent("false")) {
-      attribute_ = NumToString(istrue);
-      ECHECK(TryTypedValue(name, kTokenIdentifier, IsBool(e.type.base_type), e,
-                           BASE_TYPE_BOOL, &match));
+    // Try a float number.
+    TRY_ECHECK(false, kTokenFloatConstant, IsFloat(e.type.base_type),
+               BASE_TYPE_FLOAT);
+    // Integer token can init any scalar (integer of float).
+    TRY_ECHECK(true, kTokenIntegerConstant, IsScalar(e.type.base_type),
+               BASE_TYPE_INT);
+  }
+  #undef TRY_ECHECK
+
+  if (!match) return TokenError();
+
+  // The check_now flag must be true when parse a fbs-schema.
+  // This flag forces to check default scalar values or metadata of field.
+  // For JSON parser the flag should be false.
+  // If it is set for JSON each value will be checked twice (see ParseTable).
+  if (check_now && IsScalar(e.type.base_type)) {
+    // "re-pack" an integer scalar to remove any ambiguities like leading zeros
+    // which can be treated as octal-literal (idl_gen_cpp/GenDefaultConstant).
+    const auto repack = IsInteger(e.type.base_type);
+    switch (e.type.base_type) {
+    // clang-format off
+    #define FLATBUFFERS_TD(ENUM, IDLTYPE, \
+            CTYPE, JTYPE, GTYPE, NTYPE, PTYPE, RTYPE) \
+            case BASE_TYPE_ ## ENUM: {\
+                CTYPE val; \
+                ECHECK(atot(e.constant.c_str(), *this, &val)); \
+                if(repack) e.constant = NumToString(val); \
+              break; }
+    FLATBUFFERS_GEN_TYPES_SCALAR(FLATBUFFERS_TD);
+    #undef FLATBUFFERS_TD
+    default: break;
+    // clang-format on
     }
-    if (!match) return TokenError();
   }
   return NoError();
 }
@@ -1564,7 +1656,7 @@ CheckedError Parser::ParseEnum(bool is_union, EnumDef **dest) {
       }
       if (Is('=')) {
         NEXT();
-        ev.value = StringToInt(attribute_.c_str());
+        ECHECK(atot(attribute_.c_str(), *this, &ev.value));
         EXPECT(kTokenIntegerConstant);
         if (!opts.proto_mode && prevsize &&
             enum_def->vals.vec[prevsize - 1]->value >= ev.value)
@@ -2253,14 +2345,17 @@ bool Parser::ParseFlexBuffer(const char *source, const char *source_filename,
 
 bool Parser::Parse(const char *source, const char **include_paths,
                    const char *source_filename) {
-  return !ParseRoot(source, include_paths, source_filename).Check();
+  FLATBUFFERS_ASSERT(0 == recurse_protection_counter);
+  auto r = !ParseRoot(source, include_paths, source_filename).Check();
+  FLATBUFFERS_ASSERT(0 == recurse_protection_counter);
+  return r;
 }
 
 CheckedError Parser::StartParseFile(const char *source,
                                     const char *source_filename) {
   file_being_parsed_ = source_filename ? source_filename : "";
-  source_ = cursor_ = source;
-  line_ = 1;
+  source_ = source;
+  ResetState(source_);
   error_.clear();
   ECHECK(SkipByteOrderMark());
   NEXT();
@@ -2447,6 +2542,9 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
                                                  ? file_identifier_.c_str()
                                                  : nullptr);
       }
+      // Check that JSON file doesn't contain more objects or IDL directives.
+      // Comments after JSON are allowed.
+      EXPECT(kTokenEof);
     } else if (IsIdent("enum")) {
       ECHECK(ParseEnum(false, nullptr));
     } else if (IsIdent("union")) {
@@ -2602,7 +2700,9 @@ Offset<reflection::Field> FieldDef::Serialize(FlatBufferBuilder *builder,
   return reflection::CreateField(
       *builder, builder->CreateString(name), value.type.Serialize(builder), id,
       value.offset,
+      // Is uint64>max(int64) tested?
       IsInteger(value.type.base_type) ? StringToInt(value.constant.c_str()) : 0,
+      // result may be platform-dependent if underlying is float (not double)
       IsFloat(value.type.base_type) ? strtod(value.constant.c_str(), nullptr)
                                     : 0.0,
       deprecated, required, key, SerializeAttributes(builder, parser),
@@ -2755,6 +2855,97 @@ std::string Parser::ConformTo(const Parser &base) {
     }
   }
   return "";
+}
+
+// Locate all code related to LOCALE_INDEPENDENT in one compilation unit.
+// Is it better to return this code to the util.h?
+#if defined(FLATBUFFERS_FORCE_LOCALE_INDEPENDENT)
+// Static RAII holder of default C-locale
+class UtilDefaultLocale final {
+ public:
+  // clang-format off
+  #ifdef _MSC_VER
+  typedef _locale_t locale_type;
+  #else
+  typedef locale_t locale_type;
+  #endif
+  // clang-format on
+  static locale_type get() { return instance_.locale_; }
+
+ private:
+  static UtilDefaultLocale instance_;
+  locale_type locale_;
+
+  // clang-format offx
+  #ifdef _MSC_VER
+  UtilDefaultLocale() : locale_(_create_locale(LC_ALL, "C")) {}
+  ~UtilDefaultLocale() { _free_locale(locale_); }
+  #else
+  UtilDefaultLocale() : locale_(newlocale(LC_ALL, "C", (locale_t)0)) {}
+  ~UtilDefaultLocale() { freelocale(locale_); }
+  #endif
+  // clang-format onx
+};
+// allocate locate at startup of application
+UtilDefaultLocale UtilDefaultLocale::instance_;
+
+#endif
+
+double strtod_impl(const char *str, char **str_end){
+  // Result of strtod (printf, etc) depends from current C-locale.
+  // Most of locales use the dot '.' as decimal delimiter, but some use ','
+  // instead.
+  // User should predefine macro FLATBUFFERS_FORCE_LOCALE_INDEPENDENT to enable
+  // strtod_l/strtof_l usage.
+  // 1) _strtod_l is available in MSVC since VS2005
+  // 2) #if (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ > 2))
+
+  // clang-format off
+  #if !defined(FLATBUFFERS_FORCE_LOCALE_INDEPENDENT)
+    return strtod(str, str_end);
+  #else
+    #ifdef _MSC_VER
+      return _strtod_l(str, str_end, UtilDefaultLocale::get());
+    #else
+      return strtod_l(str, str_end, UtilDefaultLocale::get());
+    #endif
+  #endif
+  // clang-format on
+}
+
+float strtof_impl(const char *str, char **str_end)
+{
+// Use "strtof" for float and strtod for double to avoid double=>float rounding
+// problems (see https://en.cppreference.com/w/cpp/numeric/fenv/feround) or
+// problems with std::numeric_limits<float>::is_iec559==false.
+// Example:
+//  for (int mode : { FE_DOWNWARD, FE_TONEAREST, FE_TOWARDZERO, FE_UPWARD }){
+//    const char *s = "-4e38";
+//    std::fesetround(mode);
+//    std::cout << strtof(s, nullptr) << "; " << strtod(s, nullptr) << "; "
+//              << static_cast<float>(strtod(s, nullptr)) << "\n";
+//  }
+// Gives:
+//  -inf; -4e+38; -inf
+//  -inf; -4e+38; -inf
+//  -inf; -4e+38; -3.40282e+38
+//  -inf; -4e+38; -3.40282e+38
+
+  // clang-format off
+  #if !defined(FLATBUFFERS_HAS_EXTRA_FLOAT)
+    return static_cast<float>(strtod_impl(str, str_end));
+  #else
+    #if !defined(FLATBUFFERS_FORCE_LOCALE_INDEPENDENT)
+      return strtof(str, str_end);
+    #else
+      #ifdef _MSC_VER
+        return _strtof_l(str, str_end, UtilDefaultLocale::get());
+      #else
+        return strtof_l(str, str_end, UtilDefaultLocale::get());
+      #endif
+    #endif
+  #endif
+  // clang-format on
 }
 
 }  // namespace flatbuffers

--- a/tests/fuzzer/.clang-format
+++ b/tests/fuzzer/.clang-format
@@ -1,0 +1,13 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+DerivePointerAlignment: false
+PointerAlignment: Right
+IndentPPDirectives: AfterHash
+Cpp11BracedListStyle: false
+AlwaysBreakTemplateDeclarations: false
+AllowShortCaseLabelsOnASingleLine: true
+SpaceAfterTemplateKeyword: false
+AllowShortBlocksOnASingleLine: true
+...
+

--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.9)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+# remove Release
+set(CMAKE_CONFIGURATION_TYPES Debug CACHE TYPE INTERNAL FORCE)
+message("Build type: ${CMAKE_BUILD_TYPE}")
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type was overridden to Debug" FORCE)
+endif(NOT CMAKE_BUILD_TYPE)
+
+project(FlatBuffersFuzzerTests)
+
+set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -pedantic -Werror -Wextra -Wno-unused-parameter -fsigned-char")
+
+set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS} -g -fsigned-char -fno-omit-frame-pointer")
+
+set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS} -fsanitize=fuzzer,address,undefined,alignment,signed-integer-overflow")
+
+set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS} -fsanitize-coverage=edge,trace-cmp")
+
+# enable link-time optimisation
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
+
+# https://llvm.org/docs/Passes.html
+# save IR to see call graph
+# make one bitcode file:> llvm-link *.bc -o out.bc
+# print call-graph:> opt out.bc -analyze -print-callgraph &> callgraph.txt
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -save-temps -flto")
+
+# use llvm-linker lld
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fuse-ld=lld")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+
+set(FLATBUFFERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
+
+set(FlatBuffers_Library_SRCS
+  ${FLATBUFFERS_DIR}/include/flatbuffers/code_generators.h
+  ${FLATBUFFERS_DIR}/include/flatbuffers/base.h
+  ${FLATBUFFERS_DIR}/include/flatbuffers/flatbuffers.h
+  ${FLATBUFFERS_DIR}/include/flatbuffers/hash.h
+  ${FLATBUFFERS_DIR}/include/flatbuffers/idl.h
+  ${FLATBUFFERS_DIR}/include/flatbuffers/util.h
+  ${FLATBUFFERS_DIR}/include/flatbuffers/reflection.h
+  ${FLATBUFFERS_DIR}/include/flatbuffers/reflection_generated.h
+  ${FLATBUFFERS_DIR}/include/flatbuffers/stl_emulation.h
+  ${FLATBUFFERS_DIR}/include/flatbuffers/flexbuffers.h
+  ${FLATBUFFERS_DIR}/include/flatbuffers/registry.h
+  ${FLATBUFFERS_DIR}/include/flatbuffers/minireflect.h
+  ${FLATBUFFERS_DIR}/src/code_generators.cpp
+  ${FLATBUFFERS_DIR}/src/idl_parser.cpp
+  ${FLATBUFFERS_DIR}/src/idl_gen_text.cpp
+  ${FLATBUFFERS_DIR}/src/reflection.cpp
+  ${FLATBUFFERS_DIR}/src/util.cpp
+)
+
+include_directories(${FLATBUFFERS_DIR}/include)
+add_library(flatbuffers STATIC ${FlatBuffers_Library_SRCS})
+
+# force to check the RecursionError in the test
+target_compile_definitions(flatbuffers PRIVATE
+  FLATBUFFERS_MAX_PARSING_DEPTH=8)
+
+# enable locale independend code and check it
+target_compile_definitions(flatbuffers PUBLIC
+  FLATBUFFERS_FORCE_LOCALE_INDEPENDENT="ru_RU.CP1251")
+
+
+add_executable(scalar_fuzzer flatbuffers_scalar_fuzzer.cc)
+target_link_libraries(scalar_fuzzer PRIVATE flatbuffers)
+
+add_executable(parser_fuzzer flatbuffers_parser_fuzzer.cc)
+target_link_libraries(parser_fuzzer PRIVATE flatbuffers)
+
+add_executable(verifier_fuzzer flatbuffers_verifier_fuzzer.cc)
+target_link_libraries(verifier_fuzzer PRIVATE flatbuffers)
+target_include_directories(verifier_fuzzer PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../")

--- a/tests/fuzzer/flatbuffers_parser_fuzzer.cc
+++ b/tests/fuzzer/flatbuffers_parser_fuzzer.cc
@@ -3,14 +3,52 @@
 // found in the LICENSE file.
 #include <stddef.h>
 #include <stdint.h>
+#include <clocale>
 #include <string>
 
 #include "flatbuffers/idl.h"
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  flatbuffers::Parser parser;
+#define flags_strict_json 0x01
+#define flags_skip_unexpected_fields_in_json 0x02
+#define flags_allow_non_utf8 0x04
+#define flags_flag_4 0x08
+#define flags_flag_5 0x10
+#define flags_flag_6 0x20
+#define flags_flag_7 0x40
+#define flags_clocale 0x80  // change default C-locale
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  // Reserve one byte for Parser flags.
+  if (size < 1) return 0;
+  // REMEMBER: the first character in crash dump is not part of input!
+  // Extract single byte for fuzzing flags value.
+  const uint8_t flags = data[0];
+  data += 1;  // move to next
+  size -= 1;
+
+  const std::string original(reinterpret_cast<const char *>(data), size);
+  auto input = std::string(original.c_str());  // until '\0'
+  if (input.empty()) return 0;
+
+// Change default ASCII locale (affects to isalpha, isalnum, decimal
+// delimiters, other). https://en.cppreference.com/w/cpp/locale/setlocale
+#if defined(FLATBUFFERS_FORCE_LOCALE_INDEPENDENT)
+  if (flags & flags_clocale) {
+    // The ru_RU.CP1251 use ',' as decimal point delimiter instead of '.'.
+    // std::to_string(12.0) will return "12,0000".
+    // Ubuntu:>sudo locale-gen ru_RU.CP1251
+    assert(std::setlocale(LC_ALL, FLATBUFFERS_FORCE_LOCALE_INDEPENDENT));
+  }
+#endif
+
+  flatbuffers::IDLOptions opts;
+  opts.strict_json = (flags & flags_strict_json);
+  opts.skip_unexpected_fields_in_json =
+      (flags & flags_skip_unexpected_fields_in_json);
+  opts.allow_non_utf8 = (flags & flags_allow_non_utf8);
+
+  flatbuffers::Parser parser(opts);
   // Guarantee 0-termination.
-  std::string s(reinterpret_cast<const char *>(data), size);
-  parser.Parse(s.c_str());
+  parser.Parse(input.c_str());
   return 0;
 }

--- a/tests/fuzzer/flatbuffers_scalar_fuzzer.cc
+++ b/tests/fuzzer/flatbuffers_scalar_fuzzer.cc
@@ -1,0 +1,380 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <algorithm>
+#include <clocale>
+#include <memory>
+#include <regex>
+#include <string>
+
+#include "flatbuffers/idl.h"
+
+#define flags_scalar_type 0x0F  // type of scalar value
+#define flags_quotes_kind 0x10  // quote " or '
+#define flags_json_bracer 0x20  // {} or []
+#define flags_0x40 0x40         // reserved flag
+#define flags_clocale 0x80      // change default C-locale
+
+#define TEST_OUTPUT_LINE(...)     \
+  {                               \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n");        \
+  }
+
+static void TestFail(const char *expval, const char *val, const char *exp,
+                     const char *file, int line) {
+  TEST_OUTPUT_LINE("VALUE: \"%s\"", expval);
+  TEST_OUTPUT_LINE("EXPECTED: \"%s\"", val);
+  TEST_OUTPUT_LINE("TEST FAILED: %s:%d, %s", file, line, exp);
+  assert(0);
+}
+
+static void TestEqStr(const char *expval, const char *val, const char *exp,
+                      const char *file, int line) {
+  if (strcmp(expval, val) != 0) { TestFail(expval, val, exp, file, line); }
+}
+
+template<typename T, typename U>
+void TestEq(T expval, U val, const char *exp, const char *file, int line) {
+  if (U(expval) != val) {
+    TestFail(flatbuffers::NumToString(expval).c_str(),
+             flatbuffers::NumToString(val).c_str(), exp, file, line);
+  }
+}
+
+#define TEST_EQ(exp, val) TestEq(exp, val, #exp, __FILE__, __LINE__)
+#define TEST_NOTNULL(exp) TestEq(exp == NULL, false, #exp, __FILE__, __LINE__)
+#define TEST_EQ_STR(exp, val) TestEqStr(exp, val, #exp, __FILE__, __LINE__)
+
+static void BreakSequence(std::string &s, const char *subj, char repl) {
+  size_t pos = 0;
+  while (pos = s.find(subj, pos), pos != std::string::npos) s.at(pos) = repl;
+}
+
+static std::string strip_string(const std::string &s, const char *pattern,
+                                size_t *pos = nullptr) {
+  if (pos) *pos = 0;
+  // leading
+  auto first = s.find_first_not_of(pattern);
+  if (std::string::npos == first) return "";
+  if (pos) *pos = first;
+  // trailing
+  auto last = s.find_last_not_of(pattern);
+  assert(last < s.length());
+  assert(first <= last);
+  return s.substr(first, last - first + 1);
+}
+
+class RegexMatcher {
+ protected:
+  virtual bool match_number(const std::string &input) = 0;
+
+ public:
+  virtual ~RegexMatcher() = default;
+
+  struct MatchResult {
+    size_t pos{ 0 };
+    size_t len{ 0 };
+    bool res{ false };
+    bool quoted{ false };
+  };
+
+  MatchResult math(const std::string &input) {
+    MatchResult r;
+    // strip leading and trailing "spaces" accepted by flatbuffer
+    auto test = strip_string(input, "\t\r\n ", &r.pos);
+    r.len = test.size();
+    // check quotes
+    if (test.size() >= 2) {
+      auto fch = test.front();
+      auto lch = test.back();
+      r.quoted = (fch == lch) && (fch == '\'' || fch == '\"');
+      if (r.quoted) {
+        // remove quotes for regex test
+        test = test.substr(1, test.size() - 2);
+      }
+    }
+    // Fast check:
+    // A string with valid scalar shouldn't have non-ascii symbols.
+    // If this string had comments "/**/"" or "//" they should be broken before
+    // regex matching.
+    const auto bad =
+        (test.end() != std::find_if(test.begin(), test.end(), [](char c) {
+           // locale-independent check, isascii is deprecated
+           auto u = static_cast<unsigned char>(c);
+           // from ' ' to `~` (ignore DEL)
+           return !(0x20 <= u && u < 0x7F);
+         }));
+    if (!test.empty() && !bad) { r.res = match_number(test); }
+    return r;
+  }
+
+  bool match_regex_list(const std::string &input,
+                        const std::vector<std::regex> &re_list) {
+    auto str = strip_string(input, " ");
+    if (str.empty()) return false;
+    for (auto &re : re_list) {
+      std::smatch match;
+      auto done = std::regex_match(str, match, re);
+      if (done) return true;
+    }
+    return false;
+  }
+};
+
+class IntegerRegex : public RegexMatcher {
+ protected:
+  bool match_number(const std::string &input) override {
+    static const std::vector<std::regex> re_list = {
+      std::regex{ R"(^[-+]?[0-9]+$)", std::regex_constants::optimize },
+
+      std::regex{
+          R"(^[-+]?0[xX][0-9a-fA-F]+$)", std::regex_constants::optimize }
+    };
+    return match_regex_list(input, re_list);
+  }
+
+ public:
+  IntegerRegex() = default;
+  virtual ~IntegerRegex() = default;
+};
+
+class UIntegerRegex : public RegexMatcher {
+ protected:
+  bool match_number(const std::string &input) override {
+    static const std::vector<std::regex> re_list = {
+      std::regex{ R"(^[+]?[0-9]+$)", std::regex_constants::optimize },
+      std::regex{
+          R"(^[+]?0[xX][0-9a-fA-F]+$)", std::regex_constants::optimize },
+      // accept -0 number
+      std::regex{ R"(^[-](?:0[xX])?0+$)", std::regex_constants::optimize }
+    };
+    return match_regex_list(input, re_list);
+  }
+
+ public:
+  UIntegerRegex() = default;
+  virtual ~UIntegerRegex() = default;
+};
+
+class BooleanRegex : public IntegerRegex {
+ protected:
+  bool match_number(const std::string &input) override {
+    if (input == "true" || input == "false") return true;
+    return IntegerRegex::match_number(input);
+  }
+
+ public:
+  BooleanRegex() = default;
+  virtual ~BooleanRegex() = default;
+};
+
+class FloatRegex : public RegexMatcher {
+ protected:
+  bool match_number(const std::string &input) override {
+    static const std::vector<std::regex> re_list = {
+      // hex-float
+      std::regex{
+          R"(^[-+]?0[xX](?:(?:[.][0-9a-fA-F]+)|(?:[0-9a-fA-F]+[.][0-9a-fA-F]*)|(?:[0-9a-fA-F]+))[pP][-+]?[0-9]+$)",
+          std::regex_constants::optimize },
+      // dec-float
+      std::regex{
+          R"(^[-+]?(?:(?:[.][0-9]+)|(?:[0-9]+[.][0-9]*)|(?:[0-9]+))(?:[eE][-+]?[0-9]+)?$)",
+          std::regex_constants::optimize },
+
+      std::regex{ R"(^[-+]?(?:nan|inf|infinity)$)",
+                  std::regex_constants::optimize | std::regex_constants::icase }
+    };
+    return match_regex_list(input, re_list);
+  }
+
+ public:
+  FloatRegex() = default;
+  virtual ~FloatRegex() = default;
+};
+
+std::pair<std::string, RegexMatcher::MatchResult> GetScalarType(
+    uint8_t flags, const std::string &input) {
+  std::string type = "";
+  std::unique_ptr<RegexMatcher> matcher;
+
+  switch (flags & flags_scalar_type) {
+    case 0x0: {
+      type = "float";
+      matcher.reset(new FloatRegex());
+      break;
+    }
+    case 0x1: {
+      type = "double";
+      matcher.reset(new FloatRegex());
+      break;
+    }
+    case 0x2: {
+      type = "int8";
+      matcher.reset(new IntegerRegex());
+      break;
+    }
+    case 0x3: {
+      type = "uint8";
+      matcher.reset(new UIntegerRegex());
+      break;
+    }
+    case 0x4: {
+      type = "int16";
+      matcher.reset(new IntegerRegex());
+      break;
+    }
+    case 0x5: {
+      type = "uint16";
+      matcher.reset(new UIntegerRegex());
+      break;
+    }
+    case 0x6: {
+      type = "int32";
+      matcher.reset(new IntegerRegex());
+      break;
+    }
+    case 0x7: {
+      type = "uint32";
+      matcher.reset(new UIntegerRegex());
+      break;
+    }
+    case 0x8: {
+      type = "int64";
+      matcher.reset(new IntegerRegex());
+      break;
+    }
+    case 0x9: {
+      type = "uint64";
+      matcher.reset(new UIntegerRegex());
+      break;
+    }
+    case 0xA: {
+      type = "bool";
+      matcher.reset(new BooleanRegex());
+      break;
+    }
+    default: {
+      type = "float";
+      matcher.reset(new FloatRegex());
+      break;
+    }
+  }
+  auto check = matcher->math(input);
+  return { type, check };
+}
+
+static bool ParseTest(flatbuffers::Parser &parser, const std::string &json,
+                      std::string *_text) {
+  auto done = parser.Parse(json.c_str());
+  if (done) {
+    TEST_EQ(GenerateText(parser, parser.builder_.GetBufferPointer(), _text),
+            true);
+  } else {
+    *_text = parser.error_;
+  }
+  return done;
+}
+
+// llvm std::regex have problem with stack overflow, limit maximum length.
+// ./scalar_fuzzer -max_len=3000 -timeout=10 ../.corpus/ ../.seed/
+// Flag -only_ascii=1 is usefull for fast number-compatibilty checking.
+// Additional flags: -reduce_depth=1 -use_value_profile=1 -shrink=1
+// Help: -help=1
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  // Reserve one byte for Parser flags.
+  if (size < 1) return 0;
+  // REMEMBER: the first character in crash dump is not part of input!
+  // Extract single byte for fuzzing flags value.
+  const uint8_t flags = data[0];
+  data += 1;  // move to next
+  size -= 1;
+
+// Change default ASCII locale (affects to isalpha, isalnum, decimal
+// delimiters, other). https://en.cppreference.com/w/cpp/locale/setlocale
+#if defined(FLATBUFFERS_FORCE_LOCALE_INDEPENDENT)
+  if (flags & flags_clocale) {
+    // The ru_RU.CP1251 use ',' as decimal point delimiter instead of '.'.
+    // std::to_string(12.0) will return "12,0000".
+    // Ubuntu:>sudo locale-gen ru_RU.CP1251
+    assert(std::setlocale(LC_ALL, FLATBUFFERS_FORCE_LOCALE_INDEPENDENT));
+  }
+#endif
+
+  // Guarantee 0-termination.
+  const std::string original(reinterpret_cast<const char *>(data), size);
+  auto input = std::string(original.c_str());  // until '\0'
+
+  if (input.empty()) return 0;
+  // Break comments in json to avoid complexity with regex matcher.
+  BreakSequence(input, "//", '@');  // "//" -> "@/"
+  BreakSequence(input, "/*", '@');  // "/*" -> "@*"
+
+  // Detect type of scalar and check input with regex patterns.
+  const auto atype = GetScalarType(flags, input);
+  const auto &recheck = atype.second;
+
+  // Create parser
+  flatbuffers::IDLOptions opts;
+  opts.force_defaults = true;
+  opts.output_default_scalars_in_json = true;
+  opts.indent_step = -1;
+  opts.strict_json = true;
+  flatbuffers::Parser parser(opts);
+  auto schema = "table X { Y: " + atype.first + "; } root_type X;";
+  TEST_EQ(parser.Parse(schema.c_str()), true);
+
+  // Parse original input as-is.
+  auto orig_scalar = "{ \"Y\" : " + input + " }";
+  std::string orig_back;
+  auto orig_done = ParseTest(parser, orig_scalar, &orig_back);
+  if (recheck.res != orig_done) {
+    // look for "does not fit" or "doesn't fit" or "out of range"
+    if ((orig_back.find("does not fit") == std::string::npos) &&
+        (orig_back.find("out of range") == std::string::npos)) {
+      // Print error message for debug purpose.
+      TEST_OUTPUT_LINE("Original FAILED: %d != %d", orig_done, recheck.res);
+      TEST_EQ_STR(orig_back.c_str(),
+                  input.substr(recheck.pos, recheck.len).c_str());
+      TEST_EQ(orig_done, recheck.res);
+    }
+  }
+
+#if defined(FLATBUFFERS_FORCE_LOCALE_INDEPENDENT)
+  // restore locale to default
+  if (flags & flags_clocale) {
+    assert(std::setlocale(LC_ALL, "C"));
+    std::string orig_back_c;
+    auto orig_done_c = ParseTest(parser, orig_scalar, &orig_back_c);
+    TEST_EQ_STR(orig_back_c.c_str(), orig_back.c_str());
+    TEST_EQ(orig_done_c, orig_done);
+  }
+#endif
+
+  bool fixed = false;
+  if (true == recheck.quoted) {
+    // we can't simply remove quotes, it maybe nested "'12'".
+    // original string "\'12\'" converted to "'12'".
+    // The string maybe an invalid string by JSON rules but after quotes removed
+    // can be valid.
+    assert(recheck.len >= 2);
+  } else {
+    const auto quote = (flags & flags_quotes_kind) ? '\"' : '\'';
+    input.insert(recheck.pos + recheck.len, 1, quote);
+    input.insert(recheck.pos, 1, quote);
+    fixed = true;
+  }
+
+  if (fixed) {
+    auto fix_scalar = "{ \"Y\" : " + input + " }";
+    std::string fix_back;
+    auto fix_done = ParseTest(parser, fix_scalar, &fix_back);
+    if (orig_done != fix_done) {
+      // Print error message for debug purpose.
+      TEST_OUTPUT_LINE("Fix FAILED: %d != %d", fix_done, orig_done);
+      TEST_EQ_STR(fix_back.c_str(), orig_back.c_str());
+    }
+    if (orig_done) { TEST_EQ_STR(fix_back.c_str(), orig_back.c_str()); }
+    TEST_EQ(fix_done, orig_done);
+  }
+  return 0;
+}

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cmath>
+#if defined(FLATBUFFERS_FORCE_LOCALE_INDEPENDENT)
+#include <clocale>
+#endif
 
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
@@ -1181,7 +1185,6 @@ void TestError(const char *src, const char *error_substr,
 void ErrorTest() {
   // In order they appear in idl_parser.cpp
   TestError("table X { Y:byte; } root_type X; { Y: 999 }", "does not fit");
-  TestError(".0", "floating point");
   TestError("\"\0", "illegal");
   TestError("\"\\q", "escape code");
   TestError("table ///", "documentation");
@@ -1219,25 +1222,42 @@ void ErrorTest() {
   TestError("table X { Y:int; } table X {", "datatype already");
   TestError("struct X (force_align: 7) { Y:int; }", "force_align");
   TestError("{}", "no root");
-  TestError("table X { Y:byte; } root_type X; { Y:1 } { Y:1 }", "one json");
+  TestError("table X { Y:byte; } root_type X; { Y:1 } { Y:1 }", "end of file");
+  TestError("table X { Y:byte; } root_type X; { Y:1 } table Y{ Z:int }",
+            "end of file");
   TestError("root_type X;", "unknown root");
   TestError("struct X { Y:int; } root_type X;", "a table");
   TestError("union X { Y }", "referenced");
   TestError("union Z { X } struct X { Y:int; }", "only tables");
   TestError("table X { Y:[int]; YLength:int; }", "clash");
   TestError("table X { Y:byte; } root_type X; { Y:1, Y:2 }", "more than once");
+  // float to integer conversion is forbidden
+  TestError("table X { Y:int; } root_type X; { Y:1.0 }", "float");
+  TestError("table X { Y:bool; } root_type X; { Y:1.0 }", "float");
 }
 
 template<typename T> T TestValue(const char *json, const char *type_name) {
   flatbuffers::Parser parser;
-
+  parser.builder_.ForceDefaults(true);  // return defaults
+  auto check_default = json ? false : true;
+  if (check_default) { parser.opts.output_default_scalars_in_json = true; }
   // Simple schema.
-  TEST_EQ(parser.Parse(std::string("table X { Y:" + std::string(type_name) +
-                                   "; } root_type X;")
-                           .c_str()),
-          true);
+  std::string schema =
+      "table X { Y:" + std::string(type_name) + "; } root_type X;";
+  TEST_EQ(parser.Parse(schema.c_str()), true);
 
-  TEST_EQ(parser.Parse(json), true);
+  auto done = parser.Parse(check_default ? "{}" : json);
+  TEST_EQ_STR(parser.error_.c_str(), "");
+  TEST_EQ(done, true);
+
+  // Check with print.
+  std::string print_back;
+  parser.opts.indent_step = -1;
+  TEST_EQ(GenerateText(parser, parser.builder_.GetBufferPointer(), &print_back),
+          true);
+  // restore value from its default
+  if (check_default) { TEST_EQ(parser.Parse(print_back.c_str()), true); }
+
   auto root = flatbuffers::GetRoot<flatbuffers::Table>(
       parser.builder_.GetBufferPointer());
   return root->GetField<T>(flatbuffers::FieldIndexToOffset(0), 0);
@@ -1251,17 +1271,44 @@ void ValueTest() {
   TEST_EQ(FloatCompare(TestValue<float>("{ Y:0.0314159e+2 }", "float"),
                        (float)3.14159),
           true);
+  // number in string
+  TEST_EQ(FloatCompare(TestValue<float>("{ Y:\"0.0314159e+2\" }", "float"),
+    (float)3.14159),
+    true);
 
   // Test conversion functions.
   TEST_EQ(FloatCompare(TestValue<float>("{ Y:cos(rad(180)) }", "float"), -1),
           true);
 
+  // int embedded to string
+  TEST_EQ(TestValue<int>("{ Y:\"-876\" }", "int=-123"), -876);
+  TEST_EQ(TestValue<int>("{ Y:\"876\" }", "int=-123"), 876);
+
   // Test negative hex constant.
-  TEST_EQ(TestValue<int>("{ Y:-0x80 }", "int"), -128);
+  TEST_EQ(TestValue<int>("{ Y:-0x8ea0 }", "int=-0x8ea0"), -36512);
+  TEST_EQ(TestValue<int>(nullptr, "int=-0x8ea0"), -36512);
+
+  // positive hex constant
+  TEST_EQ(TestValue<int>("{ Y:0x1abcdef }", "int=0x1"), 0x1abcdef);
+  // with optional '+' sign
+  TEST_EQ(TestValue<int>("{ Y:+0x1abcdef }", "int=+0x1"), 0x1abcdef);
+  // hex in string
+  TEST_EQ(TestValue<int>("{ Y:\"0x1abcdef\" }", "int=+0x1"), 0x1abcdef);
 
   // Make sure we do unsigned 64bit correctly.
   TEST_EQ(TestValue<uint64_t>("{ Y:12335089644688340133 }", "ulong"),
           12335089644688340133ULL);
+
+  // bool in string
+  TEST_EQ(TestValue<bool>("{ Y:\"false\" }", "bool=true"), false);
+  TEST_EQ(TestValue<bool>("{ Y:\"true\" }", "bool=\"true\""), true);
+  TEST_EQ(TestValue<bool>("{ Y:'false' }", "bool=true"), false);
+  TEST_EQ(TestValue<bool>("{ Y:'true' }", "bool=\"true\""), true);
+
+  // check comments before and after json object
+  TEST_EQ(TestValue<int>("/*before*/ { Y:1 } /*after*/", "int"), 1);
+  TEST_EQ(TestValue<int>("//before \n { Y:1 } //after", "int"), 1);
+
 }
 
 void NestedListTest() {
@@ -1310,6 +1357,47 @@ void IntegerOutOfRangeTest() {
             "constant does not fit");
   TestError("table T { F:uint; } root_type T; { F:-1 }",
             "constant does not fit");
+  // Check fixed width aliases
+  TestError("table X { Y:uint8; } root_type X; { Y: -1 }", "does not fit");
+  TestError("table X { Y:uint8; } root_type X; { Y: 256 }", "does not fit");
+  TestError("table X { Y:uint16; } root_type X; { Y: -1 }", "does not fit");
+  TestError("table X { Y:uint16; } root_type X; { Y: 65536 }", "does not fit");
+  TestError("table X { Y:uint32; } root_type X; { Y: -1 }", "");
+  TestError("table X { Y:uint32; } root_type X; { Y: 4294967296 }",
+            "does not fit");
+  TestError("table X { Y:uint64; } root_type X; { Y: -1 }", "");
+  TestError("table X { Y:uint64; } root_type X; { Y: -9223372036854775809 }",
+            "does not fit");
+  TestError("table X { Y:uint64; } root_type X; { Y: 18446744073709551616 }",
+            "does not fit");
+
+  TestError("table X { Y:int8; } root_type X; { Y: -129 }", "does not fit");
+  TestError("table X { Y:int8; } root_type X; { Y: 128 }", "does not fit");
+  TestError("table X { Y:int16; } root_type X; { Y: -32769 }", "does not fit");
+  TestError("table X { Y:int16; } root_type X; { Y: 32768 }", "does not fit");
+  TestError("table X { Y:int32; } root_type X; { Y: -2147483649 }", "");
+  TestError("table X { Y:int32; } root_type X; { Y: 2147483648 }",
+            "does not fit");
+  TestError("table X { Y:int64; } root_type X; { Y: -9223372036854775809 }",
+            "does not fit");
+  TestError("table X { Y:int64; } root_type X; { Y: 9223372036854775808 }",
+            "does not fit");
+  // check out-of-int64 as int8
+  TestError("table X { Y:int8; } root_type X; { Y: -9223372036854775809 }",
+            "does not fit");
+  TestError("table X { Y:int8; } root_type X; { Y: 9223372036854775808 }",
+            "does not fit");
+
+  // Check default values
+  TestError("table X { Y:int64=-9223372036854775809; } root_type X; {}",
+            "does not fit");
+  TestError("table X { Y:int64= 9223372036854775808; } root_type X; {}",
+            "does not fit");
+  TestError("table X { Y:uint64; } root_type X; { Y: -1 }", "");
+  TestError("table X { Y:uint64=-9223372036854775809; } root_type X; {}",
+            "does not fit");
+  TestError("table X { Y:uint64= 18446744073709551616; } root_type X; {}",
+            "does not fit");
 }
 
 void IntegerBoundaryTest() {
@@ -1332,6 +1420,191 @@ void IntegerBoundaryTest() {
   TEST_EQ(TestValue<uint64_t>("{ Y:18446744073709551615 }", "ulong"),
           18446744073709551615U);
   TEST_EQ(TestValue<uint64_t>("{ Y:0 }", "ulong"), 0);
+  TEST_EQ(TestValue<uint64_t>("{ Y: 18446744073709551615 }", "uint64"),
+          18446744073709551615ULL);
+  // check that the default works
+  TEST_EQ(TestValue<uint64_t>(nullptr, "uint64 = 18446744073709551615"),
+          18446744073709551615ULL);
+}
+
+void ValidFloatTest() {
+  const auto infinityf = flatbuffers::numeric_limits<float>::infinity();
+  const auto infinityd = flatbuffers::numeric_limits<double>::infinity();
+  // check rounding to infinity
+  TEST_EQ(TestValue<float>("{ Y:+3.4029e+38 }", "float"), +infinityf);
+  TEST_EQ(TestValue<float>("{ Y:-3.4029e+38 }", "float"), -infinityf);
+  TEST_EQ(TestValue<double>("{ Y:+1.7977e+308 }", "double"), +infinityd);
+  TEST_EQ(TestValue<double>("{ Y:-1.7977e+308 }", "double"), -infinityd);
+
+  TEST_EQ(FloatCompare(TestValue<float>("{ Y:0.0314159e+2 }", "float"),
+                       (float)3.14159),
+          true);
+  // float in string
+  TEST_EQ(FloatCompare(TestValue<float>("{ Y:\" 0.0314159e+2  \" }", "float"),
+                       (float)3.14159),
+          true);
+
+  TEST_EQ(TestValue<float>("{ Y:1 }", "float"), 1.0f);
+  TEST_EQ(TestValue<float>("{ Y:1.0 }", "float"), 1.0f);
+  TEST_EQ(TestValue<float>("{ Y:1. }", "float"), 1.0f);
+  TEST_EQ(TestValue<float>("{ Y:+1. }", "float"), 1.0f);
+  TEST_EQ(TestValue<float>("{ Y:-1. }", "float"), -1.0f);
+  TEST_EQ(TestValue<float>("{ Y:1.e0 }", "float"), 1.0f);
+  TEST_EQ(TestValue<float>("{ Y:1.e+0 }", "float"), 1.0f);
+  TEST_EQ(TestValue<float>("{ Y:1.e-0 }", "float"), 1.0f);
+  TEST_EQ(TestValue<float>("{ Y:0.125 }", "float"), 0.125f);
+  TEST_EQ(TestValue<float>("{ Y:.125 }", "float"), 0.125f);
+  TEST_EQ(TestValue<float>("{ Y:-.125 }", "float"), -0.125f);
+  TEST_EQ(TestValue<float>("{ Y:+.125 }", "float"), +0.125f);
+
+  #if defined(FLATBUFFERS_HAS_EXTRA_FLOAT) && (FLATBUFFERS_HAS_EXTRA_FLOAT)
+  // Old MSVC versions may have problem with this check.
+  // https://www.exploringbinary.com/visual-c-plus-plus-strtod-still-broken/
+  TEST_EQ(TestValue<double>("{ Y:6.9294956446009195e15 }", "double"),
+    6929495644600920);
+  // check nan's
+  TEST_EQ(std::isnan(TestValue<double>("{ Y:nan }", "double")), true);
+  TEST_EQ(std::isnan(TestValue<float>("{ Y:nan }", "float")), true);
+  TEST_EQ(std::isnan(TestValue<float>("{ Y:\"nan\" }", "float")), true);
+  TEST_EQ(std::isnan(TestValue<float>("{ Y:+nan }", "float")), true);
+  TEST_EQ(std::isnan(TestValue<float>("{ Y:-nan }", "float")), true);
+  TEST_EQ(std::isnan(TestValue<float>(nullptr, "float=nan")), true);
+  TEST_EQ(std::isnan(TestValue<float>(nullptr, "float=-nan")), true);
+  // check inf
+  TEST_EQ(TestValue<float>("{ Y:inf }", "float"), infinityf);
+  TEST_EQ(TestValue<float>("{ Y:\"inf\" }", "float"), infinityf);
+  TEST_EQ(TestValue<float>("{ Y:+inf }", "float"), infinityf);
+  TEST_EQ(TestValue<float>("{ Y:-inf }", "float"), -infinityf);
+  TEST_EQ(TestValue<float>(nullptr, "float=inf"), infinityf);
+  TEST_EQ(TestValue<float>(nullptr, "float=-inf"), -infinityf);
+  TestValue<double>(
+      "{ Y : [0.2, .2, 1.0, -1.0, -2., 2., 1e0, -1e0, 1.0e0, -1.0e0, -3.e2, "
+      "3.0e2] }",
+      "[double]");
+  TestValue<float>(
+      "{ Y : [0.2, .2, 1.0, -1.0, -2., 2., 1e0, -1e0, 1.0e0, -1.0e0, -3.e2, "
+      "3.0e2] }",
+      "[float]");
+
+  // Test binary format of float point.
+  // https://en.cppreference.com/w/cpp/language/floating_literal
+  // 0x11.12p-1 = (1*16^1 + 2*16^0 + 3*16^-1 + 4*16^-2) * 2^-1 =
+  TEST_EQ(TestValue<double>("{ Y:0x12.34p-1 }", "double"), 9.1015625);
+  // hex fraction 1.2 (decimal 1.125) scaled by 2^3, that is 9.0
+  TEST_EQ(TestValue<float>("{ Y:-0x0.2p0 }", "float"), -0.125f);
+  TEST_EQ(TestValue<float>("{ Y:-0x.2p1 }", "float"), -0.25f);
+  TEST_EQ(TestValue<float>("{ Y:0x1.2p3 }", "float"), 9.0f);
+  TEST_EQ(TestValue<float>("{ Y:0x10.1p0 }", "float"), 16.0625f);
+  TEST_EQ(TestValue<double>("{ Y:0x1.2p3 }", "double"), 9.0);
+  TEST_EQ(TestValue<double>("{ Y:0x10.1p0 }", "double"), 16.0625);
+  TEST_EQ(TestValue<double>("{ Y:0xC.68p+2 }", "double"), 49.625);
+  TestValue<double>("{ Y : [0x20.4ep1, +0x20.4ep1, -0x20.4ep1] }", "[double]");
+  TestValue<float>("{ Y : [0x20.4ep1, +0x20.4ep1, -0x20.4ep1] }", "[float]");
+
+#else   // FLATBUFFERS_HAS_EXTRA_FLOAT
+  TEST_OUTPUT_LINE("FLATBUFFERS_HAS_EXTRA_FLOAT tests skipped");
+#endif  // FLATBUFFERS_HAS_EXTRA_FLOAT
+}
+
+void InvalidFloatTest() {
+  auto invalid_msg = "invalid number";
+  auto comma_msg = "expecting: ,";
+  TestError("table T { F:float; } root_type T; { F:1,0 }", "");
+  TestError("table T { F:float; } root_type T; { F:. }", "");
+  TestError("table T { F:float; } root_type T; { F:- }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:+ }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:-. }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:+. }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:.e }", "");
+  TestError("table T { F:float; } root_type T; { F:-e }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:+e }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:-.e }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:+.e }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:-e1 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:+e1 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:1.0e+ }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:1.0e- }", invalid_msg);
+  // exponent pP is mandatory for hex-float
+  TestError("table T { F:float; } root_type T; { F:0x0 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:-0x. }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x. }", invalid_msg);
+  // eE not exponent in hex-float!
+  TestError("table T { F:float; } root_type T; { F:0x0.0e+ }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x0.0e- }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x0.0p }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x0.0p+ }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x0.0p- }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x0.0pa1 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x0.0e+ }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x0.0e- }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x0.0e+0 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x0.0e-0 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x0.0ep+ }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0x0.0ep- }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:1.2.3 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:1.2.e3 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:1.2e.3 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:1.2e0.3 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:1.2e3. }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:1.2e3.0 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:+-1.0 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:1.0e+-1 }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:\"1.0e+-1\" }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:1.e0e }", comma_msg);
+  TestError("table T { F:float; } root_type T; { F:0x1.p0e }", comma_msg);
+  TestError("table T { F:float; } root_type T; { F:\" 0x10 \" }", invalid_msg);
+  // floats in string
+  TestError("table T { F:float; } root_type T; { F:\"1,2.\" }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:\"1.2e3.\" }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:\"0x1.p0e\" }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:\"0x1.0\" }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:\" 0x1.0\" }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:\"+ 0\" }", invalid_msg);
+  // disable escapes for "number-in-string"
+  TestError("table T { F:float; } root_type T; { F:\"\\f1.2e3.\" }", "escape");
+  TestError("table T { F:float; } root_type T; { F:\"\\t1.2e3.\" }", "escape");
+  TestError("table T { F:float; } root_type T; { F:\"\\n1.2e3.\" }", "escape");
+  TestError("table T { F:float; } root_type T; { F:\"\\r1.2e3.\" }", "escape");
+  TestError("table T { F:float; } root_type T; { F:\"4\\x005\" }", "escape");
+  TestError("table T { F:float; } root_type T; { F:\"\'12\'\" }", invalid_msg);
+  // null is not a number constant!
+  TestError("table T { F:float; } root_type T; { F:\"null\" }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:null }", invalid_msg);
+}
+
+template<typename T>
+void NumericUtilsTestInteger(const char *lower, const char *upper) {
+  T x;
+  TEST_EQ(flatbuffers::StringToNumber("1q", &x), false);
+  TEST_EQ(x, 0);
+  TEST_EQ(flatbuffers::StringToNumber(upper, &x), false);
+  TEST_EQ(x, flatbuffers::numeric_limits<T>::max());
+  TEST_EQ(flatbuffers::StringToNumber(lower, &x), false);
+  auto expval = std::is_unsigned<T>::value
+                    ? flatbuffers::numeric_limits<T>::max()
+                    : flatbuffers::numeric_limits<T>::lowest();
+  TEST_EQ(x, expval);
+}
+
+template<typename T>
+void NumericUtilsTestFloat(const char *lower, const char *upper) {
+  T f;
+  TEST_EQ(flatbuffers::StringToNumber("1q", &f), false);
+  TEST_EQ(f, 0);
+  TEST_EQ(flatbuffers::StringToNumber(upper, &f), true);
+  TEST_EQ(f, +flatbuffers::numeric_limits<T>::infinity());
+  TEST_EQ(flatbuffers::StringToNumber(lower, &f), true);
+  TEST_EQ(f, -flatbuffers::numeric_limits<T>::infinity());
+}
+
+void NumericUtilsTest() {
+  NumericUtilsTestInteger<uint64_t>("-1", "18446744073709551616");
+  NumericUtilsTestInteger<uint8_t>("-1", "256");
+  NumericUtilsTestInteger<int64_t>("-9223372036854775809",
+                                   "9223372036854775808");
+  NumericUtilsTestInteger<int8_t>("-129", "128");
+  NumericUtilsTestFloat<float>("-3.4029e+38", "+3.4029e+38");
+  NumericUtilsTestFloat<float>("-1.7977e+308", "+1.7977e+308");
 }
 
 void UnicodeTest() {
@@ -1545,6 +1818,15 @@ void InvalidUTF8Test() {
       // U+10400 "encoded" as U+D801 U+DC00
       "{ F:\"\xED\xA0\x81\xED\xB0\x80\"}",
       "illegal UTF-8 sequence");
+
+  // Check independence of identifier from locale.
+  std::string locale_ident;
+  locale_ident += "table T { F";
+  locale_ident += static_cast<char>(-32); // unsigned 0xE0
+  locale_ident += " :string; }";
+  locale_ident += "root_type T;";
+  locale_ident += "{}";
+  TestError(locale_ident.c_str(), "");
 }
 
 void UnknownFieldsTest() {
@@ -2015,6 +2297,13 @@ int FlatBufferTests() {
     );
   #endif
 
+  // If request testing under specific C-locale.
+  #if defined(FLATBUFFERS_FORCE_LOCALE_INDEPENDENT)
+  // Assume that FLATBUFFERS_FORCE_LOCALE_INDEPENDENT is string with locale for test.
+  TEST_OUTPUT_LINE("Set global C-locale to: %s", FLATBUFFERS_FORCE_LOCALE_INDEPENDENT);
+  TEST_NOTNULL(std::setlocale(LC_ALL, FLATBUFFERS_FORCE_LOCALE_INDEPENDENT));
+  #endif
+
   // Run our various test suites:
 
   std::string rawbuf;
@@ -2072,17 +2361,21 @@ int FlatBufferTests() {
   ParseProtoBufAsciiTest();
   TypeAliasesTest();
   EndianSwapTest();
-
   JsonDefaultTest();
-
   FlexBuffersTest();
   UninitializedVectorTest();
   EqualOperatorTest();
+  NumericUtilsTest();
+  ValidFloatTest();
+  InvalidFloatTest();
 
   return 0;
 }
 
 int main(int /*argc*/, const char * /*argv*/ []) {
+  // Disable stdout buffering to prevent information lost on assertion.
+  setvbuf(stdout, NULL, _IONBF, 0);
+  setvbuf(stderr, NULL, _IONBF, 0);
 
   FlatBufferTests();
   FlatBufferBuilderTest();


### PR DESCRIPTION
This PR fixes some detected problems with numbers parsing (#4859).
Also, this PR adds support of [hexadecimal float-point literals](https://en.cppreference.com/w/cpp/language/floating_literal)
Converting between hexadecimal and binary is guaranteed to be exact.

Summary:
The parser will reject incomplete numbers like '-', '-.' or '-.1'.
More accurate parse of float and double when overflow or underflow.
Check "out-of-range" of uint64 fields.
Check correctness of default values and metadata.
An error message from the parser shows both line number and cursor position (helpful for arrays).

This is the big pack of changes.
Main changes located at `Parser::Next()`, `Parser::ParseSingleVlaue()` and `Parser::TryTypedValue()`.
