### PR TITLE
Make flatbuffer C++ tests work when vendored with bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -143,6 +143,7 @@ cc_test(
     ],
     copts = [
         "-DFLATBUFFERS_TRACK_VERIFIER_BUFFER_SIZE",
+        "-DBAZEL_TEST_DATA_PATH",
     ],
     data = [
         ":tests/include_test/include_test1.fbs",

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -50,7 +50,12 @@ uint32_t lcg_rand() {
 }
 void lcg_reset() { lcg_seed = 48271; }
 
-std::string test_data_path = "tests/";
+std::string test_data_path =
+#ifdef BAZEL_TEST_DATA_PATH
+    "../com_github_google_flatbuffers/tests/";
+#else
+    "tests/";
+#endif
 
 // example of how to build up a serialized buffer algorithmically:
 flatbuffers::DetachedBuffer CreateFlatBufferTest(std::string &buffer) {


### PR DESCRIPTION
Tests for third_party code are run out of the main workspace.  This
isn't an issue when the main workspace is the
com_github_google_flatbuffers workspace, but is an issue when you are
running the tests from another repository.

To reproduce, use "git_repository" to add flatbuffers to a project and
then run:
  bazel test @com_github_google_flatbuffers//:flatbuffers_test