### PR TITLE
Java: Adds __reset method to Struct and Table

### DIFF
--- a/java/com/google/flatbuffers/Struct.java
+++ b/java/com/google/flatbuffers/Struct.java
@@ -28,6 +28,20 @@ public class Struct {
   protected int bb_pos;
   /** The underlying ByteBuffer to hold the data of the Struct. */
   protected ByteBuffer bb;
+
+  /**
+   * Resets internal state with a null {@code ByteBuffer} and a zero position.
+   *
+   * This method exists primarily to allow recycling Struct instances without risking memory leaks
+   * due to {@code ByteBuffer} references. The instance will be unusable until it is assigned
+   * again to a {@code ByteBuffer}.
+   *
+   * @param struct the instance to reset to initial state
+   */
+  public void __reset() {
+    bb = null;
+    bb_pos = 0;
+  }
 }
 
 /// @endcond

--- a/java/com/google/flatbuffers/Table.java
+++ b/java/com/google/flatbuffers/Table.java
@@ -292,6 +292,18 @@ public class Table {
     }
     return len_1 - len_2;
   }
+
+  /**
+   * Resets the internal state with a null {@code ByteBuffer} and a zero position.
+   *
+   * This method exists primarily to allow recycling Table instances without risking memory leaks
+   * due to {@code ByteBuffer} references. The instance will be unusable until it is assigned
+   * again to a {@code ByteBuffer}.
+   */
+  public void __reset() {
+    bb = null;
+    bb_pos = 0;
+  }
 }
 
 /// @endcond


### PR DESCRIPTION
This allow recycling/pooling instances without leaking ByteBuffers, by
providing a mechanism to reset instance to newly constructed state.