### PR TITLE
Add assert to fail tests on the first failure

### DIFF
--- a/tests/test_assert.cpp
+++ b/tests/test_assert.cpp
@@ -7,6 +7,7 @@ void TestFail(const char *expval, const char *val, const char *exp,
   TEST_OUTPUT_LINE("VALUE: \"%s\"", expval);
   TEST_OUTPUT_LINE("EXPECTED: \"%s\"", val);
   TEST_OUTPUT_LINE("TEST FAILED: %s:%d, %s in %s", file, line, exp, func? func : "");
+  assert(0);
   testing_fails++;
 }
 


### PR DESCRIPTION
I added `assert(0)` back. `testing_fails` is no longer relevant in `Debug` builds anymore. In `Release` builds multi-test failure is reported as such. I'm not sure how much valuable that is. If you think `testing_fails` should also be removed, I'll update.