### PR TITLE
Fix 'no_sanitize_undefined' attribute for GCC4.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ function(add_fsanitize_to_target _target _sanitizer)
   # FLATBUFFERS_CODE_SANITIZE: boolean {ON,OFF,YES,NO} or string with list of sanitizer.
   # List of sanitizer is string starts with '=': "=address,undefined,thread,memory".
   if((${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") OR
-    ((${CMAKE_CXX_COMPILER_ID} MATCHES "GNU") AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8"))
+    ((${CMAKE_CXX_COMPILER_ID} MATCHES "GNU") AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9"))
   )
     set(_sanitizer_flags "=address,undefined")
     if(_sanitizer MATCHES "=.*")

--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -212,7 +212,7 @@
 // - __supress_ubsan__("signed-integer-overflow")
 #if defined(__clang__)
   #define __supress_ubsan__(type) __attribute__((no_sanitize(type)))
-#elif defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 408)
+#elif defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 409)
   #define __supress_ubsan__(type) __attribute__((no_sanitize_undefined))
 #else
   #define __supress_ubsan__(type)


### PR DESCRIPTION
This PR fix #5079 issue.
It has been checked with GCC 4.8.4 using Travis CI.