### PR TITLE
rust: Fixed MakeCamelCase issues with Upper_Snake_Case

### DIFF
--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -33,13 +33,19 @@ static std::string GeneratedFileName(const std::string &path,
 std::string MakeSnakeCase(const std::string &in) {
   std::string s;
   for (size_t i = 0; i < in.length(); i++) {
-    if (islower(in[i])) {
-      s += static_cast<char>(in[i]);
-    } else {
-      if (i > 0) {
+    if (i == 0) {
+      s += static_cast<char>(tolower(in[0]));
+    } else if (in[i] == '_') {
+      s += '_';
+    } else if (!islower(in[i])) {
+      // Prevent duplicate underscores for Upper_Snake_Case strings
+      // and UPPERCASE strings.
+      if (islower(in[i - 1])) {
         s += '_';
       }
       s += static_cast<char>(tolower(in[i]));
+    } else {
+      s += in[i];
     }
   }
   return s;

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -1110,7 +1110,7 @@ impl<'a> Monster<'a> {
 
   #[inline]
   #[allow(non_snake_case)]
-  pub fn test_as_my_game___example_2___monster(&'a self) -> Option<super::example_2::Monster> {
+  pub fn test_as_my_game_example_2_monster(&'a self) -> Option<super::example_2::Monster> {
     if self.test_type() == Any::MyGame_Example2_Monster {
       self.test().map(|u| super::example_2::Monster::init_from_table(u))
     } else {

--- a/tests/namespace_test/namespace_test1_generated.rs
+++ b/tests/namespace_test/namespace_test1_generated.rs
@@ -34,8 +34,8 @@ pub enum EnumInNestedNS {
 
 }
 
-const ENUM_MIN_ENUM_IN_NESTED_N_S: i8 = 0;
-const ENUM_MAX_ENUM_IN_NESTED_N_S: i8 = 2;
+const ENUM_MIN_ENUM_IN_NESTED_NS: i8 = 0;
+const ENUM_MAX_ENUM_IN_NESTED_NS: i8 = 2;
 
 impl<'a> flatbuffers::Follow<'a> for EnumInNestedNS {
   type Inner = Self;
@@ -69,22 +69,22 @@ impl flatbuffers::Push for EnumInNestedNS {
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_ENUM_IN_NESTED_N_S:[EnumInNestedNS; 3] = [
+const ENUM_VALUES_ENUM_IN_NESTED_NS:[EnumInNestedNS; 3] = [
   EnumInNestedNS::A,
   EnumInNestedNS::B,
   EnumInNestedNS::C
 ];
 
 #[allow(non_camel_case_types)]
-const ENUM_NAMES_ENUM_IN_NESTED_N_S:[&'static str; 3] = [
+const ENUM_NAMES_ENUM_IN_NESTED_NS:[&'static str; 3] = [
     "A",
     "B",
     "C"
 ];
 
-pub fn enum_name_enum_in_nested_n_s(e: EnumInNestedNS) -> &'static str {
+pub fn enum_name_enum_in_nested_ns(e: EnumInNestedNS) -> &'static str {
   let index: usize = e as usize;
-  ENUM_NAMES_ENUM_IN_NESTED_N_S[index]
+  ENUM_NAMES_ENUM_IN_NESTED_NS[index]
 }
 
 // struct StructInNestedNS, aligned to 4

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -331,7 +331,7 @@ mod roundtrip_generated_code {
                    Some("foo"));
         assert_eq!(mon.test_as_monster().unwrap().name(), Some("foo"));
         assert_eq!(mon.test_as_test_simple_table_with_enum(), None);
-        assert_eq!(mon.test_as_my_game___example_2___monster(), None);
+        assert_eq!(mon.test_as_my_game_example_2_monster(), None);
     }
     #[test]
     fn union_default() {


### PR DESCRIPTION
Supercedes #4934

This fixes #4932 and some wrongly generated indents.
Note that rust unit tests were modified by assuming that [this line](https://github.com/google/flatbuffers/blob/master/tests/rust_usage_test/tests/integration_test.rs#L334) is incorrect and that `test_as_my_game___example_2___monster` should rather be `test_as_my_game_example_2_monster`.
```
diff old/monster_test_generated.rs new/monster_test_generated.rs
9,10c9,10
<   #![allow(dead_code)]
<   #![allow(unused_imports)]
---
> #![allow(dead_code)]
> #![allow(unused_imports)]
12,13c12,13
<   use std::mem;
<   use std::cmp::Ordering;
---
> use std::mem;
> use std::cmp::Ordering;
15,16c15,16
<   extern crate flatbuffers;
<   use self::flatbuffers::EndianScalar;
---
> extern crate flatbuffers;
> use self::flatbuffers::EndianScalar;
82,83c82,83
<   #![allow(dead_code)]
<   #![allow(unused_imports)]
---
> #![allow(dead_code)]
> #![allow(unused_imports)]
85,86c85,86
<   use std::mem;
<   use std::cmp::Ordering;
---
> use std::mem;
> use std::cmp::Ordering;
88,89c88,89
<   extern crate flatbuffers;
<   use self::flatbuffers::EndianScalar;
---
> extern crate flatbuffers;
> use self::flatbuffers::EndianScalar;
157,158c157,158
<   #![allow(dead_code)]
<   #![allow(unused_imports)]
---
> #![allow(dead_code)]
> #![allow(unused_imports)]
160,161c160,161
<   use std::mem;
<   use std::cmp::Ordering;
---
> use std::mem;
> use std::cmp::Ordering;
163,164c163,164
<   extern crate flatbuffers;
<   use self::flatbuffers::EndianScalar;
---
> extern crate flatbuffers;
> use self::flatbuffers::EndianScalar;
1113c1113
<   pub fn test_as_my_game___example_2___monster(&'a self) -> Option<super::example_2::Monster> {
---
>   pub fn test_as_my_game_example_2_monster(&'a self) -> Option<super::example_2::Monster> {
```