### PR TITLE
Unify line ending rules in '.editorconfig' and '.gitattributes'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,12 @@
 root = true
-[*.{cpp,cc,h,sh}]
-end_of_line = LF
+[*.{cpp,cc,h,bat}]
+end_of_line = CRLF
 indent_style = space
 indent_size = 2
 insert_final_newline = true
 
+[*.{sh}]
+end_of_line = LF
+indent_style = space
+indent_size = 2
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,7 @@
 root = true
-[*.{cpp,cc,h,bat}]
-end_of_line = CRLF
-indent_style = space
-indent_size = 2
-insert_final_newline = true
-
-[*.{sh}]
-end_of_line = LF
+# Don't set line endings to avoid conflict with core.autocrlf flag.
+# Line endings on checkout/checkin are controlled by .gitattributes file.
+[*]
 indent_style = space
 indent_size = 2
 insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.cpp text eol=crlf
+*.h   text eol=crlf
+*.md  text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,2 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
-
-# Declare files that will always have CRLF line endings on checkout.
-*.cpp text eol=crlf
-*.h   text eol=crlf
-*.md  text eol=crlf

--- a/.travis/check-sources.sh.py
+++ b/.travis/check-sources.sh.py
@@ -18,12 +18,11 @@ def check_encoding(encoding, scan_dir, regex_pattern):
         btext.decode(encoding=encoding, errors="strict")
         if encoding == "utf-8" and btext.startswith(b'\xEF\xBB\xBF'):
           raise ValueError("unexpected BOM in file")
-        # check strict CRLF line-ending
-        LF = btext.count(b'\r')
-        CRLF = btext.count(b'\r\n')
-        assert LF >= CRLF, "CRLF logic error"
-        if CRLF != LF:
-          raise ValueError("CRLF violation: found {} LF characters".format(LF - CRLF))
+        # check LF line endings
+        LF = btext.count(b'\n')
+        CR = btext.count(b'\r')
+        if CR!=0:
+          raise ValueError("invalid line endings: LF({})/CR({})".format(LF, CR))
   except Exception as err:
     print("ERROR with [{}]: {}".format(fname, err))
     return -1


### PR DESCRIPTION
Issue: MSVC takes '.editorconfig' and saves all source files with LF line ending.
This PR specify the line ending rules for the source code and shell scripts.
Related issue: #5188