### PR TITLE
Add repository name to build_defs.bzl

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -1,7 +1,7 @@
 # Description:
 #   BUILD rules for generating flatbuffer files in various languages.
 
-flatc_path = "//:flatc"
+flatc_path = "@com_github_google_flatbuffers//:flatc"
 
 DEFAULT_INCLUDE_PATHS = [
     "./",
@@ -214,7 +214,7 @@ def flatbuffer_cc_library(
             "-parse_headers",
         ],
         deps = [
-            "//:runtime_cc",
+            "@com_github_google_flatbuffers//:runtime_cc",
         ],
         includes = [],
         linkstatic = 1,


### PR DESCRIPTION
In flatbuffers, build_defs.bzl has been updated to have the bazel rule `flatbuffer_cc_library` defined. Therefore, it should be possible to build another application and using `flatbuffer_cc_library`
directly with:

```
load("@com_github_google_flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
```

However, when I tried to do the above, I saw the following errors in bazel:
```
ERROR: /root/.cache/bazel/_bazel_root/c27e9809996ce9a9c0ed8dd79ef0897b \
/external/arrow/BUILD.bazel:12:1: in deps attribute of cc_library rule \
@arrow//:arrow_format: target '@arrow//:runtime_cc' does not exist. \
Since this rule was created by the macro 'flatbuffer_cc_library', the error \
might have been caused by the macro implementation in \
/root/.cache/bazel/_bazel_root/c27e9809996ce9a9c0ed8dd79ef0897b\
/external/com_github_google_flatbuffers/build_defs.bzl:216:16
```

The reason for the bazel error was that `//:runtime_cc` and `//:flatc` does not have
the repo name prefixed.

By prefix `@com_github_google_flatbuffers` (`"@com_github_google_flatbuffers//:flatc"`) the above bazel build error could be resolved.

This fix should help other programs to use flatbuffers directly through bazel.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
