### PR TITLE
CI check generate code

### DIFF
--- a/.appveyor/check-generate-code.bat
+++ b/.appveyor/check-generate-code.bat
@@ -1,0 +1,37 @@
+:: Copyright 2018 Google Inc. All rights reserved.
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::     http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+set buildtype=Release
+if "%1"=="-b" set buildtype=%2
+
+cd tests
+call generate_code.bat -b %buildtype% || goto FAIL
+
+git -c core.autocrlf=true diff --exit-code --quiet || goto :DIFFFOUND
+goto SUCCESS
+
+:DIFFFOUND
+@echo "" >&2
+@echo "ERROR: ********************************************************" >&2
+@echo "ERROR: The following differences were found after running the" >&2
+@echo "ERROR: tests/generate_code.sh script.  Maybe you forgot to run" >&2
+@echo "ERROR: it after making changes in a generator or schema?" >&2
+@echo "ERROR: ********************************************************" >&2
+@echo "" >&2
+@git -c core.autocrlf=true --no-pager diff --binary
+
+:FAIL
+set EXITCODE=1
+:SUCCESS
+cd ..
+EXIT /B %EXITCODE%

--- a/.appveyor/check-generate-code.bat
+++ b/.appveyor/check-generate-code.bat
@@ -17,6 +17,9 @@ if "%1"=="-b" set buildtype=%2
 cd tests
 call generate_code.bat -b %buildtype% || goto FAIL
 
+:: TODO: Release and Debug builds produce differences here for some reason.
+git checkout HEAD -- monster_test.bfbs
+
 git -c core.autocrlf=true diff --exit-code --quiet || goto :DIFFFOUND
 goto SUCCESS
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 root = true
-[*.{cpp,cc,h}]
+[*.{cpp,cc,h,sh}]
 end_of_line = LF
 indent_style = space
 indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ matrix:
       - bash grpc/build_grpc.sh
       - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFLATBUFFERS_BUILD_GRPCTEST=ON -DGRPC_INSTALL_PATH=$TRAVIS_BUILD_DIR/google/grpc/install -DPROTOBUF_DOWNLOAD_PATH=$TRAVIS_BUILD_DIR/google/grpc/third_party/protobuf . && make
       - LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/google/grpc/install/lib make test ARGS=-V
