### PR TITLE
--keep-prefix for JS generator

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -472,6 +472,12 @@ inline std::string StripFileName(const std::string &filepath) {
   return i != std::string::npos ? filepath.substr(0, i) : "";
 }
 
+// Check if `path` is an absolute path.
+inline bool IsAbsPath(const std::string &path)
+{
+  return !path.empty() && (path[0] == kPathSeparator || path[0] == kPathSeparatorWindows);
+}
+
 // Concatenates a path with a filename, regardless of wether the path
 // ends in a separator or not.
 inline std::string ConCatPathFileName(const std::string &path,
@@ -523,10 +529,10 @@ inline std::string AbsolutePath(const std::string &filepath) {
   #else
     #ifdef _WIN32
       char abs_path[MAX_PATH];
-      return GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr)
+      return (!IsAbsPath(filepath) && GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr))
     #else
       char abs_path[PATH_MAX];
-      return realpath(filepath.c_str(), abs_path)
+      return (!IsAbsPath(filepath) && realpath(filepath.c_str(), abs_path))
     #endif
       ? abs_path
       : filepath;

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -473,9 +473,9 @@ inline std::string StripFileName(const std::string &filepath) {
 }
 
 // Check if `path` is an absolute path.
-inline bool IsAbsPath(const std::string &path)
-{
-  return !path.empty() && (path[0] == kPathSeparator || path[0] == kPathSeparatorWindows);
+inline bool IsAbsPath(const std::string &path) {
+  return !path.empty() &&
+         (path[0] == kPathSeparator || path[0] == kPathSeparatorWindows);
 }
 
 // Concatenates a path with a filename, regardless of wether the path

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -472,12 +472,6 @@ inline std::string StripFileName(const std::string &filepath) {
   return i != std::string::npos ? filepath.substr(0, i) : "";
 }
 
-// Check if `path` is an absolute path.
-inline bool IsAbsPath(const std::string &path) {
-  return !path.empty() &&
-         (path[0] == kPathSeparator || path[0] == kPathSeparatorWindows);
-}
-
 // Concatenates a path with a filename, regardless of wether the path
 // ends in a separator or not.
 inline std::string ConCatPathFileName(const std::string &path,
@@ -529,10 +523,10 @@ inline std::string AbsolutePath(const std::string &filepath) {
   #else
     #ifdef _WIN32
       char abs_path[MAX_PATH];
-      return (!IsAbsPath(filepath) && GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr))
+      return GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr)
     #else
       char abs_path[PATH_MAX];
-      return (!IsAbsPath(filepath) && realpath(filepath.c_str(), abs_path))
+      return realpath(filepath.c_str(), abs_path)
     #endif
       ? abs_path
       : filepath;

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -524,10 +524,13 @@ class JsGenerator : public BaseGenerator {
     return "NS" + std::to_string(HashFnv1a<uint64_t>(file.c_str()));
   }
 
-  static std::string GenPrefixedImport(const std::string &full_file_name,
+  std::string GenPrefixedImport(const std::string &full_file_name,
                                        const std::string &base_file_name) {
     return "import * as " + GenFileNamespacePrefix(full_file_name) +
-           " from \"./" + base_file_name + "\";\n";
+           " from ./" 
+           + flatbuffers::ConCatPathFileName(parser_.opts.include_prefix, 
+                                             parser_.opts.keep_include_path? full_file_name : base_file_name) 
+           + "\";\n";
   }
 
   // Adds a source-dependent prefix, for of import * statements.

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -525,7 +525,7 @@ class JsGenerator : public BaseGenerator {
 
   std::string GenPrefixedImport(const std::string &full_file_name,
                                 const std::string &base_name) {
-    // either keep the include path as it was
+    // Either keep the include path as it was
     // or use only the base_name + kGeneratedFileNamePostfix
     std::string path;
     if (parser_.opts.keep_include_path) {
@@ -537,13 +537,9 @@ class JsGenerator : public BaseGenerator {
       path = base_name + kGeneratedFileNamePostfix;
     }
 
-    // add the include prefix
+    // Add the include prefix and make the path always relative
     path = flatbuffers::ConCatPathFileName(parser_.opts.include_prefix, path);
-
-    if (!flatbuffers::IsAbsPath(path)) {
-      // make it a strictly relative path
-      path = std::string(".") + kPathSeparator + path;
-    }
+    path = std::string(".") + kPathSeparator + path;
 
     return "import * as " + GenFileNamespacePrefix(full_file_name) +
            " from \"" + path + "\";\n";

--- a/src/idl_gen_js.cpp
+++ b/src/idl_gen_js.cpp
@@ -525,14 +525,14 @@ class JsGenerator : public BaseGenerator {
 
   std::string GenPrefixedImport(const std::string &full_file_name,
                                 const std::string &base_name) {
-    
     // either keep the include path as it was
     // or use only the base_name + kGeneratedFileNamePostfix
     std::string path;
     if (parser_.opts.keep_include_path) {
       auto it = parser_.included_files_.find(full_file_name);
       FLATBUFFERS_ASSERT(it != parser_.included_files_.end());
-      path = flatbuffers::StripExtension(it->second) + kGeneratedFileNamePostfix;
+      path =
+          flatbuffers::StripExtension(it->second) + kGeneratedFileNamePostfix;
     } else {
       path = base_name + kGeneratedFileNamePostfix;
     }
@@ -540,8 +540,7 @@ class JsGenerator : public BaseGenerator {
     // add the include prefix
     path = flatbuffers::ConCatPathFileName(parser_.opts.include_prefix, path);
 
-    if(!flatbuffers::IsAbsPath(path))
-    {
+    if (!flatbuffers::IsAbsPath(path)) {
       // make it a strictly relative path
       path = std::string(".") + kPathSeparator + path;
     }


### PR DESCRIPTION
This is the PR for issue #4879
I added the --keep-prefix for the JS generation. This is very useful!
The option --include_prefix is also handled as well

The two files need to be formatted with clang, since they both have lots of places where they do not adhere to the style guide. For review purposes, I will format them at the end of the review process.

Thanks


