### PR TITLE
Update Conan version Automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ env:
 
 conan-linux: &conan-linux
   os: linux
-  sudo: required
+  dist: xenial
   language: python
-  python: "3.6"
+  python: "3.7"
   services:
     - docker
   install:
@@ -132,8 +132,11 @@ matrix:
       osx_image: xcode9
       env: CONAN_APPLE_CLANG_VERSIONS=9.0
     - <<: *conan-osx
-      osx_image: xcode9.3
+      osx_image: xcode9.4
       env: CONAN_APPLE_CLANG_VERSIONS=9.1
+    - <<: *conan-osx
+      osx_image: xcode10
+      env: CONAN_APPLE_CLANG_VERSIONS=10.0
 
     - language: android
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,23 +105,23 @@ matrix:
       - DYLD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/google/grpc/install/lib ./grpctest
 
     - <<: *conan-linux
-      env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=lasote/conangcc49
+      env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49
     - <<: *conan-linux
-      env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc5
+      env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5
     - <<: *conan-linux
-      env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=lasote/conangcc6
+      env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=conanio/gcc6
     - <<: *conan-linux
-      env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=lasote/conangcc7
+      env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7
     - <<: *conan-linux
-      env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=lasote/conangcc8
+      env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8
     - <<: *conan-linux
-      env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39
+      env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39
     - <<: *conan-linux
-      env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40
+      env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40
     - <<: *conan-linux
-      env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=lasote/conanclang50
+      env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=conanio/clang50
     - <<: *conan-linux
-      env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=lasote/conanclang60
+      env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=conanio/clang60
     - <<: *conan-osx
       osx_image: xcode7.3
       env: CONAN_APPLE_CLANG_VERSIONS=7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ matrix:
       - make
       - LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/google/grpc/install/lib make test ARGS=-V
       - bash .travis/check-generate-code.sh
-      - if [ "$CONAN" == "true" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo pip install conan && conan create . google/testing -s build_type=$BUILD_TYPE -tf conan/test_package; fi
+      - if [ "$CONAN" == "true" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo pip install conan && conan create . flatbuffers/${TRAVIS_BRANCH}@google/testing -s build_type=$BUILD_TYPE -tf conan/test_package; fi
 
     - language: cpp
       os: osx

--- a/conan/build.py
+++ b/conan/build.py
@@ -23,10 +23,10 @@ def get_branch():
             line = line.strip()
             if line.startswith("*") and " (HEAD detached" not in line:
                 return line.replace("*", "", 1).strip()
-        return None
+        return ""
     except Exception:
         pass
-    return None
+    return ""
 
 
 def get_version():
@@ -35,7 +35,9 @@ def get_version():
         version = os.getenv("TRAVIS_BRANCH")
 
     if os.getenv("APPVEYOR", False):
-        version = os.getenv("APPVEYOR_REPO_TAG_NAME")
+        version = os.getenv("APPVEYOR_REPO_BRANCH")
+        if os.getenv("APPVEYOR_REPO_TAG") == "true":
+            version = os.getenv("APPVEYOR_REPO_TAG_NAME")
 
     match = re.search(r"v(\d+\.\d+\.\d+.*)", version)
     if match:

--- a/conan/build.py
+++ b/conan/build.py
@@ -35,7 +35,7 @@ def get_version():
         version = os.getenv("TRAVIS_BRANCH")
 
     if os.getenv("APPVEYOR", False):
-        version = os.getenv("APPVEYOR_REPO_BRANCH")
+        version = os.getenv("APPVEYOR_REPO_TAG_NAME")
 
     match = re.search(r"v(\d+\.\d+\.\d+.*)", version)
     if match:

--- a/conanfile.py
+++ b/conanfile.py
@@ -57,6 +57,7 @@ class FlatbuffersConan(ConanFile):
         cmake = self.configure_cmake()
         cmake.install()
         self.copy(pattern="LICENSE.txt", dst="licenses")
+        self.copy(pattern="FindFlatBuffers.cmake", dst=os.path.join("lib", "cmake", "flatbuffers"), src="CMake")
         self.copy(pattern="flathash*", dst="bin", src="bin")
         self.copy(pattern="flatc*", dst="bin", src="bin")
         if self.settings.os == "Windows" and self.options.shared:

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,15 +10,15 @@ from conans import ConanFile, CMake, tools
 
 class FlatbuffersConan(ConanFile):
     name = "flatbuffers"
-    version = "1.10.0"
     license = "Apache-2.0"
     url = "https://github.com/google/flatbuffers"
     homepage = "http://google.github.io/flatbuffers/"
     author = "Wouter van Oortmerssen"
+    topics = ("conan", "flatbuffers", "serialization", "rpc", "json-parser")
     description = "Memory Efficient Serialization Library"
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = "shared=False", "fPIC=True"
+    default_options = {"shared": False, "fPIC": True}
     generators = "cmake"
     exports = "LICENSE.txt"
     exports_sources = ["CMake/*", "include/*", "src/*", "grpc/*", "CMakeLists.txt", "conan/CMakeLists.txt"]


### PR DESCRIPTION
Hi!

#### Fixes:
- #5026 Copy FindFlatBuffers to Conan package

#### Features:
- Add OSX 10 in Travis file
- Update Linux distro to Xenial on Travis - sudo is no longer required
- Update Conan default_options to dictionary - new Conan conventions from 1.8.0
- Remove Conan package version from recipe - The version will be collected from branch/tag name. Thus is no more required update the recipe for new release. 
- Update Conan docker images to conanio organization
- Add topics on Conan recipe - They could be used to fill bintray page or search package.

As there is a filter to run Conan jobs only when a tag is created, so I released the version **v1.10.102** on my fork. The logs could be checked here:

https://travis-ci.org/uilianries/flatbuffers/builds/453067980
https://travis-ci.org/uilianries/flatbuffers/builds/453068606

https://ci.appveyor.com/project/uilianries/flatbuffers/builds/20186254
https://ci.appveyor.com/project/uilianries/flatbuffers/builds/20186281

Let's wait for the jobs to get the full result.

Regards!

closes #5026 