### PR TITLE
[Java] Make ByteBufferFactory an abstract class in order to make FlatBuffers compatible with Java7.

### DIFF
--- a/tests/JavaTest.java
+++ b/tests/JavaTest.java
@@ -232,7 +232,7 @@ class JavaTest {
     }
 
     static void TestByteBufferFactory() {
-        final class MappedByteBufferFactory implements FlatBufferBuilder.ByteBufferFactory {
+        final class MappedByteBufferFactory extends FlatBufferBuilder.ByteBufferFactory {
             @Override
             public ByteBuffer newByteBuffer(int capacity) {
                 ByteBuffer bb;


### PR DESCRIPTION
- Make ByteBufferFactory an abstract class (default methods are not supported on Java 7)
- Introduce a HeapByteBufferFactory singleton instance in order to reduce allocations.
- Clarify the usage of LITTLE_ENDIAN ByteBuffers in ByteBufferFactory.