### PR TITLE
Repair of `fallthrough`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ set(FlatBuffers_GRPCTest_SRCS
 if(EXISTS "${CMAKE_TOOLCHAIN_FILE}")
   # do not apply any global settings if the toolchain
   # is being configured externally
+  message(STATUS "Using toolchain file: ${CMAKE_TOOLCHAIN_FILE}.")
 elseif(APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror -Wextra -Wno-unused-parameter")
@@ -185,6 +186,9 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
   set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -pedantic -Werror -Wextra -Wno-unused-parameter")
   set(FLATBUFFERS_PRIVATE_CXX_FLAGS "-Wold-style-cast")
+  if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.8)
+    list(APPEND FLATBUFFERS_PRIVATE_CXX_FLAGS "-Wimplicit-fallthrough") # enable warning
+  endif()
   if(FLATBUFFERS_LIBCXX_WITH_CLANG)
     if(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
       set(CMAKE_CXX_FLAGS

--- a/grpc/src/compiler/java_generator.cc
+++ b/grpc/src/compiler/java_generator.cc
@@ -37,9 +37,6 @@
 #define XSTR(s) STR(s)
 #endif
 
-#ifndef FALLTHROUGH_INTENDED
-#define FALLTHROUGH_INTENDED
-#endif
 
 typedef grpc_generator::Printer Printer;
 typedef std::map<grpc::string, grpc::string> VARS;
@@ -479,7 +476,7 @@ static void PrintStub(Printer* p, VARS& vars, const ServiceDescriptor* service,
       break;
     case BLOCKING_CLIENT_INTERFACE:
       interface = true;
-      FALLTHROUGH_INTENDED;  // fallthrough
+      FLATBUFFERS_FALLTHROUGH(); // fall thru
     case BLOCKING_CLIENT_IMPL:
       call_type = BLOCKING_CALL;
       stub_name += "BlockingStub";
@@ -487,7 +484,7 @@ static void PrintStub(Printer* p, VARS& vars, const ServiceDescriptor* service,
       break;
     case FUTURE_CLIENT_INTERFACE:
       interface = true;
-      FALLTHROUGH_INTENDED;  // fallthrough
+      FLATBUFFERS_FALLTHROUGH(); // fall thru
     case FUTURE_CLIENT_IMPL:
       call_type = FUTURE_CALL;
       stub_name += "FutureStub";

--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -70,6 +70,18 @@
 // Use the _MSC_VER and _MSVC_LANG definition instead of the __cplusplus  for compatibility.
 // The _MSVC_LANG macro reports the Standard version regardless of the '/Zc:__cplusplus' switch.
 
+#if defined(__GNUC__) && !defined(__clang__)
+  #define FLATBUFFERS_GCC (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#else
+  #define FLATBUFFERS_GCC 0
+#endif
+
+#if defined(__clang__)
+  #define FLATBUFFERS_CLANG (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+#else
+  #define FLATBUFFERS_CLANG 0
+#endif
+
 /// @cond FLATBUFFERS_INTERNAL
 #if __cplusplus <= 199711L && \
     (!defined(_MSC_VER) || _MSC_VER < 1600) && \
@@ -236,12 +248,22 @@ template<typename T> FLATBUFFERS_CONSTEXPR inline bool IsConstTrue(T t) {
 }
 
 // Enable C++ attribute [[]] if std:c++17 or higher.
-#if (defined(__cplusplus) &&  (__cplusplus >= 201703L)) || \
-    (defined(_MSVC_LANG) &&  (_MSVC_LANG >= 201703L))
+#if ((__cplusplus >= 201703L) \
+    || (defined(_MSVC_LANG) &&  (_MSVC_LANG >= 201703L)))
   // All attributes unknown to an implementation are ignored without causing an error.
   #define FLATBUFFERS_ATTRIBUTE(attr) [[attr]]
+
+  #define FLATBUFFERS_FALLTHROUGH() [[fallthrough]]
 #else
   #define FLATBUFFERS_ATTRIBUTE(attr)
+
+  #if FLATBUFFERS_CLANG >= 30800
+    #define FLATBUFFERS_FALLTHROUGH() [[clang::fallthrough]]
+  #elif FLATBUFFERS_GCC >= 70300
+    #define FLATBUFFERS_FALLTHROUGH() [[gnu::fallthrough]]
+  #else
+    #define FLATBUFFERS_FALLTHROUGH()
+  #endif
 #endif
 
 /// @endcond

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -306,7 +306,7 @@ class GeneralGenerator : public BaseGenerator {
       case BASE_TYPE_UNION:
         // Unions in C# use a generic Table-derived type for better type safety
         if (lang_.language == IDLOptions::kCSharp) return "TTable";
-        // fall through
+        FLATBUFFERS_FALLTHROUGH();  // else fall thru
       default: return "Table";
     }
   }
@@ -327,7 +327,7 @@ class GeneralGenerator : public BaseGenerator {
       case BASE_TYPE_UINT: return Type(BASE_TYPE_LONG);
       case BASE_TYPE_VECTOR:
         if (vectorelem) return DestinationType(type.VectorType(), vectorelem);
-        // else fall thru
+        FLATBUFFERS_FALLTHROUGH(); // else fall thru
       default: return type;
     }
   }
@@ -371,7 +371,7 @@ class GeneralGenerator : public BaseGenerator {
       case BASE_TYPE_UINT: return " & 0xFFFFFFFFL";
       case BASE_TYPE_VECTOR:
         if (vectorelem) return DestinationMask(type.VectorType(), vectorelem);
-        // else fall thru
+        FLATBUFFERS_FALLTHROUGH(); // else fall thru
       default: return "";
     }
   }

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -130,6 +130,7 @@ FullType GetFullType(const Type &type) {
       case ftUnionKey:
       case ftUnionValue: {
         FLATBUFFERS_ASSERT(false && "vectors of unions are unsupported");
+        break;
       }
       default: {
         FLATBUFFERS_ASSERT(false && "vector of vectors are unsupported");

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -411,10 +411,8 @@ CheckedError Parser::Next() {
           }
           cursor_ += 2;
           break;
-        } else {
-          // fall thru
         }
-        FLATBUFFERS_ATTRIBUTE(fallthrough);
+        FLATBUFFERS_FALLTHROUGH(); // else fall thru
       default:
         const auto has_sign = (c == '+') || (c == '-');
         // '-'/'+' and following identifier - can be a predefined constant like:

--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -431,7 +431,7 @@ Offset<const Table *> CopyTable(FlatBufferBuilder &fbb,
               break;
             }
           }
-          // FALL-THRU
+          FLATBUFFERS_FALLTHROUGH(); // fall thru
           default: {  // Scalars and structs.
             auto element_size = GetTypeSize(element_base_type);
             if (elemobjectdef && elemobjectdef->is_struct())
@@ -466,7 +466,7 @@ Offset<const Table *> CopyTable(FlatBufferBuilder &fbb,
           break;
         }
       }
-      // ELSE FALL-THRU
+      FLATBUFFERS_FALLTHROUGH(); // fall thru
       case reflection::Union:
       case reflection::String:
       case reflection::Vector:


### PR DESCRIPTION
This PR repairs `fallthrough` which was broken by d4493165 (#5115).

1) Restores `fallthrough` (#5129 for details).
The compatibility with GCC 7.3 and GCC 8.2 was tested using `std=c++11` and `std=c++17`.

2) Adds `-Wimplicit-fallthrough` flag to detect a future `fallthrough` problems with help of Clang.
The #5130 allows testing the code using modern compilers (GCC 8.2 and Clang 8).