### PR TITLE
[C++]Support reverse iterator in Vector

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -98,6 +98,7 @@ template<typename T, typename IT> struct VectorIterator {
   VectorIterator(const uint8_t *data, uoffset_t i)
       : data_(data + IndirectHelper<T>::element_stride * i) {}
   VectorIterator(const VectorIterator &other) : data_(other.data_) {}
+  VectorIterator() : data_(nullptr) {}
 
   VectorIterator &operator=(const VectorIterator &other) {
     data_ = other.data_;
@@ -179,6 +180,19 @@ template<typename T, typename IT> struct VectorIterator {
   const uint8_t *data_;
 };
 
+template<typename Iterator> struct VectorReverseIterator :
+  public std::reverse_iterator<Iterator> {
+
+  explicit VectorReverseIterator(Iterator iter) : iter_(iter) {}
+
+  typename Iterator::value_type operator*() const { return *(iter_ - 1); }
+
+  typename Iterator::value_type operator->() const { return *(iter_ - 1); }
+
+ private:
+  Iterator iter_;
+};
+
 struct String;
 
 // This is used as a helper type for accessing vectors.
@@ -189,6 +203,8 @@ template<typename T> class Vector {
       iterator;
   typedef VectorIterator<T, typename IndirectHelper<T>::return_type>
       const_iterator;
+  typedef VectorReverseIterator<iterator> reverse_iterator;
+  typedef VectorReverseIterator<const_iterator> const_reverse_iterator;
 
   uoffset_t size() const { return EndianScalar(length_); }
 
@@ -233,6 +249,20 @@ template<typename T> class Vector {
 
   iterator end() { return iterator(Data(), size()); }
   const_iterator end() const { return const_iterator(Data(), size()); }
+
+  reverse_iterator rbegin() { return reverse_iterator(end()); }
+  const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+
+  reverse_iterator rend() { return reverse_iterator(end()); }
+  const_reverse_iterator rend() const { return const_reverse_iterator(end()); }
+
+  const_iterator cbegin() const { return begin(); }
+
+  const_iterator cend() const { return end(); }
+
+  const_reverse_iterator crbegin() const { return rbegin(); }
+
+  const_reverse_iterator crend() const { return rend(); }
 
   // Change elements if you have a non-const pointer to this object.
   // Scalars only. See reflection.h, and the documentation.

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -165,7 +165,7 @@ template<typename T, typename IT> struct VectorIterator {
     return temp;
   }
 
-  VectorIterator operator-(const uoffset_t &offset) {
+  VectorIterator operator-(const uoffset_t &offset) const {
     return VectorIterator(data_ - offset * IndirectHelper<T>::element_stride,
                           0);
   }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -254,6 +254,24 @@ void AccessFlatBufferTest(const uint8_t *flatbuf, size_t length,
     TEST_EQ(*it, inv_data[indx]);
   }
 
+  for (auto it = inventory->cbegin(); it != inventory->cend(); ++it) {
+    auto indx = it - inventory->cbegin();
+    TEST_EQ(*it, inv_vec.at(indx));  // Use bounds-check.
+    TEST_EQ(*it, inv_data[indx]);
+  }
+
+  for (auto it = inventory->rbegin(); it != inventory->rend(); ++it) {
+    auto indx = inventory->rend() - it;
+    TEST_EQ(*it, inv_vec.at(indx));  // Use bounds-check.
+    TEST_EQ(*it, inv_data[indx]);
+  }
+
+  for (auto it = inventory->crbegin(); it != inventory->crend(); ++it) {
+    auto indx = inventory->crend() - it;
+    TEST_EQ(*it, inv_vec.at(indx));  // Use bounds-check.
+    TEST_EQ(*it, inv_data[indx]);
+  }
+
   TEST_EQ(monster->color(), Color_Blue);
 
   // Example of accessing a union:


### PR DESCRIPTION
Introduced a new VectorReverseIterator type. We cannot directly use
`std::reverse_iterator<VectorIterator>` because the signature of
`operator*` and `operator->` in the VectorIterator class are not
standard signatures.

Also added `rbegin()`, `rend()`, `cbegin()`, `cend()`, `crbegin()`
and `crend()` in the Vector class.

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
