### PR TITLE
Fix incorrect code generation on Solaris Sparc.

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -130,6 +130,9 @@ template<> inline std::string NumToString<signed char>(signed char t) {
 template<> inline std::string NumToString<unsigned char>(unsigned char t) {
   return NumToString(static_cast<int>(t));
 }
+template<> inline std::string NumToString<char>(char t) {
+  return NumToString(static_cast<int>(t));
+}
 #if defined(FLATBUFFERS_CPP98_STL)
 template<> inline std::string NumToString<long long>(long long t) {
   char buf[21];  // (log((1 << 63) - 1) / log(10)) + 2


### PR DESCRIPTION
On Solaris Sparc, calling NumToString() with a char called the primary
version, not the signed char or unsigned char specializations, which
caused integer to string conversions to be missed.

This addresses the remaining failures in #5202.