### PR TITLE
Fix high certainty warnings from PVS-studio

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -59,14 +59,14 @@
 // Clang 3.4 and later implement all of the ISO C++ 2014 standard.
 // http://clang.llvm.org/cxx_status.html
 
-// MSVC note: requires `/Zc:__cplusplus` or use _MSVC_LANG
-// > The MSVC compiler’s definition of the __cplusplus predefined macro leaps ahead 20 years
-// > in Visual Studio 2017 version 15.7 Preview 3. This macro has stubbornly remained at the value
-// > “199711L”, indicating (erroneously!) that the compiler conformed to the C++98 Standard.
-// > ...
-// > You need to compile with the /Zc:__cplusplus switch to see the updated value
-// > of the __cplusplus macro.
-// https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus/
+// Note the MSVC value '__cplusplus' may be incorrect:
+// The '__cplusplus' predefined macro in the MSVC stuck at the value 199711L,
+// indicating (erroneously!) that the compiler conformed to the C++98 Standard.
+// This value should be correct starting from MSVC2017-15.7-Preview-3.
+// The '__cplusplus' will be valid only if MSVC2017-15.7-P3 and the `/Zc:__cplusplus` switch is set.
+// Workaround (for details see MSDN):
+// Use the _MSC_VER and _MSVC_LANG definition instead of the __cplusplus  for compatibility.
+// The _MSVC_LANG macro reports the Standard version regardless of the '/Zc:__cplusplus' switch.
 
 /// @cond FLATBUFFERS_INTERNAL
 #if __cplusplus <= 199711L && \

--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -59,6 +59,15 @@
 // Clang 3.4 and later implement all of the ISO C++ 2014 standard.
 // http://clang.llvm.org/cxx_status.html
 
+// MSVC note: requires `/Zc:__cplusplus` or use _MSVC_LANG
+// > The MSVC compiler’s definition of the __cplusplus predefined macro leaps ahead 20 years
+// > in Visual Studio 2017 version 15.7 Preview 3. This macro has stubbornly remained at the value
+// > “199711L”, indicating (erroneously!) that the compiler conformed to the C++98 Standard.
+// > ...
+// > You need to compile with the /Zc:__cplusplus switch to see the updated value
+// > of the __cplusplus macro.
+// https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus/
+
 /// @cond FLATBUFFERS_INTERNAL
 #if __cplusplus <= 199711L && \
     (!defined(_MSC_VER) || _MSC_VER < 1600) && \
@@ -223,6 +232,15 @@
 template<typename T> FLATBUFFERS_CONSTEXPR inline bool IsConstTrue(T t) {
   return !!t;
 }
