### PR TITLE
[C#] Fix FlatBuffers.Tests when ENABLE_SPAN_T is defined

### DIFF
--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -258,7 +258,7 @@ namespace FlatBuffers.Test
             }
             else
             {
-                Assert.IsTrue(monster.GetTestarrayofboolsBytes().Length == 0);
+                Assert.IsTrue(monster.GetTestarrayofboolsBytes().Length != 0);
             }
 #else
             var nameBytes = monster.GetNameBytes().Value;


### PR DESCRIPTION
There is a test code error that causes the CanReadCppGeneratedWireFile test to fail when ENABLE_SPAN_T is defined. When TestarrayofboolsLength is not 0, then the GetTestarrayofboolsBytes() should have a length.

/cc @ccifra 