### PR TITLE
Add RPM packaging support

### DIFF
--- a/CMake/DESCRIPTION.txt
+++ b/CMake/DESCRIPTION.txt
@@ -1,0 +1,4 @@
+FlatBuffers is an efficient cross platform serialization library for
+C++, with support for Java, C# and Go. It was created at Google
+specifically for game development and other performance-critical
+applications.

--- a/CMake/PackageRedhat.cmake
+++ b/CMake/PackageRedhat.cmake
@@ -1,0 +1,34 @@
+if (UNIX)
+    set(CPACK_GENERATOR "RPM")
+    set(CPACK_SOURCE_TGZ "ON")
+
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "FlatBuffers serialization library and schema compiler.")
+    
+    set(CPACK_RPM_PACKAGE_HOMEPAGE "https://github.com/google/flatbuffers")
+    set(CPACK_RPM_PACKAGE_MAINTAINER "Vitaly Isaev <vitalyisaev2@gmail.com>")
+
+    set(CPACK_PACKAGE_VERSION_MAJOR ${VERSION_MAJOR})
+    set(CPACK_PACKAGE_VERSION_MINOR ${VERSION_MINOR})
+    set(CPACK_PACKAGE_VERSION_PATCH ${VERSION_PATCH})
+    set(CPACK_PACKAGE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-${VERSION_COMMIT}")
+    set(CPACK_RPM_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION}")
+
+    set(CPACK_RPM_PACKAGE_NAME "flatbuffers")
+
+    # Assume this is not a cross complation build.
+    if(NOT CPACK_RPM_PACKAGE_ARCHITECTURE)
+        set(CPACK_RPM_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")
+    endif(NOT CPACK_RPM_PACKAGE_ARCHITECTURE)
+
+    set(CPACK_RPM_PACKAGE_VENDOR "Google, Inc.")
+    set(CPACK_RPM_PACKAGE_LICENSE "Apache 2.0")
+    set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE.txt)
+    set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_SOURCE_DIR}/CMake/DESCRIPTION.txt)
+
+    # This may reduce rpm compatiblity with very old systems.
+    set(CPACK_RPM_COMPRESSION_TYPE lzma)
+    
+    set(CPACK_RPM_PACKAGE_NAME "flatbuffers")
+    set(CPACK_PACKAGE_FILE_NAME
+        "${CPACK_RPM_PACKAGE_NAME}_${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_ARCHITECTURE}")
+endif(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,10 @@ option(FLATBUFFERS_LIBCXX_WITH_CLANG "Force libc++ when using Clang" ON)
 option(FLATBUFFERS_CODE_SANITIZE
       "Add '-fsanitize' flags to 'flattests' and 'flatc' targets."
       OFF)
-
+option(FLATBUFFERS_PACKAGE_REDHAT
+       "Build an rpm using package target."
+       OFF)
+  
 if(NOT FLATBUFFERS_BUILD_FLATC AND FLATBUFFERS_BUILD_TESTS)
     message(WARNING
     "Cannot build tests without building the compiler. Tests will be disabled.")
@@ -445,6 +448,14 @@ endif()
 
 include(CMake/BuildFlatBuffers.cmake)
 
-if(FLATBUFFERS_PACKAGE_DEBIAN)
-    include(CMake/PackageDebian.cmake)
+if(UNIX)
+    # Use of CPack only support on Linux systems.
+    if (FLATBUFFERS_PACKAGE_REDHAT)
+        include(CMake/PackageRedhat.cmake)
+    endif()
+    # Currently no option available.
+    # if(FLATBUFFERS_PACKAGE_DEBIAN)
+    #     include(CMake/PackageDebian.cmake)
+    # endif()
+    include(CPack)
 endif()


### PR DESCRIPTION
Using the existing PackageDebian as template add support for
generating an rpm with the package target.

I made no modifications to PackageDebian as I currently do not have access to a debian system for testing.
