### PR TITLE
Removing 'using namespace' usage in test_builder

### DIFF
--- a/grpc/tests/message_builder_test.cpp
+++ b/grpc/tests/message_builder_test.cpp
@@ -3,6 +3,10 @@
 #include "test_assert.h"
 #include "test_builder.h"
 
+using MyGame::Example::Vec3;
+using MyGame::Example::CreateStat;
+using MyGame::Example::Any_NONE;
+
 bool verify(flatbuffers::grpc::Message<Monster> &msg, const std::string &expected_name, Color color) {
   const Monster *monster = msg.GetRoot();
   return (monster->name()->str() == expected_name) && (monster->color() == color);

--- a/tests/test_builder.h
+++ b/tests/test_builder.h
@@ -7,7 +7,9 @@
 #include "flatbuffers/flatbuffers.h"
 #include "test_assert.h"
 
-using namespace MyGame::Example;
+using MyGame::Example::Color;
+using MyGame::Example::Monster;
+
 namespace flatbuffers {
 namespace grpc {
 class MessageBuilder;


### PR DESCRIPTION
`using namespace MyGame::Example` is disallowed by the Wheader-hygiene flag:
`error: using namespace directive in global context in header`

This error is preventing rolling the most up to date version of flatbuffers into Chromium.