### PR TITLE
Fix big-endian build.

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -363,6 +363,11 @@ void WriteScalar(void *p, T t) {
   *reinterpret_cast<T *>(p) = EndianScalar(t);
 }
 
+template<typename T> struct Offset;
+template<typename T> __supress_ubsan__("alignment") void WriteScalar(void *p, Offset<T> t) {
+  *reinterpret_cast<uoffset_t *>(p) = EndianScalar(t.o);
+}
+
 // Computes how many bytes you'd have to pad to be able to write an
 // "scalar_size" scalar if the buffer had grown to "buf_size" (downwards in
 // memory).


### PR DESCRIPTION
For some reason, Offset<T> is being considered a scalar, which
causes EndianSwap to be passed an Offset<T>.  This doesn't work,
as it does not support types with non-trivial constructors.  This
change adds an overload to WriteScalar(), which works around this.

This addresses #5202, although there are still outstanding issues.