### PR TITLE
Fix 'upper_bound_' is not used build error [C++]

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1978,7 +1978,9 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
         max_depth_(_max_depth),
         num_tables_(0),
         max_tables_(_max_tables),
+      #ifdef FLATBUFFERS_TRACK_VERIFIER_BUFFER_SIZE
         upper_bound_(0),
+      #endif
         check_alignment_(_check_alignment)
   {
     FLATBUFFERS_ASSERT(size_ < FLATBUFFERS_MAX_BUFFER_SIZE);
@@ -2193,7 +2195,9 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
   uoffset_t max_depth_;
   uoffset_t num_tables_;
   uoffset_t max_tables_;
+#ifdef FLATBUFFERS_TRACK_VERIFIER_BUFFER_SIZE
   mutable size_t upper_bound_;
+#endif
   bool check_alignment_;
 };
 


### PR DESCRIPTION
Fix build error:

```
/flatbuffers/include/flatbuffers/flatbuffers.h:2196:18: error: 
      private field 'upper_bound_' is not used [-Werror,-Wunused-private-field]
  mutable size_t upper_bound_;
                 ^
1 error generated.
```

Repro:
```
git clone git@github.com:google/flatbuffers.git && cd flatbuffers
cmake -G "Unix Makefiles" .
make
```

@gwvo @aardappel cc7f9b89f3795b44bb7ec38ac96c15f95e1c7d24