### PR TITLE
Fix typo in Dart documentation

### DIFF
--- a/docs/source/DartUsage.md
+++ b/docs/source/DartUsage.md
@@ -16,7 +16,7 @@ documentation to build `flatc` and should be familiar with
 
 ## FlatBuffers Dart library code location
 
-The code for the FlatBuffers Go library can be found at
+The code for the FlatBuffers Dart library can be found at
 `flatbuffers/dart`. You can browse the library code on the [FlatBuffers
 GitHub page](https://github.com/google/flatbuffers/tree/master/dart).
 


### PR DESCRIPTION
There was a typo in the documentation for using flatbuffers with Dart.
