### PR TITLE
Adding option to skip byte-array fields when outputting to JSON. [JSON]

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -366,6 +366,7 @@ struct IDLOptions {
   bool use_goog_js_export_format;
   bool use_ES6_js_export_format;
   bool output_default_scalars_in_json;
+  bool output_ubyte_array_fields_in_json;
   int indent_step;
   bool output_enum_identifiers;
   bool prefixed_enums;
@@ -440,6 +441,7 @@ struct IDLOptions {
         use_goog_js_export_format(false),
         use_ES6_js_export_format(false),
         output_default_scalars_in_json(false),
+        output_ubyte_array_fields_in_json(true),
         indent_step(2),
         output_enum_identifiers(true),
         prefixed_enums(true),

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -208,7 +208,10 @@ static bool GenStruct(const StructDef &struct_def, const Table *table,
     auto is_present = struct_def.fixed || table->CheckField(fd.value.offset);
     auto output_anyway = opts.output_default_scalars_in_json &&
                          IsScalar(fd.value.type.base_type) && !fd.deprecated;
-    if (is_present || output_anyway) {
+    auto skip_field = !opts.output_ubyte_array_fields_in_json &&
+                      fd.value.type.base_type == BASE_TYPE_VECTOR &&
+                      fd.value.type.element == BASE_TYPE_UCHAR;
+    if ((is_present || output_anyway) && !skip_field) {
       if (fieldout++) {
         if (!opts.protobuf_ascii_alike) text += ",";
       }


### PR DESCRIPTION
We're using the JSON text emitter to generate test goldens, but due to the apparent non-determinism in the Flatbuf library when encoding tables as bytes, it appears our tests can be flaky for byte-array fields that contain serialized flatbuf tables. This issue appears to worsen with larger tables of data (which makes sense).

This commit adds an option to skip byte-array typed fields (`output_ubyte_array_fields_in_json`) when outputting flatbuf tables to JSON, which thus avoids the flaky fields that contain serialized flatbuf tables. It also adds a relevant test function for the new option.