### PR TITLE
[C++/Flexbuffers] Add missing const on Reference::As<>

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -591,7 +591,7 @@ class Reference {
     }
   }
 
-  template<typename T> T As();
+  template<typename T> T As() const;
 
   // Experimental: Mutation functions.
   // These allow scalars in an already created buffer to be updated in-place.
@@ -704,35 +704,35 @@ class Reference {
 };
 
 // Template specialization for As().
-template<> inline bool Reference::As<bool>() { return AsBool(); }
+template<> inline bool Reference::As<bool>() const { return AsBool(); }
 
-template<> inline int8_t Reference::As<int8_t>() { return AsInt8(); }
-template<> inline int16_t Reference::As<int16_t>() { return AsInt16(); }
-template<> inline int32_t Reference::As<int32_t>() { return AsInt32(); }
-template<> inline int64_t Reference::As<int64_t>() { return AsInt64(); }
+template<> inline int8_t Reference::As<int8_t>() const { return AsInt8(); }
+template<> inline int16_t Reference::As<int16_t>() const { return AsInt16(); }
+template<> inline int32_t Reference::As<int32_t>() const { return AsInt32(); }
+template<> inline int64_t Reference::As<int64_t>() const { return AsInt64(); }
 
-template<> inline uint8_t Reference::As<uint8_t>() { return AsUInt8(); }
-template<> inline uint16_t Reference::As<uint16_t>() { return AsUInt16(); }
-template<> inline uint32_t Reference::As<uint32_t>() { return AsUInt32(); }
-template<> inline uint64_t Reference::As<uint64_t>() { return AsUInt64(); }
+template<> inline uint8_t Reference::As<uint8_t>() const { return AsUInt8(); }
+template<> inline uint16_t Reference::As<uint16_t>() const { return AsUInt16(); }
+template<> inline uint32_t Reference::As<uint32_t>() const { return AsUInt32(); }
+template<> inline uint64_t Reference::As<uint64_t>() const { return AsUInt64(); }
 
-template<> inline double Reference::As<double>() { return AsDouble(); }
-template<> inline float Reference::As<float>() { return AsFloat(); }
+template<> inline double Reference::As<double>() const { return AsDouble(); }
+template<> inline float Reference::As<float>() const { return AsFloat(); }
 
-template<> inline String Reference::As<String>() { return AsString(); }
-template<> inline std::string Reference::As<std::string>() {
+template<> inline String Reference::As<String>() const { return AsString(); }
+template<> inline std::string Reference::As<std::string>() const {
   return AsString().str();
 }
 
-template<> inline Blob Reference::As<Blob>() { return AsBlob(); }
-template<> inline Vector Reference::As<Vector>() { return AsVector(); }
-template<> inline TypedVector Reference::As<TypedVector>() {
+template<> inline Blob Reference::As<Blob>() const { return AsBlob(); }
+template<> inline Vector Reference::As<Vector>() const { return AsVector(); }
+template<> inline TypedVector Reference::As<TypedVector>() const {
   return AsTypedVector();
 }
-template<> inline FixedTypedVector Reference::As<FixedTypedVector>() {
+template<> inline FixedTypedVector Reference::As<FixedTypedVector>() const {
   return AsFixedTypedVector();
 }
-template<> inline Map Reference::As<Map>() { return AsMap(); }
+template<> inline Map Reference::As<Map>() const { return AsMap(); }
 
 inline uint8_t PackedType(BitWidth bit_width, Type type) {
   return static_cast<uint8_t>(bit_width | (type << 2));


### PR DESCRIPTION
Reference::As<> was needlessly mutable which made them
less safe and harder to use
