### PR TITLE
C++: IterateValue: Use ReadScalar instead of unportable reinterpret_casts

### DIFF
--- a/include/flatbuffers/minireflect.h
+++ b/include/flatbuffers/minireflect.h
@@ -122,58 +122,58 @@ inline void IterateValue(ElementaryType type, const uint8_t *val,
                          soffset_t vector_index, IterationVisitor *visitor) {
   switch (type) {
     case ET_UTYPE: {
-      auto tval = *reinterpret_cast<const uint8_t *>(val);
+      auto tval = ReadScalar<uint8_t>(val);
       visitor->UType(tval, EnumName(tval, type_table));
       break;
     }
     case ET_BOOL: {
-      visitor->Bool(*reinterpret_cast<const uint8_t *>(val) != 0);
+      visitor->Bool(ReadScalar<uint8_t>(val) != 0);
       break;
     }
     case ET_CHAR: {
-      auto tval = *reinterpret_cast<const int8_t *>(val);
+      auto tval = ReadScalar<int8_t>(val);
       visitor->Char(tval, EnumName(tval, type_table));
       break;
     }
     case ET_UCHAR: {
-      auto tval = *reinterpret_cast<const uint8_t *>(val);
+      auto tval = ReadScalar<uint8_t>(val);
       visitor->UChar(tval, EnumName(tval, type_table));
       break;
     }
     case ET_SHORT: {
-      auto tval = *reinterpret_cast<const int16_t *>(val);
+      auto tval = ReadScalar<int16_t>(val);
       visitor->Short(tval, EnumName(tval, type_table));
       break;
     }
     case ET_USHORT: {
-      auto tval = *reinterpret_cast<const uint16_t *>(val);
+      auto tval = ReadScalar<uint16_t>(val);
       visitor->UShort(tval, EnumName(tval, type_table));
       break;
     }
     case ET_INT: {
-      auto tval = *reinterpret_cast<const int32_t *>(val);
+      auto tval = ReadScalar<int32_t>(val);
       visitor->Int(tval, EnumName(tval, type_table));
       break;
     }
     case ET_UINT: {
-      auto tval = *reinterpret_cast<const uint32_t *>(val);
+      auto tval = ReadScalar<uint32_t>(val);
       visitor->UInt(tval, EnumName(tval, type_table));
       break;
     }
     case ET_LONG: {
-      visitor->Long(*reinterpret_cast<const int64_t *>(val));
+      visitor->Long(ReadScalar<int64_t>(val));
       break;
     }
     case ET_ULONG: {
-      visitor->ULong(*reinterpret_cast<const uint64_t *>(val));
+      visitor->ULong(ReadScalar<uint64_t>(val));
       break;
     }
     case ET_FLOAT: {
-      visitor->Float(*reinterpret_cast<const float *>(val));
+      visitor->Float(ReadScalar<float>(val));
       break;
     }
     case ET_DOUBLE: {
-      visitor->Double(*reinterpret_cast<const double *>(val));
+      visitor->Double(ReadScalar<double>(val));
       break;
     }
     case ET_STRING: {


### PR DESCRIPTION
This fixes the testcase MiniReflectFlatBuffersTest on big endian.

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
