### PR TITLE
Remove hard-coded C++ version checks for experimental string_view

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -165,7 +165,7 @@
       }
       #define FLATBUFFERS_HAS_STRING_VIEW 1
     // Check for std::experimental::string_view (in c++14, compiler-dependent)
-    #elif __has_include(<experimental/string_view>) && (__cplusplus >= 201411)
+    #elif __has_include(<experimental/string_view>)
       #include <experimental/string_view>
       namespace flatbuffers {
         typedef std::experimental::string_view string_view;


### PR DESCRIPTION
As discussed in the comments of #4730 after it was merged.

This allows toolchains which provide `std::experimental::string_view` to use their implementation, without checking the canonical `__cplusplus` version.

Easy enough to extend this to the C++17 `std::string_view` checks as well, although I believe PR #4876 resolved an MSVC bug and perhaps that `__cplusplus` version check should stay as-is.