### PR TITLE
don't crash when calling EnumNameXXX on sparse enum

### DIFF
--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -55,6 +55,7 @@ inline const char * const *EnumNamesColor() {
 }
 
 inline const char *EnumNameColor(Color e) {
+  if (e < Color_Red || e > Color_Blue) return "";
   const size_t index = static_cast<int>(e);
   return EnumNamesColor()[index];
 }
@@ -84,6 +85,7 @@ inline const char * const *EnumNamesEquipment() {
 }
 
 inline const char *EnumNameEquipment(Equipment e) {
+  if (e < Equipment_NONE || e > Equipment_Weapon) return "";
   const size_t index = static_cast<int>(e);
   return EnumNamesEquipment()[index];
 }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -990,6 +990,10 @@ class CppGenerator : public BaseGenerator {
 
       code_ += "inline const char *EnumName{{ENUM_NAME}}({{ENUM_NAME}} e) {";
 
+      code_ += "  if (e < " + GetEnumValUse(enum_def, *enum_def.vals.vec.front()) +
+               " || e > " + GetEnumValUse(enum_def, *enum_def.vals.vec.back()) +
+               ") return \"\";";
+
       code_ += "  const size_t index = static_cast<int>(e)\\";
       if (enum_def.vals.vec.front()->value) {
         auto vals = GetEnumValUse(enum_def, *enum_def.vals.vec.front());

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -122,6 +122,7 @@ inline const char * const *EnumNamesColor() {
 }
 
 inline const char *EnumNameColor(Color e) {
+  if (e < Color_Red || e > Color_Blue) return "";
   const size_t index = static_cast<int>(e) - static_cast<int>(Color_Red);
   return EnumNamesColor()[index];
 }
@@ -157,6 +158,7 @@ inline const char * const *EnumNamesAny() {
 }
 
 inline const char *EnumNameAny(Any e) {
+  if (e < Any_NONE || e > Any_MyGame_Example2_Monster) return "";
   const size_t index = static_cast<int>(e);
   return EnumNamesAny()[index];
 }

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -45,6 +45,7 @@ inline const char * const *EnumNamesEnumInNestedNS() {
 }
 
 inline const char *EnumNameEnumInNestedNS(EnumInNestedNS e) {
+  if (e < EnumInNestedNS_A || e > EnumInNestedNS_C) return "";
   const size_t index = static_cast<int>(e);
   return EnumNamesEnumInNestedNS()[index];
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1285,6 +1285,14 @@ void EnumStringsTest() {
           true);
 }
 
+void EnumNamesTest() {
+  TEST_EQ_STR("Red", EnumNameColor(Color_Red));
+  TEST_EQ_STR("Green", EnumNameColor(Color_Green));
+  TEST_EQ_STR("Blue", EnumNameColor(Color_Blue));
+  TEST_EQ_STR("", EnumNameColor(static_cast<Color>(-1)));
+  TEST_EQ_STR("", EnumNameColor(static_cast<Color>(1000)));
+}
+
 void IntegerOutOfRangeTest() {
   TestError("table T { F:byte; } root_type T; { F:128 }",
             "constant does not fit");
@@ -2058,6 +2066,7 @@ int FlatBufferTests() {
   ErrorTest();
   ValueTest();
   EnumStringsTest();
+  EnumNamesTest();
   IntegerOutOfRangeTest();
   IntegerBoundaryTest();
   UnicodeTest();

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -69,6 +69,7 @@ inline const char * const *EnumNamesCharacter() {
 }
 
 inline const char *EnumNameCharacter(Character e) {
+  if (e < Character_NONE || e > Character_Unused) return "";
   const size_t index = static_cast<int>(e);
   return EnumNamesCharacter()[index];
 }


### PR DESCRIPTION
Make an out-of-bounds check for enum values before using them to index the
names array.  For consistency with non-sparse enums an empty string is
returned.

Fixes #4821