### PR TITLE
cpp code generator produces verify code that reports error when the c…

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -1198,7 +1198,7 @@ class CppGenerator : public BaseGenerator {
         code_ += "    }";
       }
     }
-    code_ += "    default: return false;";
+    code_ += "    default: return true;";
     code_ += "  }";
     code_ += "}";
     code_ += "";


### PR DESCRIPTION
`union ObjectV1 {
    Thing
}`

`table ContainerV1 {
    update: ObjectV1;
}`

`union ObjectV2 {
    Thing,
    NewThing
}`

`table ContainerV2 {
    update: ObjectV2;
}`

ContainerV1 and ContainerV2 are backward/forward compatible. However the cpp verify methods will indicate that V2 is compatible with V1, but V1 is incompatible with V2.

default switch statement for unknown type causes the issue.