### PR TITLE
[C++]bug fix for (#5096) and (#5099)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ include(CheckCXXSymbolExists)
 
 project(FlatBuffers)
 
+#include_directories(/home/henry/evolvability/protobuf/src)
+
 # NOTE: Code coverage only works on Linux & OSX.
 option(FLATBUFFERS_CODE_COVERAGE "Enable the code coverage build option." OFF)
 option(FLATBUFFERS_BUILD_TESTS "Enable the build of tests and samples." ON)
@@ -170,10 +172,10 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
   if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.4)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
       set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} -faligned-new -Werror=implicit-fallthrough=2")
+        "${CMAKE_CXX_FLAGS} -faligned-new")
     endif()
     set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -Wunused-result -Werror=unused-result -Wunused-parameter -Werror=unused-parameter")
+      "${CMAKE_CXX_FLAGS} -Wunused-result -Werror=unused-result -Wno-unused-parameter")
   endif()
 
   # Certain platforms such as ARM do not use signed chars by default

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ include(CheckCXXSymbolExists)
 
 project(FlatBuffers)
 
-#include_directories(/home/henry/evolvability/protobuf/src)
-
 # NOTE: Code coverage only works on Linux & OSX.
 option(FLATBUFFERS_CODE_COVERAGE "Enable the code coverage build option." OFF)
 option(FLATBUFFERS_BUILD_TESTS "Enable the build of tests and samples." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
   if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.4)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
       set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} -faligned-new")
+        "${CMAKE_CXX_FLAGS} -faligned-new -Werror=implicit-fallthrough=2")
     endif()
     set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -Wunused-result -Werror=unused-result -Wno-unused-parameter")

--- a/grpc/samples/greeter/Makefile
+++ b/grpc/samples/greeter/Makefile
@@ -1,5 +1,5 @@
 CXXFLAGS ?= -I../../../include
-LDFLAGS ?= -L/usr/local/lib/ -L/usr/lib/
+LDFLAGS ?=
 
 .PHONY: all
 all: greeter_generated.h greeter_server greeter_client

--- a/grpc/samples/greeter/Makefile
+++ b/grpc/samples/greeter/Makefile
@@ -1,14 +1,14 @@
 CXXFLAGS ?= -I../../../include
-LDFLAGS ?=
+LDFLAGS ?= -L/usr/local/lib/ -L/usr/lib/
 
 .PHONY: all
-all: server client
+all: greeter_server greeter_client
 
 greeter_generated.h: greeter.fbs
 	flatc --grpc --cpp $<
 
-server: server.cpp greeter.grpc.fb.cc greeter_generated.h greeter.grpc.fb.h
-	g++ -std=c++11 -O2 $(CXXFLAGS) $(LDFLAGS) -lgpr -lgrpc -lgrpc++ server.cpp greeter.grpc.fb.cc -o $@
+greeter_server: server.cpp greeter.grpc.fb.cc greeter_generated.h greeter.grpc.fb.h
+	g++ -std=c++11 -O2 $(CXXFLAGS) $(LDFLAGS) server.cpp greeter.grpc.fb.cc -lgpr -lgrpc -lgrpc++ -o $@
 
-client: client.cpp greeter.grpc.fb.cc greeter_generated.h greeter.grpc.fb.h
-	g++ -std=c++11 -O2 $(CXXFLAGS) $(LDFLAGS) -lgpr -lgrpc -lgrpc++ client.cpp greeter.grpc.fb.cc -o $@
+greeter_client: client.cpp greeter.grpc.fb.cc greeter_generated.h greeter.grpc.fb.h
+	g++ -std=c++11 -O2 $(CXXFLAGS) $(LDFLAGS) client.cpp greeter.grpc.fb.cc -lgpr -lgrpc -lgrpc++ -o $@

--- a/grpc/samples/greeter/Makefile
+++ b/grpc/samples/greeter/Makefile
@@ -2,7 +2,7 @@ CXXFLAGS ?= -I../../../include
 LDFLAGS ?= -L/usr/local/lib/ -L/usr/lib/
 
 .PHONY: all
-all: greeter_server greeter_client
+all: greeter_generated.h greeter_server greeter_client
 
 greeter_generated.h: greeter.fbs
 	flatc --grpc --cpp $<

