### PR TITLE
CMakeLists: fix installation of flatc and flathash binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,3 +342,6 @@ include(CMake/BuildFlatBuffers.cmake)
 if(FLATBUFFERS_PACKAGE_DEBIAN)
     include(CMake/PackageDebian.cmake)
 endif()
+
+configure_file(flatbuffers.pc.in flatbuffers.pc @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/flatbuffers.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,9 +290,8 @@ if(FLATBUFFERS_INSTALL)
 
   if(FLATBUFFERS_BUILD_FLATC)
     install(
-      TARGETS flatc EXPORT FlatcTargets
+      TARGETS flatc flathash EXPORT FlatcTargets
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-      CONFIGURATIONS Release
     )
 
     install(
@@ -300,7 +299,6 @@ if(FLATBUFFERS_INSTALL)
       FILE FlatcTargets.cmake
       NAMESPACE flatbuffers::
       DESTINATION ${FB_CMAKE_DIR}
-      CONFIGURATIONS Release
     )
   endif()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,7 +18,7 @@ class FlatbuffersConan(ConanFile):
     default_options = "shared=False"
     generators = "cmake"
     exports = "LICENSE.txt"
-    exports_sources = ["CMake/*", "include/*", "src/*", "grpc/*", "CMakeLists.txt"]
+    exports_sources = ["CMake/*", "include/*", "src/*", "grpc/*", "CMakeLists.txt", "flatbuffers.pc.in"]
 
     def _inject_magic_lines(self):
         """Inject Conan setup in cmake file to solve exteral dependencies.

--- a/flatbuffers.pc.in
+++ b/flatbuffers.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+
+Requires:
+Libs: -L${libdir} -lflatbuffers
+Cflags: -I${includedir}


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
