### PR TITLE
[php] Changing  array to be an associative array so that the Name function …

### DIFF
--- a/src/idl_gen_php.cpp
+++ b/src/idl_gen_php.cpp
@@ -828,7 +828,7 @@ class PhpGenerator : public BaseGenerator {
     for (auto it = enum_def.vals.vec.begin(); it != enum_def.vals.vec.end();
          ++it) {
       auto &ev = **it;
-      code += Indent + Indent + "\"" + ev.name + "\",\n";
+      code += Indent + Indent + enum_def.name + "::" + ev.name + "=>" + "\"" + ev.name + "\",\n";
     }
 
     code += Indent + ");\n\n";


### PR DESCRIPTION
…can work with non-sequential enums as well as those beginning at something other than zero.

Change affects Character.php

```
<?php
// automatically generated by the FlatBuffers compiler, do not modify

class Character
{
    const NONE = 0;
    const MuLan = 1;
    const Rapunzel = 2;
    const Belle = 3;
    const BookFan = 4;
    const Other = 5;
    const Unused = 6;

    private static $names = array(
        "NONE",
        "MuLan",
        "Rapunzel",
        "Belle",
        "BookFan",
        "Other",
        "Unused",
    );

    public static function Name($e)
    {
        if (!isset(self::$names[$e])) {
            throw new \Exception();
        }
        return self::$names[$e];
    }
}

```

Becomes

```
<?php
// automatically generated by the FlatBuffers compiler, do not modify

class Character
{
    const NONE = 0;
    const MuLan = 1;
    const Rapunzel = 2;
    const Belle = 3;
    const BookFan = 4;
    const Other = 5;
    const Unused = 6;

    private static $names = array(
        Character::NONE=>"NONE",
        Character::MuLan=>"MuLan",
        Character::Rapunzel=>"Rapunzel",
        Character::Belle=>"Belle",
        Character::BookFan=>"BookFan",
        Character::Other=>"Other",
        Character::Unused=>"Unused",
    );

    public static function Name($e)
    {
        if (!isset(self::$names[$e])) {
            throw new \Exception();
        }
        return self::$names[$e];
    }
}
```