### PR TITLE
[C++] Only use __movsb on architectures that support it

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -153,7 +153,7 @@ inline uint64_t ReadUInt64(const uint8_t *data, uint8_t byte_width) {
   // constant, which here it isn't. Test if memcpy is still faster than
   // the conditionals in ReadSizedScalar. Can also use inline asm.
   // clang-format off
-  #ifdef _MSC_VER
+  #if defined(_MSC_VER) && (defined(_M_X64) || defined _M_IX86)
     uint64_t u = 0;
     __movsb(reinterpret_cast<uint8_t *>(&u),
             reinterpret_cast<const uint8_t *>(data), byte_width);


### PR DESCRIPTION
With the introduction of Windows 10 on ARM (ARM64), code that assumes
that Windows targets are always x86 or x86_64 targets needs to be
updated.

The hot function ReadUInt64 has been optimized in MSVC builds using the
compiler intrinsic __movsb. Since this does not exist on ARM64 Windows,
this change uses the pure C++ path that other platforms use instead.