### PR TITLE
Javascript - Generate bidirectional mappings for enums

### DIFF
--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -355,9 +355,22 @@ class JsGenerator : public BaseGenerator {
         if (it != enum_def.vals.vec.begin()) { code += '\n'; }
         GenDocComment(ev.doc_comment, code_ptr, "", "  ");
       }
+
+      // Generate mapping between EnumName: EnumValue(int)
       code += "  " + ev.name;
       code += lang_.language == IDLOptions::kTs ? "= " : ": ";
       code += NumToString(ev.value);
+
+      if (lang_.language == IDLOptions::kJs) {
+        // In pure Javascript, generate mapping between EnumValue(int):
+        // 'EnumName' so enums can be looked up by their ID.
+        code += ", ";
+
+        code += NumToString(ev.value);
+        code += lang_.language == IDLOptions::kTs ? "= " : ": ";
+        code += "'" + ev.name + "'";
+      }
+
       code += (it + 1) != enum_def.vals.vec.end() ? ",\n" : "\n";
 
       if (ev.union_type.struct_def) {

--- a/tests/monster_test_generated.js
+++ b/tests/monster_test_generated.js
@@ -28,19 +28,19 @@ MyGame.OtherNameSpace = MyGame.OtherNameSpace || {};
  * @enum
  */
 MyGame.Example.Color = {
-  Red: 1,
-  Green: 2,
-  Blue: 8
+  Red: 1, 1: 'Red',
+  Green: 2, 2: 'Green',
+  Blue: 8, 8: 'Blue'
 };
 
 /**
  * @enum
  */
 MyGame.Example.Any = {
-  NONE: 0,
-  Monster: 1,
-  TestSimpleTableWithEnum: 2,
-  MyGame_Example2_Monster: 3
+  NONE: 0, 0: 'NONE',
+  Monster: 1, 1: 'Monster',
+  TestSimpleTableWithEnum: 2, 2: 'TestSimpleTableWithEnum',
+  MyGame_Example2_Monster: 3, 3: 'MyGame_Example2_Monster'
 };
 
 /**

--- a/tests/namespace_test/namespace_test1_generated.js
+++ b/tests/namespace_test/namespace_test1_generated.js
@@ -16,9 +16,9 @@ NamespaceA.NamespaceB = NamespaceA.NamespaceB || {};
  * @enum
  */
 NamespaceA.NamespaceB.EnumInNestedNS = {
-  A: 0,
-  B: 1,
-  C: 2
+  A: 0, 0: 'A',
+  B: 1, 1: 'B',
+  C: 2, 2: 'C'
 };
 
 /**

--- a/tests/union_vector/union_vector_generated.js
+++ b/tests/union_vector/union_vector_generated.js
@@ -4,13 +4,13 @@
  * @enum
  */
 var Character = {
-  NONE: 0,
-  MuLan: 1,
-  Rapunzel: 2,
-  Belle: 3,
-  BookFan: 4,
-  Other: 5,
-  Unused: 6
+  NONE: 0, 0: 'NONE',
+  MuLan: 1, 1: 'MuLan',
+  Rapunzel: 2, 2: 'Rapunzel',
+  Belle: 3, 3: 'Belle',
+  BookFan: 4, 4: 'BookFan',
+  Other: 5, 5: 'Other',
+  Unused: 6, 6: 'Unused'
 };
 
 /**


### PR DESCRIPTION
This implements a feature described in #4506, generating a bi-directional mapping between enum name and enum value in Javascript. This makes it possible to lookup the name of an enum given its integer value.

```js
MyGame.Example.Color = {
  Red: 1, 1: 'Red',
  Green: 2, 2: 'Green',
  Blue: 8, 8: 'Blue'
};
```

This makes it so you can do things like:
```js
   const my_color = MyGame.Example.Color.Red;
   console.log("My color is " + MyGame.Example.Color[my_color]);
```