### PR TITLE
Fix bazel build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -133,7 +133,6 @@ cc_test(
         "src/idl_parser.cpp",
         "src/reflection.cpp",
         "src/util.cpp",
-        "monster_test_generated.h",
         "tests/namespace_test/namespace_test1_generated.h",
         "tests/namespace_test/namespace_test2_generated.h",
         "tests/test.cpp",
@@ -162,6 +161,10 @@ cc_test(
         ":tests/union_vector/union_vector.fbs",
     ],
     includes = ["include/"],
+    deps = [
+        ":monster_extra_cc_fbs",
+        ":monster_test_cc_fbs",
+    ],
 )
 
 # Test bzl rules
@@ -174,4 +177,9 @@ flatbuffer_cc_library(
         "tests/include_test/include_test1.fbs",
         "tests/include_test/sub/include_test2.fbs",
     ],
+)
+
+flatbuffer_cc_library(
+    name = "monster_extra_cc_fbs",
+    srcs = ["tests/monster_extra.fbs"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,15 @@
 workspace(name = "com_github_google_flatbuffers")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.13.0/rules_go-0.13.0.tar.gz"],
-    sha256 = "ba79c532ac400cefd1859cbc8a9829346aa69e3b99482cd5a54432092cbc3933",
+    sha256 = "492c3ac68ed9dcf527a07e6a1b2dcbf199c6bf8b35517951467ac32e421c06c1",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.17.0/rules_go-0.17.0.tar.gz"],
 )
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
 go_rules_dependencies()
+
 go_register_toolchains()


### PR DESCRIPTION
rules_go was out of date.  Update that.  Also, a dependency on monster_extra_cc_fbs snuck in.  So, let's add that so everything passes again

Fixes: #5163 