### PR TITLE
Reference::ToString should be const

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -494,7 +494,7 @@ class Reference {
   }
 
   // Unlike AsString(), this will convert any type to a std::string.
-  std::string ToString() {
+  std::string ToString() const {
     std::string s;
     ToString(false, false, s);
     return s;


### PR DESCRIPTION
I missed this when committing #4975, sorry about that.
