### PR TITLE
Feature --keep-prefix for JS 

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -596,15 +596,13 @@ class vector_downward {
     scratch_ = buf_;
   }
 
-  void clear_allocator()
-  {
+  void clear_allocator() {
     if (own_allocator_ && allocator_) { delete allocator_; }
     allocator_ = nullptr;
     own_allocator_ = false;
   }
 
-  void clear_buffer()
-  {
+  void clear_buffer() {
     if (buf_) Deallocate(allocator_, buf_, reserved_);
     buf_ = nullptr;
   }

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -611,7 +611,7 @@ class vector_downward {
 
   // Relinquish the pointer to the caller.
   uint8_t *release_raw(size_t &size, size_t &offset) {
-    uint8_t *buf = buf_;
+    auto *buf = buf_;
     size = reserved_;
     offset = static_cast<size_t>(cur_ - buf_);
 

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -573,15 +573,12 @@ class vector_downward {
         scratch_(nullptr) {}
 
   ~vector_downward() {
-    if (buf_) Deallocate(allocator_, buf_, reserved_);
-    if (own_allocator_ && allocator_) { delete allocator_; }
+    clear_buffer();
+    clear_allocator();
   }
 
   void reset() {
-    if (buf_) {
-      Deallocate(allocator_, buf_, reserved_);
-      buf_ = nullptr;
-    }
+    clear_buffer();
     clear();
   }
 
@@ -599,17 +596,27 @@ class vector_downward {
     scratch_ = buf_;
   }
 
+  void clear_allocator()
+  {
+    if (own_allocator_ && allocator_) { delete allocator_; }
+    allocator_ = nullptr;
+    own_allocator_ = false;
+  }
+
+  void clear_buffer()
+  {
+    if (buf_) Deallocate(allocator_, buf_, reserved_);
+    buf_ = nullptr;
+  }
+
   // Relinquish the pointer to the caller.
   uint8_t *release_raw(size_t &size, size_t &offset) {
     uint8_t *buf = buf_;
     size = reserved_;
     offset = static_cast<size_t>(cur_ - buf_);
 
-    if (own_allocator_ && allocator_) { delete allocator_; }
-
-    allocator_ = nullptr;
-    own_allocator_ = false;
     buf_ = nullptr;
+    clear_allocator();
     clear();
     return buf;
   }

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -608,9 +608,9 @@ class vector_downward {
   }
 
   // Relinquish the pointer to the caller.
-  uint8_t *release_raw(size_t &size, size_t &offset) {
+  uint8_t *release_raw(size_t &allocated_bytes, size_t &offset) {
     auto *buf = buf_;
-    size = reserved_;
+    allocated_bytes = reserved_;
     offset = static_cast<size_t>(cur_ - buf_);
 
     buf_ = nullptr;

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -849,7 +849,7 @@ class FlatBufferBuilder {
   /// `FlatBuffer` starts.
   /// @return A raw pointer to the start of the memory block containing 
   /// the serialized `FlatBuffer`. 
-  /// @remark If the allocator is owned, it get deleted during this call.
+  /// @remark If the allocator is owned, it gets deleted during this call.
   uint8_t *ReleaseRaw(size_t &size, size_t &offset) {
     Finished();
     return buf_.release_raw(size, offset);

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -600,6 +600,21 @@ class vector_downward {
   }
 
   // Relinquish the pointer to the caller.
+  uint8_t *release_raw(size_t &size, size_t &offset) {
+    uint8_t *buf = buf_;
+    size = reserved_;
+    offset = static_cast<size_t>(cur_ - buf_);
+
+    if (own_allocator_ && allocator_) { delete allocator_; }
+
+    allocator_ = nullptr;
+    own_allocator_ = false;
+    buf_ = nullptr;
+    clear();
+    return buf;
+  }
+
+  // Relinquish the pointer to the caller.
   DetachedBuffer release() {
     DetachedBuffer fb(allocator_, own_allocator_, buf_, reserved_, cur_,
                       size());
@@ -825,6 +840,19 @@ class FlatBufferBuilder {
   DetachedBuffer Release() {
     Finished();
     return buf_.release();
+  }
+
+  /// @brief Get the released pointer to the serialized buffer.
+  /// @param The size of the memory block containing 
+  /// the serialized `FlatBuffer`.
+  /// @param The offset from the released pointer where the finished 
+  /// `FlatBuffer` starts.
+  /// @return A raw pointer to the start of the memory block containing 
+  /// the serialized `FlatBuffer`. 
+  /// @remark If the allocator is owned, it get deleted during this call.
+  uint8_t *ReleaseRaw(size_t &size, size_t &offset) {
+    Finished();
+    return buf_.release_raw(size, offset);
   }
 
   /// @brief get the minimum alignment this buffer needs to be accessed

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -276,9 +276,9 @@ inline std::string StripFileName(const std::string &filepath) {
 }
 
 // Check if `path` is an absolute path.
-inline bool IsAbsPath(const std::string &path)
-{
-  return !path.empty() && (path[0] == kPathSeparator || path[0] == kPathSeparatorWindows);
+inline bool IsAbsPath(const std::string &path) {
+  return !path.empty() &&
+         (path[0] == kPathSeparator || path[0] == kPathSeparatorWindows);
 }
 
 // Concatenates a path with a filename, regardless of wether the path

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -275,6 +275,12 @@ inline std::string StripFileName(const std::string &filepath) {
   return i != std::string::npos ? filepath.substr(0, i) : "";
 }
 
+// Check if `path` is an absolute path.
+inline bool IsAbsPath(const std::string &path)
+{
+  return !path.empty() && (path[0] == kPathSeparator || path[0] == kPathSeparatorWindows);
+}
+
 // Concatenates a path with a filename, regardless of wether the path
 // ends in a separator or not.
 inline std::string ConCatPathFileName(const std::string &path,
@@ -326,10 +332,10 @@ inline std::string AbsolutePath(const std::string &filepath) {
   #else
     #ifdef _WIN32
       char abs_path[MAX_PATH];
-      return GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr)
+      return (!IsAbsPath(filepath) && GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr))
     #else
       char abs_path[PATH_MAX];
-      return realpath(filepath.c_str(), abs_path)
+      return (!IsAbsPath(filepath) && realpath(filepath.c_str(), abs_path))
     #endif
       ? abs_path
       : filepath;

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -511,10 +511,13 @@ class JsGenerator : public BaseGenerator {
                       std::hash<std::string>()(file)));
   }
 
-  static std::string GenPrefixedImport(const std::string &full_file_name,
+  std::string GenPrefixedImport(const std::string &full_file_name,
                                        const std::string &base_file_name) {
     return "import * as " + GenFileNamespacePrefix(full_file_name) +
-           " from \"./" + base_file_name + "\";\n";
+           " from ./" 
+           + flatbuffers::ConCatPathFileName(parser_.opts.include_prefix, 
+                                             parser_.opts.keep_include_path? full_file_name : base_file_name) 
+           + "\";\n";
   }
 
   // Adds a source-dependent prefix, for of import * statements.

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -512,14 +512,14 @@ class JsGenerator : public BaseGenerator {
 
   std::string GenPrefixedImport(const std::string &full_file_name,
                                 const std::string &base_name) {
-    
     // either keep the include path as it was
     // or use only the base_name + kGeneratedFileNamePostfix
     std::string path;
     if (parser_.opts.keep_include_path) {
       auto it = parser_.included_files_.find(full_file_name);
       FLATBUFFERS_ASSERT(it != parser_.included_files_.end());
-      path = flatbuffers::StripExtension(it->second) + kGeneratedFileNamePostfix;
+      path =
+          flatbuffers::StripExtension(it->second) + kGeneratedFileNamePostfix;
     } else {
       path = base_name + kGeneratedFileNamePostfix;
     }
@@ -527,8 +527,7 @@ class JsGenerator : public BaseGenerator {
     // add the include prefix
     path = flatbuffers::ConCatPathFileName(parser_.opts.include_prefix, path);
 
-    if(!flatbuffers::IsAbsPath(path))
-    {
+    if (!flatbuffers::IsAbsPath(path)) {
       // make it a strictly relative path
       path = std::string(".") + kPathSeparator + path;
     }

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -527,11 +527,6 @@ class JsGenerator : public BaseGenerator {
     // add the include prefix
     path = flatbuffers::ConCatPathFileName(parser_.opts.include_prefix, path);
 
-    if (!flatbuffers::IsAbsPath(path)) {
-      // make it a strictly relative path
-      path = std::string(".") + kPathSeparator + path;
-    }
-
     return "import * as " + GenFileNamespacePrefix(full_file_name) +
            " from \"" + path + "\";\n";
   }

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -128,8 +128,7 @@ class JsGenerator : public BaseGenerator {
       const auto basename =
           flatbuffers::StripPath(flatbuffers::StripExtension(file));
       if (basename != file_name_) {
-        const auto file_name = basename + kGeneratedFileNamePostfix;
-        code += GenPrefixedImport(file, file_name);
+        code += GenPrefixedImport(file, basename);
       }
     }
   }
@@ -512,12 +511,30 @@ class JsGenerator : public BaseGenerator {
   }
 
   std::string GenPrefixedImport(const std::string &full_file_name,
-                                       const std::string &base_file_name) {
+                                const std::string &base_name) {
+    
+    // either keep the include path as it was
+    // or use only the base_name + kGeneratedFileNamePostfix
+    std::string path;
+    if (parser_.opts.keep_include_path) {
+      auto it = parser_.included_files_.find(full_file_name);
+      FLATBUFFERS_ASSERT(it != parser_.included_files_.end());
+      path = flatbuffers::StripExtension(it->second) + kGeneratedFileNamePostfix;
+    } else {
+      path = base_name + kGeneratedFileNamePostfix;
+    }
+
+    // add the include prefix
+    path = flatbuffers::ConCatPathFileName(parser_.opts.include_prefix, path);
+
+    if(!flatbuffers::IsAbsPath(path))
+    {
+      // make it a strictly relative path
+      path = std::string(".") + kPathSeparator + path;
+    }
+
     return "import * as " + GenFileNamespacePrefix(full_file_name) +
-           " from ./" 
-           + flatbuffers::ConCatPathFileName(parser_.opts.include_prefix, 
-                                             parser_.opts.keep_include_path? full_file_name : base_file_name) 
-           + "\";\n";
+           " from \"" + path + "\";\n";
   }
 
   // Adds a source-dependent prefix, for of import * statements.


### PR DESCRIPTION
This is the PR for issue #4879 

I added the --keep-prefix for the JS generation. This is very useful!
- I removed the default "./" in `import NS123123123 from "./A_generated"` because its not necessary.
- the option --include_prefix is also handled as well

The two files need to be formated with clang, since they both have lots of places where they do not adhere to the style guide. For review purposes I will format them at the end of the review process.

Thanks