### PR TITLE
Wrong int32 min-max range definition on numTypes.lua

### DIFF
--- a/lua/flatbuffers/numTypes.lua
+++ b/lua/flatbuffers/numTypes.lua
@@ -119,8 +119,8 @@ local int16_mt =
 local int32_mt = 
 {
     bytewidth = 4,
-    min_value = -2^32,
-    max_value = 2^32-1,
+    min_value = -2^31,
+    max_value = 2^31-1,
     lua_type = type(1),
     name = "int32",
     packFmt = "<i4"

--- a/lua/flatbuffers/numTypes.lua
+++ b/lua/flatbuffers/numTypes.lua
@@ -119,8 +119,8 @@ local int16_mt =
 local int32_mt = 
 {
     bytewidth = 4,
-    min_value = -2^15,
-    max_value = 2^15-1,
+    min_value = -2^32,
+    max_value = 2^32-1,
     lua_type = type(1),
     name = "int32",
     packFmt = "<i4"


### PR DESCRIPTION
"int32" min-max range was wrongly defined.

Proposing proper value: -2^31 - 1 ~ 2^31

