### PR TITLE
Fix rust crate for big-endian targets

### DIFF
--- a/.travis/build-and-run-docker-test-containers.sh
+++ b/.travis/build-and-run-docker-test-containers.sh
@@ -20,7 +20,7 @@ docker build -t build_flatc_debian_stretch -f tests/docker/Dockerfile.testing.bu
 BUILD_CONTAINER_ID=$(docker create --read-only build_flatc_debian_stretch)
 docker cp ${BUILD_CONTAINER_ID}:/code/flatc flatc_debian_stretch
 
-for f in $(ls tests/docker/languages | sort)
+for f in $(ls tests/docker/languages | grep endian | sort)
 do
         # docker pull sometimes fails for unknown reasons, probably travisci-related. this retries the pull we need a few times.
         REQUIRED_BASE_IMAGE=$(cat tests/docker/languages/${f} | head -n 1  | awk ' { print $2 } ')

--- a/.travis/build-and-run-docker-test-containers.sh
+++ b/.travis/build-and-run-docker-test-containers.sh
@@ -20,7 +20,7 @@ docker build -t build_flatc_debian_stretch -f tests/docker/Dockerfile.testing.bu
 BUILD_CONTAINER_ID=$(docker create --read-only build_flatc_debian_stretch)
 docker cp ${BUILD_CONTAINER_ID}:/code/flatc flatc_debian_stretch
 
-for f in $(ls tests/docker/languages | grep endian | sort)
+for f in $(ls tests/docker/languages | sort)
 do
         # docker pull sometimes fails for unknown reasons, probably travisci-related. this retries the pull we need a few times.
         REQUIRED_BASE_IMAGE=$(cat tests/docker/languages/${f} | head -n 1  | awk ' { print $2 } ')

--- a/rust/flatbuffers/src/endian_scalar.rs
+++ b/rust/flatbuffers/src/endian_scalar.rs
@@ -88,7 +88,7 @@ impl EndianScalar for f32 {
         }
         #[cfg(not(target_endian = "little"))]
         {
-            byte_swap_f32(&self)
+            byte_swap_f32(self)
         }
     }
     /// Convert f32 from little-endian to host endian-ness.
@@ -100,7 +100,7 @@ impl EndianScalar for f32 {
         }
         #[cfg(not(target_endian = "little"))]
         {
-            byte_swap_f32(&self)
+            byte_swap_f32(self)
         }
     }
 }
@@ -115,7 +115,7 @@ impl EndianScalar for f64 {
         }
         #[cfg(not(target_endian = "little"))]
         {
-            byte_swap_f64(&self)
+            byte_swap_f64(self)
         }
     }
     /// Convert f64 from little-endian to host endian-ness.
@@ -127,7 +127,7 @@ impl EndianScalar for f64 {
         }
         #[cfg(not(target_endian = "little"))]
         {
-            byte_swap_f64(&self)
+            byte_swap_f64(self)
         }
     }
 }

--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -85,6 +85,7 @@ mod le_safe_slice_impls {
     impl super::SafeSliceAccess for f64 {}
 }
 
+#[cfg(target_endian = "little")]
 pub use self::le_safe_slice_impls::*;
 
 pub fn follow_cast_ref<'a, T: Sized + 'a>(buf: &'a [u8], loc: usize) -> &'a T {

--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -19,7 +19,9 @@ use std::mem::size_of;
 use std::slice::from_raw_parts;
 use std::str::from_utf8_unchecked;
 
-use endian_scalar::{EndianScalar, read_scalar};
+#[cfg(target_endian = "little")]
+use endian_scalar::EndianScalar;
+use endian_scalar::read_scalar;
 use follow::Follow;
 use primitives::*;
 
@@ -105,6 +107,7 @@ impl<'a> Follow<'a> for &'a str {
     }
 }
 
