### PR TITLE
[C++] remove zero width space character <U+200B>'s from util.h

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -272,7 +272,7 @@ inline void strtoval_impl(float *val, const char *str, char **endptr) {
 //
 // Return value (like strtoull and strtoll, but reject partial result):
 // - If successful, an integer value corresponding to the str is returned.
-// - If full string conversion can't be performed, ​0​ is returned.
+// - If full string conversion can't be performed, 0 is returned.
 // - If the converted value falls out of range of corresponding return type, a
 // range error occurs. In this case value MAX(T)/MIN(T) is returned.
 template<typename T>
@@ -316,7 +316,7 @@ inline bool StringToFloatImpl(T *val, const char *const str) {
 // Convert a string to an instance of T.
 // Return value (matched with StringToInteger64Impl and strtod):
 // - If successful, a numeric value corresponding to the str is returned.
-// - If full string conversion can't be performed, ​0​ is returned.
+// - If full string conversion can't be performed, 0 is returned.
 // - If the converted value falls out of range of corresponding return type, a
 // range error occurs. In this case value MAX(T)/MIN(T) is returned.
 template<typename T> inline bool StringToNumber(const char *s, T *val) {


### PR DESCRIPTION
There're ZWSP <U+200B>'s in util.h, and my MSVC was generating warning C4819 everywhere, [I believe](https://google.github.io/styleguide/cppguide.html#Non-ASCII_Characters) it's better to get rid of them