### PR TITLE
Get rid of reproducible build warning by removing build date & time from flatc version

### DIFF
--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -18,11 +18,14 @@
 
 #include <list>
 
-
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdate-time"
+#endif
 #define FLATC_VERSION "1.10.0 (" __DATE__ " " __TIME__ ")"
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 namespace flatbuffers {
 

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -18,7 +18,11 @@
 
 #include <list>
 
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdate-time"
 #define FLATC_VERSION "1.10.0 (" __DATE__ " " __TIME__ ")"
+#pragma GCC diagnostic pop
 
 namespace flatbuffers {
 

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -18,14 +18,7 @@
 
 #include <list>
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdate-time"
-#endif
-#define FLATC_VERSION "1.10.0 (" __DATE__ " " __TIME__ ")"
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+#define FLATC_VERSION "1.10.0"
 
 namespace flatbuffers {
 


### PR DESCRIPTION
Fix for #4567