### PR TITLE
disallow c style casts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ if(EXISTS "${CMAKE_TOOLCHAIN_FILE}")
 elseif(APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror -Wextra -Wno-unused-parameter")
+  set(FLATBUFFERS_PRIVATE_CXX_FLAGS "-Wold-style-cast")
 elseif(CMAKE_COMPILER_IS_GNUCXX)
   if(CYGWIN)
     set(CMAKE_CXX_FLAGS
@@ -140,6 +141,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
   endif(CYGWIN)
   set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror -Wextra -Werror=shadow")
+  set(FLATBUFFERS_PRIVATE_CXX_FLAGS "-Wold-style-cast")
   if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.4)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
       set(CMAKE_CXX_FLAGS
@@ -157,6 +159,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
   set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -pedantic -Werror -Wextra -Wno-unused-parameter")
+  set(FLATBUFFERS_PRIVATE_CXX_FLAGS "-Wold-style-cast")
   if(FLATBUFFERS_LIBCXX_WITH_CLANG)
     if(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
       set(CMAKE_CXX_FLAGS
@@ -200,10 +203,12 @@ if(FLATBUFFERS_BUILD_FLATLIB)
   # CMake > 2.8.11: Attach header directory for when build via add_subdirectory().
   target_include_directories(flatbuffers INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+  target_compile_options(flatbuffers PRIVATE "${FLATBUFFERS_PRIVATE_CXX_FLAGS}")
 endif()
 
 if(FLATBUFFERS_BUILD_FLATC)
   add_executable(flatc ${FlatBuffers_Compiler_SRCS})
+  target_compile_options(flatc PRIVATE "${FLATBUFFERS_PRIVATE_CXX_FLAGS}")
   if(NOT FLATBUFFERS_FLATC_EXECUTABLE)
     set(FLATBUFFERS_FLATC_EXECUTABLE $<TARGET_FILE:flatc>)
   endif()
@@ -259,6 +264,7 @@ if(FLATBUFFERS_BUILD_TESTS)
   compile_flatbuffers_schema_to_cpp(tests/monster_test.fbs)
   include_directories(${CMAKE_CURRENT_BINARY_DIR}/tests)
   add_executable(flattests ${FlatBuffers_Tests_SRCS})
+  target_compile_options(flattests PRIVATE "${FLATBUFFERS_PRIVATE_CXX_FLAGS}")
   set_property(TARGET flattests
     PROPERTY COMPILE_DEFINITIONS FLATBUFFERS_TRACK_VERIFIER_BUFFER_SIZE
     FLATBUFFERS_DEBUG_VERIFICATION_FAILURE=1)

--- a/grpc/src/compiler/java_generator.cc
+++ b/grpc/src/compiler/java_generator.cc
@@ -72,13 +72,14 @@ void GenerateImports(grpc_generator::File* file,
 //   - remove embedded underscores & capitalize the following letter
 static string MixedLower(const string& word) {
   string w;
-  w += (string::value_type)tolower(word[0]);
+  w += static_cast<string::value_type>(tolower(word[0]));
   bool after_underscore = false;
   for (size_t i = 1; i < word.length(); ++i) {
     if (word[i] == '_') {
       after_underscore = true;
     } else {
-      w += after_underscore ? (string::value_type)toupper(word[i]) : word[i];
+      w += after_underscore ? static_cast<string::value_type>(toupper(word[i]))
+                            : word[i];
       after_underscore = false;
     }
   }
@@ -92,7 +93,7 @@ static string MixedLower(const string& word) {
 static string ToAllUpperCase(const string& word) {
   string w;
   for (size_t i = 0; i < word.length(); ++i) {
-    w += (string::value_type)toupper(word[i]);
+    w += static_cast<string::value_type>(toupper(word[i]));
     if ((i < word.length() - 1) && islower(word[i]) && isupper(word[i + 1])) {
       w += '_';
     }
@@ -345,8 +346,8 @@ static void PrintMethodFields(Printer* p, VARS& vars,
 
   for (int i = 0; i < service->method_count(); ++i) {
     auto method = service->method(i);
-    vars["arg_in_id"] = to_string((long)2 * i); //trying to make msvc 10 happy
-    vars["arg_out_id"] = to_string((long)2 * i + 1);
+    vars["arg_in_id"] = to_string(2L * i); //trying to make msvc 10 happy
+    vars["arg_out_id"] = to_string(2L * i + 1);
     vars["method_name"] = method->name();
     vars["input_type_name"] = method->get_input_type_name();
     vars["output_type_name"] = method->get_output_type_name();

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1503,7 +1503,7 @@ class FlatBufferBuilder {
     extern T Pack(const S &);
     typedef T (*Pack_t)(const S &);
     std::vector<T> vv(len);
-    std::transform(v, v + len, vv.begin(), *(Pack_t)&Pack);
+    std::transform(v, v + len, vv.begin(), static_cast<Pack_t&>(Pack));
     return CreateVectorOfStructs<T>(vv.data(), vv.size());
   }
 
@@ -1641,7 +1641,7 @@ class FlatBufferBuilder {
     extern T Pack(const S &);
     typedef T (*Pack_t)(const S &);
     std::vector<T> vv(len);
-    std::transform(v, v + len, vv.begin(), *(Pack_t)&Pack);
+    std::transform(v, v + len, vv.begin(), static_cast<Pack_t&>(Pack));
     return CreateVectorOfSortedStructs<T>(vv, len);
   }
 

--- a/include/flatbuffers/reflection.h
+++ b/include/flatbuffers/reflection.h
@@ -228,7 +228,7 @@ inline std::string GetAnyVectorElemS(const VectorOfAny *vec,
 template<typename T>
 T *GetAnyVectorElemPointer(const VectorOfAny *vec, size_t i) {
   auto elem_ptr = vec->Data() + sizeof(uoffset_t) * i;
-  return (T *)(elem_ptr + ReadScalar<uoffset_t>(elem_ptr));
+  return reinterpret_cast<T*>(elem_ptr + ReadScalar<uoffset_t>(elem_ptr));
 }
 
 // Get the inline-address of a vector element. Useful for Structs (pass Struct
@@ -239,20 +239,19 @@ T *GetAnyVectorElemPointer(const VectorOfAny *vec, size_t i) {
 template<typename T>
 T *GetAnyVectorElemAddressOf(const VectorOfAny *vec, size_t i,
                              size_t elem_size) {
-  // C-cast to allow const conversion.
-  return (T *)(vec->Data() + elem_size * i);
+  return reinterpret_cast<T *>(vec->Data() + elem_size * i);
 }
 
 // Similarly, for elements of tables.
 template<typename T>
 T *GetAnyFieldAddressOf(const Table &table, const reflection::Field &field) {
-  return (T *)table.GetAddressOf(field.offset());
+  return reinterpret_cast<T *>(table.GetAddressOf(field.offset()));
 }
 
 // Similarly, for elements of structs.
 template<typename T>
 T *GetAnyFieldAddressOf(const Struct &st, const reflection::Field &field) {
-  return (T *)st.GetAddressOf(field.offset());
+  return reinterpret_cast<T *>(st.GetAddressOf(field.offset()));
 }
 
 // ------------------------- SETTERS -------------------------

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2163,9 +2163,11 @@ class CppGenerator : public BaseGenerator {
         auto cpp_type = field.attributes.Lookup("cpp_type");
         std::string indexing;
         if (field.value.type.enum_def) {
-          indexing += "(" + WrapInNameSpace(*field.value.type.enum_def) + ")";
+          indexing += "static_cast<" +
+                      WrapInNameSpace(*field.value.type.enum_def) + ">(";
         }
         indexing += "_e->Get(_i)";
+        if (field.value.type.enum_def) { indexing += ")"; }
         if (field.value.type.element == BASE_TYPE_BOOL) { indexing += " != 0"; }
 
         // Generate code that pushes data from _e to _o in the form:

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -395,7 +395,7 @@ static void StructBuilderArgs(const StructDef &struct_def,
                         (nameprefix + (field.name + "_")).c_str(), code_ptr);
     } else {
       std::string &code = *code_ptr;
-      code += (std::string) ", " + nameprefix;
+      code += std::string(", ") + nameprefix;
       code += GoIdentity(field.name);
       code += " " + GenTypeBasic(field.value.type);
     }

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -459,8 +459,9 @@ class JsGenerator : public BaseGenerator {
       case BASE_TYPE_LONG:
       case BASE_TYPE_ULONG: {
         int64_t constant = StringToInt(value.constant.c_str());
-        return context + ".createLong(" + NumToString((int32_t)constant) +
-               ", " + NumToString((int32_t)(constant >> 32)) + ")";
+        return context + ".createLong(" +
+               NumToString(static_cast<int32_t>(constant)) + ", " +
+               NumToString(static_cast<int32_t>(constant >> 32)) + ")";
       }
 
       default: return value.constant;

--- a/src/idl_gen_lua.cpp
+++ b/src/idl_gen_lua.cpp
@@ -362,7 +362,7 @@ namespace lua {
         }
         else {
           std::string &code = *code_ptr;
-          code += (std::string) ", " + nameprefix;
+          code += std::string(", ") + nameprefix;
           code += MakeCamel(NormalizedName(field), false);
         }
       }

--- a/src/idl_gen_php.cpp
+++ b/src/idl_gen_php.cpp
@@ -454,7 +454,7 @@ class PhpGenerator : public BaseGenerator {
                           (nameprefix + (field.name + "_")).c_str(), code_ptr);
       } else {
         std::string &code = *code_ptr;
-        code += (std::string) ", $" + nameprefix;
+        code += std::string(", $") + nameprefix;
         code += MakeCamel(field.name, false);
       }
     }

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -383,7 +383,7 @@ class PythonGenerator : public BaseGenerator {
                           (nameprefix + (NormalizedName(field) + "_")).c_str(), code_ptr);
       } else {
         std::string &code = *code_ptr;
-        code += (std::string) ", " + nameprefix;
+        code += std::string(", ") + nameprefix;
         code += MakeCamel(NormalizedName(field), false);
       }
     }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -46,7 +46,7 @@ void FlatBufferBuilderTest();
 // http://en.wikipedia.org/wiki/Park%E2%80%93Miller_random_number_generator
 uint32_t lcg_seed = 48271;
 uint32_t lcg_rand() {
-  return lcg_seed = ((uint64_t)lcg_seed * 279470273UL) % 4294967291UL;
+  return lcg_seed = (static_cast<uint64_t>(lcg_seed) * 279470273UL) % 4294967291UL;
 }
 void lcg_reset() { lcg_seed = 48271; }
 
@@ -1279,12 +1279,12 @@ bool FloatCompare(float a, float b) { return fabs(a - b) < 0.001; }
 void ValueTest() {
   // Test scientific notation numbers.
   TEST_EQ(FloatCompare(TestValue<float>("{ Y:0.0314159e+2 }", "float"),
-                       (float)3.14159),
+                       3.14159f),
           true);
   // number in string
   TEST_EQ(FloatCompare(TestValue<float>("{ Y:\"0.0314159e+2\" }", "float"),
-    (float)3.14159),
-    true);
+                       3.14159f),
+          true);
 
   // Test conversion functions.
   TEST_EQ(FloatCompare(TestValue<float>("{ Y:cos(rad(180)) }", "float"), -1),
@@ -1454,12 +1454,12 @@ void ValidFloatTest() {
   TEST_EQ(TestValue<double>("{ Y:+1.7977e+308 }", "double"), +infinityd);
   TEST_EQ(TestValue<double>("{ Y:-1.7977e+308 }", "double"), -infinityd);
 
-  TEST_EQ(FloatCompare(TestValue<float>("{ Y:0.0314159e+2 }", "float"),
-                       (float)3.14159),
-          true);
+  TEST_EQ(
+      FloatCompare(TestValue<float>("{ Y:0.0314159e+2 }", "float"), 3.14159f),
+      true);
   // float in string
   TEST_EQ(FloatCompare(TestValue<float>("{ Y:\" 0.0314159e+2  \" }", "float"),
-                       (float)3.14159),
+                       3.14159f),
           true);
 
   TEST_EQ(TestValue<float>("{ Y:1 }", "float"), 1.0f);

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -477,7 +477,7 @@ inline void Movie::UnPackTo(MovieT *_o, const flatbuffers::resolver_function_t *
   (void)_resolver;
   { auto _e = main_character_type(); _o->main_character.type = _e; };
   { auto _e = main_character(); if (_e) _o->main_character.value = CharacterUnion::UnPack(_e, main_character_type(), _resolver); };
-  { auto _e = characters_type(); if (_e) { _o->characters.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->characters[_i].type = (Character)_e->Get(_i); } } };
+  { auto _e = characters_type(); if (_e) { _o->characters.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->characters[_i].type = static_cast<Character>(_e->Get(_i)); } } };
   { auto _e = characters(); if (_e) { _o->characters.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->characters[_i].value = CharacterUnion::UnPack(_e->Get(_i), characters_type()->GetEnum<Character>(_i), _resolver); } } };
 }
 


### PR DESCRIPTION
Fixes #4857.

I've noticed that when running `tests/generate_code.sh` the following files where also changed:
```
        modified:   monster_test.bfbs
        modified:   monster_test_my_game.example2_generated.dart
        modified:   monster_test_my_game_generated.dart
```
I've not included them in this PR since they seem unrelated (I get the same difference when running `tests/generate_code.sh` on master).