### PR TITLE
C++ - Allow tables that are entirely composed of native inlines to be copied

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -1299,7 +1299,8 @@ class CppGenerator : public BaseGenerator {
           for (auto fit = ev.union_type.struct_def->fields.vec.begin();
                fit != ev.union_type.struct_def->fields.vec.end(); ++fit) {
             const auto &field = **fit;
-            if (!field.deprecated && field.value.type.struct_def) {
+            if (!field.deprecated && field.value.type.struct_def &&
+                !field.native_inline) {
               copyable = false;
               break;
             }


### PR DESCRIPTION
This PR tightens the constraints a little bit on the heuristic for determining if a table within a struct is non-copyable in C++. Unions generate a copy constructor in C++ code. Union types that are not copyable get an `assert`, like this:

```c++
inline CharacterUnion::CharacterUnion(const CharacterUnion &u) FLATBUFFERS_NOEXCEPT : type(u.type), value(nullptr) {
  switch (type) {
    case Character_MuLan: {
      value = new AttackerT(*reinterpret_cast<AttackerT *>(u.value));
      break;
    }
    // ...
    case Character_NonCopyable: {
      FLATBUFFERS_ASSERT(false);  // NonCopyable not copyable.
      break;
    }
```

This PR changes the check to only mark a type as non-copyable if the type contains struct fields that are non-`native_inline`. This causes `native_inline` fields to be treated in the same was as scalar/primitive type fields.

> If you make changes to any of the code generators, be sure to run `cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated code changes in the PR. This allows us to better see the effect of the PR.

This doesn't change any of the generated code, because `union_vector.fbs` doesn't currently include any non-copyable types.