### PR TITLE
Assert tests on the first failure.

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2014 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2083,6 +2083,7 @@ int FlatBufferTests() {
 }
 
 int main(int /*argc*/, const char * /*argv*/ []) {
+  InitTestEngine();
 
   FlatBufferTests();
   FlatBufferBuilderTest();

--- a/tests/test_assert.cpp
+++ b/tests/test_assert.cpp
@@ -1,6 +1,6 @@
 #ifdef _MSC_VER
-#include <assert.h>
-#include <crtdbg.h>
+#  include <assert.h>
+#  include <crtdbg.h>
 #endif
 
 #include "test_assert.h"
@@ -11,9 +11,10 @@ void TestFail(const char *expval, const char *val, const char *exp,
               const char *file, int line, const char *func) {
   TEST_OUTPUT_LINE("VALUE: \"%s\"", expval);
   TEST_OUTPUT_LINE("EXPECTED: \"%s\"", val);
-  TEST_OUTPUT_LINE("TEST FAILED: %s:%d, %s in %s", file, line, exp, func? func : "");
+  TEST_OUTPUT_LINE("TEST FAILED: %s:%d, %s in %s", file, line, exp,
+                   func ? func : "");
   testing_fails++;
-  assert(0); // assert on first failure under debug
+  assert(0);  // assert on first failure under debug
 }
 
 void TestEqStr(const char *expval, const char *val, const char *exp,
@@ -22,13 +23,9 @@ void TestEqStr(const char *expval, const char *val, const char *exp,
 }
 
 // Without this hook function the message box not suppressed.
-int msvc_no_dialog_box_on_assert(int nRptType, char *szMsg,
-                                 int * /* retVal */) {
-  // Generate the debug report using the current settings for the report type,
-  // mode, and file. In addition, by specifying the _CrtDbgReport return value
-  // in returnValue, the application can also control whether a debug break
-  // occurs.
-  TEST_OUTPUT_LINE("TEST ASSERTED: %d: %s", nRptType, szMsg);
+int msvc_no_dialog_box_on_assert(int rpt_type, char *msg, int *ret_val) {
+  (void)ret_val;
+  TEST_OUTPUT_LINE("TEST ASSERTED: %d: %s", rpt_type, msg);
   return 1;
 }
 
@@ -39,12 +36,15 @@ void InitTestEngine() {
   setvbuf(stdout, NULL, _IONBF, 0);
   setvbuf(stderr, NULL, _IONBF, 0);
 
-#ifdef _MSC_VER
-  // Suppress pop-up message box on assertion (MSVC2010, MSVC2012).
-  // This message box hangs CI-test on the hour until timeout expired.
-  // Default mode is file, file is stderr.
-  _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
-  _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
-  _CrtSetReportHook(msvc_no_dialog_box_on_assert);
-#endif
+  // clang-format off
+
+  #ifdef _MSC_VER
+    // Suppress pop-up message box on assertion (MSVC2010, MSVC2012).
+    // This message box hangs CI-test on the hour until timeout expired.
+    // Default mode is file, file is stderr.
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    _CrtSetReportHook(msvc_no_dialog_box_on_assert);
+  #endif
+  // clang-format on
 }

--- a/tests/test_assert.cpp
+++ b/tests/test_assert.cpp
@@ -1,3 +1,8 @@
+#ifdef _MSC_VER
+#include <assert.h>
+#include <crtdbg.h>
+#endif
+
 #include "test_assert.h"
 
 int testing_fails = 0;
@@ -8,6 +13,7 @@ void TestFail(const char *expval, const char *val, const char *exp,
   TEST_OUTPUT_LINE("EXPECTED: \"%s\"", val);
   TEST_OUTPUT_LINE("TEST FAILED: %s:%d, %s in %s", file, line, exp, func? func : "");
   testing_fails++;
+  assert(0); // assert on first failure under debug
 }
 
 void TestEqStr(const char *expval, const char *val, const char *exp,
@@ -15,3 +21,30 @@ void TestEqStr(const char *expval, const char *val, const char *exp,
   if (strcmp(expval, val) != 0) { TestFail(expval, val, exp, file, line); }
 }
 
+// Without this hook function the message box not suppressed.
+int msvc_no_dialog_box_on_assert(int nRptType, char *szMsg,
+                                 int * /* retVal */) {
+  // Generate the debug report using the current settings for the report type,
+  // mode, and file. In addition, by specifying the _CrtDbgReport return value
+  // in returnValue, the application can also control whether a debug break
+  // occurs.
+  TEST_OUTPUT_LINE("TEST ASSERTED: %d: %s", nRptType, szMsg);
+  return 1;
+}
+
+void InitTestEngine() {
+  testing_fails = 0;
+  // Disable stdout buffering to prevent information lost on assertion or core
+  // dump.
+  setvbuf(stdout, NULL, _IONBF, 0);
+  setvbuf(stderr, NULL, _IONBF, 0);
+
+#ifdef _MSC_VER
+  // Suppress pop-up message box on assertion (MSVC2010, MSVC2012).
+  // This message box hangs CI-test on the hour until timeout expired.
+  // Default mode is file, file is stderr.
+  _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+  _CrtSetReportHook(msvc_no_dialog_box_on_assert);
+#endif
+}

--- a/tests/test_assert.cpp
+++ b/tests/test_assert.cpp
@@ -22,12 +22,14 @@ void TestEqStr(const char *expval, const char *val, const char *exp,
   if (strcmp(expval, val) != 0) { TestFail(expval, val, exp, file, line); }
 }
 
+#ifdef _MSC_VER
 // Without this hook function the message box not suppressed.
 int msvc_no_dialog_box_on_assert(int rpt_type, char *msg, int *ret_val) {
   (void)ret_val;
   TEST_OUTPUT_LINE("TEST ASSERTED: %d: %s", rpt_type, msg);
   return 1;
 }
+#endif
 
 void InitTestEngine() {
   testing_fails = 0;

--- a/tests/test_assert.h
+++ b/tests/test_assert.h
@@ -17,6 +17,9 @@
 
 extern int testing_fails;
 
+// Prepare test engine (MSVC assertion setup, etc)
+void InitTestEngine();
+
 void TestFail(const char *expval, const char *val, const char *exp,
               const char *file, int line, const char *func = 0);
 


### PR DESCRIPTION
- This PR restores an assertion on the first failure in tests.
- This PR disables pop-up message box on assertion under Windows for old MSVC.

Before PR, MSVC2010 and MSVC2012 continuous integration tests are stalled until a timeout expired.
The pop-up message box with "Abort", "Retry" and "Ignore" buttons blocks CI until the timeout (60 minutes).