+
+// Enable of std:c++17 or higher.
+#if (defined(__cplusplus) &&  (__cplusplus >= 201703L)) || \
+    (defined(_MSVC_LANG) &&  (_MSVC_LANG >= 201703L))
+  // All attributes unknown to an implementation are ignored without causing an error.
+  #define FLATBUFFERS_ATTRIBUTE(attr) // [[attr]] - will be enabled in a future release
+#else
+  #define FLATBUFFERS_ATTRIBUTE(attr)
+#endif
 
 /// @endcond
 

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -211,6 +211,7 @@ template<typename T> class Vector {
   uoffset_t size() const { return EndianScalar(length_); }
 
   // Deprecated: use size(). Here for backwards compatibility.
+  FLATBUFFERS_ATTRIBUTE(deprecated("use size() instead"))
   uoffset_t Length() const { return size(); }
 
   typedef typename IndirectHelper<T>::return_type return_type;
@@ -996,8 +997,8 @@ class FlatBufferBuilder {
   /// @warning Do NOT attempt to use this FlatBufferBuilder afterwards!
   /// @return A `FlatBuffer` that owns the buffer and its allocator and
   /// behaves similar to a `unique_ptr` with a deleter.
-  /// Deprecated: use Release() instead
-  DetachedBuffer ReleaseBufferPointer() {
+  FLATBUFFERS_ATTRIBUTE(deprecated("use Release() instead")) DetachedBuffer
+  ReleaseBufferPointer() {
     Finished();
     return buf_.release();
   }
@@ -1205,7 +1206,7 @@ class FlatBufferBuilder {
         auto vt_offset_ptr = reinterpret_cast<uoffset_t *>(it);
         auto vt2 = reinterpret_cast<voffset_t *>(buf_.data_at(*vt_offset_ptr));
         auto vt2_size = *vt2;
-        if (vt1_size != vt2_size || memcmp(vt2, vt1, vt1_size)) continue;
+        if (vt1_size != vt2_size || 0 != memcmp(vt2, vt1, vt1_size)) continue;
         vt_use = *vt_offset_ptr;
         buf_.pop(GetSize() - vtableoffsetloc);
         break;
@@ -1226,7 +1227,7 @@ class FlatBufferBuilder {
     return vtableoffsetloc;
   }
 
-  // DEPRECATED: call the version above instead.
+  FLATBUFFERS_ATTRIBUTE(deprecated("call the version above instead"))
   uoffset_t EndTable(uoffset_t start, voffset_t /*numfields*/) {
     return EndTable(start);
   }
@@ -2114,7 +2115,7 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
     if (!Verify<uoffset_t>(start)) return 0;
     auto o = ReadScalar<uoffset_t>(buf_ + start);
     // May not point to itself.
-    Check(o != 0);
+    if (!Check(o != 0)) return 0;
     // Can't wrap around / buffers are max 2GB.
     if (!Check(static_cast<soffset_t>(o) >= 0)) return 0;
     // Must be inside the buffer to create a pointer from it (pointer outside

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -326,7 +326,7 @@ inline size_t InlineAlignment(const Type &type) {
 
 struct EnumVal {
   EnumVal(const std::string &_name, int64_t _val) : name(_name), value(_val) {}
-  EnumVal(){};
+  EnumVal() : value(0){};
 
   Offset<reflection::EnumVal> Serialize(FlatBufferBuilder *builder, const Parser &parser) const;
 
@@ -672,7 +672,7 @@ class Parser : public ParserState {
   bool Deserialize(const reflection::Schema* schema);
 
   Type* DeserializeType(const reflection::Type* type);
-  
+
   // Checks that the schema represented by this parser is a safe evolution
   // of the schema provided. Returns non-empty error on any problems.
   std::string ConformTo(const Parser &base);

--- a/include/flatbuffers/registry.h
+++ b/include/flatbuffers/registry.h
@@ -72,7 +72,7 @@ class Registry {
       return DetachedBuffer();
     }
     // We have a valid FlatBuffer. Detach it from the builder and return.
-    return parser.builder_.ReleaseBufferPointer();
+    return parser.builder_.Release();
   }
 
   // Modify any parsing / output options used by the other functions.

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -66,7 +66,7 @@ inline bool is_digit(char c) { return check_in_range(c, '0', '9'); }
 
 inline bool is_xdigit(char c) {
   // Replace by look-up table.
-  return is_digit(c) | check_in_range(c & 0xDF, 'a' & 0xDF, 'f' & 0xDF);
+  return is_digit(c) || check_in_range(c & 0xDF, 'a' & 0xDF, 'f' & 0xDF);
 }
 
 // Case-insensitive isalnum

--- a/samples/sample_bfbs.cpp
+++ b/samples/sample_bfbs.cpp
@@ -44,7 +44,7 @@ int main(int /*argc*/, const char * /*argv*/[]) {
   flatbuffers::Parser parser1;
   ok = parser1.Parse(schema_file.c_str(), include_directories);
   assert(ok);
-  
+
   // inizialize parser by deserializing bfbs schema
   flatbuffers::Parser parser2;
   ok = parser2.Deserialize((uint8_t *)bfbs_file.c_str(), bfbs_file.length());
@@ -52,6 +52,7 @@ int main(int /*argc*/, const char * /*argv*/[]) {
 
   // parse json in parser from fbs and bfbs
   ok = parser1.Parse(json_file.c_str(), include_directories);
+  assert(ok);
   ok = parser2.Parse(json_file.c_str(), include_directories);
   assert(ok);
 

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -411,8 +411,10 @@ CheckedError Parser::Next() {
           }
           cursor_ += 2;
           break;
+        } else {
+          // fall thru
         }
-        // fall thru
+        FLATBUFFERS_ATTRIBUTE(fallthrough);
       default:
         const auto has_sign = (c == '+') || (c == '-');
         // '-'/'+' and following identifier - can be a predefined constant like:
@@ -2752,7 +2754,7 @@ bool StructDef::Deserialize(Parser &parser, const reflection::Object *object) {
   minalign = object->minalign();
   predecl = false;
   sortbysize = attributes.Lookup("original_order") == nullptr && !fixed;
-  std::vector<uoffset_t> indexes = 
+  std::vector<uoffset_t> indexes =
     std::vector<uoffset_t>(object->fields()->Length());
   for (uoffset_t i = 0; i < object->fields()->Length(); i++)
     indexes[object->fields()->Get(i)->id()] = i;
@@ -2768,7 +2770,7 @@ bool StructDef::Deserialize(Parser &parser, const reflection::Object *object) {
       // Recompute padding since that's currently not serialized.
       auto size = InlineSize(field_def->value.type);
       auto next_field =
-          i + 1 < indexes.size() 
+          i + 1 < indexes.size()
           ? object->fields()->Get(indexes[i+1])
           : nullptr;
       bytesize += size;
@@ -3036,7 +3038,7 @@ bool Parser::Deserialize(const uint8_t *buf, const size_t size) {
       return false;
     else
       size_prefixed = true;
-  } 
+  }
   auto verify_fn = size_prefixed ? &reflection::VerifySizePrefixedSchemaBuffer
                                  : &reflection::VerifySchemaBuffer;
   if (!verify_fn(verifier)) {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -200,7 +200,7 @@ flatbuffers::DetachedBuffer CreateFlatBufferTest(std::string &buffer) {
       reinterpret_cast<const char *>(builder.GetBufferPointer());
   buffer.assign(bufferpointer, bufferpointer + builder.GetSize());
 
-  return builder.ReleaseBufferPointer();
+  return builder.Release();
 }
 
 //  example of accessing a buffer loaded in memory:
@@ -2032,6 +2032,7 @@ void UnionVectorTest() {
     TEST_EQ(cts->GetEnum<Character>(4) == Character_Unused, true);
 
     auto rapunzel = movie->main_character_as_Rapunzel();
+    TEST_NOTNULL(rapunzel);
     TEST_EQ(rapunzel->hair_length(), 6);
 
     auto cs = movie->characters();
@@ -2309,16 +2310,17 @@ void TypeAliasesTest() {
   TEST_EQ(ta->u64(), flatbuffers::numeric_limits<uint64_t>::max());
   TEST_EQ(ta->f32(), 2.3f);
   TEST_EQ(ta->f64(), 2.3);
-  TEST_EQ(sizeof(ta->i8()), 1);
-  TEST_EQ(sizeof(ta->i16()), 2);
-  TEST_EQ(sizeof(ta->i32()), 4);
-  TEST_EQ(sizeof(ta->i64()), 8);
-  TEST_EQ(sizeof(ta->u8()), 1);
-  TEST_EQ(sizeof(ta->u16()), 2);
-  TEST_EQ(sizeof(ta->u32()), 4);
-  TEST_EQ(sizeof(ta->u64()), 8);
-  TEST_EQ(sizeof(ta->f32()), 4);
-  TEST_EQ(sizeof(ta->f64()), 8);
+  using namespace flatbuffers; // is_same
+  static_assert(is_same<decltype(ta->i8()), int8_t>::value, "invalid type");
+  static_assert(is_same<decltype(ta->i16()), int16_t>::value, "invalid type");
+  static_assert(is_same<decltype(ta->i32()), int32_t>::value, "invalid type");
+  static_assert(is_same<decltype(ta->i64()), int64_t>::value, "invalid type");
+  static_assert(is_same<decltype(ta->u8()), uint8_t>::value, "invalid type");
+  static_assert(is_same<decltype(ta->u16()), uint16_t>::value, "invalid type");
+  static_assert(is_same<decltype(ta->u32()), uint32_t>::value, "invalid type");
+  static_assert(is_same<decltype(ta->u64()), uint64_t>::value, "invalid type");
+  static_assert(is_same<decltype(ta->f32()), float>::value, "invalid type");
+  static_assert(is_same<decltype(ta->f64()), double>::value, "invalid type");
 }
 
 void EndianSwapTest() {


### PR DESCRIPTION
The Flatbuffers has checked with the PVS-studio static code analyzer.
This PR fixes several high certainty warnings and introduces `FLATBUFFERS_ATTRIBUTE` macro definition.

The `FLATBUFFERS_ATTRIBUTE` temporary disabled until the deprecated `Vector::Length()` is not resolved.

Unexpected changes: some source lines modified by removing trailing whitespaces on file save.
Need to revert them back?