### PR TITLE
Fix issue #5036 when write a double value into bytebuffer at big endian machine with unsafe mode.(#5036)

### DIFF
--- a/net/FlatBuffers/ByteBuffer.cs
+++ b/net/FlatBuffers/ByteBuffer.cs
@@ -554,7 +554,7 @@ namespace FlatBuffers
             }
             else
             {
-                *(ulong*)(ptr + offset) = ReverseBytes(*(ulong*)(ptr + offset));
+                *(ulong*)(ptr + offset) = ReverseBytes(*(ulong*)(&value));
             }
         }
 #else // !UNSAFE_BYTEBUFFER


### PR DESCRIPTION
Fix issue #5036 when write a double value into bytebuffer at big endian machine with unsafe mode.(#5036)