### PR TITLE
Java: Removed unused duplicate of bytebuffer from "Table#__string" method.

### DIFF
--- a/java/com/google/flatbuffers/Table.java
+++ b/java/com/google/flatbuffers/Table.java
@@ -89,8 +89,7 @@ public class Table {
    */
   protected String __string(int offset) {
     offset += bb.getInt(offset);
-    ByteBuffer src = bb.duplicate().order(ByteOrder.LITTLE_ENDIAN);
-    int length = src.getInt(offset);
+    int length = bb.getInt(offset);
     return utf8.decodeUtf8(bb, offset + SIZEOF_INT, length);
   }
 


### PR DESCRIPTION
This commit resolves #5196