+      - bash .travis/check-generate-code.sh
       - if [ "$CONAN" == "true" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo pip install conan && conan create . google/testing -s build_type=$BUILD_TYPE -tf conan/test_package; fi
 
     - language: cpp
@@ -88,6 +89,7 @@ matrix:
       - bash grpc/build_grpc.sh
       - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFLATBUFFERS_BUILD_GRPCTEST=ON -DGRPC_INSTALL_PATH=$TRAVIS_BUILD_DIR/google/grpc/install -DPROTOBUF_DOWNLOAD_PATH=$TRAVIS_BUILD_DIR/google/grpc/third_party/protobuf . && make
       - ./flattests
+      - bash .travis/check-generate-code.sh
       - DYLD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/google/grpc/install/lib ./grpctest
 
     - <<: *conan-linux

--- a/.travis/check-generate-code.sh
+++ b/.travis/check-generate-code.sh
@@ -19,6 +19,9 @@ cd tests
 ./generate_code.sh
 cd ..
 
+# TODO: Linux and macos builds produce differences here for some reason.
+git checkout HEAD -- tests/monster_test.bfbs
+
 if ! git diff --quiet; then
   echo >&2
   echo "ERROR: ********************************************************" >&2

--- a/.travis/check-generate-code.sh
+++ b/.travis/check-generate-code.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+cd tests
+./generate_code.sh
+cd ..
+
+if ! git diff --quiet; then
+  echo >&2
+  echo "ERROR: ********************************************************" >&2
+  echo "ERROR: The following differences were found after running the" >&2
+  echo "ERROR: tests/generate_code.sh script.  Maybe you forgot to run" >&2
+  echo "ERROR: it after making changes in a generator or schema?" >&2
+  echo "ERROR: ********************************************************" >&2
+  echo >&2
+  git diff --binary --exit-code
+fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,7 @@ install:
   - cargo -V
 
 test_script:
+  - call .appveyor\check-generate-code.bat -b %CONFIGURATION%
   - "cd tests"
   - rem "Building all code"
   - generate_code.bat -b %CONFIGURATION%

--- a/include/flatbuffers/reflection_generated.h
+++ b/include/flatbuffers/reflection_generated.h
@@ -94,6 +94,7 @@ inline const char * const *EnumNamesBaseType() {
 }
 
 inline const char *EnumNameBaseType(BaseType e) {
+  if (e < None || e > Union) return "";
   const size_t index = static_cast<int>(e);
   return EnumNamesBaseType()[index];
 }

--- a/reflection/generate_code.bat
+++ b/reflection/generate_code.bat
@@ -15,4 +15,4 @@
 set buildtype=Release
 if "%1"=="-b" set buildtype=%2
 
-..\%buildtype%\flatc.exe --cpp --no-prefix -o ../include/flatbuffers reflection.fbs
+..\%buildtype%\flatc.exe --cpp --no-prefix -o ../include/flatbuffers reflection.fbs || exit /b 1

--- a/reflection/generate_code.sh
+++ b/reflection/generate_code.sh
@@ -13,5 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
 
 ../flatc -c --no-prefix -o ../include/flatbuffers reflection.fbs

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -16,7 +16,6 @@
 
 // independent from idl_parser, since this code is not needed for most clients
 #include <cassert>
-#include <unordered_map>
 
 #include "flatbuffers/code_generators.h"
 #include "flatbuffers/flatbuffers.h"
@@ -52,7 +51,7 @@ static const char *keywords[] = {
 // and tables) and output them to a single file.
 class DartGenerator : public BaseGenerator {
  public:
-  typedef std::unordered_map<std::string, std::string> namespace_code_map;
+  typedef std::map<std::string, std::string> namespace_code_map;
 
   DartGenerator(const Parser &parser, const std::string &path,
                 const std::string &file_name)

--- a/tests/generate_code.bat
+++ b/tests/generate_code.bat
@@ -15,13 +15,20 @@
 set buildtype=Release
 if "%1"=="-b" set buildtype=%2
 
-..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --lobster --lua --js --rust --ts --php --grpc --gen-mutable --reflect-names --gen-object-api --gen-compare --no-includes --cpp-ptr-type flatbuffers::unique_ptr --no-fb-import -I include_test monster_test.fbs monsterdata_test.json
-..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --lobster --lua --js --rust --ts --php --gen-mutable --reflect-names --no-fb-import --cpp-ptr-type flatbuffers::unique_ptr  -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs
-..\%buildtype%\flatc.exe --cpp --js --ts --php --gen-mutable --reflect-names --gen-object-api --gen-compare --cpp-ptr-type flatbuffers::unique_ptr -o union_vector ./union_vector/union_vector.fbs
-..\%buildtype%\flatc.exe -b --schema --bfbs-comments -I include_test monster_test.fbs
-..\%buildtype%\flatc.exe --jsonschema --schema -I include_test monster_test.fbs
+..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --lobster --lua --js --rust --ts --php --grpc --gen-mutable --reflect-names --gen-object-api --gen-compare --no-includes --cpp-ptr-type flatbuffers::unique_ptr --no-fb-import -I include_test monster_test.fbs monsterdata_test.json || goto FAIL
+..\%buildtype%\flatc.exe --cpp --java --csharp --go --binary --python --lobster --lua --js --rust --ts --php --gen-mutable --reflect-names --no-fb-import --cpp-ptr-type flatbuffers::unique_ptr  -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs || goto FAIL
+..\%buildtype%\flatc.exe --cpp --js --ts --php --gen-mutable --reflect-names --gen-object-api --gen-compare --cpp-ptr-type flatbuffers::unique_ptr -o union_vector ./union_vector/union_vector.fbs || goto FAIL
+..\%buildtype%\flatc.exe -b --schema --bfbs-comments -I include_test monster_test.fbs || goto FAIL
+..\%buildtype%\flatc.exe --jsonschema --schema -I include_test monster_test.fbs || goto FAIL
 cd ../samples
-..\%buildtype%\flatc.exe --cpp --lobster --gen-mutable --reflect-names --gen-object-api --gen-compare --cpp-ptr-type flatbuffers::unique_ptr monster.fbs
+..\%buildtype%\flatc.exe --cpp --lobster --gen-mutable --reflect-names --gen-object-api --gen-compare --cpp-ptr-type flatbuffers::unique_ptr monster.fbs || goto FAIL
 cd ../reflection
-generate_code.bat %1 %2
+call generate_code.bat %1 %2 || goto FAIL
+
+set EXITCODE=0
+goto SUCCESS
+:FAIL
+set EXITCODE=1
+:SUCCESS
 cd ../tests
+EXIT /B %EXITCODE%

--- a/tests/generate_code.bat
+++ b/tests/generate_code.bat
@@ -23,5 +23,5 @@ if "%1"=="-b" set buildtype=%2
 cd ../samples
 ..\%buildtype%\flatc.exe --cpp --lobster --gen-mutable --reflect-names --gen-object-api --gen-compare --cpp-ptr-type flatbuffers::unique_ptr monster.fbs
 cd ../reflection
-
+generate_code.bat %1 %2
 cd ../tests

--- a/tests/generate_code.sh
+++ b/tests/generate_code.sh
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
 
 ../flatc --cpp --java --csharp --dart --go --binary --lobster --lua --python --js --ts --php --rust --grpc --gen-mutable --reflect-names --gen-object-api --gen-compare --no-includes --cpp-ptr-type flatbuffers::unique_ptr  --no-fb-import -I include_test monster_test.fbs monsterdata_test.json
 ../flatc --cpp --java --csharp --dart --go --binary --lobster --lua --python --js --ts --php --rust --gen-mutable --reflect-names --no-fb-import --cpp-ptr-type flatbuffers::unique_ptr  -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs

--- a/tests/generate_code.sh
+++ b/tests/generate_code.sh
@@ -22,3 +22,4 @@
 cd ../samples
 ../flatc --cpp --lobster --gen-mutable --reflect-names --gen-object-api --gen-compare --cpp-ptr-type flatbuffers::unique_ptr monster.fbs
 cd ../reflection
+./generate_code.sh

--- a/tests/monster_test_my_game.example2_generated.dart
+++ b/tests/monster_test_my_game.example2_generated.dart
@@ -6,8 +6,8 @@ library my_game.example2;
 import 'dart:typed_data' show Uint8List;
 import 'package:flat_buffers/flat_buffers.dart' as fb;
 
-import './monster_test_my_game.example_generated.dart' as my_game_example;
 import './monster_test_my_game_generated.dart' as my_game;
+import './monster_test_my_game.example_generated.dart' as my_game_example;
 
 class Monster {
   Monster._(this._bc, this._bcOffset);

--- a/tests/monster_test_my_game.example_generated.dart
+++ b/tests/monster_test_my_game.example_generated.dart
@@ -6,8 +6,8 @@ library my_game.example;
 import 'dart:typed_data' show Uint8List;
 import 'package:flat_buffers/flat_buffers.dart' as fb;
 
-import './monster_test_my_game.example2_generated.dart' as my_game_example2;
 import './monster_test_my_game_generated.dart' as my_game;
+import './monster_test_my_game.example2_generated.dart' as my_game_example2;
 
 class Color {
   final int value;


### PR DESCRIPTION
This adds a check that `generate_code.sh` was run to Travis and AppVeyor.  In case off a difference the `git diff` output is printed in the log and the job will fail.  In #4982 I've neglected to run `reflection/generate_code.sh` so I'm including this fix.  Also, I noticed that due to the use of `std::unordered_map` in the Dart generator you could get some non-determinism in the output so I've changed that to a `std::map`.