### PR TITLE
[Go] Make enums into real types, add String()

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -83,7 +83,7 @@ class GoGenerator : public BaseGenerator {
       if (parser_.opts.one_file) {
         one_file_code += enumcode;
       } else {
-        if (!SaveType(**it, enumcode, false)) return false;
+        if (!SaveType(**it, enumcode, false, true)) return false;
       }
     }
 
@@ -95,13 +95,14 @@ class GoGenerator : public BaseGenerator {
       if (parser_.opts.one_file) {
         one_file_code += declcode;
       } else {
-        if (!SaveType(**it, declcode, true)) return false;
+        if (!SaveType(**it, declcode, true, false)) return false;
       }
     }
 
     if (parser_.opts.one_file) {
       std::string code = "";
-      BeginFile(LastNamespacePart(go_namespace_), true, &code);
+      const bool is_enum = !parser_.enums_.vec.empty();
+      BeginFile(LastNamespacePart(go_namespace_), true, is_enum, &code);
       code += one_file_code;
       const std::string filename = GeneratedFileName(path_, file_name_);
       return SaveFile(filename.c_str(), code, false);
@@ -134,7 +135,7 @@ class GoGenerator : public BaseGenerator {
     code += "\n}\n\n";
   }
 
-  // Construct the name of the type alias for this enum.
+  // Construct the name of the type for this enum.
   std::string GetEnumTypeName(const EnumDef &enum_def) {
     return WrapInNameSpaceAndTrack(cur_name_space_, GoIdentity(enum_def.name));
   }
@@ -142,8 +143,8 @@ class GoGenerator : public BaseGenerator {
   // Create a type for the enum values.
   void GenEnumType(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "type " + GetEnumTypeName(enum_def) + " = ";
-    code += GenTypeBasic(enum_def.underlying_type) + "\n";
+    code += "type " + GetEnumTypeName(enum_def) + " ";
+    code += GenTypeBasic(enum_def.underlying_type) + "\n\n";
   }
 
   // Begin enum code with a class declaration.
@@ -154,12 +155,13 @@ class GoGenerator : public BaseGenerator {
 
   // A single enum member.
   void EnumMember(const EnumDef &enum_def, const EnumVal &ev,
-                  std::string *code_ptr) {
+                  const int max_name_length, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "\t";
     code += enum_def.name;
     code += ev.name;
     code += " ";
+    code += std::string(max_name_length - ev.name.length(), ' ');
     code += GetEnumTypeName(enum_def);
     code += " = ";
     code += enum_def.ToString(ev) + "\n";
@@ -171,7 +173,7 @@ class GoGenerator : public BaseGenerator {
     code += ")\n\n";
   }
 
-  // Begin enum name code.
+  // Begin enum name map.
   void BeginEnumNames(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "var EnumNames";
@@ -181,18 +183,59 @@ class GoGenerator : public BaseGenerator {
 
   // A single enum name member.
   void EnumNameMember(const EnumDef &enum_def, const EnumVal ev,
-                      std::string *code_ptr) {
+                      const int max_name_length, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "\t";
     code += enum_def.name;
     code += ev.name;
-    code += ":\"";
+    code += ": ";
+    code += std::string(max_name_length - ev.name.length(), ' ');
+    code += "\"";
     code += ev.name;
     code += "\",\n";
   }
 
-  // End enum name code.
+  // End enum name map.
   void EndEnumNames(std::string *code_ptr) {
+    std::string &code = *code_ptr;
+    code += "}\n\n";
+  }
+
+  // Generate String() method on enum type.
+  void EnumStringer(const EnumDef &enum_def, std::string *code_ptr) {
+    std::string &code = *code_ptr;
+    code += "func (v " + enum_def.name + ") String() string {\n";
+    code += "\tif s, ok := EnumNames" + enum_def.name + "[v]; ok {\n";
+    code += "\t\treturn s\n";
+    code += "\t}\n";
+    code += "\treturn \""+ enum_def.name;
+    code += "(\" + strconv.FormatInt(int64(v), 10) + \")\"\n";
+    code += "}\n\n";
+  }
+
+  // Begin enum value map.
+  void BeginEnumValues(const EnumDef &enum_def, std::string *code_ptr) {
+    std::string &code = *code_ptr;
+    code += "var EnumValues";
+    code += enum_def.name;
+    code += " = map[string]" + GetEnumTypeName(enum_def) + "{\n";
+  }
+
+  // A single enum value member.
+  void EnumValueMember(const EnumDef &enum_def, const EnumVal ev,
+                       const int max_name_length, std::string *code_ptr) {
+    std::string &code = *code_ptr;
+    code += "\t\"";
+    code += ev.name;
+    code += "\": ";
+    code += std::string(max_name_length - ev.name.length(), ' ');
+    code += enum_def.name;
+    code += ev.name;
+    code += ",\n";
+  }
+
+  // End enum value map.
+  void EndEnumValues(std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "}\n\n";
   }
@@ -275,9 +318,11 @@ class GoGenerator : public BaseGenerator {
     GenReceiver(struct_def, code_ptr);
     code += " " + MakeCamel(field.name);
     code += "() " + TypeName(field) + " {\n";
-    code += "\treturn " + getter;
-    code += "(rcv._tab.Pos + flatbuffers.UOffsetT(";
-    code += NumToString(field.value.offset) + "))\n}\n";
+    code += "\treturn " + CastToEnum(
+        field.value.type,
+        getter + "(rcv._tab.Pos + flatbuffers.UOffsetT(" +
+        NumToString(field.value.offset) + "))");
+    code += "\n}\n";
   }
 
   // Get the value of a table's scalar.
@@ -289,8 +334,9 @@ class GoGenerator : public BaseGenerator {
     GenReceiver(struct_def, code_ptr);
     code += " " + MakeCamel(field.name);
     code += "() " + TypeName(field) + " ";
-    code += OffsetPrefix(field) + "\t\treturn " + getter;
-    code += "(o + rcv._tab.Pos)\n\t}\n";
+    code += OffsetPrefix(field) + "\t\treturn ";
+    code += CastToEnum(field.value.type, getter + "(o + rcv._tab.Pos)");
+    code += "\n\t}\n";
     code += "\treturn " + GenConstant(field) + "\n";
     code += "}\n\n";
   }
@@ -358,7 +404,7 @@ class GoGenerator : public BaseGenerator {
     std::string &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
     code += " " + MakeCamel(field.name) + "(";
-    code += "obj " + TypeName(field) + ") bool ";
+    code += "obj " + GenTypePointer(field.value.type) + ") bool ";
     code += OffsetPrefix(field);
     code += "\t\t" + GenGetter(field.value.type);
     code += "(obj, o)\n\t\treturn true\n\t}\n";
@@ -389,8 +435,7 @@ class GoGenerator : public BaseGenerator {
     code += "}\n\n";
   }
 
-  // Get the value of a vector's non-struct member. Uses a named return
-  // argument to conveniently set the zero value for the result.
+  // Get the value of a vector's non-struct member.
   void GetMemberOfVectorOfNonStruct(const StructDef &struct_def,
                                     const FieldDef &field,
                                     std::string *code_ptr) {
@@ -402,10 +447,11 @@ class GoGenerator : public BaseGenerator {
     code += "(j int) " + TypeName(field) + " ";
     code += OffsetPrefix(field);
     code += "\t\ta := rcv._tab.Vector(o)\n";
-    code += "\t\treturn " + GenGetter(field.value.type) + "(";
-    code += "a + flatbuffers.UOffsetT(j*";
-    code += NumToString(InlineSize(vectortype)) + "))\n";
-    code += "\t}\n";
+    code += "\t\treturn " + CastToEnum(
+        field.value.type,
+        GenGetter(field.value.type) + "(a + flatbuffers.UOffsetT(j*" +
+        NumToString(InlineSize(vectortype)) + "))");
+    code += "\n\t}\n";
     if (vectortype.base_type == BASE_TYPE_STRING) {
       code += "\treturn nil\n";
     } else if (vectortype.base_type == BASE_TYPE_BOOL) {
@@ -603,7 +649,8 @@ class GoGenerator : public BaseGenerator {
     code += " Mutate" + MakeCamel(field.name);
     code += "(n " + TypeName(field) + ") bool {\n\treturn " + setter;
     code += "(rcv._tab.Pos+flatbuffers.UOffsetT(";
-    code += NumToString(field.value.offset) + "), n)\n}\n\n";
+    code += NumToString(field.value.offset) + "), ";
+    code += CastToBaseType(field.value.type, "n") + ")\n}\n\n";
   }
 
   // Mutate the value of a table's scalar.
@@ -616,7 +663,8 @@ class GoGenerator : public BaseGenerator {
     GenReceiver(struct_def, code_ptr);
     code += " Mutate" + MakeCamel(field.name);
     code += "(n " + TypeName(field) + ") bool {\n\treturn ";
-    code += setter + "(" + NumToString(field.value.offset) + ", n)\n";
+    code += setter + "(" + NumToString(field.value.offset) + ", ";
+    code += CastToBaseType(field.value.type, "n") + ")\n";
     code += "}\n\n";
   }
 
@@ -635,7 +683,8 @@ class GoGenerator : public BaseGenerator {
     code += "\t\ta := rcv._tab.Vector(o)\n";
     code += "\t\treturn " + setter + "(";
     code += "a+flatbuffers.UOffsetT(j*";
-    code += NumToString(InlineSize(vectortype)) + "), n)\n";
+    code += NumToString(InlineSize(vectortype)) + "), ";
+    code += CastToBaseType(vectortype, "n") + ")\n";
     code += "\t}\n";
     code += "\treturn false\n";
     code += "}\n\n";
@@ -720,6 +769,7 @@ class GoGenerator : public BaseGenerator {
   void GenEnum(const EnumDef &enum_def, std::string *code_ptr) {
     if (enum_def.generated) return;
 
+    const int max_name_length = MaxNameLength(enum_def);
     cur_name_space_ = enum_def.defined_namespace;
 
     GenComment(enum_def.doc_comment, code_ptr, nullptr);
@@ -728,16 +778,26 @@ class GoGenerator : public BaseGenerator {
     for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
       auto &ev = **it;
       GenComment(ev.doc_comment, code_ptr, nullptr, "\t");
-      EnumMember(enum_def, ev, code_ptr);
+      EnumMember(enum_def, ev, max_name_length, code_ptr);
     }
     EndEnum(code_ptr);
 
     BeginEnumNames(enum_def, code_ptr);
     for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
       auto &ev = **it;
-      EnumNameMember(enum_def, ev, code_ptr);
+      EnumNameMember(enum_def, ev, max_name_length, code_ptr);
     }
     EndEnumNames(code_ptr);
+
+    BeginEnumValues(enum_def, code_ptr);
+    for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end();
+         ++it) {
+      auto &ev = **it;
+      EnumValueMember(enum_def, ev, max_name_length, code_ptr);
+    }
+    EndEnumValues(code_ptr);
+
+    EnumStringer(enum_def, code_ptr);
   }
 
   // Returns the function name that is able to read a value of the given type.
@@ -782,7 +842,7 @@ class GoGenerator : public BaseGenerator {
   }
 
   std::string GenTypeGet(const Type &type) {
-    if (type.enum_def != nullptr && !type.enum_def->is_union) {
+    if (type.enum_def != nullptr) {
       return GetEnumTypeName(*type.enum_def);
     }
     return IsScalar(type.base_type) ? GenTypeBasic(type) : GenTypePointer(type);
@@ -790,6 +850,26 @@ class GoGenerator : public BaseGenerator {
 
   std::string TypeName(const FieldDef &field) {
     return GenTypeGet(field.value.type);
+  }
+
+  // If type is an enum, returns value with a cast to the enum type, otherwise
+  // returns value as-is.
+  std::string CastToEnum(const Type &type, std::string value) {
+    if (type.enum_def == nullptr) {
+      return value;
+    } else {
+      return GenTypeGet(type) + "(" + value + ")";
+    }
+  }
+
+  // If type is an enum, returns value with a cast to the enum base type,
+  // otherwise returns value as-is.
+  std::string CastToBaseType(const Type &type, std::string value) {
+    if (type.enum_def == nullptr) {
+      return value;
+    } else {
+      return GenTypeBasic(type) + "(" + value + ")";
+    }
   }
 
   std::string GenConstant(const FieldDef &field) {
@@ -810,12 +890,15 @@ class GoGenerator : public BaseGenerator {
   }
   // Begin by declaring namespace and imports.
   void BeginFile(const std::string name_space_name, const bool needs_imports,
-                 std::string *code_ptr) {
+                 const bool is_enum, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code = code + "// Code generated by the FlatBuffers compiler. DO NOT EDIT.\n\n";
     code += "package " + name_space_name + "\n\n";
     if (needs_imports) {
       code += "import (\n";
+      if (is_enum) {
+        code += "\t\"strconv\"\n\n";
+      }
       if (!parser_.opts.go_import.empty()) {
         code += "\tflatbuffers \"" + parser_.opts.go_import + "\"\n";
       } else {
@@ -831,19 +914,26 @@ class GoGenerator : public BaseGenerator {
         }
       }
       code += ")\n\n";
+    } else {
+      if (is_enum) {
+        code += "import \"strconv\"\n\n";
+      }
     }
   }
 
   // Save out the generated code for a Go Table type.
   bool SaveType(const Definition &def, const std::string &classcode,
-                bool needs_imports) {
+                const bool needs_imports, const bool is_enum) {
     if (!classcode.length()) return true;
 
     Namespace &ns = go_namespace_.components.empty() ? *def.defined_namespace
                                                      : go_namespace_;
     std::string code = "";
-    BeginFile(LastNamespacePart(ns), needs_imports, &code);
+    BeginFile(LastNamespacePart(ns), needs_imports, is_enum, &code);
     code += classcode;
+    while (code.substr(code.length() - 2) == "\n\n") {
+      code.pop_back();
+    }
     std::string filename = NamespaceDir(ns) + def.name + ".go";
     return SaveFile(filename.c_str(), code, false);
   }
@@ -891,6 +981,16 @@ class GoGenerator : public BaseGenerator {
   }
 
   const Namespace *CurrentNameSpace() const { return cur_name_space_; }
+
+  static int MaxNameLength(const EnumDef &enum_def) {
+    int max = 0;
+    for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end();
+        ++it) {
+      const int length = (*it)->name.length();
+      max = length > max ? length : max;
+    }
+    return max;
+  }
 };
 }  // namespace go
 

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -931,7 +931,8 @@ class GoGenerator : public BaseGenerator {
     std::string code = "";
     BeginFile(LastNamespacePart(ns), needs_imports, is_enum, &code);
     code += classcode;
-    while (code.substr(code.length() - 2) == "\n\n") {
+    // Strip extra newlines at end of file to make it gofmt-clean.
+    while (code.length() > 2 && code.substr(code.length() - 2) == "\n\n") {
       code.pop_back();
     }
     std::string filename = NamespaceDir(ns) + def.name + ".go";

--- a/tests/MyGame/Example/Any.go
+++ b/tests/MyGame/Example/Any.go
@@ -2,18 +2,34 @@
 
 package Example
 
-type Any = byte
+import "strconv"
+
+type Any byte
+
 const (
-	AnyNONE Any = 0
-	AnyMonster Any = 1
+	AnyNONE                    Any = 0
+	AnyMonster                 Any = 1
 	AnyTestSimpleTableWithEnum Any = 2
 	AnyMyGame_Example2_Monster Any = 3
 )
 
 var EnumNamesAny = map[Any]string{
-	AnyNONE:"NONE",
-	AnyMonster:"Monster",
-	AnyTestSimpleTableWithEnum:"TestSimpleTableWithEnum",
-	AnyMyGame_Example2_Monster:"MyGame_Example2_Monster",
+	AnyNONE:                    "NONE",
+	AnyMonster:                 "Monster",
+	AnyTestSimpleTableWithEnum: "TestSimpleTableWithEnum",
+	AnyMyGame_Example2_Monster: "MyGame_Example2_Monster",
 }
 
+var EnumValuesAny = map[string]Any{
+	"NONE":                    AnyNONE,
+	"Monster":                 AnyMonster,
+	"TestSimpleTableWithEnum": AnyTestSimpleTableWithEnum,
+	"MyGame_Example2_Monster": AnyMyGame_Example2_Monster,
+}
+
+func (v Any) String() string {
+	if s, ok := EnumNamesAny[v]; ok {
+		return s
+	}
+	return "Any(" + strconv.FormatInt(int64(v), 10) + ")"
+}

--- a/tests/MyGame/Example/AnyAmbiguousAliases.go
+++ b/tests/MyGame/Example/AnyAmbiguousAliases.go
@@ -2,18 +2,34 @@
 
 package Example
 
-type AnyAmbiguousAliases = byte
+import "strconv"
+
+type AnyAmbiguousAliases byte
+
 const (
 	AnyAmbiguousAliasesNONE AnyAmbiguousAliases = 0
-	AnyAmbiguousAliasesM1 AnyAmbiguousAliases = 1
-	AnyAmbiguousAliasesM2 AnyAmbiguousAliases = 2
-	AnyAmbiguousAliasesM3 AnyAmbiguousAliases = 3
+	AnyAmbiguousAliasesM1   AnyAmbiguousAliases = 1
+	AnyAmbiguousAliasesM2   AnyAmbiguousAliases = 2
+	AnyAmbiguousAliasesM3   AnyAmbiguousAliases = 3
 )
 
 var EnumNamesAnyAmbiguousAliases = map[AnyAmbiguousAliases]string{
-	AnyAmbiguousAliasesNONE:"NONE",
-	AnyAmbiguousAliasesM1:"M1",
-	AnyAmbiguousAliasesM2:"M2",
-	AnyAmbiguousAliasesM3:"M3",
+	AnyAmbiguousAliasesNONE: "NONE",
+	AnyAmbiguousAliasesM1:   "M1",
+	AnyAmbiguousAliasesM2:   "M2",
+	AnyAmbiguousAliasesM3:   "M3",
 }
 
+var EnumValuesAnyAmbiguousAliases = map[string]AnyAmbiguousAliases{
+	"NONE": AnyAmbiguousAliasesNONE,
+	"M1":   AnyAmbiguousAliasesM1,
+	"M2":   AnyAmbiguousAliasesM2,
+	"M3":   AnyAmbiguousAliasesM3,
+}
+
+func (v AnyAmbiguousAliases) String() string {
+	if s, ok := EnumNamesAnyAmbiguousAliases[v]; ok {
+		return s
+	}
+	return "AnyAmbiguousAliases(" + strconv.FormatInt(int64(v), 10) + ")"
+}

--- a/tests/MyGame/Example/AnyUniqueAliases.go
+++ b/tests/MyGame/Example/AnyUniqueAliases.go
@@ -2,18 +2,34 @@
 
 package Example
 
-type AnyUniqueAliases = byte
+import "strconv"
+
+type AnyUniqueAliases byte
+
 const (
 	AnyUniqueAliasesNONE AnyUniqueAliases = 0
-	AnyUniqueAliasesM AnyUniqueAliases = 1
-	AnyUniqueAliasesT AnyUniqueAliases = 2
-	AnyUniqueAliasesM2 AnyUniqueAliases = 3
+	AnyUniqueAliasesM    AnyUniqueAliases = 1
+	AnyUniqueAliasesT    AnyUniqueAliases = 2
+	AnyUniqueAliasesM2   AnyUniqueAliases = 3
 )
 
 var EnumNamesAnyUniqueAliases = map[AnyUniqueAliases]string{
-	AnyUniqueAliasesNONE:"NONE",
-	AnyUniqueAliasesM:"M",
-	AnyUniqueAliasesT:"T",
-	AnyUniqueAliasesM2:"M2",
+	AnyUniqueAliasesNONE: "NONE",
+	AnyUniqueAliasesM:    "M",
+	AnyUniqueAliasesT:    "T",
+	AnyUniqueAliasesM2:   "M2",
 }
 
+var EnumValuesAnyUniqueAliases = map[string]AnyUniqueAliases{
+	"NONE": AnyUniqueAliasesNONE,
+	"M":    AnyUniqueAliasesM,
+	"T":    AnyUniqueAliasesT,
+	"M2":   AnyUniqueAliasesM2,
+}
+
+func (v AnyUniqueAliases) String() string {
+	if s, ok := EnumNamesAnyUniqueAliases[v]; ok {
+		return s
+	}
+	return "AnyUniqueAliases(" + strconv.FormatInt(int64(v), 10) + ")"
+}

--- a/tests/MyGame/Example/Color.go
+++ b/tests/MyGame/Example/Color.go
@@ -2,16 +2,31 @@
 
 package Example
 
-type Color = byte
+import "strconv"
+
+type Color byte
+
 const (
-	ColorRed Color = 1
+	ColorRed   Color = 1
 	ColorGreen Color = 2
-	ColorBlue Color = 8
+	ColorBlue  Color = 8
 )
 
 var EnumNamesColor = map[Color]string{
-	ColorRed:"Red",
-	ColorGreen:"Green",
-	ColorBlue:"Blue",
+	ColorRed:   "Red",
+	ColorGreen: "Green",
+	ColorBlue:  "Blue",
 }
 
+var EnumValuesColor = map[string]Color{
+	"Red":   ColorRed,
+	"Green": ColorGreen,
+	"Blue":  ColorBlue,
+}
+
+func (v Color) String() string {
+	if s, ok := EnumNamesColor[v]; ok {
+		return s
+	}
+	return "Color(" + strconv.FormatInt(int64(v), 10) + ")"
+}

--- a/tests/MyGame/Example/Monster.go
+++ b/tests/MyGame/Example/Monster.go
@@ -111,25 +111,25 @@ func (rcv *Monster) MutateInventory(j int, n byte) bool {
 func (rcv *Monster) Color() Color {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		return Color(rcv._tab.GetByte(o + rcv._tab.Pos))
 	}
 	return 8
 }
 
 func (rcv *Monster) MutateColor(n Color) bool {
-	return rcv._tab.MutateByteSlot(16, n)
+	return rcv._tab.MutateByteSlot(16, byte(n))
 }
 
-func (rcv *Monster) TestType() byte {
+func (rcv *Monster) TestType() Any {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		return Any(rcv._tab.GetByte(o + rcv._tab.Pos))
 	}
 	return 0
 }
 
-func (rcv *Monster) MutateTestType(n byte) bool {
-	return rcv._tab.MutateByteSlot(18, n)
+func (rcv *Monster) MutateTestType(n Any) bool {
+	return rcv._tab.MutateByteSlot(18, byte(n))
 }
 
 func (rcv *Monster) Test(obj *flatbuffers.Table) bool {
@@ -739,16 +739,16 @@ func (rcv *Monster) MutateVectorOfNonOwningReferences(j int, n uint64) bool {
 	return false
 }
 
-func (rcv *Monster) AnyUniqueType() byte {
+func (rcv *Monster) AnyUniqueType() AnyUniqueAliases {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(90))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		return AnyUniqueAliases(rcv._tab.GetByte(o + rcv._tab.Pos))
 	}
 	return 0
 }
 
-func (rcv *Monster) MutateAnyUniqueType(n byte) bool {
-	return rcv._tab.MutateByteSlot(90, n)
+func (rcv *Monster) MutateAnyUniqueType(n AnyUniqueAliases) bool {
+	return rcv._tab.MutateByteSlot(90, byte(n))
 }
 
 func (rcv *Monster) AnyUnique(obj *flatbuffers.Table) bool {
@@ -760,16 +760,16 @@ func (rcv *Monster) AnyUnique(obj *flatbuffers.Table) bool {
 	return false
 }
 
-func (rcv *Monster) AnyAmbiguousType() byte {
+func (rcv *Monster) AnyAmbiguousType() AnyAmbiguousAliases {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(94))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		return AnyAmbiguousAliases(rcv._tab.GetByte(o + rcv._tab.Pos))
 	}
 	return 0
 }
 
-func (rcv *Monster) MutateAnyAmbiguousType(n byte) bool {
-	return rcv._tab.MutateByteSlot(94, n)
+func (rcv *Monster) MutateAnyAmbiguousType(n AnyAmbiguousAliases) bool {
+	return rcv._tab.MutateByteSlot(94, byte(n))
 }
 
 func (rcv *Monster) AnyAmbiguous(obj *flatbuffers.Table) bool {
@@ -785,7 +785,7 @@ func (rcv *Monster) VectorOfEnums(j int) Color {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(98))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
-		return rcv._tab.GetByte(a + flatbuffers.UOffsetT(j*1))
+		return Color(rcv._tab.GetByte(a + flatbuffers.UOffsetT(j*1)))
 	}
 	return 0
 }
@@ -810,7 +810,7 @@ func (rcv *Monster) MutateVectorOfEnums(j int, n Color) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(98))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
-		return rcv._tab.MutateByte(a+flatbuffers.UOffsetT(j*1), n)
+		return rcv._tab.MutateByte(a+flatbuffers.UOffsetT(j*1), byte(n))
 	}
 	return false
 }

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.go
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.go
@@ -29,13 +29,13 @@ func (rcv *TestSimpleTableWithEnum) Table() flatbuffers.Table {
 func (rcv *TestSimpleTableWithEnum) Color() Color {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		return Color(rcv._tab.GetByte(o + rcv._tab.Pos))
 	}
 	return 2
 }
 
 func (rcv *TestSimpleTableWithEnum) MutateColor(n Color) bool {
-	return rcv._tab.MutateByteSlot(4, n)
+	return rcv._tab.MutateByteSlot(4, byte(n))
 }
 
 func TestSimpleTableWithEnumStart(builder *flatbuffers.Builder) {

--- a/tests/MyGame/Example/Vec3.go
+++ b/tests/MyGame/Example/Vec3.go
@@ -48,10 +48,10 @@ func (rcv *Vec3) MutateTest1(n float64) bool {
 }
 
 func (rcv *Vec3) Test2() Color {
-	return rcv._tab.GetByte(rcv._tab.Pos + flatbuffers.UOffsetT(24))
+	return Color(rcv._tab.GetByte(rcv._tab.Pos + flatbuffers.UOffsetT(24)))
 }
 func (rcv *Vec3) MutateTest2(n Color) bool {
-	return rcv._tab.MutateByte(rcv._tab.Pos+flatbuffers.UOffsetT(24), n)
+	return rcv._tab.MutateByte(rcv._tab.Pos+flatbuffers.UOffsetT(24), byte(n))
 }
 
 func (rcv *Vec3) Test3(obj *Test) *Test {

--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -351,7 +351,7 @@ func CheckMutateBuffer(org []byte, offset flatbuffers.UOffsetT, fail func(string
 		testcase{"Pos.Y", func() bool { return monster.Pos(nil).MutateY(20.0) }},
 		testcase{"Pos.Z", func() bool { return monster.Pos(nil).MutateZ(30.0) }},
 		testcase{"Pos.Test1", func() bool { return monster.Pos(nil).MutateTest1(30.0) }},
-		testcase{"Pos.Test2", func() bool { return monster.Pos(nil).MutateTest2(example.Color(20)) }},
+		testcase{"Pos.Test2", func() bool { return monster.Pos(nil).MutateTest2(example.ColorBlue) }},
 		testcase{"Pos.Test3.A", func() bool { return monster.Pos(nil).Test3(nil).MutateA(50) }},
 		testcase{"Pos.Test3.B", func() bool { return monster.Pos(nil).Test3(nil).MutateB(60) }},
 		testcase{"Inventory[2]", func() bool { return monster.MutateInventory(2, 200) }},
@@ -365,10 +365,15 @@ func CheckMutateBuffer(org []byte, offset flatbuffers.UOffsetT, fail func(string
 		testcase{"Pos.Y'", func() bool { return monster.Pos(nil).Y() == float32(20.0) }},
 		testcase{"Pos.Z'", func() bool { return monster.Pos(nil).Z() == float32(30.0) }},
 		testcase{"Pos.Test1'", func() bool { return monster.Pos(nil).Test1() == float64(30.0) }},
-		testcase{"Pos.Test2'", func() bool { return monster.Pos(nil).Test2() == example.Color(20) }},
+		testcase{"Pos.Test2'", func() bool { return monster.Pos(nil).Test2() == example.ColorBlue }},
 		testcase{"Pos.Test3.A", func() bool { return monster.Pos(nil).Test3(nil).A() == int16(50) }},
 		testcase{"Pos.Test3.B", func() bool { return monster.Pos(nil).Test3(nil).B() == int8(60) }},
 		testcase{"Inventory[2]", func() bool { return monster.Inventory(2) == byte(200) }},
+	}
+
+	testInvalidEnumValues := []testcase{
+		testcase{"Pos.Test2", func() bool { return monster.Pos(nil).MutateTest2(example.Color(20)) }},
+		testcase{"Pos.Test2", func() bool { return monster.Pos(nil).Test2() == example.Color(20) }},
 	}
 
 	// make sure original values are okay
@@ -406,6 +411,14 @@ func CheckMutateBuffer(org []byte, offset flatbuffers.UOffsetT, fail func(string
 		}
 	}
 
+	// a couple extra tests for "invalid" enum values, which don't correspond to
+	// anything in the schema, but are allowed
+	for _, t := range testInvalidEnumValues {
+		if !t.testfn() {
+			fail("field '" + t.field + "' doesn't work with an invalid enum value")
+		}
+	}
+
 	// reverting all fields to original values should
 	// re-create the original buffer. Mutate all fields
 	// back to their original values and compare buffers.
@@ -418,7 +431,7 @@ func CheckMutateBuffer(org []byte, offset flatbuffers.UOffsetT, fail func(string
 	monster.Pos(nil).MutateY(2.0)
 	monster.Pos(nil).MutateZ(3.0)
 	monster.Pos(nil).MutateTest1(3.0)
-	monster.Pos(nil).MutateTest2(2)
+	monster.Pos(nil).MutateTest2(example.ColorGreen)
 	monster.Pos(nil).Test3(nil).MutateA(5)
 	monster.Pos(nil).Test3(nil).MutateB(6)
 	monster.MutateInventory(2, 2)

--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -205,8 +205,8 @@ func CheckReadBuffer(buf []byte, offset flatbuffers.UOffsetT, fail func(string, 
 			fail(FailString("Pos.Test1", float64(3.0), got))
 		}
 
-		if got := vec.Test2(); example.Color(2) != got {
-			fail(FailString("Pos.Test2", example.Color(2), got))
+		if got := vec.Test2(); example.ColorGreen != got {
+			fail(FailString("Pos.Test2", example.ColorGreen, got))
 		}
 
 		// initialize a Test from Test3(...)
@@ -337,7 +337,7 @@ func CheckMutateBuffer(org []byte, offset flatbuffers.UOffsetT, fail func(string
 		testcase{"Pos.Y'", func() bool { return monster.Pos(nil).Y() == float32(2.0) }},
 		testcase{"Pos.Z'", func() bool { return monster.Pos(nil).Z() == float32(3.0) }},
 		testcase{"Pos.Test1'", func() bool { return monster.Pos(nil).Test1() == float64(3.0) }},
-		testcase{"Pos.Test2'", func() bool { return monster.Pos(nil).Test2() == example.Color(2) }},
+		testcase{"Pos.Test2'", func() bool { return monster.Pos(nil).Test2() == example.ColorGreen }},
 		testcase{"Pos.Test3.A", func() bool { return monster.Pos(nil).Test3(nil).A() == int16(5) }},
 		testcase{"Pos.Test3.B", func() bool { return monster.Pos(nil).Test3(nil).B() == int8(6) }},
 		testcase{"Inventory[2]", func() bool { return monster.Inventory(2) == byte(2) }},
@@ -351,7 +351,7 @@ func CheckMutateBuffer(org []byte, offset flatbuffers.UOffsetT, fail func(string
 		testcase{"Pos.Y", func() bool { return monster.Pos(nil).MutateY(20.0) }},
 		testcase{"Pos.Z", func() bool { return monster.Pos(nil).MutateZ(30.0) }},
 		testcase{"Pos.Test1", func() bool { return monster.Pos(nil).MutateTest1(30.0) }},
-		testcase{"Pos.Test2", func() bool { return monster.Pos(nil).MutateTest2(20) }},
+		testcase{"Pos.Test2", func() bool { return monster.Pos(nil).MutateTest2(example.Color(20)) }},
 		testcase{"Pos.Test3.A", func() bool { return monster.Pos(nil).Test3(nil).MutateA(50) }},
 		testcase{"Pos.Test3.B", func() bool { return monster.Pos(nil).Test3(nil).MutateB(60) }},
 		testcase{"Inventory[2]", func() bool { return monster.MutateInventory(2, 200) }},

--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -106,6 +106,12 @@ func TestAll(t *testing.T) {
 	// Verify the enum names
 	CheckEnumNames(t.Fatalf)
 
+	// Verify enum String methods
+	CheckEnumString(t.Fatalf)
+
+	// Verify the enum values maps
+	CheckEnumValues(t.Fatalf)
+
 	// Verify that the Go code used in FlatBuffers documentation passes
 	// some sanity checks:
 	CheckDocExample(generated, off, t.Fatalf)
@@ -199,8 +205,8 @@ func CheckReadBuffer(buf []byte, offset flatbuffers.UOffsetT, fail func(string, 
 			fail(FailString("Pos.Test1", float64(3.0), got))
 		}
 
-		if got := vec.Test2(); uint8(2) != got {
-			fail(FailString("Pos.Test2", uint8(2), got))
+		if got := vec.Test2(); example.Color(2) != got {
+			fail(FailString("Pos.Test2", example.Color(2), got))
 		}
 
 		// initialize a Test from Test3(...)
@@ -331,7 +337,7 @@ func CheckMutateBuffer(org []byte, offset flatbuffers.UOffsetT, fail func(string
 		testcase{"Pos.Y'", func() bool { return monster.Pos(nil).Y() == float32(2.0) }},
 		testcase{"Pos.Z'", func() bool { return monster.Pos(nil).Z() == float32(3.0) }},
 		testcase{"Pos.Test1'", func() bool { return monster.Pos(nil).Test1() == float64(3.0) }},
-		testcase{"Pos.Test2'", func() bool { return monster.Pos(nil).Test2() == uint8(2) }},
+		testcase{"Pos.Test2'", func() bool { return monster.Pos(nil).Test2() == example.Color(2) }},
 		testcase{"Pos.Test3.A", func() bool { return monster.Pos(nil).Test3(nil).A() == int16(5) }},
 		testcase{"Pos.Test3.B", func() bool { return monster.Pos(nil).Test3(nil).B() == int8(6) }},
 		testcase{"Inventory[2]", func() bool { return monster.Inventory(2) == byte(2) }},
@@ -359,7 +365,7 @@ func CheckMutateBuffer(org []byte, offset flatbuffers.UOffsetT, fail func(string
 		testcase{"Pos.Y'", func() bool { return monster.Pos(nil).Y() == float32(20.0) }},
 		testcase{"Pos.Z'", func() bool { return monster.Pos(nil).Z() == float32(30.0) }},
 		testcase{"Pos.Test1'", func() bool { return monster.Pos(nil).Test1() == float64(30.0) }},
-		testcase{"Pos.Test2'", func() bool { return monster.Pos(nil).Test2() == uint8(20) }},
+		testcase{"Pos.Test2'", func() bool { return monster.Pos(nil).Test2() == example.Color(20) }},
 		testcase{"Pos.Test3.A", func() bool { return monster.Pos(nil).Test3(nil).A() == int16(50) }},
 		testcase{"Pos.Test3.B", func() bool { return monster.Pos(nil).Test3(nil).B() == int8(60) }},
 		testcase{"Inventory[2]", func() bool { return monster.Inventory(2) == byte(200) }},
@@ -1379,7 +1385,6 @@ func CheckFinishedBytesError(fail func(string, ...interface{})) {
 // CheckEnumNames checks that the generated enum names are correct.
 func CheckEnumNames(fail func(string, ...interface{})) {
 	{
-
 		want := map[example.Any]string{
 			example.AnyNONE:                    "NONE",
 			example.AnyMonster:                 "Monster",
@@ -1398,6 +1403,43 @@ func CheckEnumNames(fail func(string, ...interface{})) {
 			example.ColorBlue:  "Blue",
 		}
 		got := example.EnumNamesColor
+		if !reflect.DeepEqual(got, want) {
+			fail("enum name is not equal")
+		}
+	}
+}
+
+// CheckEnumString checks the String method on generated enum types.
+func CheckEnumString(fail func(string, ...interface{})) {
+	if got := example.AnyMonster.String(); got != "Monster" {
+		fail("Monster.String: %q != %q", got, "Monster")
+	}
+	if got := fmt.Sprintf("color: %s", example.ColorGreen); got != "color: Green" {
+		fail("color.String: %q != %q", got, "color: Green")
+	}
+}
+
+// CheckEnumValues checks that the generated enum values maps are correct.
+func CheckEnumValues(fail func(string, ...interface{})) {
+	{
+		want := map[string]example.Any{
+			"NONE":                    example.AnyNONE,
+			"Monster":                 example.AnyMonster,
+			"TestSimpleTableWithEnum": example.AnyTestSimpleTableWithEnum,
+			"MyGame_Example2_Monster": example.AnyMyGame_Example2_Monster,
+		}
+		got := example.EnumValuesAny
+		if !reflect.DeepEqual(got, want) {
+			fail("enum name is not equal")
+		}
+	}
+	{
+		want := map[string]example.Color{
+			"Red":   example.ColorRed,
+			"Green": example.ColorGreen,
+			"Blue":  example.ColorBlue,
+		}
+		got := example.EnumValuesColor
 		if !reflect.DeepEqual(got, want) {
 			fail("enum name is not equal")
 		}

--- a/tests/namespace_test/NamespaceA/NamespaceB/EnumInNestedNS.go
+++ b/tests/namespace_test/NamespaceA/NamespaceB/EnumInNestedNS.go
@@ -2,7 +2,10 @@
 
 package NamespaceB
 
-type EnumInNestedNS = int8
+import "strconv"
+
+type EnumInNestedNS int8
+
 const (
 	EnumInNestedNSA EnumInNestedNS = 0
 	EnumInNestedNSB EnumInNestedNS = 1
@@ -10,8 +13,20 @@ const (
 )
 
 var EnumNamesEnumInNestedNS = map[EnumInNestedNS]string{
-	EnumInNestedNSA:"A",
-	EnumInNestedNSB:"B",
-	EnumInNestedNSC:"C",
+	EnumInNestedNSA: "A",
+	EnumInNestedNSB: "B",
+	EnumInNestedNSC: "C",
 }
 
+var EnumValuesEnumInNestedNS = map[string]EnumInNestedNS{
+	"A": EnumInNestedNSA,
+	"B": EnumInNestedNSB,
+	"C": EnumInNestedNSC,
+}
+
+func (v EnumInNestedNS) String() string {
+	if s, ok := EnumNamesEnumInNestedNS[v]; ok {
+		return s
+	}
+	return "EnumInNestedNS(" + strconv.FormatInt(int64(v), 10) + ")"
+}

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.go
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.go
@@ -44,13 +44,13 @@ func (rcv *TableInFirstNS) FooTable(obj *NamespaceA__NamespaceB.TableInNestedNS)
 func (rcv *TableInFirstNS) FooEnum() EnumInNestedNS {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
-		return rcv._tab.GetInt8(o + rcv._tab.Pos)
+		return EnumInNestedNS(rcv._tab.GetInt8(o + rcv._tab.Pos))
 	}
 	return 0
 }
 
 func (rcv *TableInFirstNS) MutateFooEnum(n EnumInNestedNS) bool {
-	return rcv._tab.MutateInt8Slot(6, n)
+	return rcv._tab.MutateInt8Slot(6, int8(n))
 }
 
 func (rcv *TableInFirstNS) FooStruct(obj *NamespaceA__NamespaceB.StructInNestedNS) *NamespaceA__NamespaceB.StructInNestedNS {


### PR DESCRIPTION
This changes the generated code for enums: instead of type aliases,
they're now distinct types, allowing for better type-checking. Some
client code may have to be changed to add casts.

Enum types now have a String() method, so they implement fmt.Stringer.

An EnumValues map is now generated, in addition to the existing
EnumNames map, to easily map strings to values.

Generated enum files are now gofmt-clean.

Fixes #5207

-----

Comments and questions:

This was a little more involved than I expected because of all the casts that had to be added to the generated code, but go_test.go hardly changed at all.

I took the format of unknown values from stringer.

And speaking of stringer, in [this pr](https://golang.org/cl/129816) one of the Go developers expressed some concern about global maps' effect on initialization time. This change adds another global map per enum, so it might be the right time to ask if this is the right approach. Here's a few options for consideration:

1. As implemented in this change: add a new global map.
2. Make EnumValuesX into a function that returns a map, use sync.Once to initialize it on-demand.
3. Don't expose a global map at all, only expose a XFromString function, which initializes a map on-demand and does a lookup in it.
4. Get much more clever and use various heuristics like stringer does to generate smaller+faster code.

(We could ask the same question for the EnumNamesX map too, though removing it might be too much of a breaking change for clients.)