### PR TITLE
Add compare operator to code generated for c++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ function(compile_flatbuffers_schema_to_cpp SRC_FBS)
   add_custom_command(
     OUTPUT ${GEN_HEADER}
     COMMAND "${FLATBUFFERS_FLATC_EXECUTABLE}" -c --no-includes --gen-mutable
-            --gen-object-api -o "${SRC_FBS_DIR}"
+            --gen-object-api --gen-compare -o "${SRC_FBS_DIR}"
             --cpp-ptr-type flatbuffers::unique_ptr # Used to test with C++98 STLs
             --reflect-names
             -I "${CMAKE_CURRENT_SOURCE_DIR}/tests/include_test"

--- a/docs/source/Compiler.md
+++ b/docs/source/Compiler.md
@@ -96,6 +96,8 @@ Additional options:
     at the cost of efficiency (object allocation). Recommended only to be used
     if other options are insufficient.
 
+-   `--gen-compare` :  Generate operator== for object-based API types.
+
 -   `--gen-onefile` :  Generate single output file (useful for C#)
 
 -   `--gen-all`: Generate not just code for the current schema files, but

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -379,6 +379,7 @@ struct IDLOptions {
   bool skip_unexpected_fields_in_json;
   bool generate_name_strings;
   bool generate_object_based_api;
+  bool gen_compare;
   std::string cpp_object_api_pointer_type;
   std::string cpp_object_api_string_type;
   bool gen_nullable;
@@ -453,6 +454,7 @@ struct IDLOptions {
         skip_unexpected_fields_in_json(false),
         generate_name_strings(false),
         generate_object_based_api(false),
+        gen_compare(false),
         cpp_object_api_pointer_type("std::unique_ptr"),
         gen_nullable(false),
         object_suffix("T"),

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -10,14 +10,15 @@ namespace MyGame {
 namespace Sample {
 
 struct Vec3;
-bool operator==(const Vec3 &lhs, const Vec3 &rhs);
 
 struct Monster;
 struct MonsterT;
-bool operator==(const MonsterT &lhs, const MonsterT &rhs);
 
 struct Weapon;
 struct WeaponT;
+
+bool operator==(const Vec3 &lhs, const Vec3 &rhs);
+bool operator==(const MonsterT &lhs, const MonsterT &rhs);
 bool operator==(const WeaponT &lhs, const WeaponT &rhs);
 
 inline const flatbuffers::TypeTable *Vec3TypeTable();
@@ -140,12 +141,15 @@ struct EquipmentUnion {
 inline bool operator==(const EquipmentUnion &lhs, const EquipmentUnion &rhs) {
   if (lhs.type != rhs.type) return false;
   switch (lhs.type) {
+    case Equipment_NONE: {
+      return true;
+    }
     case Equipment_Weapon: {
       return *(reinterpret_cast<const WeaponT *>(lhs.value)) ==
              *(reinterpret_cast<const WeaponT *>(rhs.value));
     }
     default: {
-      return true;
+      return false;
     }
   }
 }

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -10,12 +10,15 @@ namespace MyGame {
 namespace Sample {
 
 struct Vec3;
+bool operator==(const Vec3 &lhs, const Vec3 &rhs);
 
 struct Monster;
 struct MonsterT;
+bool operator==(const MonsterT &lhs, const MonsterT &rhs);
 
 struct Weapon;
 struct WeaponT;
+bool operator==(const WeaponT &lhs, const WeaponT &rhs);
 
 inline const flatbuffers::TypeTable *Vec3TypeTable();
 
@@ -133,6 +136,19 @@ struct EquipmentUnion {
   }
 };
 
+
+inline bool operator==(const EquipmentUnion &lhs, const EquipmentUnion &rhs) {
+  if (lhs.type != rhs.type) return false;
+  switch (lhs.type) {
+    case Equipment_Weapon: {
+      return *(reinterpret_cast<const WeaponT *>(lhs.value)) ==
+             *(reinterpret_cast<const WeaponT *>(rhs.value));
+    }
+    default: {
+      return true;
+    }
+  }
+}
 bool VerifyEquipment(flatbuffers::Verifier &verifier, const void *obj, Equipment type);
 bool VerifyEquipmentVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<uint8_t> *types);
 
@@ -172,6 +188,13 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Vec3 FLATBUFFERS_FINAL_CLASS {
 };
 FLATBUFFERS_STRUCT_END(Vec3, 12);
 
+inline bool operator==(const Vec3 &lhs, const Vec3 &rhs) {
+  return
+      (lhs.x() == rhs.x()) &&
+      (lhs.y() == rhs.y()) &&
+      (lhs.z() == rhs.z());
+}
+
 struct MonsterT : public flatbuffers::NativeTable {
   typedef Monster TableType;
   flatbuffers::unique_ptr<Vec3> pos;
@@ -188,6 +211,18 @@ struct MonsterT : public flatbuffers::NativeTable {
         color(Color_Blue) {
   }
 };
+
+inline bool operator==(const MonsterT &lhs, const MonsterT &rhs) {
+  return
+      (lhs.pos == rhs.pos) &&
+      (lhs.mana == rhs.mana) &&
+      (lhs.hp == rhs.hp) &&
+      (lhs.name == rhs.name) &&
+      (lhs.inventory == rhs.inventory) &&
+      (lhs.color == rhs.color) &&
+      (lhs.weapons == rhs.weapons) &&
+      (lhs.equipped == rhs.equipped);
+}
 
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MonsterT NativeTableType;
@@ -390,6 +425,12 @@ struct WeaponT : public flatbuffers::NativeTable {
       : damage(0) {
   }
 };
+
+inline bool operator==(const WeaponT &lhs, const WeaponT &rhs) {
+  return
+      (lhs.name == rhs.name) &&
+      (lhs.damage == rhs.damage);
+}
 
 struct Weapon FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef WeaponT NativeTableType;

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -88,6 +88,7 @@ std::string FlatCompiler::GetUsageString(const char *program_name) const {
     "  --gen-onefile      Generate single output file for C# and Go.\n"
     "  --gen-name-strings Generate type name functions for C++.\n"
     "  --gen-object-api   Generate an additional object-based API.\n"
+    "  --gen-compare      Generate operator== for object-based API types.\n"
     "  --cpp-ptr-type T   Set object API pointer type (default std::unique_ptr)\n"
     "  --cpp-str-type T   Set object API string type (default std::string)\n"
     "                     T::c_str() and T::length() must be supported\n"
@@ -222,6 +223,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.generate_name_strings = true;
       } else if (arg == "--gen-object-api") {
         opts.generate_object_based_api = true;
+      } else if (arg == "--gen-compare") {
+        opts.gen_compare = true;
       } else if (arg == "--cpp-ptr-type") {
         if (++argi >= argc) Error("missing type following" + arg, true);
         opts.cpp_object_api_pointer_type = argv[argi];

--- a/tests/generate_code.bat
+++ b/tests/generate_code.bat
@@ -15,13 +15,13 @@
 set buildtype=Release
 if "%1"=="-b" set buildtype=%2
 
-..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --lobster --lua --js --rust --ts --php --grpc --gen-mutable --reflect-names --gen-object-api --no-includes --cpp-ptr-type flatbuffers::unique_ptr --no-fb-import -I include_test monster_test.fbs monsterdata_test.json
+..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --lobster --lua --js --rust --ts --php --grpc --gen-mutable --reflect-names --gen-object-api --gen-compare --no-includes --cpp-ptr-type flatbuffers::unique_ptr --no-fb-import -I include_test monster_test.fbs monsterdata_test.json
 ..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --lobster --lua --js --rust --ts --php --gen-mutable --reflect-names --no-fb-import --cpp-ptr-type flatbuffers::unique_ptr  -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs
-..\%buildtype%\flatc.exe --cpp --js --ts --php --gen-mutable --reflect-names --gen-object-api --cpp-ptr-type flatbuffers::unique_ptr -o union_vector ./union_vector/union_vector.fbs
+..\%buildtype%\flatc.exe --cpp --js --ts --php --gen-mutable --reflect-names --gen-object-api --gen-compare --cpp-ptr-type flatbuffers::unique_ptr -o union_vector ./union_vector/union_vector.fbs
 ..\%buildtype%\flatc.exe -b --schema --bfbs-comments -I include_test monster_test.fbs
 ..\%buildtype%\flatc.exe --jsonschema --schema -I include_test monster_test.fbs
 cd ../samples
-..\%buildtype%\flatc.exe --cpp --lobster --gen-mutable --reflect-names --gen-object-api --cpp-ptr-type flatbuffers::unique_ptr monster.fbs
+..\%buildtype%\flatc.exe --cpp --lobster --gen-mutable --reflect-names --gen-object-api --gen-compare --cpp-ptr-type flatbuffers::unique_ptr monster.fbs
 cd ../reflection
 
 cd ../tests

--- a/tests/generate_code.sh
+++ b/tests/generate_code.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-../flatc --cpp --java --csharp --dart --go --binary --lobster --lua --python --js --ts --php --grpc --gen-mutable --reflect-names --gen-object-api --gen-compare --no-includes --cpp-ptr-type flatbuffers::unique_ptr  --no-fb-import -I include_test monster_test.fbs monsterdata_test.json
-../flatc --cpp --java --csharp --dart --go --binary --lobster --lua --python --js --ts --php --gen-mutable --reflect-names --no-fb-import --cpp-ptr-type flatbuffers::unique_ptr  -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs
+../flatc --cpp --java --csharp --dart --go --binary --lobster --lua --python --js --ts --php --rust --grpc --gen-mutable --reflect-names --gen-object-api --gen-compare --no-includes --cpp-ptr-type flatbuffers::unique_ptr  --no-fb-import -I include_test monster_test.fbs monsterdata_test.json
+../flatc --cpp --java --csharp --dart --go --binary --lobster --lua --python --js --ts --php --rust --gen-mutable --reflect-names --no-fb-import --cpp-ptr-type flatbuffers::unique_ptr  -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs
 ../flatc --cpp --js --ts --php --gen-mutable --reflect-names --gen-object-api --gen-compare --cpp-ptr-type flatbuffers::unique_ptr -o union_vector ./union_vector/union_vector.fbs
 ../flatc -b --schema --bfbs-comments -I include_test monster_test.fbs
 ../flatc --jsonschema --schema -I include_test monster_test.fbs

--- a/tests/generate_code.sh
+++ b/tests/generate_code.sh
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-../flatc --cpp --java --csharp --dart --go --binary --lobster --lua --python --js --ts --php --rust --grpc --gen-mutable --reflect-names --gen-object-api --no-includes --cpp-ptr-type flatbuffers::unique_ptr  --no-fb-import -I include_test monster_test.fbs monsterdata_test.json
-../flatc --cpp --java --csharp --dart --go --binary --lobster --lua --python --js --ts --php --rust --gen-mutable --reflect-names --no-fb-import --cpp-ptr-type flatbuffers::unique_ptr  -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs
-../flatc --cpp --js --ts --php --gen-mutable --reflect-names --gen-object-api --cpp-ptr-type flatbuffers::unique_ptr -o union_vector ./union_vector/union_vector.fbs
+../flatc --cpp --java --csharp --dart --go --binary --lobster --lua --python --js --ts --php --grpc --gen-mutable --reflect-names --gen-object-api --gen-compare --no-includes --cpp-ptr-type flatbuffers::unique_ptr  --no-fb-import -I include_test monster_test.fbs monsterdata_test.json
+../flatc --cpp --java --csharp --dart --go --binary --lobster --lua --python --js --ts --php --gen-mutable --reflect-names --no-fb-import --cpp-ptr-type flatbuffers::unique_ptr  -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs
+../flatc --cpp --js --ts --php --gen-mutable --reflect-names --gen-object-api --gen-compare --cpp-ptr-type flatbuffers::unique_ptr -o union_vector ./union_vector/union_vector.fbs
 ../flatc -b --schema --bfbs-comments -I include_test monster_test.fbs
 ../flatc --jsonschema --schema -I include_test monster_test.fbs
 cd ../samples
-../flatc --cpp --lobster --gen-mutable --reflect-names --gen-object-api --cpp-ptr-type flatbuffers::unique_ptr monster.fbs
+../flatc --cpp --lobster --gen-mutable --reflect-names --gen-object-api --gen-compare --cpp-ptr-type flatbuffers::unique_ptr monster.fbs
 cd ../reflection

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -11,45 +11,54 @@ namespace MyGame {
 
 struct InParentNamespace;
 struct InParentNamespaceT;
-bool operator==(const InParentNamespaceT &lhs, const InParentNamespaceT &rhs);
 
 namespace Example2 {
 
 struct Monster;
 struct MonsterT;
-bool operator==(const MonsterT &lhs, const MonsterT &rhs);
 
 }  // namespace Example2
 
 namespace Example {
 
 struct Test;
-bool operator==(const Test &lhs, const Test &rhs);
 
 struct TestSimpleTableWithEnum;
 struct TestSimpleTableWithEnumT;
-bool operator==(const TestSimpleTableWithEnumT &lhs, const TestSimpleTableWithEnumT &rhs);
 
 struct Vec3;
-bool operator==(const Vec3 &lhs, const Vec3 &rhs);
 
 struct Ability;
-bool operator==(const Ability &lhs, const Ability &rhs);
 
 struct Stat;
 struct StatT;
-bool operator==(const StatT &lhs, const StatT &rhs);
 
 struct Referrable;
 struct ReferrableT;
-bool operator==(const ReferrableT &lhs, const ReferrableT &rhs);
 
 struct Monster;
 struct MonsterT;
-bool operator==(const MonsterT &lhs, const MonsterT &rhs);
 
 struct TypeAliases;
 struct TypeAliasesT;
+
+}  // namespace Example
+
+bool operator==(const InParentNamespaceT &lhs, const InParentNamespaceT &rhs);
+namespace Example2 {
+
+bool operator==(const MonsterT &lhs, const MonsterT &rhs);
+}  // namespace Example2
+
+namespace Example {
+
+bool operator==(const Test &lhs, const Test &rhs);
+bool operator==(const TestSimpleTableWithEnumT &lhs, const TestSimpleTableWithEnumT &rhs);
+bool operator==(const Vec3 &lhs, const Vec3 &rhs);
+bool operator==(const Ability &lhs, const Ability &rhs);
+bool operator==(const StatT &lhs, const StatT &rhs);
+bool operator==(const ReferrableT &lhs, const ReferrableT &rhs);
+bool operator==(const MonsterT &lhs, const MonsterT &rhs);
 bool operator==(const TypeAliasesT &lhs, const TypeAliasesT &rhs);
 
 }  // namespace Example
@@ -229,6 +238,9 @@ struct AnyUnion {
 inline bool operator==(const AnyUnion &lhs, const AnyUnion &rhs) {
   if (lhs.type != rhs.type) return false;
   switch (lhs.type) {
+    case Any_NONE: {
+      return true;
+    }
     case Any_Monster: {
       return *(reinterpret_cast<const MonsterT *>(lhs.value)) ==
              *(reinterpret_cast<const MonsterT *>(rhs.value));
@@ -242,7 +254,7 @@ inline bool operator==(const AnyUnion &lhs, const AnyUnion &rhs) {
              *(reinterpret_cast<const MyGame::Example2::MonsterT *>(rhs.value));
     }
     default: {
-      return true;
+      return false;
     }
   }
 }

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -11,36 +11,46 @@ namespace MyGame {
 
 struct InParentNamespace;
 struct InParentNamespaceT;
+bool operator==(const InParentNamespaceT &lhs, const InParentNamespaceT &rhs);
 
 namespace Example2 {
 
 struct Monster;
 struct MonsterT;
+bool operator==(const MonsterT &lhs, const MonsterT &rhs);
 
 }  // namespace Example2
 
 namespace Example {
 
 struct Test;
+bool operator==(const Test &lhs, const Test &rhs);
 
 struct TestSimpleTableWithEnum;
 struct TestSimpleTableWithEnumT;
+bool operator==(const TestSimpleTableWithEnumT &lhs, const TestSimpleTableWithEnumT &rhs);
 
 struct Vec3;
+bool operator==(const Vec3 &lhs, const Vec3 &rhs);
 
 struct Ability;
+bool operator==(const Ability &lhs, const Ability &rhs);
 
 struct Stat;
 struct StatT;
+bool operator==(const StatT &lhs, const StatT &rhs);
 
 struct Referrable;
 struct ReferrableT;
+bool operator==(const ReferrableT &lhs, const ReferrableT &rhs);
 
 struct Monster;
 struct MonsterT;
+bool operator==(const MonsterT &lhs, const MonsterT &rhs);
 
 struct TypeAliases;
 struct TypeAliasesT;
+bool operator==(const TypeAliasesT &lhs, const TypeAliasesT &rhs);
 
 }  // namespace Example
 
@@ -215,6 +225,27 @@ struct AnyUnion {
   }
 };
 
+
+inline bool operator==(const AnyUnion &lhs, const AnyUnion &rhs) {
+  if (lhs.type != rhs.type) return false;
+  switch (lhs.type) {
+    case Any_Monster: {
+      return *(reinterpret_cast<const MonsterT *>(lhs.value)) ==
+             *(reinterpret_cast<const MonsterT *>(rhs.value));
+    }
+    case Any_TestSimpleTableWithEnum: {
+      return *(reinterpret_cast<const TestSimpleTableWithEnumT *>(lhs.value)) ==
+             *(reinterpret_cast<const TestSimpleTableWithEnumT *>(rhs.value));
+    }
+    case Any_MyGame_Example2_Monster: {
+      return *(reinterpret_cast<const MyGame::Example2::MonsterT *>(lhs.value)) ==
+             *(reinterpret_cast<const MyGame::Example2::MonsterT *>(rhs.value));
+    }
+    default: {
+      return true;
+    }
+  }
+}
 bool VerifyAny(flatbuffers::Verifier &verifier, const void *obj, Any type);
 bool VerifyAnyVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<uint8_t> *types);
 
@@ -248,6 +279,12 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(2) Test FLATBUFFERS_FINAL_CLASS {
   }
 };
 FLATBUFFERS_STRUCT_END(Test, 4);
+
+inline bool operator==(const Test &lhs, const Test &rhs) {
+  return
+      (lhs.a() == rhs.a()) &&
+      (lhs.b() == rhs.b());
+}
 
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(16) Vec3 FLATBUFFERS_FINAL_CLASS {
  private:
@@ -318,6 +355,16 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(16) Vec3 FLATBUFFERS_FINAL_CLASS {
 };
 FLATBUFFERS_STRUCT_END(Vec3, 32);
 
+inline bool operator==(const Vec3 &lhs, const Vec3 &rhs) {
+  return
+      (lhs.x() == rhs.x()) &&
+      (lhs.y() == rhs.y()) &&
+      (lhs.z() == rhs.z()) &&
+      (lhs.test1() == rhs.test1()) &&
+      (lhs.test2() == rhs.test2()) &&
+      (lhs.test3() == rhs.test3());
+}
+
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Ability FLATBUFFERS_FINAL_CLASS {
  private:
   uint32_t id_;
@@ -352,6 +399,12 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Ability FLATBUFFERS_FINAL_CLASS {
 };
 FLATBUFFERS_STRUCT_END(Ability, 8);
 
+inline bool operator==(const Ability &lhs, const Ability &rhs) {
+  return
+      (lhs.id() == rhs.id()) &&
+      (lhs.distance() == rhs.distance());
+}
+
 }  // namespace Example
 
 struct InParentNamespaceT : public flatbuffers::NativeTable {
@@ -359,6 +412,10 @@ struct InParentNamespaceT : public flatbuffers::NativeTable {
   InParentNamespaceT() {
   }
 };
+
+inline bool operator==(const InParentNamespaceT &, const InParentNamespaceT &) {
+  return true;
+}
 
 struct InParentNamespace FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef InParentNamespaceT NativeTableType;
@@ -404,6 +461,10 @@ struct MonsterT : public flatbuffers::NativeTable {
   MonsterT() {
   }
 };
+
+inline bool operator==(const MonsterT &, const MonsterT &) {
+  return true;
+}
 
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MonsterT NativeTableType;
@@ -453,6 +514,11 @@ struct TestSimpleTableWithEnumT : public flatbuffers::NativeTable {
       : color(Color_Green) {
   }
 };
+
+inline bool operator==(const TestSimpleTableWithEnumT &lhs, const TestSimpleTableWithEnumT &rhs) {
+  return
+      (lhs.color == rhs.color);
+}
 
 struct TestSimpleTableWithEnum FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TestSimpleTableWithEnumT NativeTableType;
@@ -516,6 +582,13 @@ struct StatT : public flatbuffers::NativeTable {
         count(0) {
   }
 };
+
+inline bool operator==(const StatT &lhs, const StatT &rhs) {
+  return
+      (lhs.id == rhs.id) &&
+      (lhs.val == rhs.val) &&
+      (lhs.count == rhs.count);
+}
 
 struct Stat FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef StatT NativeTableType;
@@ -615,6 +688,11 @@ struct ReferrableT : public flatbuffers::NativeTable {
       : id(0) {
   }
 };
+
+inline bool operator==(const ReferrableT &lhs, const ReferrableT &rhs) {
+  return
+      (lhs.id == rhs.id);
+}
 
 struct Referrable FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef ReferrableT NativeTableType;
@@ -738,6 +816,51 @@ struct MonsterT : public flatbuffers::NativeTable {
         non_owning_reference(nullptr) {
   }
 };
+
+inline bool operator==(const MonsterT &lhs, const MonsterT &rhs) {
+  return
+      (lhs.pos == rhs.pos) &&
+      (lhs.mana == rhs.mana) &&
+      (lhs.hp == rhs.hp) &&
+      (lhs.name == rhs.name) &&
+      (lhs.inventory == rhs.inventory) &&
+      (lhs.color == rhs.color) &&
+      (lhs.test == rhs.test) &&
+      (lhs.test4 == rhs.test4) &&
+      (lhs.testarrayofstring == rhs.testarrayofstring) &&
+      (lhs.testarrayoftables == rhs.testarrayoftables) &&
+      (lhs.enemy == rhs.enemy) &&
+      (lhs.testnestedflatbuffer == rhs.testnestedflatbuffer) &&
+      (lhs.testempty == rhs.testempty) &&
+      (lhs.testbool == rhs.testbool) &&
+      (lhs.testhashs32_fnv1 == rhs.testhashs32_fnv1) &&
+      (lhs.testhashu32_fnv1 == rhs.testhashu32_fnv1) &&
+      (lhs.testhashs64_fnv1 == rhs.testhashs64_fnv1) &&
+      (lhs.testhashu64_fnv1 == rhs.testhashu64_fnv1) &&
+      (lhs.testhashs32_fnv1a == rhs.testhashs32_fnv1a) &&
+      (lhs.testhashu32_fnv1a == rhs.testhashu32_fnv1a) &&
+      (lhs.testhashs64_fnv1a == rhs.testhashs64_fnv1a) &&
+      (lhs.testhashu64_fnv1a == rhs.testhashu64_fnv1a) &&
+      (lhs.testarrayofbools == rhs.testarrayofbools) &&
+      (lhs.testf == rhs.testf) &&
+      (lhs.testf2 == rhs.testf2) &&
+      (lhs.testf3 == rhs.testf3) &&
+      (lhs.testarrayofstring2 == rhs.testarrayofstring2) &&
+      (lhs.testarrayofsortedstruct == rhs.testarrayofsortedstruct) &&
+      (lhs.flex == rhs.flex) &&
+      (lhs.test5 == rhs.test5) &&
+      (lhs.vector_of_longs == rhs.vector_of_longs) &&
+      (lhs.vector_of_doubles == rhs.vector_of_doubles) &&
+      (lhs.parent_namespace_test == rhs.parent_namespace_test) &&
+      (lhs.vector_of_referrables == rhs.vector_of_referrables) &&
+      (lhs.single_weak_reference == rhs.single_weak_reference) &&
+      (lhs.vector_of_weak_references == rhs.vector_of_weak_references) &&
+      (lhs.vector_of_strong_referrables == rhs.vector_of_strong_referrables) &&
+      (lhs.co_owning_reference == rhs.co_owning_reference) &&
+      (lhs.vector_of_co_owning_references == rhs.vector_of_co_owning_references) &&
+      (lhs.non_owning_reference == rhs.non_owning_reference) &&
+      (lhs.vector_of_non_owning_references == rhs.vector_of_non_owning_references);
+}
 
 /// an example documentation comment: monster object
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -1506,6 +1629,22 @@ struct TypeAliasesT : public flatbuffers::NativeTable {
         f64(0.0) {
   }
 };
+
+inline bool operator==(const TypeAliasesT &lhs, const TypeAliasesT &rhs) {
+  return
+      (lhs.i8 == rhs.i8) &&
+      (lhs.u8 == rhs.u8) &&
+      (lhs.i16 == rhs.i16) &&
+      (lhs.u16 == rhs.u16) &&
+      (lhs.i32 == rhs.i32) &&
+      (lhs.u32 == rhs.u32) &&
+      (lhs.i64 == rhs.i64) &&
+      (lhs.u64 == rhs.u64) &&
+      (lhs.f32 == rhs.f32) &&
+      (lhs.f64 == rhs.f64) &&
+      (lhs.v8 == rhs.v8) &&
+      (lhs.vf64 == rhs.vf64);
+}
 
 struct TypeAliases FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TypeAliasesT NativeTableType;

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1978,6 +1978,25 @@ void UninitializedVectorTest() {
   TEST_EQ(test_1->b(), 40);
 }
 
+void EqualOperatorTest() {
+  MonsterT a;
+  MonsterT b;
+  TEST_EQ(b == a, true);
+
+  b.mana = 33;
+  TEST_EQ(b == a, false);
+  b.mana = 150;
+  TEST_EQ(b == a, true);
+
+  b.inventory.push_back(3);
+  TEST_EQ(b == a, false);
+  b.inventory.clear();
+  TEST_EQ(b == a, true);
+
+  b.test.type = Any_Monster;
+  TEST_EQ(b == a, false);
+}
+
 // For testing any binaries, e.g. from fuzzing.
 void LoadVerifyBinaryTest() {
   std::string binary;
@@ -2062,6 +2081,7 @@ int main(int /*argc*/, const char * /*argv*/ []) {
 
   FlexBuffersTest();
   UninitializedVectorTest();
+  EqualOperatorTest();
 
   if (!testing_fails) {
     TEST_OUTPUT_LINE("ALL TESTS PASSED");

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -8,13 +8,17 @@
 
 struct Attacker;
 struct AttackerT;
+bool operator==(const AttackerT &lhs, const AttackerT &rhs);
 
 struct Rapunzel;
+bool operator==(const Rapunzel &lhs, const Rapunzel &rhs);
 
 struct BookReader;
+bool operator==(const BookReader &lhs, const BookReader &rhs);
 
 struct Movie;
 struct MovieT;
+bool operator==(const MovieT &lhs, const MovieT &rhs);
 
 inline const flatbuffers::TypeTable *AttackerTypeTable();
 
@@ -138,6 +142,39 @@ struct CharacterUnion {
   }
 };
 
+
+inline bool operator==(const CharacterUnion &lhs, const CharacterUnion &rhs) {
+  if (lhs.type != rhs.type) return false;
+  switch (lhs.type) {
+    case Character_MuLan: {
+      return *(reinterpret_cast<const AttackerT *>(lhs.value)) ==
+             *(reinterpret_cast<const AttackerT *>(rhs.value));
+    }
+    case Character_Rapunzel: {
+      return *(reinterpret_cast<const Rapunzel *>(lhs.value)) ==
+             *(reinterpret_cast<const Rapunzel *>(rhs.value));
+    }
+    case Character_Belle: {
+      return *(reinterpret_cast<const BookReader *>(lhs.value)) ==
+             *(reinterpret_cast<const BookReader *>(rhs.value));
+    }
+    case Character_BookFan: {
+      return *(reinterpret_cast<const BookReader *>(lhs.value)) ==
+             *(reinterpret_cast<const BookReader *>(rhs.value));
+    }
+    case Character_Other: {
+      return *(reinterpret_cast<const std::string *>(lhs.value)) ==
+             *(reinterpret_cast<const std::string *>(rhs.value));
+    }
+    case Character_Unused: {
+      return *(reinterpret_cast<const std::string *>(lhs.value)) ==
+             *(reinterpret_cast<const std::string *>(rhs.value));
+    }
+    default: {
+      return true;
+    }
+  }
+}
 bool VerifyCharacter(flatbuffers::Verifier &verifier, const void *obj, Character type);
 bool VerifyCharacterVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<uint8_t> *types);
 
@@ -161,6 +198,11 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Rapunzel FLATBUFFERS_FINAL_CLASS {
 };
 FLATBUFFERS_STRUCT_END(Rapunzel, 4);
 
+inline bool operator==(const Rapunzel &lhs, const Rapunzel &rhs) {
+  return
+      (lhs.hair_length() == rhs.hair_length());
+}
+
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) BookReader FLATBUFFERS_FINAL_CLASS {
  private:
   int32_t books_read_;
@@ -181,6 +223,11 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) BookReader FLATBUFFERS_FINAL_CLASS {
 };
 FLATBUFFERS_STRUCT_END(BookReader, 4);
 
+inline bool operator==(const BookReader &lhs, const BookReader &rhs) {
+  return
+      (lhs.books_read() == rhs.books_read());
+}
+
 struct AttackerT : public flatbuffers::NativeTable {
   typedef Attacker TableType;
   int32_t sword_attack_damage;
@@ -188,6 +235,11 @@ struct AttackerT : public flatbuffers::NativeTable {
       : sword_attack_damage(0) {
   }
 };
+
+inline bool operator==(const AttackerT &lhs, const AttackerT &rhs) {
+  return
+      (lhs.sword_attack_damage == rhs.sword_attack_damage);
+}
 
 struct Attacker FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef AttackerT NativeTableType;
@@ -248,6 +300,12 @@ struct MovieT : public flatbuffers::NativeTable {
   MovieT() {
   }
 };
+
+inline bool operator==(const MovieT &lhs, const MovieT &rhs) {
+  return
+      (lhs.main_character == rhs.main_character) &&
+      (lhs.characters == rhs.characters);
+}
 
 struct Movie FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MovieT NativeTableType;

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -8,16 +8,17 @@
 
 struct Attacker;
 struct AttackerT;
-bool operator==(const AttackerT &lhs, const AttackerT &rhs);
 
 struct Rapunzel;
-bool operator==(const Rapunzel &lhs, const Rapunzel &rhs);
 
 struct BookReader;
-bool operator==(const BookReader &lhs, const BookReader &rhs);
 
 struct Movie;
 struct MovieT;
+
+bool operator==(const AttackerT &lhs, const AttackerT &rhs);
+bool operator==(const Rapunzel &lhs, const Rapunzel &rhs);
+bool operator==(const BookReader &lhs, const BookReader &rhs);
 bool operator==(const MovieT &lhs, const MovieT &rhs);
 
 inline const flatbuffers::TypeTable *AttackerTypeTable();
@@ -146,6 +147,9 @@ struct CharacterUnion {
 inline bool operator==(const CharacterUnion &lhs, const CharacterUnion &rhs) {
   if (lhs.type != rhs.type) return false;
   switch (lhs.type) {
+    case Character_NONE: {
+      return true;
+    }
     case Character_MuLan: {
       return *(reinterpret_cast<const AttackerT *>(lhs.value)) ==
              *(reinterpret_cast<const AttackerT *>(rhs.value));
@@ -171,7 +175,7 @@ inline bool operator==(const CharacterUnion &lhs, const CharacterUnion &rhs) {
              *(reinterpret_cast<const std::string *>(rhs.value));
     }
     default: {
-      return true;
+      return false;
     }
   }
 }


### PR DESCRIPTION
New "--gen-compare" option for flatc to generate compare operators. The operators are defined based on the object based api.

Inspired by issue #263