### PR TITLE
Add flatc build testing against clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,21 @@ matrix:
       script:
         - bash .travis/build-and-run-docker-test-containers.sh
 
+    # run separately from build-and-run-docker-test-containers.sh because of build timeouts
+    - language: cpp
+      os:
+        - linux
+
+      addons:
+        apt:
+          packages:
+            - docker-ce
+      env:
+        - TESTING_SUFFIX=cpp.clang_3_8_1
+
+      script:
+        - docker build --build-arg JOBS=${JOBS} -f tests/docker/Dockerfile.testing.${TESTING_SUFFIX} .
+
     - language: cpp
       os:
         - linux

--- a/grpc/build_grpc.sh
+++ b/grpc/build_grpc.sh
@@ -2,13 +2,15 @@
 
 grpc_1_15_1_githash=1a60e6971f428323245a930031ad267bb3142ba4
 
+JOBS="${JOBS:-1}"
+
 function build_grpc () {
   git clone https://github.com/grpc/grpc.git google/grpc
   cd google/grpc
   git checkout ${grpc_1_15_1_githash} 
   git submodule update --init
-  make
-  make install prefix=`pwd`/install
+  make -j"$JOBS"
+  make -j"$JOBS" install prefix=`pwd`/install
   if [ ! -f ${GRPC_INSTALL_PATH}/lib/libgrpc++_unsecure.so.1 ]; then
     ln -s ${GRPC_INSTALL_PATH}/lib/libgrpc++_unsecure.so.6 ${GRPC_INSTALL_PATH}/lib/libgrpc++_unsecure.so.1
   fi

--- a/tests/docker/Dockerfile.testing.cpp.clang_3_8_1
+++ b/tests/docker/Dockerfile.testing.cpp.clang_3_8_1
@@ -1,0 +1,34 @@
+FROM debian:9.6-slim as base
+RUN apt -qq update >/dev/null
+RUN apt -qq install -y cmake make build-essential >/dev/null
+RUN apt -qq install -y autoconf git libtool >/dev/null
+FROM base
+WORKDIR /code
+ARG JOBS=1
+ENV UBSAN_OPTIONS "halt_on_error=1"
+ENV ASAN_OPTIONS "halt_on_error=1"
+
+# Uncomment once bug #5099 (https://github.com/google/flatbuffers/issues/5099) is fixed.
+#ADD grpc/build_grpc.sh grpc/build_grpc.sh
+#RUN bash grpc/build_grpc.sh
+
+RUN apt -qq install -y clang >/dev/null
+ENV CC /usr/bin/clang
+ENV CXX /usr/bin/clang++
+ADD . .
+RUN cmake \
+   -DCMAKE_BUILD_TYPE=Release  \
+   -DFLATBUFFERS_BUILD_TESTS=ON \
+   -DGRPC_INSTALL_PATH=/code/google/grpc/install  \
+   -DPROTOBUF_DOWNLOAD_PATH=/code/google/grpc/third_party/protobuf \
+   -DFLATBUFFERS_CODE_SANITIZE=ON \
+   -j${JOBS} \
+   .
+RUN cmake --build . -- -j${JOBS}
+RUN LD_LIBRARY_PATH=/code/google/grpc/install/lib ctest --extra-verbose --output-on-failure -j${JOBS}
+RUN bash .travis/check-generate-code.sh
+
+# Once bug #5099 (https://github.com/google/flatbuffers/issues/5099)
+# is fixed, insert this line in the cmake above:
+#   -DFLATBUFFERS_BUILD_GRPCTEST=ON  \
+#

--- a/tests/docker/Dockerfile.testing.cpp.gcc_6_3_0
+++ b/tests/docker/Dockerfile.testing.cpp.gcc_6_3_0
@@ -1,0 +1,31 @@
+FROM debian:9.6-slim as base
+RUN apt -qq update >/dev/null
+RUN apt -qq install -y cmake make build-essential >/dev/null
+RUN apt -qq install -y autoconf git libtool >/dev/null
+FROM base
+WORKDIR /code
+ARG JOBS=1
+ENV UBSAN_OPTIONS "halt_on_error=1"
+ENV ASAN_OPTIONS "halt_on_error=1"
+
+# Uncomment once bug #5099 (https://github.com/google/flatbuffers/issues/5099) is fixed.
+#ADD grpc/build_grpc.sh grpc/build_grpc.sh
+#RUN bash grpc/build_grpc.sh
+
+ADD . .
+RUN cmake \
+   -DCMAKE_BUILD_TYPE=Release  \
+   -DFLATBUFFERS_BUILD_TESTS=ON \
+   -DGRPC_INSTALL_PATH=/code/google/grpc/install  \
+   -DPROTOBUF_DOWNLOAD_PATH=/code/google/grpc/third_party/protobuf \
+   -DFLATBUFFERS_CODE_SANITIZE=ON \
+   -j${JOBS} \
+   .
+RUN cmake --build . -- -j${JOBS}
+RUN LD_LIBRARY_PATH=/code/google/grpc/install/lib ctest --extra-verbose --output-on-failure -j${JOBS}
+RUN bash .travis/check-generate-code.sh
+
+# Once bug #5099 (https://github.com/google/flatbuffers/issues/5099)
+# is fixed, insert this line in the cmake above:
+#   -DFLATBUFFERS_BUILD_GRPCTEST=ON  \
+#


### PR DESCRIPTION
This adds a Dockerfile which tests building flatc against clang.  See discussion at #5119.  It's a copy of the gcc-based Dockerfile with an additional package (`clang`) and the appropriate `CC` environment variables.