--- a/grpc/samples/greeter/README.md
+++ b/grpc/samples/greeter/README.md
@@ -4,13 +4,22 @@ This sample code is a synchronous client and server borrowed from [here](https:/
 
 # build
 
+```
 ./make
+```
 
 # run
 
+- client
+
+```
 ./greeter_server &
 Server listening on 0.0.0.0:50051
+```
 
+- server
+
+```
 ./greeter_client 
 Greeter received: Hello, world
 Greeter received: Many hellos, world
@@ -23,5 +32,5 @@ Greeter received: Many hellos, world
 Greeter received: Many hellos, world
 Greeter received: Many hellos, world
 Greeter received: Many hellos, world
-
+```
 

--- a/grpc/samples/greeter/README.md
+++ b/grpc/samples/greeter/README.md
@@ -1,0 +1,27 @@
+# description
+
+This sample code is a synchronous client and server borrowed from [here](https://github.com/grpc/grpc/tree/master/examples/cpp/helloworld).
+
+# build
+
+./make
+
+# run
+
+./greeter_server &
+Server listening on 0.0.0.0:50051
+
+./greeter_client 
+Greeter received: Hello, world
+Greeter received: Many hellos, world
+Greeter received: Many hellos, world
+Greeter received: Many hellos, world
+Greeter received: Many hellos, world
+Greeter received: Many hellos, world
+Greeter received: Many hellos, world
+Greeter received: Many hellos, world
+Greeter received: Many hellos, world
+Greeter received: Many hellos, world
+Greeter received: Many hellos, world
+
+

--- a/grpc/src/compiler/config.h
+++ b/grpc/src/compiler/config.h
@@ -1,40 +1,91 @@
 /*
  *
- * Copyright 2015, Google Inc.
- * All rights reserved.
+ * Copyright 2015 gRPC authors.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above
- * copyright notice, this list of conditions and the following disclaimer
- * in the documentation and/or other materials provided with the
- * distribution.
- *     * Neither the name of Google Inc. nor the names of its
- * contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
 #ifndef SRC_COMPILER_CONFIG_H
 #define SRC_COMPILER_CONFIG_H
 
-// This file is here only because schema_interface.h, which is copied from gRPC,
-// includes it. There is nothing for Flatbuffers to configure.
+#include <grpcpp/impl/codegen/config_protobuf.h>
+
+#ifndef GRPC_CUSTOM_CODEGENERATOR
+#include <google/protobuf/compiler/code_generator.h>
+#define GRPC_CUSTOM_CODEGENERATOR ::google::protobuf::compiler::CodeGenerator
+#define GRPC_CUSTOM_GENERATORCONTEXT \
+  ::google::protobuf::compiler::GeneratorContext
+#endif
+
+#ifndef GRPC_CUSTOM_PRINTER
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/printer.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+#define GRPC_CUSTOM_PRINTER ::google::protobuf::io::Printer
+#define GRPC_CUSTOM_CODEDOUTPUTSTREAM ::google::protobuf::io::CodedOutputStream
+#define GRPC_CUSTOM_STRINGOUTPUTSTREAM \
+  ::google::protobuf::io::StringOutputStream
+#endif
+
+#ifndef GRPC_CUSTOM_PLUGINMAIN
+#include <google/protobuf/compiler/plugin.h>
+#define GRPC_CUSTOM_PLUGINMAIN ::google::protobuf::compiler::PluginMain
+#endif
+
+#ifndef GRPC_CUSTOM_PARSEGENERATORPARAMETER
+#include <google/protobuf/compiler/code_generator.h>
+#define GRPC_CUSTOM_PARSEGENERATORPARAMETER \
+  ::google::protobuf::compiler::ParseGeneratorParameter
+#endif
+
+#ifndef GRPC_CUSTOM_STRING
+#include <string>
+#define GRPC_CUSTOM_STRING std::string
+#endif
+
+namespace grpc {
+
+typedef GRPC_CUSTOM_STRING string;
+
+namespace protobuf {
+
+namespace compiler {
+typedef GRPC_CUSTOM_CODEGENERATOR CodeGenerator;
+typedef GRPC_CUSTOM_GENERATORCONTEXT GeneratorContext;
+static inline int PluginMain(int argc, char* argv[],
+                             const CodeGenerator* generator) {
+  return GRPC_CUSTOM_PLUGINMAIN(argc, argv, generator);
+}
+static inline void ParseGeneratorParameter(
+    const string& parameter, std::vector<std::pair<string, string> >* options) {
+  GRPC_CUSTOM_PARSEGENERATORPARAMETER(parameter, options);
+}
+
+}  // namespace compiler
+namespace io {
+typedef GRPC_CUSTOM_PRINTER Printer;
+typedef GRPC_CUSTOM_CODEDOUTPUTSTREAM CodedOutputStream;
+typedef GRPC_CUSTOM_STRINGOUTPUTSTREAM StringOutputStream;
+}  // namespace io
+}  // namespace protobuf
+}  // namespace grpc
+
+namespace grpc_cpp_generator {
+
+static const char* const kCppGeneratorMessageHeaderExt = ".pb.h";
+static const char* const kCppGeneratorServiceHeaderExt = ".grpc.pb.h";
+
+}  // namespace grpc_cpp_generator
 
 #endif  // SRC_COMPILER_CONFIG_H

--- a/grpc/src/compiler/config.h
+++ b/grpc/src/compiler/config.h
@@ -23,8 +23,8 @@ namespace grpc {}  // namespace grpc
 
 namespace grpc_cpp_generator {
 
-static const char* const kCppGeneratorMessageHeaderExt = ".pb.h";
-static const char* const kCppGeneratorServiceHeaderExt = ".grpc.pb.h";
+static const char* const kCppGeneratorMessageHeaderExt = "_generated.h";
+static const char* const kCppGeneratorServiceHeaderExt = ".grpc.fb.h";
 
 }  // namespace grpc_cpp_generator
 

--- a/grpc/src/compiler/config.h
+++ b/grpc/src/compiler/config.h
@@ -19,67 +19,7 @@
 #ifndef SRC_COMPILER_CONFIG_H
 #define SRC_COMPILER_CONFIG_H
 
-#include <grpcpp/impl/codegen/config_protobuf.h>
-
-#ifndef GRPC_CUSTOM_CODEGENERATOR
-#include <google/protobuf/compiler/code_generator.h>
-#define GRPC_CUSTOM_CODEGENERATOR ::google::protobuf::compiler::CodeGenerator
-#define GRPC_CUSTOM_GENERATORCONTEXT \
-  ::google::protobuf::compiler::GeneratorContext
-#endif
-
-#ifndef GRPC_CUSTOM_PRINTER
-#include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/io/printer.h>
-#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
-#define GRPC_CUSTOM_PRINTER ::google::protobuf::io::Printer
-#define GRPC_CUSTOM_CODEDOUTPUTSTREAM ::google::protobuf::io::CodedOutputStream
-#define GRPC_CUSTOM_STRINGOUTPUTSTREAM \
-  ::google::protobuf::io::StringOutputStream
-#endif
-
-#ifndef GRPC_CUSTOM_PLUGINMAIN
-#include <google/protobuf/compiler/plugin.h>
-#define GRPC_CUSTOM_PLUGINMAIN ::google::protobuf::compiler::PluginMain
-#endif
-
-#ifndef GRPC_CUSTOM_PARSEGENERATORPARAMETER
-#include <google/protobuf/compiler/code_generator.h>
-#define GRPC_CUSTOM_PARSEGENERATORPARAMETER \
-  ::google::protobuf::compiler::ParseGeneratorParameter
-#endif
-
-#ifndef GRPC_CUSTOM_STRING
-#include <string>
-#define GRPC_CUSTOM_STRING std::string
-#endif
-
-namespace grpc {
-
-typedef GRPC_CUSTOM_STRING string;
-
-namespace protobuf {
-
-namespace compiler {
-typedef GRPC_CUSTOM_CODEGENERATOR CodeGenerator;
-typedef GRPC_CUSTOM_GENERATORCONTEXT GeneratorContext;
-static inline int PluginMain(int argc, char* argv[],
-                             const CodeGenerator* generator) {
-  return GRPC_CUSTOM_PLUGINMAIN(argc, argv, generator);
-}
-static inline void ParseGeneratorParameter(
-    const string& parameter, std::vector<std::pair<string, string> >* options) {
-  GRPC_CUSTOM_PARSEGENERATORPARAMETER(parameter, options);
-}
-
-}  // namespace compiler
-namespace io {
-typedef GRPC_CUSTOM_PRINTER Printer;
-typedef GRPC_CUSTOM_CODEDOUTPUTSTREAM CodedOutputStream;
-typedef GRPC_CUSTOM_STRINGOUTPUTSTREAM StringOutputStream;
-}  // namespace io
-}  // namespace protobuf
-}  // namespace grpc
+namespace grpc {}  // namespace grpc
 
 namespace grpc_cpp_generator {
 

--- a/grpc/src/compiler/cpp_generator.cc
+++ b/grpc/src/compiler/cpp_generator.cc
@@ -16,6 +16,7 @@
  *
  */
 
+#include <cassert>
 #include <map>
 
 #include "src/compiler/cpp_generator.h"

--- a/grpc/src/compiler/cpp_generator.h
+++ b/grpc/src/compiler/cpp_generator.h
@@ -1,33 +1,18 @@
 /*
  *
- * Copyright 2015, Google Inc.
- * All rights reserved.
+ * Copyright 2015 gRPC authors.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above
- * copyright notice, this list of conditions and the following disclaimer
- * in the documentation and/or other materials provided with the
- * distribution.
- *     * Neither the name of Google Inc. nor the names of its
- * contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
@@ -65,73 +50,77 @@ struct Parameters {
   bool use_system_headers;
   // Prefix to any grpc include
   grpc::string grpc_search_path;
-  // Generate GMOCK code to facilitate unit testing.
+  // Generate Google Mock code to facilitate unit testing.
   bool generate_mock_code;
+  // Google Mock search path, when non-empty, local includes will be used.
+  grpc::string gmock_search_path;
+  // *EXPERIMENTAL* Additional include files in grpc.pb.h
+  std::vector<grpc::string> additional_header_includes;
 };
 
 // Return the prologue of the generated header file.
-grpc::string GetHeaderPrologue(grpc_generator::File *file,
-                               const Parameters &params);
+grpc::string GetHeaderPrologue(grpc_generator::File* file,
+                               const Parameters& params);
 
 // Return the includes needed for generated header file.
-grpc::string GetHeaderIncludes(grpc_generator::File *file,
-                               const Parameters &params);
+grpc::string GetHeaderIncludes(grpc_generator::File* file,
+                               const Parameters& params);
 
 // Return the includes needed for generated source file.
-grpc::string GetSourceIncludes(grpc_generator::File *file,
-                               const Parameters &params);
+grpc::string GetSourceIncludes(grpc_generator::File* file,
+                               const Parameters& params);
 
 // Return the epilogue of the generated header file.
-grpc::string GetHeaderEpilogue(grpc_generator::File *file,
-                               const Parameters &params);
+grpc::string GetHeaderEpilogue(grpc_generator::File* file,
+                               const Parameters& params);
 
 // Return the prologue of the generated source file.
-grpc::string GetSourcePrologue(grpc_generator::File *file,
-                               const Parameters &params);
+grpc::string GetSourcePrologue(grpc_generator::File* file,
+                               const Parameters& params);
 
 // Return the services for generated header file.
-grpc::string GetHeaderServices(grpc_generator::File *file,
-                               const Parameters &params);
+grpc::string GetHeaderServices(grpc_generator::File* file,
+                               const Parameters& params);
 
 // Return the services for generated source file.
-grpc::string GetSourceServices(grpc_generator::File *file,
-                               const Parameters &params);
+grpc::string GetSourceServices(grpc_generator::File* file,
+                               const Parameters& params);
 
 // Return the epilogue of the generated source file.
-grpc::string GetSourceEpilogue(grpc_generator::File *file,
-                               const Parameters &params);
+grpc::string GetSourceEpilogue(grpc_generator::File* file,
+                               const Parameters& params);
 
 // Return the prologue of the generated mock file.
-grpc::string GetMockPrologue(grpc_generator::File *file,
-                             const Parameters &params);
+grpc::string GetMockPrologue(grpc_generator::File* file,
+                             const Parameters& params);
 
 // Return the includes needed for generated mock file.
-grpc::string GetMockIncludes(grpc_generator::File *file,
-                             const Parameters &params);
+grpc::string GetMockIncludes(grpc_generator::File* file,
+                             const Parameters& params);
 
 // Return the services for generated mock file.
-grpc::string GetMockServices(grpc_generator::File *file,
-                             const Parameters &params);
+grpc::string GetMockServices(grpc_generator::File* file,
+                             const Parameters& params);
 
 // Return the epilogue of generated mock file.
-grpc::string GetMockEpilogue(grpc_generator::File *file,
-                             const Parameters &params);
+grpc::string GetMockEpilogue(grpc_generator::File* file,
+                             const Parameters& params);
 
 // Return the prologue of the generated mock file.
-grpc::string GetMockPrologue(grpc_generator::File *file,
-                             const Parameters &params);
+grpc::string GetMockPrologue(grpc_generator::File* file,
+                             const Parameters& params);
 
 // Return the includes needed for generated mock file.
-grpc::string GetMockIncludes(grpc_generator::File *file,
-                             const Parameters &params);
+grpc::string GetMockIncludes(grpc_generator::File* file,
+                             const Parameters& params);
 
 // Return the services for generated mock file.
-grpc::string GetMockServices(grpc_generator::File *file,
-                             const Parameters &params);
+grpc::string GetMockServices(grpc_generator::File* file,
+                             const Parameters& params);
 
 // Return the epilogue of generated mock file.
-grpc::string GetMockEpilogue(grpc_generator::File *file,
-                             const Parameters &params);
+grpc::string GetMockEpilogue(grpc_generator::File* file,
+                             const Parameters& params);
 
 }  // namespace grpc_cpp_generator
 

--- a/grpc/src/compiler/schema_interface.h
+++ b/grpc/src/compiler/schema_interface.h
@@ -1,33 +1,18 @@
 /*
  *
- * Copyright 2015, Google Inc.
- * All rights reserved.
+ * Copyright 2015 gRPC authors.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *     * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above
- * copyright notice, this list of conditions and the following disclaimer
- * in the documentation and/or other materials provided with the
- * distribution.
- *     * Neither the name of Google Inc. nor the names of its
- * contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
@@ -40,8 +25,8 @@
 #include <vector>
 
 #ifndef GRPC_CUSTOM_STRING
-#  include <string>
-#  define GRPC_CUSTOM_STRING std::string
+#include <string>
+#define GRPC_CUSTOM_STRING std::string
 #endif
 
 namespace grpc {
@@ -71,10 +56,10 @@ struct Method : public CommentHolder {
   virtual grpc::string output_type_name() const = 0;
 
   virtual bool get_module_and_message_path_input(
-      grpc::string *str, grpc::string generator_file_name,
+      grpc::string* str, grpc::string generator_file_name,
       bool generate_in_pb2_grpc, grpc::string import_prefix) const = 0;
   virtual bool get_module_and_message_path_output(
-      grpc::string *str, grpc::string generator_file_name,
+      grpc::string* str, grpc::string generator_file_name,
       bool generate_in_pb2_grpc, grpc::string import_prefix) const = 0;
 
   virtual grpc::string get_input_type_name() const = 0;
@@ -98,9 +83,10 @@ struct Service : public CommentHolder {
 struct Printer {
   virtual ~Printer() {}
 
-  virtual void Print(const std::map<grpc::string, grpc::string> &vars,
-                     const char *template_string) = 0;
-  virtual void Print(const char *string) = 0;
+  virtual void Print(const std::map<grpc::string, grpc::string>& vars,
+                     const char* template_string) = 0;
+  virtual void Print(const char* string) = 0;
+  virtual void PrintRaw(const char* string) = 0;
   virtual void Indent() = 0;
   virtual void Outdent() = 0;
 };
@@ -119,7 +105,7 @@ struct File : public CommentHolder {
   virtual int service_count() const = 0;
   virtual std::unique_ptr<const Service> service(int i) const = 0;
 
-  virtual std::unique_ptr<Printer> CreatePrinter(grpc::string *str) const = 0;
+  virtual std::unique_ptr<Printer> CreatePrinter(grpc::string* str) const = 0;
 };
 }  // namespace grpc_generator
 

--- a/include/flatbuffers/grpc.h
+++ b/include/flatbuffers/grpc.h
@@ -321,6 +321,17 @@ template<class T> class SerializationTraits<flatbuffers::grpc::Message<T>> {
     }
 #endif
   }
+
+  static grpc::Status Deserialize(ByteBuffer *buffer,
+                                  flatbuffers::grpc::Message<T> *msg) {
+    return Deserialize(buffer->get_buffer(), msg);
+  }
+
+  static grpc::Status Deserialize(ByteBuffer::ByteBufferPointer p,
+                                  flatbuffers::grpc::Message<T> *msg) {
+    return Deserialize((grpc_byte_buffer*)(p) , msg);
+  }
+
 };
 
 }  // namespace grpc

--- a/src/idl_gen_grpc.cpp
+++ b/src/idl_gen_grpc.cpp
@@ -167,6 +167,10 @@ class FlatBufPrinter : public grpc_generator::Printer {
     }
   }
 
+  void PrintRaw(const char* data){
+    Print(data);
+  }
+
   void Indent() { indent_++; }
 
   void Outdent() {

--- a/src/idl_gen_grpc.cpp
+++ b/src/idl_gen_grpc.cpp
@@ -167,7 +167,7 @@ class FlatBufPrinter : public grpc_generator::Printer {
     }
   }
 
-  void PrintRaw(const char* data){
+  void PrintRaw(const char *data){
     Print(data);
   }
 

--- a/tests/monster_test.grpc.fb.cc
+++ b/tests/monster_test.grpc.fb.cc
@@ -2,8 +2,8 @@
 // If you make any local change, they will be lost.
 // source: monster_test
 
-#include "monster_test.pb.h"
-#include "monster_test.grpc.pb.h"
+#include "monster_test_generated.h"
+#include "monster_test.grpc.fb.h"
 
 #include <functional>
 #include <grpcpp/impl/codegen/async_stream.h>

--- a/tests/monster_test.grpc.fb.cc
+++ b/tests/monster_test.grpc.fb.cc
@@ -2,17 +2,20 @@
 // If you make any local change, they will be lost.
 // source: monster_test
 
-#include "monster_test_generated.h"
-#include "monster_test.grpc.fb.h"
+#include "monster_test.pb.h"
+#include "monster_test.grpc.pb.h"
 
-#include <grpc++/impl/codegen/async_stream.h>
-#include <grpc++/impl/codegen/async_unary_call.h>
-#include <grpc++/impl/codegen/channel_interface.h>
-#include <grpc++/impl/codegen/client_unary_call.h>
-#include <grpc++/impl/codegen/method_handler_impl.h>
-#include <grpc++/impl/codegen/rpc_service_method.h>
-#include <grpc++/impl/codegen/service_type.h>
-#include <grpc++/impl/codegen/sync_stream.h>
+#include <functional>
+#include <grpcpp/impl/codegen/async_stream.h>
+#include <grpcpp/impl/codegen/async_unary_call.h>
+#include <grpcpp/impl/codegen/channel_interface.h>
+#include <grpcpp/impl/codegen/client_unary_call.h>
+#include <grpcpp/impl/codegen/client_callback.h>
+#include <grpcpp/impl/codegen/method_handler_impl.h>
+#include <grpcpp/impl/codegen/rpc_service_method.h>
+#include <grpcpp/impl/codegen/server_callback.h>
+#include <grpcpp/impl/codegen/service_type.h>
+#include <grpcpp/impl/codegen/sync_stream.h>
 namespace MyGame {
 namespace Example {
 
@@ -24,6 +27,7 @@ static const char* MonsterStorage_method_names[] = {
 };
 
 std::unique_ptr< MonsterStorage::Stub> MonsterStorage::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
+  (void)options;
   std::unique_ptr< MonsterStorage::Stub> stub(new MonsterStorage::Stub(channel));
   return stub;
 }
@@ -39,6 +43,10 @@ MonsterStorage::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& cha
   return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Store_, context, request, response);
 }
 
+void MonsterStorage::Stub::experimental_async::Store(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Monster>* request, flatbuffers::grpc::Message<Stat>* response, std::function<void(::grpc::Status)> f) {
+  return ::grpc::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_Store_, context, request, response, std::move(f));
+}
+
 ::grpc::ClientAsyncResponseReader< flatbuffers::grpc::Message<Stat>>* MonsterStorage::Stub::AsyncStoreRaw(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Monster>& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< flatbuffers::grpc::Message<Stat>>::Create(channel_.get(), cq, rpcmethod_Store_, context, request, true);
 }
@@ -49,6 +57,10 @@ MonsterStorage::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& cha
 
 ::grpc::ClientReader< flatbuffers::grpc::Message<Monster>>* MonsterStorage::Stub::RetrieveRaw(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Stat>& request) {
   return ::grpc::internal::ClientReaderFactory< flatbuffers::grpc::Message<Monster>>::Create(channel_.get(), rpcmethod_Retrieve_, context, request);
+}
+
+void MonsterStorage::Stub::experimental_async::Retrieve(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* request, ::grpc::experimental::ClientReadReactor< flatbuffers::grpc::Message<Monster>>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< flatbuffers::grpc::Message<Monster>>::Create(stub_->channel_.get(), stub_->rpcmethod_Retrieve_, context, request, reactor);
 }
 
 ::grpc::ClientAsyncReader< flatbuffers::grpc::Message<Monster>>* MonsterStorage::Stub::AsyncRetrieveRaw(::grpc::ClientContext* context, const flatbuffers::grpc::Message<Stat>& request, ::grpc::CompletionQueue* cq, void* tag) {
@@ -63,6 +75,10 @@ MonsterStorage::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& cha
   return ::grpc::internal::ClientWriterFactory< flatbuffers::grpc::Message<Monster>>::Create(channel_.get(), rpcmethod_GetMaxHitPoint_, context, response);
 }
 
+void MonsterStorage::Stub::experimental_async::GetMaxHitPoint(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::experimental::ClientWriteReactor< flatbuffers::grpc::Message<Monster>>* reactor) {
+  ::grpc::internal::ClientCallbackWriterFactory< flatbuffers::grpc::Message<Monster>>::Create(stub_->channel_.get(), stub_->rpcmethod_GetMaxHitPoint_, context, response, reactor);
+}
+
 ::grpc::ClientAsyncWriter< flatbuffers::grpc::Message<Monster>>* MonsterStorage::Stub::AsyncGetMaxHitPointRaw(::grpc::ClientContext* context, flatbuffers::grpc::Message<Stat>* response, ::grpc::CompletionQueue* cq, void* tag) {
   return ::grpc::internal::ClientAsyncWriterFactory< flatbuffers::grpc::Message<Monster>>::Create(channel_.get(), cq, rpcmethod_GetMaxHitPoint_, context, response, true, tag);
 }
@@ -73,6 +89,10 @@ MonsterStorage::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& cha
 
 ::grpc::ClientReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* MonsterStorage::Stub::GetMinMaxHitPointsRaw(::grpc::ClientContext* context) {
   return ::grpc::internal::ClientReaderWriterFactory< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>::Create(channel_.get(), rpcmethod_GetMinMaxHitPoints_, context);
+}
+
+void MonsterStorage::Stub::experimental_async::GetMinMaxHitPoints(::grpc::ClientContext* context, ::grpc::experimental::ClientBidiReactor< flatbuffers::grpc::Message<Monster>,flatbuffers::grpc::Message<Stat>>* reactor) {
+  ::grpc::internal::ClientCallbackReaderWriterFactory< flatbuffers::grpc::Message<Monster>,flatbuffers::grpc::Message<Stat>>::Create(stub_->channel_.get(), stub_->rpcmethod_GetMinMaxHitPoints_, context, reactor);
 }
 
 ::grpc::ClientAsyncReaderWriter< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* MonsterStorage::Stub::AsyncGetMinMaxHitPointsRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {

--- a/tests/monster_test.grpc.fb.h
+++ b/tests/monster_test.grpc.fb.h
@@ -4,7 +4,7 @@
 #ifndef GRPC_monster_5ftest__INCLUDED
 #define GRPC_monster_5ftest__INCLUDED
 
-#include "monster_test.pb.h"
+#include "monster_test_generated.h"
 #include "flatbuffers/grpc.h"
 
 #include <functional>


### PR DESCRIPTION
[C++]bug fix for (#5096) and (#5099)

- update grpc c++ code generator
- make Makefile of grpc/samples/greeter/ to workable
- add two Deserialize functions to accept ByteBuffer* and ByteBuffer::ByteBufferPointer as first parameter in  GRPC/flatbuffer glue header file
- add a PrintRaw in flatbuffer compiler cpp file for grpc as it is a virtual function in base class
- tune compiler flag
