### PR TITLE
Replace deprecated Vector::Length() with Vector::size()

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -233,11 +233,11 @@ template<typename T> FLATBUFFERS_CONSTEXPR inline bool IsConstTrue(T t) {
   return !!t;
 }
 
-// Enable of std:c++17 or higher.
+// Enable C++ attribute [[]] if std:c++17 or higher.
 #if (defined(__cplusplus) &&  (__cplusplus >= 201703L)) || \
     (defined(_MSVC_LANG) &&  (_MSVC_LANG >= 201703L))
   // All attributes unknown to an implementation are ignored without causing an error.
-  #define FLATBUFFERS_ATTRIBUTE(attr) // [[attr]] - will be enabled in a future release
+  #define FLATBUFFERS_ATTRIBUTE(attr) [[attr]]
 #else
   #define FLATBUFFERS_ATTRIBUTE(attr)
 #endif

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -360,7 +360,7 @@ const Vector<Offset<T>> *VectorCast(const Vector<Offset<U>> *ptr) {
 // Convenient helper function to get the length of any vector, regardless
 // of whether it is null or not (the field is not set).
 template<typename T> static inline size_t VectorLength(const Vector<T> *v) {
-  return v ? v->Length() : 0;
+  return v ? v->size() : 0;
 }
 
 // Lexicographically compare two strings (possibly containing nulls), and
@@ -373,12 +373,12 @@ static inline bool StringLessThan(const char *a_data, uoffset_t a_size,
 
 struct String : public Vector<char> {
   const char *c_str() const { return reinterpret_cast<const char *>(Data()); }
-  std::string str() const { return std::string(c_str(), Length()); }
+  std::string str() const { return std::string(c_str(), size()); }
 
   // clang-format off
   #ifdef FLATBUFFERS_HAS_STRING_VIEW
   flatbuffers::string_view string_view() const {
-    return flatbuffers::string_view(c_str(), Length());
+    return flatbuffers::string_view(c_str(), size());
   }
   #endif // FLATBUFFERS_HAS_STRING_VIEW
   // clang-format on
@@ -1310,7 +1310,7 @@ class FlatBufferBuilder {
   /// @param[in] str A const pointer to a `String` struct to add to the buffer.
   /// @return Returns the offset in the buffer where the string starts
   Offset<String> CreateString(const String *str) {
-    return str ? CreateString(str->c_str(), str->Length()) : 0;
+    return str ? CreateString(str->c_str(), str->size()) : 0;
   }
 
   /// @brief Store a string in the buffer, which can contain any binary data.
@@ -1370,7 +1370,7 @@ class FlatBufferBuilder {
   /// @param[in] str A const pointer to a `String` struct to add to the buffer.
   /// @return Returns the offset in the buffer where the string starts
   Offset<String> CreateSharedString(const String *str) {
-    return CreateSharedString(str->c_str(), str->Length());
+    return CreateSharedString(str->c_str(), str->size());
   }
 
   /// @cond FLATBUFFERS_INTERNAL

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -119,7 +119,7 @@ bool Print<const void *>(const void *val, Type type, int indent,
       break;
     case BASE_TYPE_STRING: {
       auto s = reinterpret_cast<const String *>(val);
-      if (!EscapeString(s->c_str(), s->Length(), _text, opts.allow_non_utf8,
+      if (!EscapeString(s->c_str(), s->size(), _text, opts.allow_non_utf8,
                         opts.natural_utf8)) {
         return false;
       }

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -94,7 +94,7 @@ std::string MakeCamel(const std::string &in, bool first) {
 void DeserializeDoc( std::vector<std::string> &doc,
                      const Vector<Offset<String>> *documentation) {
   if (documentation == nullptr) return;
-  for (uoffset_t index = 0; index < documentation->Length(); index++)
+  for (uoffset_t index = 0; index < documentation->size(); index++)
     doc.push_back(documentation->Get(index)->str());
 }
 
@@ -2755,8 +2755,8 @@ bool StructDef::Deserialize(Parser &parser, const reflection::Object *object) {
   predecl = false;
   sortbysize = attributes.Lookup("original_order") == nullptr && !fixed;
   std::vector<uoffset_t> indexes =
-    std::vector<uoffset_t>(object->fields()->Length());
-  for (uoffset_t i = 0; i < object->fields()->Length(); i++)
+    std::vector<uoffset_t>(object->fields()->size());
+  for (uoffset_t i = 0; i < object->fields()->size(); i++)
     indexes[object->fields()->Get(i)->id()] = i;
   for (size_t i = 0; i < indexes.size(); i++) {
     auto field = object->fields()->Get(indexes[i]);

--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -299,13 +299,13 @@ class ResizeContext {
 void SetString(const reflection::Schema &schema, const std::string &val,
                const String *str, std::vector<uint8_t> *flatbuf,
                const reflection::Object *root_table) {
-  auto delta = static_cast<int>(val.size()) - static_cast<int>(str->Length());
+  auto delta = static_cast<int>(val.size()) - static_cast<int>(str->size());
   auto str_start = static_cast<uoffset_t>(
       reinterpret_cast<const uint8_t *>(str) - vector_data(*flatbuf));
   auto start = str_start + static_cast<uoffset_t>(sizeof(uoffset_t));
   if (delta) {
     // Clear the old string, since we don't want parts of it remaining.
-    memset(vector_data(*flatbuf) + start, 0, str->Length());
+    memset(vector_data(*flatbuf) + start, 0, str->size());
     // Different size, we must expand (or contract).
     ResizeContext(schema, start, delta, flatbuf, root_table);
     // Set the new length.

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -265,7 +265,7 @@ void AccessFlatBufferTest(const uint8_t *flatbuf, size_t length,
 
   // Example of accessing a vector of strings:
   auto vecofstrings = monster->testarrayofstring();
-  TEST_EQ(vecofstrings->Length(), 4U);
+  TEST_EQ(vecofstrings->size(), 4U);
   TEST_EQ_STR(vecofstrings->Get(0)->c_str(), "bob");
   TEST_EQ_STR(vecofstrings->Get(1)->c_str(), "fred");
   if (pooled) {
@@ -276,14 +276,14 @@ void AccessFlatBufferTest(const uint8_t *flatbuf, size_t length,
 
   auto vecofstrings2 = monster->testarrayofstring2();
   if (vecofstrings2) {
-    TEST_EQ(vecofstrings2->Length(), 2U);
+    TEST_EQ(vecofstrings2->size(), 2U);
     TEST_EQ_STR(vecofstrings2->Get(0)->c_str(), "jane");
     TEST_EQ_STR(vecofstrings2->Get(1)->c_str(), "mary");
   }
 
   // Example of accessing a vector of tables:
   auto vecoftables = monster->testarrayoftables();
-  TEST_EQ(vecoftables->Length(), 3U);
+  TEST_EQ(vecoftables->size(), 3U);
   for (auto it = vecoftables->begin(); it != vecoftables->end(); ++it)
     TEST_EQ(strlen(it->name()->c_str()) >= 4, true);
   TEST_EQ_STR(vecoftables->Get(0)->name()->c_str(), "Barney");


### PR DESCRIPTION
- all deprecated `Vector::Length()` replaced by `Vector::size()`
- `FLATBUFFERS_ATTRIBUTE` enabled if C++17 or higher

These changes checked with MSVC2015 + `ISO C++17 Standard (/std:c++17)`.