### PR TITLE
add :runtime_cc target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -104,6 +104,18 @@ cc_binary(
     ],
 )
 
+cc_library(
+    name = "runtime_cc",
+    hdrs = [
+        "include/flatbuffers/base.h",
+        "include/flatbuffers/flatbuffers.h",
+        "include/flatbuffers/stl_emulation.h",
+        "include/flatbuffers/util.h",
+    ],
+    includes = ["include/"],
+    linkstatic = 1,
+)
+
 # Test binary.
 cc_test(
     name = "flatbuffers_test",


### PR DESCRIPTION
Looks like #4861 has been pending for a while. We can add `:runtime_cc` first in this PR.