### PR TITLE
flexbuffers blob to string implementation

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -547,6 +547,9 @@ class Reference {
       AppendToString<TypedVector>(s, AsTypedVector(), keys_quoted);
     } else if (IsFixedTypedVector()) {
       AppendToString<FixedTypedVector>(s, AsFixedTypedVector(), keys_quoted);
+    } else if (IsBlob()) {
+      auto blob = AsBlob();
+      flatbuffers::EscapeString(reinterpret_cast<const char*>(blob.data()), blob.size(), &s, true, false);
     } else {
       s += "(?)";
     }


### PR DESCRIPTION
fix for https://github.com/google/flatbuffers/issues/4983
added a toString for blob data.