### PR TITLE
[golang] Return string for string types instead of byte arrays

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -348,7 +348,7 @@ class GoGenerator : public BaseGenerator {
     code += " " + MakeCamel(field.name);
     code += "() " + TypeName(field) + " ";
     code += OffsetPrefix(field) + "\t\treturn " + GenGetter(field.value.type);
-    code += "(o + rcv._tab.Pos)\n\t}\n\treturn nil\n";
+    code += "(o + rcv._tab.Pos)\n\t}\n\treturn \"\"\n";
     code += "}\n\n";
   }
 
@@ -720,7 +720,7 @@ class GoGenerator : public BaseGenerator {
   // Returns the function name that is able to read a value of the given type.
   std::string GenGetter(const Type &type) {
     switch (type.base_type) {
-      case BASE_TYPE_STRING: return "rcv._tab.ByteVector";
+      case BASE_TYPE_STRING: return "rcv._tab.String";
       case BASE_TYPE_UNION: return "rcv._tab.Union";
       case BASE_TYPE_VECTOR: return GenGetter(type.VectorType());
       default: return "rcv._tab.Get" + MakeCamel(GenTypeBasic(type));
@@ -749,7 +749,7 @@ class GoGenerator : public BaseGenerator {
 
   std::string GenTypePointer(const Type &type) {
     switch (type.base_type) {
-      case BASE_TYPE_STRING: return "[]byte";
+      case BASE_TYPE_STRING: return "string";
       case BASE_TYPE_VECTOR: return GenTypeGet(type.VectorType());
       case BASE_TYPE_STRUCT: return WrapInNameSpaceAndTrack(*type.struct_def);
       case BASE_TYPE_UNION:

--- a/tests/MyGame/Example/Monster.go
+++ b/tests/MyGame/Example/Monster.go
@@ -66,12 +66,12 @@ func (rcv *Monster) MutateHp(n int16) bool {
 	return rcv._tab.MutateInt16Slot(8, n)
 }
 
-func (rcv *Monster) Name() []byte {
+func (rcv *Monster) Name() string {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
-		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+		return rcv._tab.String(o + rcv._tab.Pos)
 	}
-	return nil
+	return ""
 }
 
 func (rcv *Monster) Inventory(j int) byte {
@@ -151,11 +151,11 @@ func (rcv *Monster) Test4Length() int {
 	return 0
 }
 
-func (rcv *Monster) Testarrayofstring(j int) []byte {
+func (rcv *Monster) Testarrayofstring(j int) string {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
-		return rcv._tab.ByteVector(a + flatbuffers.UOffsetT(j*4))
+		return rcv._tab.String(a + flatbuffers.UOffsetT(j*4))
 	}
 	return nil
 }
@@ -404,11 +404,11 @@ func (rcv *Monster) MutateTestf3(n float32) bool {
 	return rcv._tab.MutateFloat32Slot(58, n)
 }
 
-func (rcv *Monster) Testarrayofstring2(j int) []byte {
+func (rcv *Monster) Testarrayofstring2(j int) string {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(60))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
-		return rcv._tab.ByteVector(a + flatbuffers.UOffsetT(j*4))
+		return rcv._tab.String(a + flatbuffers.UOffsetT(j*4))
 	}
 	return nil
 }

--- a/tests/MyGame/Example/Stat.go
+++ b/tests/MyGame/Example/Stat.go
@@ -26,12 +26,12 @@ func (rcv *Stat) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *Stat) Id() []byte {
+func (rcv *Stat) Id() string {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+		return rcv._tab.String(o + rcv._tab.Pos)
 	}
-	return nil
+	return ""
 }
 
 func (rcv *Stat) Val() int64 {


### PR DESCRIPTION
Hello, I modified the golang code generator so that the getters of string variables return a string (using `Table.String()`) instead of `[]byte`. #3743 discusses this improvement but no action was taken.