### PR TITLE
[Fix #5112][C++] constructors with memset for non-trivial types

### DIFF
--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -166,7 +166,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Vec3 FLATBUFFERS_FINAL_CLASS {
 
  public:
   Vec3() {
-    memset(this, 0, sizeof(Vec3));
+    memset(static_cast<void *>(this), 0, sizeof(Vec3));
   }
   Vec3(float _x, float _y, float _z)
       : x_(flatbuffers::EndianScalar(_x)),

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2617,7 +2617,7 @@ class CppGenerator : public BaseGenerator {
 
     // Generate a default constructor.
     code_ += "  {{STRUCT_NAME}}() {";
-    code_ += "    memset(this, 0, sizeof({{STRUCT_NAME}}));";
+    code_ += "    memset(static_cast<void *>(this), 0, sizeof({{STRUCT_NAME}}));";
     code_ += "  }";
 
     // Generate a constructor that takes all fields as arguments.

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -516,7 +516,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(2) Test FLATBUFFERS_FINAL_CLASS {
 
  public:
   Test() {
-    memset(this, 0, sizeof(Test));
+    memset(static_cast<void *>(this), 0, sizeof(Test));
   }
   Test(int16_t _a, int8_t _b)
       : a_(flatbuffers::EndianScalar(_a)),
@@ -559,7 +559,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Vec3 FLATBUFFERS_FINAL_CLASS {
 
  public:
   Vec3() {
-    memset(this, 0, sizeof(Vec3));
+    memset(static_cast<void *>(this), 0, sizeof(Vec3));
   }
   Vec3(float _x, float _y, float _z, double _test1, Color _test2, const Test &_test3)
       : x_(flatbuffers::EndianScalar(_x)),
@@ -631,7 +631,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Ability FLATBUFFERS_FINAL_CLASS {
 
  public:
   Ability() {
-    memset(this, 0, sizeof(Ability));
+    memset(static_cast<void *>(this), 0, sizeof(Ability));
   }
   Ability(uint32_t _id, uint32_t _distance)
       : id_(flatbuffers::EndianScalar(_id)),

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -57,7 +57,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) StructInNestedNS FLATBUFFERS_FINAL_CLASS 
 
  public:
   StructInNestedNS() {
-    memset(this, 0, sizeof(StructInNestedNS));
+    memset(static_cast<void *>(this), 0, sizeof(StructInNestedNS));
   }
   StructInNestedNS(int32_t _a, int32_t _b)
       : a_(flatbuffers::EndianScalar(_a)),

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -189,7 +189,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Rapunzel FLATBUFFERS_FINAL_CLASS {
 
  public:
   Rapunzel() {
-    memset(this, 0, sizeof(Rapunzel));
+    memset(static_cast<void *>(this), 0, sizeof(Rapunzel));
   }
   Rapunzel(int32_t _hair_length)
       : hair_length_(flatbuffers::EndianScalar(_hair_length)) {
@@ -214,7 +214,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) BookReader FLATBUFFERS_FINAL_CLASS {
 
  public:
   BookReader() {
-    memset(this, 0, sizeof(BookReader));
+    memset(static_cast<void *>(this), 0, sizeof(BookReader));
   }
   BookReader(int32_t _books_read)
       : books_read_(flatbuffers::EndianScalar(_books_read)) {


### PR DESCRIPTION
Hello,

I wanted first to generate the default constructor with initializers but I figured out that there was a simpler solution for this issue.
What do you think ?

Regards,
Stac

[monster_generated.diff.txt](https://github.com/google/flatbuffers/files/2909605/monster_generated.diff.txt)
