### PR TITLE
Install flatc as requested

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,7 +393,6 @@ if(FLATBUFFERS_INSTALL)
     install(
       TARGETS flatc EXPORT FlatcTargets
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-      CONFIGURATIONS Release
     )
 
     install(
@@ -401,7 +400,6 @@ if(FLATBUFFERS_INSTALL)
       FILE FlatcTargets.cmake
       NAMESPACE flatbuffers::
       DESTINATION ${FB_CMAKE_DIR}
-      CONFIGURATIONS Release
     )
   endif()
 


### PR DESCRIPTION
If FLATBUFFERS_BUILD_FLATC and FLATBUFFERS_INSTALL are set, flatc should
be installed regardless of the configuration.

This affects only the CMake build system.

Fixes #4753.