### PR TITLE
Turn on gRPC tests in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,9 @@ matrix:
       - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo ln -s -v -f $(which gcc-$GCC_VERSION) /usr/bin/gcc; fi
 
       script:
-      - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE . && make && make test
+      - bash grpc/build_grpc.sh
+      - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFLATBUFFERS_BUILD_GRPCTEST=ON -DGRPC_INSTALL_PATH=$TRAVIS_BUILD_DIR/google/grpc/install -DPROTOBUF_DOWNLOAD_PATH=$TRAVIS_BUILD_DIR/google/grpc/third_party/protobuf . && make
+      - LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/google/grpc/install/lib make test ARGS=-V
       - if [ "$CONAN" == "true" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo pip install conan && conan create . google/testing -s build_type=$BUILD_TYPE -tf conan/test_package; fi
 
     - language: cpp
@@ -83,7 +85,10 @@ matrix:
           - BUILD_TYPE=Debug
           - BUILD_TYPE=Release
       script:
-      - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE . && make && make test
+      - bash grpc/build_grpc.sh
+      - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFLATBUFFERS_BUILD_GRPCTEST=ON -DGRPC_INSTALL_PATH=$TRAVIS_BUILD_DIR/google/grpc/install -DPROTOBUF_DOWNLOAD_PATH=$TRAVIS_BUILD_DIR/google/grpc/third_party/protobuf . && make
+      - ./flattests
+      - DYLD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/google/grpc/install/lib ./grpctest
 
     - <<: *conan-linux
       env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=lasote/conangcc49

--- a/grpc/build_grpc.sh
+++ b/grpc/build_grpc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+grpc_1_15_1_githash=1a60e6971f428323245a930031ad267bb3142ba4
+
+function build_grpc () {
+  git clone https://github.com/grpc/grpc.git google/grpc
+  cd google/grpc
+  git checkout ${grpc_1_15_1_githash} 
+  git submodule update --init
+  make
+  make install prefix=`pwd`/install
+  if [ ! -f ${GRPC_INSTALL_PATH}/lib/libgrpc++_unsecure.so.1 ]; then
+    ln -s ${GRPC_INSTALL_PATH}/lib/libgrpc++_unsecure.so.6 ${GRPC_INSTALL_PATH}/lib/libgrpc++_unsecure.so.1
+  fi
+  cd ../..
+}
+
+GRPC_INSTALL_PATH=`pwd`/google/grpc/install
+PROTOBUF_DOWNLOAD_PATH=`pwd`/google/grpc/third_party/protobuf
+
+build_grpc


### PR DESCRIPTION
This PR updates the `.travis.yml` file to run the gRPC tests during the regular CI step. Only Linux and Mac platforms are supported at the moment. The travis file invokes `grpc/build_grpc.sh` that clones grpc repo, checkout a specfic githash (v 1.15.1 at the moment), builds it, and uses it to test the grpc tests. The test I would like to run at every flatbuffers CI are `grpc/test_message_builder.cpp`. 

Due to some quirks on Mac, `make test ARGS=-V` does not work. So it calls the tests explicitly. 