### PR TITLE
Clean-up nested_parser on all paths (#5179)

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1216,8 +1216,15 @@ CheckedError Parser::ParseNestedFlatbuffer(Value &val, FieldDef *field,
     nested_parser.uses_flexbuffers_ = uses_flexbuffers_;
 
     // Parse JSON substring into new flatbuffer builder using nested_parser
-    if (!nested_parser.Parse(substring.c_str(), nullptr, nullptr)) {
-      ECHECK(Error(nested_parser.error_));
+    bool ok = nested_parser.Parse(substring.c_str(), nullptr, nullptr);
+
+    // Clean nested_parser to avoid deleting the elements in
+    // the SymbolTables on destruction
+    nested_parser.enums_.dict.clear();
+    nested_parser.enums_.vec.clear();
+
+    if (!ok) {
+      ECHECK(Error(nested_parser.error_)); 
     }
     // Force alignment for nested flatbuffer
     builder_.ForceVectorAlignment(nested_parser.builder_.GetSize(), sizeof(uint8_t),
@@ -1226,11 +1233,6 @@ CheckedError Parser::ParseNestedFlatbuffer(Value &val, FieldDef *field,
     auto off = builder_.CreateVector(nested_parser.builder_.GetBufferPointer(),
                                      nested_parser.builder_.GetSize());
     val.constant = NumToString(off.o);
-
-    // Clean nested_parser before destruction to avoid deleting the elements in
-    // the SymbolTables
-    nested_parser.enums_.dict.clear();
-    nested_parser.enums_.vec.clear();
   }
   return NoError();
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2014 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1996,6 +1996,26 @@ void ParseUnionTest() {
           true);
 }
 
+void InvalidNestedFlatbufferTest() {
+  // First, load and parse FlatBuffer schema (.fbs)
+  std::string schemafile;
+  TEST_EQ(flatbuffers::LoadFile((test_data_path + "monster_test.fbs").c_str(),
+                                false, &schemafile),
+          true);
+  auto include_test_path =
+      flatbuffers::ConCatPathFileName(test_data_path, "include_test");
+  const char *include_directories[] = { test_data_path.c_str(),
+                                        include_test_path.c_str(), nullptr };
+  flatbuffers::Parser parser1;
+  TEST_EQ(parser1.Parse(schemafile.c_str(), include_directories), true);
+
+  // "color" inside nested flatbuffer contains invalid enum value
+  TEST_EQ(parser1.Parse("{ name: \"Bender\", testnestedflatbuffer: { name: "
+                        "\"Leela\", color: \"nonexistent\"}}"),
+          false);
+  // Check that Parser is destroyed correctly after parsing invalid json
+}
+
 void UnionVectorTest() {
   // load FlatBuffer fbs schema.
   // TODO: load a JSON file with such a vector when JSON support is ready.
@@ -2524,6 +2544,7 @@ int FlatBufferTests() {
   InvalidUTF8Test();
   UnknownFieldsTest();
   ParseUnionTest();
+  InvalidNestedFlatbufferTest();
   ConformTest();
   ParseProtoBufAsciiTest();
   TypeAliasesTest();


### PR DESCRIPTION
nested_parser is not cleaned-up if Parse() not succeeded. This leads to crash on Parser destruction or on subsequent call to Parse() .
This patch fixes it.