+#[cfg(target_endian = "little")]
 fn follow_slice_helper<T>(buf: &[u8], loc: usize) -> &[T] {
     let sz = size_of::<T>();
     debug_assert!(sz > 0);

--- a/tests/RustTest.sh
+++ b/tests/RustTest.sh
@@ -15,8 +15,14 @@ set -e
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [[ "$1" == "mips-unknown-linux-gnu" ]]; then
+    TARGET_FLAG="--target mips-unknown-linux-gnu"
+    export CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc
+    export CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="qemu-mips -L /usr/mips-linux-gnu"
+fi
+
 cd ./rust_usage_test
-cargo test -- --quiet
+cargo test $TARGET_FLAG -- --quiet
 TEST_RESULT=$?
 if [[ $TEST_RESULT  == 0 ]]; then
     echo "OK: Rust tests passed."
@@ -25,7 +31,7 @@ else
     exit 1
 fi
 
-cargo run --bin=alloc_check
+cargo run $TARGET_FLAG --bin=alloc_check
 TEST_RESULT=$?
 if [[ $TEST_RESULT  == 0 ]]; then
     echo "OK: Rust heap alloc test passed."
@@ -34,4 +40,4 @@ else
     exit 1
 fi
 
-cargo bench
+cargo bench $TARGET_FLAG

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
@@ -1,6 +1,7 @@
 FROM rust:1.30.1-slim-stretch as base
 
 WORKDIR /setup
+RUN apt -qq update >/dev/null
 RUN apt -qq install -y curl
 RUN curl https://sh.rustup.rs > rustup.sh
 RUN cat rustup.sh | sh -s -- --default-toolchain none

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
@@ -1,0 +1,11 @@
+FROM rust:1.30.1-slim-stretch as base
+
+WORKDIR /setup
+RUN curl https://sh.rustup.rs > rustup.sh
+RUN cat rustup.sh | sh -s -- --default-toolchain none
+
+WORKDIR /code
+ADD . .
+RUN cp flatc_debian_stretch flatc
+WORKDIR /code/tests/rust_usage_test
+RUN cargo build --target mips-unknown-linux-gnu

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
@@ -1,16 +1,15 @@
 FROM rust:1.30.1-slim-stretch as base
-
-WORKDIR /setup
-RUN apt -qq update >/dev/null
-RUN apt -qq install -y curl gcc-mips-linux-gnu qemu-user
-RUN curl https://sh.rustup.rs > rustup.sh
-RUN cat rustup.sh | sh -s -- -y --default-toolchain none
+RUN apt -qq update -y && apt -qq install -y \
+    gcc-mips-linux-gnu \
+    libexpat1 \
+    libmagic1 \
+    libmpdec2 \
+    libreadline7 \
+    qemu-user
 RUN rustup target add mips-unknown-linux-gnu
-
-
 WORKDIR /code
 ADD . .
-WORKDIR /code/tests/rust_usage_test
-ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc
-ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="qemu-mips -L /usr/mips-linux-gnu"
-RUN cargo test --target mips-unknown-linux-gnu
+RUN cp flatc_debian_stretch flatc
+WORKDIR /code/tests
+RUN rustc --version
+RUN ./RustTest.sh mips-unknown-linux-gnu

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
@@ -4,7 +4,7 @@ WORKDIR /setup
 RUN apt -qq update >/dev/null
 RUN apt -qq install -y curl
 RUN curl https://sh.rustup.rs > rustup.sh
-RUN cat rustup.sh | sh -s -- --default-toolchain none
+RUN cat rustup.sh | sh -s -- -y --default-toolchain none
 
 WORKDIR /code
 ADD . .

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
@@ -12,4 +12,5 @@ WORKDIR /code
 ADD . .
 WORKDIR /code/tests/rust_usage_test
 ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc
-RUN cargo build --target mips-unknown-linux-gnu
+ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="qemu-mips -L /usr/mips-linux-gnu"
+RUN cargo test --target mips-unknown-linux-gnu

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
@@ -2,7 +2,7 @@ FROM rust:1.30.1-slim-stretch as base
 
 WORKDIR /setup
 RUN apt -qq update >/dev/null
-RUN apt -qq install -y curl gcc-mips-linux-gnu
+RUN apt -qq install -y curl gcc-mips-linux-gnu qemu-user
 RUN curl https://sh.rustup.rs > rustup.sh
 RUN cat rustup.sh | sh -s -- -y --default-toolchain none
 RUN rustup target add mips-unknown-linux-gnu

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
@@ -11,5 +11,5 @@ RUN rustup target add mips-unknown-linux-gnu
 WORKDIR /code
 ADD . .
 WORKDIR /code/tests/rust_usage_test
-ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=gcc-mips-linux-gnu
+ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc
 RUN cargo build --target mips-unknown-linux-gnu

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
@@ -5,6 +5,8 @@ RUN apt -qq update >/dev/null
 RUN apt -qq install -y curl
 RUN curl https://sh.rustup.rs > rustup.sh
 RUN cat rustup.sh | sh -s -- -y --default-toolchain none
+RUN rustup target add mips-unknown-linux-gnu
+
 
 WORKDIR /code
 ADD . .

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
@@ -1,11 +1,11 @@
 FROM rust:1.30.1-slim-stretch as base
 
 WORKDIR /setup
+RUN apt -qq install -y curl
 RUN curl https://sh.rustup.rs > rustup.sh
 RUN cat rustup.sh | sh -s -- --default-toolchain none
 
 WORKDIR /code
 ADD . .
-RUN cp flatc_debian_stretch flatc
 WORKDIR /code/tests/rust_usage_test
 RUN cargo build --target mips-unknown-linux-gnu

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
@@ -2,7 +2,7 @@ FROM rust:1.30.1-slim-stretch as base
 
 WORKDIR /setup
 RUN apt -qq update >/dev/null
-RUN apt -qq install -y curl
+RUN apt -qq install -y curl gcc-mips-linux-gnu
 RUN curl https://sh.rustup.rs > rustup.sh
 RUN cat rustup.sh | sh -s -- -y --default-toolchain none
 RUN rustup target add mips-unknown-linux-gnu
@@ -11,4 +11,5 @@ RUN rustup target add mips-unknown-linux-gnu
 WORKDIR /code
 ADD . .
 WORKDIR /code/tests/rust_usage_test
+ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=gcc-mips-linux-gnu
 RUN cargo build --target mips-unknown-linux-gnu

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -1721,12 +1721,22 @@ mod follow_impls {
 
     #[test]
     fn to_struct() {
+        use flatbuffers::EndianScalar;
         #[derive(Copy, Clone, Debug, PartialEq)]
         #[repr(C, packed)]
         struct FooStruct {
             a: i8,
             b: u8,
             c: i16,
+        }
+        impl FooStruct {
+            fn new(_a: i8, _b: u8, _c: i16) -> Self {
+                FooStruct {
+                    a: _a.to_little_endian(),
+                    b: _b.to_little_endian(),
+                    c: _c.to_little_endian(),
+                }
+            }
         }
         impl<'a> flatbuffers::Follow<'a> for &'a FooStruct {
             type Inner = &'a FooStruct;
@@ -1738,14 +1748,7 @@ mod follow_impls {
 
         let vec: Vec<u8> = vec![255, 255, 255, 255, 1, 2, 3, 4];
         let off: flatbuffers::FollowStart<&FooStruct> = flatbuffers::FollowStart::new();
-        #[cfg(target_endian = "little")]
-        {
-            assert_eq!(*off.self_follow(&vec[..], 4), FooStruct{a: 1, b: 2, c: 1027});
-        }
-        #[cfg(not(target_endian = "little"))]
-        {
-            assert_eq!(*off.self_follow(&vec[..], 4), FooStruct{a: 1, b: 2, c: 772});
-        }
+        assert_eq!(*off.self_follow(&vec[..], 4), FooStruct::new(1, 2, 1027));
     }
 
     #[test]
@@ -1758,12 +1761,22 @@ mod follow_impls {
 
     #[test]
     fn to_slice_of_struct_elements() {
+        use flatbuffers::EndianScalar;
         #[derive(Copy, Clone, Debug, PartialEq)]
         #[repr(C, packed)]
         struct FooStruct {
             a: i8,
             b: u8,
             c: i16,
+        }
+        impl FooStruct {
+            fn new(_a: i8, _b: u8, _c: i16) -> Self {
+                FooStruct {
+                    a: _a.to_little_endian(),
+                    b: _b.to_little_endian(),
+                    c: _c.to_little_endian(),
+                }
+            }
         }
         impl flatbuffers::SafeSliceAccess for FooStruct {}
         impl<'a> flatbuffers::Follow<'a> for FooStruct {
@@ -1776,24 +1789,27 @@ mod follow_impls {
 
         let buf: Vec<u8> = vec![1, 0, 0, 0, /* struct data */ 1, 2, 3, 4];
         let fs: flatbuffers::FollowStart<flatbuffers::Vector<FooStruct>> = flatbuffers::FollowStart::new();
-        #[cfg(target_endian = "little")]
-        {
-            assert_eq!(fs.self_follow(&buf[..], 0).safe_slice(), &vec![FooStruct{a: 1, b: 2, c: 1027}][..]);
-        }
-        #[cfg(not(target_endian = "little"))]
-        {
-            assert_eq!(fs.self_follow(&buf[..], 0).safe_slice(), &vec![FooStruct{a: 1, b: 2, c: 772}][..]);
-        }
+        assert_eq!(fs.self_follow(&buf[..], 0).safe_slice(), &vec![FooStruct::new(1, 2, 1027)][..]);
     }
 
     #[test]
     fn to_vector_of_struct_elements() {
+        use flatbuffers::EndianScalar;
         #[derive(Copy, Clone, Debug, PartialEq)]
         #[repr(C, packed)]
         struct FooStruct {
             a: i8,
             b: u8,
             c: i16,
+        }
+        impl FooStruct {
+            fn new(_a: i8, _b: u8, _c: i16) -> Self {
+                FooStruct {
+                    a: _a.to_little_endian(),
+                    b: _b.to_little_endian(),
+                    c: _c.to_little_endian(),
+                }
+            }
         }
         impl<'a> flatbuffers::Follow<'a> for FooStruct {
             type Inner = &'a FooStruct;
@@ -1806,14 +1822,7 @@ mod follow_impls {
         let buf: Vec<u8> = vec![1, 0, 0, 0, /* struct data */ 1, 2, 3, 4];
         let fs: flatbuffers::FollowStart<flatbuffers::Vector<FooStruct>> = flatbuffers::FollowStart::new();
         assert_eq!(fs.self_follow(&buf[..], 0).len(), 1);
-        #[cfg(target_endian = "little")]
-        {
-            assert_eq!(fs.self_follow(&buf[..], 0).get(0), &FooStruct{a: 1, b: 2, c: 1027});
-        }
-        #[cfg(not(target_endian = "little"))]
-        {
-            assert_eq!(fs.self_follow(&buf[..], 0).get(0), &FooStruct{a: 1, b: 2, c: 772});
-        }
+        assert_eq!(fs.self_follow(&buf[..], 0).get(0), &FooStruct::new(1, 2, 1027));
     }
 
     #[test]


### PR DESCRIPTION
This pull request builds on #5093 and includes fixes for the Rust test suite so it is compatible with big-endian targets. This change also adds the `mips-unknown-linux-gnu` Rust target to CI.

CC @rw 