### PR TITLE
Fix Java generator bug that ignores bidi streaming attribute

### DIFF
--- a/grpc/samples/greeter/greeter.fbs
+++ b/grpc/samples/greeter/greeter.fbs
@@ -14,6 +14,4 @@ table ManyHellosRequest {
 rpc_service Greeter {
   SayHello(HelloRequest):HelloReply;
   SayManyHellos(ManyHellosRequest):HelloReply (streaming: "server");
-  SendManyHellos(HellosRequest):HelloReply (streaming: "client");
-  SendManyRecieveManyHellos(HellosRequest):HelloReply (streaming: "bidi");
 }

--- a/grpc/samples/greeter/greeter.fbs
+++ b/grpc/samples/greeter/greeter.fbs
@@ -14,4 +14,6 @@ table ManyHellosRequest {
 rpc_service Greeter {
   SayHello(HelloRequest):HelloReply;
   SayManyHellos(ManyHellosRequest):HelloReply (streaming: "server");
+  SendManyHellos(HellosRequest):HelloReply (streaming: "client");
+  SendManyRecieveManyHellos(HellosRequest):HelloReply (streaming: "bidi");
 }

--- a/grpc/src/compiler/java_generator.cc
+++ b/grpc/src/compiler/java_generator.cc
@@ -356,8 +356,8 @@ static void PrintMethodFields(Printer* p, VARS& vars,
     vars["method_field_name"] = MethodPropertiesFieldName(method.get());
     vars["method_new_field_name"] = MethodPropertiesGetterName(method.get());
     vars["method_method_name"] = MethodPropertiesGetterName(method.get());
-    bool client_streaming = method->ClientStreaming();
-    bool server_streaming = method->ServerStreaming();
+    bool client_streaming = method->ClientStreaming() || method->BidiStreaming();
+    bool server_streaming = method->ServerStreaming() || method->BidiStreaming();
     if (client_streaming) {
       if (server_streaming) {
         vars["method_type"] = "BIDI_STREAMING";
@@ -549,8 +549,8 @@ static void PrintStub(Printer* p, VARS& vars, const ServiceDescriptor* service,
     vars["output_type"] = JavaClassName(vars, method->get_output_type_name());
     vars["lower_method_name"] = LowerMethodName(&*method);
     vars["method_method_name"] = MethodPropertiesGetterName(&*method);
-    bool client_streaming = method->ClientStreaming();
-    bool server_streaming = method->ServerStreaming();
+    bool client_streaming = method->ClientStreaming() || method->BidiStreaming();
+    bool server_streaming = method->ServerStreaming() || method->BidiStreaming();
 
     if (call_type == BLOCKING_CALL && client_streaming) {
       // Blocking client interface with client streaming is not available
@@ -760,7 +760,7 @@ static void PrintMethodHandlerClass(Printer* p, VARS& vars,
 
   for (int i = 0; i < service->method_count(); ++i) {
     auto method = service->method(i);
-    if (method->ClientStreaming()) {
+    if (method->ClientStreaming() || method->BidiStreaming()) {
       continue;
     }
     vars["method_id_name"] = MethodIdFieldName(&*method);
@@ -794,7 +794,7 @@ static void PrintMethodHandlerClass(Printer* p, VARS& vars,
 
   for (int i = 0; i < service->method_count(); ++i) {
     auto method = service->method(i);
-    if (!method->ClientStreaming()) {
+    if (!(method->ClientStreaming() || method->BidiStreaming())) {
       continue;
     }
     vars["method_id_name"] = MethodIdFieldName(&*method);
@@ -930,8 +930,8 @@ static void PrintBindServiceMethodBody(Printer* p, VARS& vars,
     vars["input_type"] = JavaClassName(vars, method->get_input_type_name());
     vars["output_type"] = JavaClassName(vars, method->get_output_type_name());
     vars["method_id_name"] = MethodIdFieldName(&*method);
-    bool client_streaming = method->ClientStreaming();
-    bool server_streaming = method->ServerStreaming();
+    bool client_streaming = method->ClientStreaming() || method->BidiStreaming();
+    bool server_streaming = method->ServerStreaming() || method->BidiStreaming();
     if (client_streaming) {
       if (server_streaming) {
         vars["calls_method"] = "asyncBidiStreamingCall";

--- a/grpc/tests/GameFactory.java
+++ b/grpc/tests/GameFactory.java
@@ -1,0 +1,42 @@
+import java.nio.ByteBuffer;
+import MyGame.Example.Monster;
+import MyGame.Example.Stat;
+import com.google.flatbuffers.FlatBufferBuilder;
+
+class GameFactory {
+  public static Monster createMonster(String monsterName, short nestedMonsterHp, short nestedMonsterMana) {
+    FlatBufferBuilder builder = new FlatBufferBuilder();
+
+    int name_offset = builder.createString(monsterName);
+    Monster.startMonster(builder);
+    Monster.addName(builder, name_offset);
+    Monster.addHp(builder, nestedMonsterHp);
+    Monster.addMana(builder, nestedMonsterMana);
+    int monster_offset = Monster.endMonster(builder);
+    Monster.finishMonsterBuffer(builder, monster_offset);
+
+    ByteBuffer buffer = builder.dataBuffer();
+    Monster monster = Monster.getRootAsMonster(buffer);
+    return monster;
+  }
+
+  public static Monster createMonsterFromStat(Stat stat, int seqNo) {
+    FlatBufferBuilder builder = new FlatBufferBuilder();
+    int name_offset = builder.createString(stat.id() + " No." + seqNo);
+    Monster.startMonster(builder);
+    Monster.addName(builder, name_offset);
+    int monster_offset = Monster.endMonster(builder);
+    Monster.finishMonsterBuffer(builder, monster_offset);
+    Monster monster = Monster.getRootAsMonster(builder.dataBuffer());
+    return monster;
+  }
+
+  public static Stat createStat(String greeting, long val, int count) { 
+    FlatBufferBuilder builder = new FlatBufferBuilder();
+    int statOffset = Stat.createStat(builder, builder.createString(greeting), val, count);
+    builder.finish(statOffset);
+    Stat stat = Stat.getRootAsStat(builder.dataBuffer());
+    return stat;
+  }
+
+}

--- a/grpc/tests/JavaGrpcTest.java
+++ b/grpc/tests/JavaGrpcTest.java
@@ -22,21 +22,32 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
 import org.junit.Assert;
 
 import java.io.IOException;
+import java.lang.InterruptedException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.CountDownLatch;
 
 
 /**
  * Demonstrates basic client-server interaction using grpc-java over netty.
  */
 public class JavaGrpcTest {
-    static final String BIG_MONSTER_NAME = "big-monster";
+    static final String BIG_MONSTER_NAME = "Cyberdemon";
     static final short nestedMonsterHp = 600;
     static final short nestedMonsterMana = 1024;
     static final int numStreamedMsgs = 10;
+    static final int timeoutMs = 3000;
+    static Server server;
+    static ManagedChannel channel;
+    static MonsterStorageGrpc.MonsterStorageBlockingStub blockingStub;
+    static MonsterStorageGrpc.MonsterStorageStub asyncStub;
 
     static class MyService extends MonsterStorageGrpc.MonsterStorageImplBase {
         @Override
@@ -46,10 +57,7 @@ public class JavaGrpcTest {
             Assert.assertEquals(request.mana(), nestedMonsterMana);
             System.out.println("Received store request from " + request.name());
             // Create a response from the incoming request name.
-            FlatBufferBuilder builder = new FlatBufferBuilder();
-            int statOffset = Stat.createStat(builder, builder.createString("Hello " + request.name()), 100, 10);
-            builder.finish(statOffset);
-            Stat stat = Stat.getRootAsStat(builder.dataBuffer());
+            Stat stat = GameFactory.createStat("Hello " + request.name(), 100, 10);
             responseObserver.onNext(stat);
             responseObserver.onCompleted();
         }
@@ -58,55 +66,71 @@ public class JavaGrpcTest {
         public void retrieve(Stat request, io.grpc.stub.StreamObserver<Monster> responseObserver) {
             // Create 10 monsters for streaming response.
             for (int i=0; i<numStreamedMsgs; i++) {
-                FlatBufferBuilder builder = new FlatBufferBuilder();
-                int i1 = builder.createString(request.id() + " No." + i);
-                Monster.startMonster(builder);
-                Monster.addName(builder, i1);
-                int i2 = Monster.endMonster(builder);
-                Monster.finishMonsterBuffer(builder, i2);
-                Monster monster = Monster.getRootAsMonster(builder.dataBuffer());
+                Monster monster = GameFactory.createMonsterFromStat(request, i);
                 responseObserver.onNext(monster);
             }
             responseObserver.onCompleted();
         }
+
+        @Override
+        public StreamObserver<Monster> getMaxHitPoint(final StreamObserver<Stat> responseObserver) {
+          final AtomicInteger maxHp = new AtomicInteger();
+          final AtomicReference<String> maxHpMonsterName = new AtomicReference<String>();
+          final AtomicInteger maxHpCount = new AtomicInteger();
+
+          return new StreamObserver<Monster>() {
+            public void onNext(Monster monster) {
+              if (monster.hp() > maxHp.get()) {
+                // Found a monster of higher hit points. Store its hp, name. Reset count to 1.
+                maxHp.set(monster.hp());
+                maxHpMonsterName.set(monster.name()); 
+                maxHpCount.set(1);
+              }
+              else if (monster.hp() == maxHp.get()) {
+                // Count how many times we saw a monster of current max hit points.
+                maxHpCount.getAndIncrement();
+              }
+            }
+            public void onCompleted() {
+              Stat maxHpStat = GameFactory.createStat(maxHpMonsterName.get(), maxHp.get(), maxHpCount.get());
+              responseObserver.onNext(maxHpStat);
+              responseObserver.onCompleted();
+            }
+            public void onError(Throwable t) {
+              // Not expected
+              Assert.fail();
+            };
+          };
+        }
     }
 
-
-    private static int startServer() throws IOException {
-        Server server = ServerBuilder.forPort(0).addService(new MyService()).build().start();
-        return server.getPort();
-    }
-
-    @org.junit.Test
-    public void testMonster() throws IOException {
-        int port = startServer();
-        ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", port)
+    @org.junit.BeforeClass
+    public static void startServer() throws IOException {
+        server = ServerBuilder.forPort(0).addService(new MyService()).build().start();
+        int port = server.getPort();
+        channel = ManagedChannelBuilder.forAddress("localhost", port)
                 // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
                 // needing certificates.
                 .usePlaintext(true)
                 .directExecutor()
                 .build();
+        blockingStub = MonsterStorageGrpc.newBlockingStub(channel);
+        asyncStub = MonsterStorageGrpc.newStub(channel);
+    }
 
-        MonsterStorageGrpc.MonsterStorageBlockingStub stub = MonsterStorageGrpc.newBlockingStub(channel);
-
-        FlatBufferBuilder builder = new FlatBufferBuilder();
-
-        int o_string = builder.createString(BIG_MONSTER_NAME);
-        Monster.startMonster(builder);
-        Monster.addName(builder, o_string);
-        Monster.addHp(builder, nestedMonsterHp);
-        Monster.addMana(builder, nestedMonsterMana);
-        int monster1 = Monster.endMonster(builder);
-        Monster.finishMonsterBuffer(builder, monster1);
-
-        ByteBuffer buffer = builder.dataBuffer();
-        Monster monsterRequest = Monster.getRootAsMonster(buffer);
-        Stat stat = stub.store(monsterRequest);
+    @org.junit.Test
+    public void testUnary() throws IOException {
+        Monster monsterRequest = GameFactory.createMonster(BIG_MONSTER_NAME, nestedMonsterHp, nestedMonsterMana);
+        Stat stat = blockingStub.store(monsterRequest);
         Assert.assertEquals(stat.id(), "Hello " + BIG_MONSTER_NAME);
         System.out.println("Received stat response from service: " + stat.id());
+    }
 
-
-        Iterator<Monster> iterator = stub.retrieve(stat);
+    @org.junit.Test
+    public void testServerStreaming() throws IOException {
+        Monster monsterRequest = GameFactory.createMonster(BIG_MONSTER_NAME, nestedMonsterHp, nestedMonsterMana);
+        Stat stat = blockingStub.store(monsterRequest);
+        Iterator<Monster> iterator = blockingStub.retrieve(stat);
         int counter = 0;
         while(iterator.hasNext()) {
             Monster m = iterator.next();
@@ -115,5 +139,33 @@ public class JavaGrpcTest {
         }
         Assert.assertEquals(counter, numStreamedMsgs);
         System.out.println("FlatBuffers GRPC client/server test: completed successfully");
+    }
+
+    @org.junit.Test
+    public void testClientStream() throws IOException, InterruptedException {
+      final AtomicReference<Stat> maxHitStat = new AtomicReference<Stat>();
+      final CountDownLatch streamAlive = new CountDownLatch(1);
+
+      StreamObserver<Stat> statObserver = new StreamObserver<Stat>() {
+        public void onCompleted() { 
+          streamAlive.countDown();
+        }
+        public void onError(Throwable ex) { }
+        public void onNext(Stat stat) {
+          maxHitStat.set(stat);
+        }
+      };
+      StreamObserver<Monster> monsterStream = asyncStub.getMaxHitPoint(statObserver);
+      short count = 10;
+      for (short i = 0;i < count; ++i) {
+        Monster monster = GameFactory.createMonster(BIG_MONSTER_NAME + i, (short) (nestedMonsterHp * i), nestedMonsterMana);
+        monsterStream.onNext(monster);
+      }
+      monsterStream.onCompleted();
+      // Wait a little bit for the server to send the stats of the monster with the max hit-points.
+      streamAlive.await(timeoutMs, TimeUnit.MILLISECONDS);
+      Assert.assertEquals(maxHitStat.get().id(), BIG_MONSTER_NAME + (count - 1));
+      Assert.assertEquals(maxHitStat.get().val(), nestedMonsterHp * (count - 1));
+      Assert.assertEquals(maxHitStat.get().count(), 1);
     }
 }

--- a/tests/MyGame/Example/MonsterStorageGrpc.java
+++ b/tests/MyGame/Example/MonsterStorageGrpc.java
@@ -128,6 +128,72 @@ public final class MonsterStorageGrpc {
      return getRetrieveMethod;
   }
   
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getGetMaxHitPointMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<MyGame.Example.Monster,
+      MyGame.Example.Stat> METHOD_GET_MAX_HIT_POINT = getGetMaxHitPointMethod();
+  
+  private static volatile io.grpc.MethodDescriptor<MyGame.Example.Monster,
+      MyGame.Example.Stat> getGetMaxHitPointMethod;
+  
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<MyGame.Example.Monster,
+      MyGame.Example.Stat> getGetMaxHitPointMethod() {
+    io.grpc.MethodDescriptor<MyGame.Example.Monster, MyGame.Example.Stat> getGetMaxHitPointMethod;
+    if ((getGetMaxHitPointMethod = MonsterStorageGrpc.getGetMaxHitPointMethod) == null) {
+      synchronized (MonsterStorageGrpc.class) {
+        if ((getGetMaxHitPointMethod = MonsterStorageGrpc.getGetMaxHitPointMethod) == null) {
+          MonsterStorageGrpc.getGetMaxHitPointMethod = getGetMaxHitPointMethod = 
+              io.grpc.MethodDescriptor.<MyGame.Example.Monster, MyGame.Example.Stat>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "MyGame.Example.MonsterStorage", "GetMaxHitPoint"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(FlatbuffersUtils.marshaller(
+                  MyGame.Example.Monster.class, getExtractorOfMonster()))
+              .setResponseMarshaller(FlatbuffersUtils.marshaller(
+                  MyGame.Example.Stat.class, getExtractorOfStat()))
+                  .setSchemaDescriptor(null)
+                  .build();
+          }
+        }
+     }
+     return getGetMaxHitPointMethod;
+  }
+  
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getGetMinMaxHitPointsMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<MyGame.Example.Monster,
+      MyGame.Example.Stat> METHOD_GET_MIN_MAX_HIT_POINTS = getGetMinMaxHitPointsMethod();
+  
+  private static volatile io.grpc.MethodDescriptor<MyGame.Example.Monster,
+      MyGame.Example.Stat> getGetMinMaxHitPointsMethod;
+  
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<MyGame.Example.Monster,
+      MyGame.Example.Stat> getGetMinMaxHitPointsMethod() {
+    io.grpc.MethodDescriptor<MyGame.Example.Monster, MyGame.Example.Stat> getGetMinMaxHitPointsMethod;
+    if ((getGetMinMaxHitPointsMethod = MonsterStorageGrpc.getGetMinMaxHitPointsMethod) == null) {
+      synchronized (MonsterStorageGrpc.class) {
+        if ((getGetMinMaxHitPointsMethod = MonsterStorageGrpc.getGetMinMaxHitPointsMethod) == null) {
+          MonsterStorageGrpc.getGetMinMaxHitPointsMethod = getGetMinMaxHitPointsMethod = 
+              io.grpc.MethodDescriptor.<MyGame.Example.Monster, MyGame.Example.Stat>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+              .setFullMethodName(generateFullMethodName(
+                  "MyGame.Example.MonsterStorage", "GetMinMaxHitPoints"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(FlatbuffersUtils.marshaller(
+                  MyGame.Example.Monster.class, getExtractorOfMonster()))
+              .setResponseMarshaller(FlatbuffersUtils.marshaller(
+                  MyGame.Example.Stat.class, getExtractorOfStat()))
+                  .setSchemaDescriptor(null)
+                  .build();
+          }
+        }
+     }
+     return getGetMinMaxHitPointsMethod;
+  }
+  
   /**
    * Creates a new async stub that supports all call types for the service
    */
@@ -169,6 +235,20 @@ public final class MonsterStorageGrpc {
       asyncUnimplementedUnaryCall(getRetrieveMethod(), responseObserver);
     }
     
+    /**
+     */
+    public     io.grpc.stub.StreamObserver<MyGame.Example.Monster> getMaxHitPoint(
+        io.grpc.stub.StreamObserver<MyGame.Example.Stat> responseObserver)     {
+      return asyncUnimplementedStreamingCall(getGetMaxHitPointMethod(), responseObserver);
+    }
+    
+    /**
+     */
+    public     io.grpc.stub.StreamObserver<MyGame.Example.Monster> getMinMaxHitPoints(
+        io.grpc.stub.StreamObserver<MyGame.Example.Stat> responseObserver)     {
+      return asyncUnimplementedStreamingCall(getGetMinMaxHitPointsMethod(), responseObserver);
+    }
+    
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -185,6 +265,20 @@ public final class MonsterStorageGrpc {
                 MyGame.Example.Stat,
                 MyGame.Example.Monster>(
                   this, METHODID_RETRIEVE)))
+          .addMethod(
+            getGetMaxHitPointMethod(),
+            asyncClientStreamingCall(
+              new MethodHandlers<
+                MyGame.Example.Monster,
+                MyGame.Example.Stat>(
+                  this, METHODID_GET_MAX_HIT_POINT)))
+          .addMethod(
+            getGetMinMaxHitPointsMethod(),
+            asyncBidiStreamingCall(
+              new MethodHandlers<
+                MyGame.Example.Monster,
+                MyGame.Example.Stat>(
+                  this, METHODID_GET_MIN_MAX_HIT_POINTS)))
           .build();
     }
   }
@@ -221,6 +315,22 @@ public final class MonsterStorageGrpc {
         io.grpc.stub.StreamObserver<MyGame.Example.Monster> responseObserver)     {
       asyncServerStreamingCall(
           getChannel().newCall(getRetrieveMethod(), getCallOptions()), request, responseObserver);
+    }
+    
+    /**
+     */
+    public     io.grpc.stub.StreamObserver<MyGame.Example.Monster> getMaxHitPoint(
+        io.grpc.stub.StreamObserver<MyGame.Example.Stat> responseObserver)     {
+      return asyncClientStreamingCall(
+          getChannel().newCall(getGetMaxHitPointMethod(), getCallOptions()), responseObserver);
+    }
+    
+    /**
+     */
+    public     io.grpc.stub.StreamObserver<MyGame.Example.Monster> getMinMaxHitPoints(
+        io.grpc.stub.StreamObserver<MyGame.Example.Stat> responseObserver)     {
+      return asyncBidiStreamingCall(
+          getChannel().newCall(getGetMinMaxHitPointsMethod(), getCallOptions()), responseObserver);
     }
   }
   
@@ -287,6 +397,8 @@ public final class MonsterStorageGrpc {
   
   private static final int METHODID_STORE = 0;
   private static final int METHODID_RETRIEVE = 1;
+  private static final int METHODID_GET_MIN_MAX_HIT_POINTS = 2;
+  private static final int METHODID_GET_MAX_HIT_POINT = 3;
   
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -323,6 +435,12 @@ public final class MonsterStorageGrpc {
     public io.grpc.stub.StreamObserver<Req> invoke(
         io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
+        case METHODID_GET_MAX_HIT_POINT:
+          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.getMaxHitPoint(
+              (io.grpc.stub.StreamObserver<MyGame.Example.Stat>) responseObserver);
+        case METHODID_GET_MIN_MAX_HIT_POINTS:
+          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.getMinMaxHitPoints(
+              (io.grpc.stub.StreamObserver<MyGame.Example.Stat>) responseObserver);
         default:
           throw new AssertionError();
       }
@@ -341,6 +459,8 @@ public final class MonsterStorageGrpc {
               .setSchemaDescriptor(null)              
               .addMethod(getStoreMethod())              
               .addMethod(getRetrieveMethod())              
+              .addMethod(getGetMaxHitPointMethod())              
+              .addMethod(getGetMinMaxHitPointsMethod())              
               .build();
         }
       }

--- a/tests/MyGame/Example/MonsterStorage_grpc.go
+++ b/tests/MyGame/Example/MonsterStorage_grpc.go
@@ -17,6 +17,10 @@ type MonsterStorageClient interface{
   	opts... grpc.CallOption) (* Stat, error)  
   Retrieve(ctx context.Context, in *flatbuffers.Builder, 
   	opts... grpc.CallOption) (MonsterStorage_RetrieveClient, error)  
+  GetMaxHitPoint(ctx context.Context, 
+  	opts... grpc.CallOption) (MonsterStorage_GetMaxHitPointClient, error)  
+  GetMinMaxHitPoints(ctx context.Context, 
+  	opts... grpc.CallOption) (MonsterStorage_GetMinMaxHitPointsClient, error)  
 }
 
 type monsterStorageClient struct {
@@ -60,10 +64,69 @@ func (x *monsterStorageRetrieveClient) Recv() (*Monster, error) {
   return m, nil
 }
 
+func (c *monsterStorageClient) GetMaxHitPoint(ctx context.Context, 
+	opts... grpc.CallOption) (MonsterStorage_GetMaxHitPointClient, error) {
+  stream, err := grpc.NewClientStream(ctx, &_MonsterStorage_serviceDesc.Streams[1], c.cc, "/MyGame.Example.MonsterStorage/GetMaxHitPoint", opts...)
+  if err != nil { return nil, err }
+  x := &monsterStorageGetMaxHitPointClient{stream}
+  return x,nil
+}
+
+type MonsterStorage_GetMaxHitPointClient interface {
+  Send(*flatbuffers.Builder) error
+  CloseAndRecv() (*Stat, error)
+  grpc.ClientStream
+}
+
+type monsterStorageGetMaxHitPointClient struct{
+  grpc.ClientStream
+}
+
+func (x *monsterStorageGetMaxHitPointClient) Send(m *flatbuffers.Builder) error {
+  return x.ClientStream.SendMsg(m)
+}
+
+func (x *monsterStorageGetMaxHitPointClient) CloseAndRecv() (*Stat, error) {
+  if err := x.ClientStream.CloseSend(); err != nil { return nil, err }
+  m := new (Stat)
+  if err := x.ClientStream.RecvMsg(m); err != nil { return nil, err }
+  return m, nil
+}
+
+func (c *monsterStorageClient) GetMinMaxHitPoints(ctx context.Context, 
+	opts... grpc.CallOption) (MonsterStorage_GetMinMaxHitPointsClient, error) {
+  stream, err := grpc.NewClientStream(ctx, &_MonsterStorage_serviceDesc.Streams[2], c.cc, "/MyGame.Example.MonsterStorage/GetMinMaxHitPoints", opts...)
+  if err != nil { return nil, err }
+  x := &monsterStorageGetMinMaxHitPointsClient{stream}
+  return x,nil
+}
+
+type MonsterStorage_GetMinMaxHitPointsClient interface {
+  Send(*flatbuffers.Builder) error
+  Recv() (*Stat, error)
+  grpc.ClientStream
+}
+
+type monsterStorageGetMinMaxHitPointsClient struct{
+  grpc.ClientStream
+}
+
+func (x *monsterStorageGetMinMaxHitPointsClient) Send(m *flatbuffers.Builder) error {
+  return x.ClientStream.SendMsg(m)
+}
+
+func (x *monsterStorageGetMinMaxHitPointsClient) Recv() (*Stat, error) {
+  m := new(Stat)
+  if err := x.ClientStream.RecvMsg(m); err != nil { return nil, err }
+  return m, nil
+}
+
 // Server API for MonsterStorage service
 type MonsterStorageServer interface {
   Store(context.Context, *Monster) (*flatbuffers.Builder, error)  
   Retrieve(*Stat, MonsterStorage_RetrieveServer) error  
+  GetMaxHitPoint(MonsterStorage_GetMaxHitPointServer) error  
+  GetMinMaxHitPoints(MonsterStorage_GetMinMaxHitPointsServer) error  
 }
 
 func RegisterMonsterStorageServer(s *grpc.Server, srv MonsterStorageServer) {
@@ -107,6 +170,56 @@ func (x *monsterStorageRetrieveServer) Send(m *flatbuffers.Builder) error {
 }
 
 
+func _MonsterStorage_GetMaxHitPoint_Handler(srv interface{}, stream grpc.ServerStream) error {
+  return srv.(MonsterStorageServer).GetMaxHitPoint(&monsterStorageGetMaxHitPointServer{stream})
+}
+
+type MonsterStorage_GetMaxHitPointServer interface { 
+  Recv() (* Monster, error)
+  SendAndClose(* flatbuffers.Builder) error
+  grpc.ServerStream
+}
+
+type monsterStorageGetMaxHitPointServer struct {
+  grpc.ServerStream
+}
+
+func (x *monsterStorageGetMaxHitPointServer) Recv() (*Monster, error) {
+  m := new(Monster)
+  if err := x.ServerStream.RecvMsg(m); err != nil { return nil, err }
+  return m, nil
+}
+
+func (x *monsterStorageGetMaxHitPointServer) SendAndClose(m *flatbuffers.Builder) error {
+  return x.ServerStream.SendMsg(m)
+}
+
+
+func _MonsterStorage_GetMinMaxHitPoints_Handler(srv interface{}, stream grpc.ServerStream) error {
+  return srv.(MonsterStorageServer).GetMinMaxHitPoints(&monsterStorageGetMinMaxHitPointsServer{stream})
+}
+
+type MonsterStorage_GetMinMaxHitPointsServer interface { 
+  Send(* flatbuffers.Builder) error
+  Recv() (* Monster, error)
+  grpc.ServerStream
+}
+
+type monsterStorageGetMinMaxHitPointsServer struct {
+  grpc.ServerStream
+}
+
+func (x *monsterStorageGetMinMaxHitPointsServer) Send(m *flatbuffers.Builder) error {
+  return x.ServerStream.SendMsg(m)
+}
+
+func (x *monsterStorageGetMinMaxHitPointsServer) Recv() (*Monster, error) {
+  m := new(Monster)
+  if err := x.ServerStream.RecvMsg(m); err != nil { return nil, err }
+  return m, nil
+}
+
+
 var _MonsterStorage_serviceDesc = grpc.ServiceDesc{
   ServiceName: "MyGame.Example.MonsterStorage",
   HandlerType: (*MonsterStorageServer)(nil),
@@ -121,6 +234,17 @@ var _MonsterStorage_serviceDesc = grpc.ServiceDesc{
       StreamName: "Retrieve",
       Handler: _MonsterStorage_Retrieve_Handler, 
       ServerStreams: true,
+    },
+    {
+      StreamName: "GetMaxHitPoint",
+      Handler: _MonsterStorage_GetMaxHitPoint_Handler, 
+      ClientStreams: true,
+    },
+    {
+      StreamName: "GetMinMaxHitPoints",
+      Handler: _MonsterStorage_GetMinMaxHitPoints_Handler, 
+      ServerStreams: true,
+      ClientStreams: true,
     },
   },
 }

--- a/tests/monster_test.fbs
+++ b/tests/monster_test.fbs
@@ -120,6 +120,8 @@ table TypeAliases {
 rpc_service MonsterStorage {
   Store(Monster):Stat (streaming: "none");
   Retrieve(Stat):Monster (streaming: "server", idempotent);
+  GetMaxHitPoint(Monster):Stat (streaming: "client");
+  GetMinMaxHitPoints(Monster):Stat (streaming: "bidi");
 }
 
 root_type Monster;

--- a/tests/monster_test.grpc.fb.cc
+++ b/tests/monster_test.grpc.fb.cc
@@ -19,6 +19,8 @@ namespace Example {
 static const char* MonsterStorage_method_names[] = {
   "/MyGame.Example.MonsterStorage/Store",
   "/MyGame.Example.MonsterStorage/Retrieve",
+  "/MyGame.Example.MonsterStorage/GetMaxHitPoint",
+  "/MyGame.Example.MonsterStorage/GetMinMaxHitPoints",
 };
 
 std::unique_ptr< MonsterStorage::Stub> MonsterStorage::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -29,6 +31,8 @@ std::unique_ptr< MonsterStorage::Stub> MonsterStorage::NewStub(const std::shared
 MonsterStorage::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
   : channel_(channel)  , rpcmethod_Store_(MonsterStorage_method_names[0], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_Retrieve_(MonsterStorage_method_names[1], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_GetMaxHitPoint_(MonsterStorage_method_names[2], ::grpc::internal::RpcMethod::CLIENT_STREAMING, channel)
+  , rpcmethod_GetMinMaxHitPoints_(MonsterStorage_method_names[3], ::grpc::internal::RpcMethod::BIDI_STREAMING, channel)
   {}
   
 ::grpc::Status MonsterStorage::Stub::Store(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Monster>& request, flatbuffers::grpc::Message<Stat>* response) {
@@ -55,6 +59,30 @@ MonsterStorage::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& cha
   return ::grpc::internal::ClientAsyncReaderFactory< flatbuffers::grpc::Message<Monster>>::Create(channel_.get(), cq, rpcmethod_Retrieve_, context, request, false, nullptr);
 }
 
+::grpc::ClientWriter< flatbuffers::grpc::Message<Monster>>* MonsterStorage::Stub::GetMaxHitPointRaw(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response) {
+  return ::grpc::internal::ClientWriterFactory< flatbuffers::grpc::Message<Monster>>::Create(channel_.get(), rpcmethod_GetMaxHitPoint_, context, response);
+}
+
+::grpc::ClientAsyncWriter< flatbuffers::grpc::Message<Monster>>* MonsterStorage::Stub::AsyncGetMaxHitPointRaw(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncWriterFactory< flatbuffers::grpc::Message<Monster>>::Create(channel_.get(), cq, rpcmethod_GetMaxHitPoint_, context, response, true, tag);
+}
+
+::grpc::ClientAsyncWriter< flatbuffers::grpc::Message<Monster>>* MonsterStorage::Stub::PrepareAsyncGetMaxHitPointRaw(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncWriterFactory< flatbuffers::grpc::Message<Monster>>::Create(channel_.get(), cq, rpcmethod_GetMaxHitPoint_, context, response, false, nullptr);
+}
+
+::grpc::ClientReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* MonsterStorage::Stub::GetMinMaxHitPointsRaw(::grpc::ClientContext* context) {
+  return ::grpc::internal::ClientReaderWriterFactory< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>::Create(channel_.get(), rpcmethod_GetMinMaxHitPoints_, context);
+}
+
+::grpc::ClientAsyncReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* MonsterStorage::Stub::AsyncGetMinMaxHitPointsRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderWriterFactory< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>::Create(channel_.get(), cq, rpcmethod_GetMinMaxHitPoints_, context, true, tag);
+}
+
+::grpc::ClientAsyncReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* MonsterStorage::Stub::PrepareAsyncGetMinMaxHitPointsRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderWriterFactory< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>::Create(channel_.get(), cq, rpcmethod_GetMinMaxHitPoints_, context, false, nullptr);
+}
+
 MonsterStorage::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       MonsterStorage_method_names[0],
@@ -66,6 +94,16 @@ MonsterStorage::Service::Service() {
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< MonsterStorage::Service, flatbuffers::grpc::Message<Stat>, flatbuffers::grpc::Message<Monster>>(
           std::mem_fn(&MonsterStorage::Service::Retrieve), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      MonsterStorage_method_names[2],
+      ::grpc::internal::RpcMethod::CLIENT_STREAMING,
+      new ::grpc::internal::ClientStreamingHandler< MonsterStorage::Service, flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>(
+          std::mem_fn(&MonsterStorage::Service::GetMaxHitPoint), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      MonsterStorage_method_names[3],
+      ::grpc::internal::RpcMethod::BIDI_STREAMING,
+      new ::grpc::internal::BidiStreamingHandler< MonsterStorage::Service, flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>(
+          std::mem_fn(&MonsterStorage::Service::GetMinMaxHitPoints), this)));
 }
 
 MonsterStorage::Service::~Service() {
@@ -82,6 +120,19 @@ MonsterStorage::Service::~Service() {
   (void) context;
   (void) request;
   (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status MonsterStorage::Service::GetMaxHitPoint(::grpc::ServerContext* context, ::grpc::ServerReader< flatbuffers::grpc::Message<Monster>>* reader, flatbuffers::grpc::Message<Stat>* response) {
+  (void) context;
+  (void) reader;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status MonsterStorage::Service::GetMinMaxHitPoints(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< flatbuffers::grpc::Message<Stat>, flatbuffers::grpc::Message<Monster>>* stream) {
+  (void) context;
+  (void) stream;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 

--- a/tests/monster_test.grpc.fb.h
+++ b/tests/monster_test.grpc.fb.h
@@ -51,12 +51,36 @@ class MonsterStorage final {
     std::unique_ptr< ::grpc::ClientAsyncReaderInterface< flatbuffers::grpc::Message<Monster>>> PrepareAsyncRetrieve(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Stat>& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< flatbuffers::grpc::Message<Monster>>>(PrepareAsyncRetrieveRaw(context, request, cq));
     }
+    std::unique_ptr< ::grpc::ClientWriterInterface< flatbuffers::grpc::Message<Monster>>> GetMaxHitPoint(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response) {
+      return std::unique_ptr< ::grpc::ClientWriterInterface< flatbuffers::grpc::Message<Monster>>>(GetMaxHitPointRaw(context, response));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncWriterInterface< flatbuffers::grpc::Message<Monster>>> AsyncGetMaxHitPoint(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncWriterInterface< flatbuffers::grpc::Message<Monster>>>(AsyncGetMaxHitPointRaw(context, response, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncWriterInterface< flatbuffers::grpc::Message<Monster>>> PrepareAsyncGetMaxHitPoint(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncWriterInterface< flatbuffers::grpc::Message<Monster>>>(PrepareAsyncGetMaxHitPointRaw(context, response, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>> GetMinMaxHitPoints(::grpc::ClientContext* context) {
+      return std::unique_ptr< ::grpc::ClientReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>>(GetMinMaxHitPointsRaw(context));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>> AsyncGetMinMaxHitPoints(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>>(AsyncGetMinMaxHitPointsRaw(context, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>> PrepareAsyncGetMinMaxHitPoints(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>>(PrepareAsyncGetMinMaxHitPointsRaw(context, cq));
+    }
   private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< flatbuffers::grpc::Message<Stat>>* AsyncStoreRaw(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Monster>& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< flatbuffers::grpc::Message<Stat>>* PrepareAsyncStoreRaw(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Monster>& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientReaderInterface< flatbuffers::grpc::Message<Monster>>* RetrieveRaw(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Stat>& request) = 0;
     virtual ::grpc::ClientAsyncReaderInterface< flatbuffers::grpc::Message<Monster>>* AsyncRetrieveRaw(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Stat>& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
     virtual ::grpc::ClientAsyncReaderInterface< flatbuffers::grpc::Message<Monster>>* PrepareAsyncRetrieveRaw(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Stat>& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientWriterInterface< flatbuffers::grpc::Message<Monster>>* GetMaxHitPointRaw(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response) = 0;
+    virtual ::grpc::ClientAsyncWriterInterface< flatbuffers::grpc::Message<Monster>>* AsyncGetMaxHitPointRaw(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncWriterInterface< flatbuffers::grpc::Message<Monster>>* PrepareAsyncGetMaxHitPointRaw(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* GetMinMaxHitPointsRaw(::grpc::ClientContext* context) = 0;
+    virtual ::grpc::ClientAsyncReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* AsyncGetMinMaxHitPointsRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* PrepareAsyncGetMinMaxHitPointsRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -77,6 +101,24 @@ class MonsterStorage final {
     std::unique_ptr< ::grpc::ClientAsyncReader< flatbuffers::grpc::Message<Monster>>> PrepareAsyncRetrieve(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Stat>& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncReader< flatbuffers::grpc::Message<Monster>>>(PrepareAsyncRetrieveRaw(context, request, cq));
     }
+    std::unique_ptr< ::grpc::ClientWriter< flatbuffers::grpc::Message<Monster>>> GetMaxHitPoint(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response) {
+      return std::unique_ptr< ::grpc::ClientWriter< flatbuffers::grpc::Message<Monster>>>(GetMaxHitPointRaw(context, response));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncWriter< flatbuffers::grpc::Message<Monster>>> AsyncGetMaxHitPoint(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncWriter< flatbuffers::grpc::Message<Monster>>>(AsyncGetMaxHitPointRaw(context, response, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncWriter< flatbuffers::grpc::Message<Monster>>> PrepareAsyncGetMaxHitPoint(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncWriter< flatbuffers::grpc::Message<Monster>>>(PrepareAsyncGetMaxHitPointRaw(context, response, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>> GetMinMaxHitPoints(::grpc::ClientContext* context) {
+      return std::unique_ptr< ::grpc::ClientReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>>(GetMinMaxHitPointsRaw(context));
+    }
+    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>> AsyncGetMinMaxHitPoints(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>>(AsyncGetMinMaxHitPointsRaw(context, cq, tag));
+    }
+    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>> PrepareAsyncGetMinMaxHitPoints(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>>(PrepareAsyncGetMinMaxHitPointsRaw(context, cq));
+    }
   
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
@@ -85,8 +127,16 @@ class MonsterStorage final {
     ::grpc::ClientReader< flatbuffers::grpc::Message<Monster>>* RetrieveRaw(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Stat>& request) override;
     ::grpc::ClientAsyncReader< flatbuffers::grpc::Message<Monster>>* AsyncRetrieveRaw(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Stat>& request, ::grpc::CompletionQueue* cq, void* tag) override;
     ::grpc::ClientAsyncReader< flatbuffers::grpc::Message<Monster>>* PrepareAsyncRetrieveRaw(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Stat>& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientWriter< flatbuffers::grpc::Message<Monster>>* GetMaxHitPointRaw(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response) override;
+    ::grpc::ClientAsyncWriter< flatbuffers::grpc::Message<Monster>>* AsyncGetMaxHitPointRaw(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncWriter< flatbuffers::grpc::Message<Monster>>* PrepareAsyncGetMaxHitPointRaw(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* GetMinMaxHitPointsRaw(::grpc::ClientContext* context) override;
+    ::grpc::ClientAsyncReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* AsyncGetMinMaxHitPointsRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* PrepareAsyncGetMinMaxHitPointsRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_Store_;
     const ::grpc::internal::RpcMethod rpcmethod_Retrieve_;
+    const ::grpc::internal::RpcMethod rpcmethod_GetMaxHitPoint_;
+    const ::grpc::internal::RpcMethod rpcmethod_GetMinMaxHitPoints_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
   
@@ -96,6 +146,8 @@ class MonsterStorage final {
     virtual ~Service();
     virtual ::grpc::Status Store(::grpc::ServerContext* context, const flatbuffers::grpc::Message<Monster>* request, flatbuffers::grpc::Message<Stat>* response);
     virtual ::grpc::Status Retrieve(::grpc::ServerContext* context, const flatbuffers::grpc::Message<Stat>* request, ::grpc::ServerWriter< flatbuffers::grpc::Message<Monster>>* writer);
+    virtual ::grpc::Status GetMaxHitPoint(::grpc::ServerContext* context, ::grpc::ServerReader< flatbuffers::grpc::Message<Monster>>* reader, flatbuffers::grpc::Message<Stat>* response);
+    virtual ::grpc::Status GetMinMaxHitPoints(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< flatbuffers::grpc::Message<Stat>, flatbuffers::grpc::Message<Monster>>* stream);
   };
   template <class BaseClass>
   class WithAsyncMethod_Store : public BaseClass {
@@ -137,7 +189,47 @@ class MonsterStorage final {
       ::grpc::Service::RequestAsyncServerStreaming(1, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
-  typedef   WithAsyncMethod_Store<  WithAsyncMethod_Retrieve<  Service   >   >   AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_GetMaxHitPoint : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_GetMaxHitPoint() {
+      ::grpc::Service::MarkMethodAsync(2);
+    }
+    ~WithAsyncMethod_GetMaxHitPoint() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetMaxHitPoint(::grpc::ServerContext* context, ::grpc::ServerReader< flatbuffers::grpc::Message<Monster>>* reader, flatbuffers::grpc::Message<Stat>* response) final override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestGetMaxHitPoint(::grpc::ServerContext* context, ::grpc::ServerAsyncReader< flatbuffers::grpc::Message<Stat>, flatbuffers::grpc::Message<Monster>>* reader, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncClientStreaming(2, context, reader, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_GetMinMaxHitPoints : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_GetMinMaxHitPoints() {
+      ::grpc::Service::MarkMethodAsync(3);
+    }
+    ~WithAsyncMethod_GetMinMaxHitPoints() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetMinMaxHitPoints(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< flatbuffers::grpc::Message<Stat>, flatbuffers::grpc::Message<Monster>>* stream) final override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestGetMinMaxHitPoints(::grpc::ServerContext* context, ::grpc::ServerAsyncReaderWriter< flatbuffers::grpc::Message<Stat>, flatbuffers::grpc::Message<Monster>>* stream, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncBidiStreaming(3, context, stream, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef   WithAsyncMethod_Store<  WithAsyncMethod_Retrieve<  WithAsyncMethod_GetMaxHitPoint<  WithAsyncMethod_GetMinMaxHitPoints<  Service   >   >   >   >   AsyncService;
   template <class BaseClass>
   class WithGenericMethod_Store : public BaseClass {
    private:
@@ -168,6 +260,40 @@ class MonsterStorage final {
     }
     // disable synchronous version of this method
     ::grpc::Status Retrieve(::grpc::ServerContext* context, const flatbuffers::grpc::Message<Stat>* request, ::grpc::ServerWriter< flatbuffers::grpc::Message<Monster>>* writer) final override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_GetMaxHitPoint : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_GetMaxHitPoint() {
+      ::grpc::Service::MarkMethodGeneric(2);
+    }
+    ~WithGenericMethod_GetMaxHitPoint() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetMaxHitPoint(::grpc::ServerContext* context, ::grpc::ServerReader< flatbuffers::grpc::Message<Monster>>* reader, flatbuffers::grpc::Message<Stat>* response) final override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_GetMinMaxHitPoints : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_GetMinMaxHitPoints() {
+      ::grpc::Service::MarkMethodGeneric(3);
+    }
+    ~WithGenericMethod_GetMinMaxHitPoints() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetMinMaxHitPoints(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< flatbuffers::grpc::Message<Stat>, flatbuffers::grpc::Message<Monster>>* stream) final override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }


### PR DESCRIPTION
Java generator ignores `(streaming: "bidi")` attribute on RPCs. There's not a single call to `method->BidiStreaming()` in `java_generator.cc`. This patch fixes that. 