### PR TITLE
[Go] pack Pos field of Table in slice

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -221,8 +221,7 @@ class GoGenerator : public BaseGenerator {
     GenReceiver(struct_def, code_ptr);
     code += " Init(buf []byte, i flatbuffers.UOffsetT) ";
     code += "{\n";
-    code += "\trcv._tab.Bytes = buf\n";
-    code += "\trcv._tab.Pos = i\n";
+    code += "\trcv._tab.Init(buf, i)\n";
     code += "}\n\n";
   }
 
@@ -262,7 +261,7 @@ class GoGenerator : public BaseGenerator {
     GenReceiver(struct_def, code_ptr);
     code += " " + MakeCamel(field.name) + "Bytes(";
     code += ") []byte " + OffsetPrefix(field);
-    code += "\t\treturn rcv._tab.ByteVector(o + rcv._tab.Pos)\n\t}\n";
+    code += "\t\treturn rcv._tab.ByteVector(o + rcv._tab.Pos())\n\t}\n";
     code += "\treturn nil\n}\n\n";
   }
 
@@ -276,7 +275,7 @@ class GoGenerator : public BaseGenerator {
     code += " " + MakeCamel(field.name);
     code += "() " + TypeName(field) + " {\n";
     code += "\treturn " + getter;
-    code += "(rcv._tab.Pos + flatbuffers.UOffsetT(";
+    code += "(rcv._tab.Pos() + flatbuffers.UOffsetT(";
     code += NumToString(field.value.offset) + "))\n}\n";
   }
 
@@ -290,7 +289,7 @@ class GoGenerator : public BaseGenerator {
     code += " " + MakeCamel(field.name);
     code += "() " + TypeName(field) + " ";
     code += OffsetPrefix(field) + "\t\treturn " + getter;
-    code += "(o + rcv._tab.Pos)\n\t}\n";
+    code += "(o + rcv._tab.Pos())\n\t}\n";
     code += "\treturn " + GenConstant(field) + "\n";
     code += "}\n\n";
   }
@@ -309,7 +308,7 @@ class GoGenerator : public BaseGenerator {
     code += "\tif obj == nil {\n";
     code += "\t\tobj = new(" + TypeName(field) + ")\n";
     code += "\t}\n";
-    code += "\tobj.Init(rcv._tab.Bytes, rcv._tab.Pos+";
+    code += "\tobj.Init(rcv._tab.Bytes(), rcv._tab.Pos()+";
     code += NumToString(field.value.offset) + ")";
     code += "\n\treturn obj\n";
     code += "}\n";
@@ -327,14 +326,14 @@ class GoGenerator : public BaseGenerator {
     code += TypeName(field);
     code += ") *" + TypeName(field) + " " + OffsetPrefix(field);
     if (field.value.type.struct_def->fixed) {
-      code += "\t\tx := o + rcv._tab.Pos\n";
+      code += "\t\tx := o + rcv._tab.Pos()\n";
     } else {
-      code += "\t\tx := rcv._tab.Indirect(o + rcv._tab.Pos)\n";
+      code += "\t\tx := rcv._tab.Indirect(o + rcv._tab.Pos())\n";
     }
     code += "\t\tif obj == nil {\n";
     code += "\t\t\tobj = new(" + TypeName(field) + ")\n";
     code += "\t\t}\n";
-    code += "\t\tobj.Init(rcv._tab.Bytes, x)\n";
+    code += "\t\tobj.Init(rcv._tab.Bytes(), x)\n";
     code += "\t\treturn obj\n\t}\n\treturn nil\n";
     code += "}\n\n";
   }
@@ -348,7 +347,7 @@ class GoGenerator : public BaseGenerator {
     code += " " + MakeCamel(field.name);
     code += "() " + TypeName(field) + " ";
     code += OffsetPrefix(field) + "\t\treturn " + GenGetter(field.value.type);
-    code += "(o + rcv._tab.Pos)\n\t}\n\treturn nil\n";
+    code += "(o + rcv._tab.Pos())\n\t}\n\treturn nil\n";
     code += "}\n\n";
   }
 
@@ -383,7 +382,7 @@ class GoGenerator : public BaseGenerator {
     if (!(vectortype.struct_def->fixed)) {
       code += "\t\tx = rcv._tab.Indirect(x)\n";
     }
-    code += "\t\tobj.Init(rcv._tab.Bytes, x)\n";
+    code += "\t\tobj.Init(rcv._tab.Bytes(), x)\n";
     code += "\t\treturn true\n\t}\n";
     code += "\treturn false\n";
     code += "}\n\n";
@@ -602,7 +601,7 @@ class GoGenerator : public BaseGenerator {
     GenReceiver(struct_def, code_ptr);
     code += " Mutate" + MakeCamel(field.name);
     code += "(n " + TypeName(field) + ") bool {\n\treturn " + setter;
-    code += "(rcv._tab.Pos+flatbuffers.UOffsetT(";
+    code += "(rcv._tab.Pos()+flatbuffers.UOffsetT(";
     code += NumToString(field.value.offset) + "), n)\n}\n\n";
   }
 

--- a/tests/MyGame/Example/Ability.go
+++ b/tests/MyGame/Example/Ability.go
@@ -11,8 +11,7 @@ type Ability struct {
 }
 
 func (rcv *Ability) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *Ability) Table() flatbuffers.Table {
@@ -20,17 +19,17 @@ func (rcv *Ability) Table() flatbuffers.Table {
 }
 
 func (rcv *Ability) Id() uint32 {
-	return rcv._tab.GetUint32(rcv._tab.Pos + flatbuffers.UOffsetT(0))
+	return rcv._tab.GetUint32(rcv._tab.Pos() + flatbuffers.UOffsetT(0))
 }
 func (rcv *Ability) MutateId(n uint32) bool {
-	return rcv._tab.MutateUint32(rcv._tab.Pos+flatbuffers.UOffsetT(0), n)
+	return rcv._tab.MutateUint32(rcv._tab.Pos()+flatbuffers.UOffsetT(0), n)
 }
 
 func (rcv *Ability) Distance() uint32 {
-	return rcv._tab.GetUint32(rcv._tab.Pos + flatbuffers.UOffsetT(4))
+	return rcv._tab.GetUint32(rcv._tab.Pos() + flatbuffers.UOffsetT(4))
 }
 func (rcv *Ability) MutateDistance(n uint32) bool {
-	return rcv._tab.MutateUint32(rcv._tab.Pos+flatbuffers.UOffsetT(4), n)
+	return rcv._tab.MutateUint32(rcv._tab.Pos()+flatbuffers.UOffsetT(4), n)
 }
 
 func CreateAbility(builder *flatbuffers.Builder, id uint32, distance uint32) flatbuffers.UOffsetT {

--- a/tests/MyGame/Example/Monster.go
+++ b/tests/MyGame/Example/Monster.go
@@ -21,8 +21,7 @@ func GetRootAsMonster(buf []byte, offset flatbuffers.UOffsetT) *Monster {
 }
 
 func (rcv *Monster) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *Monster) Table() flatbuffers.Table {
@@ -32,11 +31,11 @@ func (rcv *Monster) Table() flatbuffers.Table {
 func (rcv *Monster) Pos(obj *Vec3) *Vec3 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		x := o + rcv._tab.Pos
+		x := o + rcv._tab.Pos()
 		if obj == nil {
 			obj = new(Vec3)
 		}
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return obj
 	}
 	return nil
@@ -45,7 +44,7 @@ func (rcv *Monster) Pos(obj *Vec3) *Vec3 {
 func (rcv *Monster) Mana() int16 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
-		return rcv._tab.GetInt16(o + rcv._tab.Pos)
+		return rcv._tab.GetInt16(o + rcv._tab.Pos())
 	}
 	return 150
 }
@@ -57,7 +56,7 @@ func (rcv *Monster) MutateMana(n int16) bool {
 func (rcv *Monster) Hp() int16 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
-		return rcv._tab.GetInt16(o + rcv._tab.Pos)
+		return rcv._tab.GetInt16(o + rcv._tab.Pos())
 	}
 	return 100
 }
@@ -69,7 +68,7 @@ func (rcv *Monster) MutateHp(n int16) bool {
 func (rcv *Monster) Name() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
-		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+		return rcv._tab.ByteVector(o + rcv._tab.Pos())
 	}
 	return nil
 }
@@ -94,7 +93,7 @@ func (rcv *Monster) InventoryLength() int {
 func (rcv *Monster) InventoryBytes() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
 	if o != 0 {
-		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+		return rcv._tab.ByteVector(o + rcv._tab.Pos())
 	}
 	return nil
 }
@@ -111,7 +110,7 @@ func (rcv *Monster) MutateInventory(j int, n byte) bool {
 func (rcv *Monster) Color() Color {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		return rcv._tab.GetByte(o + rcv._tab.Pos())
 	}
 	return 8
 }
@@ -123,7 +122,7 @@ func (rcv *Monster) MutateColor(n Color) bool {
 func (rcv *Monster) TestType() byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		return rcv._tab.GetByte(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -146,7 +145,7 @@ func (rcv *Monster) Test4(obj *Test, j int) bool {
 	if o != 0 {
 		x := rcv._tab.Vector(o)
 		x += flatbuffers.UOffsetT(j) * 4
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return true
 	}
 	return false
@@ -185,7 +184,7 @@ func (rcv *Monster) Testarrayoftables(obj *Monster, j int) bool {
 		x := rcv._tab.Vector(o)
 		x += flatbuffers.UOffsetT(j) * 4
 		x = rcv._tab.Indirect(x)
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return true
 	}
 	return false
@@ -204,11 +203,11 @@ func (rcv *Monster) TestarrayoftablesLength() int {
 func (rcv *Monster) Enemy(obj *Monster) *Monster {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
 	if o != 0 {
-		x := rcv._tab.Indirect(o + rcv._tab.Pos)
+		x := rcv._tab.Indirect(o + rcv._tab.Pos())
 		if obj == nil {
 			obj = new(Monster)
 		}
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return obj
 	}
 	return nil
@@ -234,7 +233,7 @@ func (rcv *Monster) TestnestedflatbufferLength() int {
 func (rcv *Monster) TestnestedflatbufferBytes() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(30))
 	if o != 0 {
-		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+		return rcv._tab.ByteVector(o + rcv._tab.Pos())
 	}
 	return nil
 }
@@ -251,11 +250,11 @@ func (rcv *Monster) MutateTestnestedflatbuffer(j int, n byte) bool {
 func (rcv *Monster) Testempty(obj *Stat) *Stat {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(32))
 	if o != 0 {
-		x := rcv._tab.Indirect(o + rcv._tab.Pos)
+		x := rcv._tab.Indirect(o + rcv._tab.Pos())
 		if obj == nil {
 			obj = new(Stat)
 		}
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return obj
 	}
 	return nil
@@ -264,7 +263,7 @@ func (rcv *Monster) Testempty(obj *Stat) *Stat {
 func (rcv *Monster) Testbool() bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(34))
 	if o != 0 {
-		return rcv._tab.GetBool(o + rcv._tab.Pos)
+		return rcv._tab.GetBool(o + rcv._tab.Pos())
 	}
 	return false
 }
@@ -276,7 +275,7 @@ func (rcv *Monster) MutateTestbool(n bool) bool {
 func (rcv *Monster) Testhashs32Fnv1() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(36))
 	if o != 0 {
-		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+		return rcv._tab.GetInt32(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -288,7 +287,7 @@ func (rcv *Monster) MutateTesthashs32Fnv1(n int32) bool {
 func (rcv *Monster) Testhashu32Fnv1() uint32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(38))
 	if o != 0 {
-		return rcv._tab.GetUint32(o + rcv._tab.Pos)
+		return rcv._tab.GetUint32(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -300,7 +299,7 @@ func (rcv *Monster) MutateTesthashu32Fnv1(n uint32) bool {
 func (rcv *Monster) Testhashs64Fnv1() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(40))
 	if o != 0 {
-		return rcv._tab.GetInt64(o + rcv._tab.Pos)
+		return rcv._tab.GetInt64(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -312,7 +311,7 @@ func (rcv *Monster) MutateTesthashs64Fnv1(n int64) bool {
 func (rcv *Monster) Testhashu64Fnv1() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(42))
 	if o != 0 {
-		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+		return rcv._tab.GetUint64(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -324,7 +323,7 @@ func (rcv *Monster) MutateTesthashu64Fnv1(n uint64) bool {
 func (rcv *Monster) Testhashs32Fnv1a() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(44))
 	if o != 0 {
-		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+		return rcv._tab.GetInt32(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -336,7 +335,7 @@ func (rcv *Monster) MutateTesthashs32Fnv1a(n int32) bool {
 func (rcv *Monster) Testhashu32Fnv1a() uint32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(46))
 	if o != 0 {
-		return rcv._tab.GetUint32(o + rcv._tab.Pos)
+		return rcv._tab.GetUint32(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -348,7 +347,7 @@ func (rcv *Monster) MutateTesthashu32Fnv1a(n uint32) bool {
 func (rcv *Monster) Testhashs64Fnv1a() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(48))
 	if o != 0 {
-		return rcv._tab.GetInt64(o + rcv._tab.Pos)
+		return rcv._tab.GetInt64(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -360,7 +359,7 @@ func (rcv *Monster) MutateTesthashs64Fnv1a(n int64) bool {
 func (rcv *Monster) Testhashu64Fnv1a() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(50))
 	if o != 0 {
-		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+		return rcv._tab.GetUint64(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -398,7 +397,7 @@ func (rcv *Monster) MutateTestarrayofbools(j int, n bool) bool {
 func (rcv *Monster) Testf() float32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(54))
 	if o != 0 {
-		return rcv._tab.GetFloat32(o + rcv._tab.Pos)
+		return rcv._tab.GetFloat32(o + rcv._tab.Pos())
 	}
 	return 3.14159
 }
@@ -410,7 +409,7 @@ func (rcv *Monster) MutateTestf(n float32) bool {
 func (rcv *Monster) Testf2() float32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(56))
 	if o != 0 {
-		return rcv._tab.GetFloat32(o + rcv._tab.Pos)
+		return rcv._tab.GetFloat32(o + rcv._tab.Pos())
 	}
 	return 3.0
 }
@@ -422,7 +421,7 @@ func (rcv *Monster) MutateTestf2(n float32) bool {
 func (rcv *Monster) Testf3() float32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(58))
 	if o != 0 {
-		return rcv._tab.GetFloat32(o + rcv._tab.Pos)
+		return rcv._tab.GetFloat32(o + rcv._tab.Pos())
 	}
 	return 0.0
 }
@@ -453,7 +452,7 @@ func (rcv *Monster) Testarrayofsortedstruct(obj *Ability, j int) bool {
 	if o != 0 {
 		x := rcv._tab.Vector(o)
 		x += flatbuffers.UOffsetT(j) * 8
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return true
 	}
 	return false
@@ -487,7 +486,7 @@ func (rcv *Monster) FlexLength() int {
 func (rcv *Monster) FlexBytes() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(64))
 	if o != 0 {
-		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+		return rcv._tab.ByteVector(o + rcv._tab.Pos())
 	}
 	return nil
 }
@@ -506,7 +505,7 @@ func (rcv *Monster) Test5(obj *Test, j int) bool {
 	if o != 0 {
 		x := rcv._tab.Vector(o)
 		x += flatbuffers.UOffsetT(j) * 4
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return true
 	}
 	return false
@@ -575,11 +574,11 @@ func (rcv *Monster) MutateVectorOfDoubles(j int, n float64) bool {
 func (rcv *Monster) ParentNamespaceTest(obj *MyGame.InParentNamespace) *MyGame.InParentNamespace {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(72))
 	if o != 0 {
-		x := rcv._tab.Indirect(o + rcv._tab.Pos)
+		x := rcv._tab.Indirect(o + rcv._tab.Pos())
 		if obj == nil {
 			obj = new(MyGame.InParentNamespace)
 		}
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return obj
 	}
 	return nil
@@ -591,7 +590,7 @@ func (rcv *Monster) VectorOfReferrables(obj *Referrable, j int) bool {
 		x := rcv._tab.Vector(o)
 		x += flatbuffers.UOffsetT(j) * 4
 		x = rcv._tab.Indirect(x)
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return true
 	}
 	return false
@@ -608,7 +607,7 @@ func (rcv *Monster) VectorOfReferrablesLength() int {
 func (rcv *Monster) SingleWeakReference() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(76))
 	if o != 0 {
-		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+		return rcv._tab.GetUint64(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -649,7 +648,7 @@ func (rcv *Monster) VectorOfStrongReferrables(obj *Referrable, j int) bool {
 		x := rcv._tab.Vector(o)
 		x += flatbuffers.UOffsetT(j) * 4
 		x = rcv._tab.Indirect(x)
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return true
 	}
 	return false
@@ -666,7 +665,7 @@ func (rcv *Monster) VectorOfStrongReferrablesLength() int {
 func (rcv *Monster) CoOwningReference() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(82))
 	if o != 0 {
-		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+		return rcv._tab.GetUint64(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -704,7 +703,7 @@ func (rcv *Monster) MutateVectorOfCoOwningReferences(j int, n uint64) bool {
 func (rcv *Monster) NonOwningReference() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(86))
 	if o != 0 {
-		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+		return rcv._tab.GetUint64(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -742,7 +741,7 @@ func (rcv *Monster) MutateVectorOfNonOwningReferences(j int, n uint64) bool {
 func (rcv *Monster) AnyUniqueType() byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(90))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		return rcv._tab.GetByte(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -763,7 +762,7 @@ func (rcv *Monster) AnyUnique(obj *flatbuffers.Table) bool {
 func (rcv *Monster) AnyAmbiguousType() byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(94))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		return rcv._tab.GetByte(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -801,7 +800,7 @@ func (rcv *Monster) VectorOfEnumsLength() int {
 func (rcv *Monster) VectorOfEnumsBytes() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(98))
 	if o != 0 {
-		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+		return rcv._tab.ByteVector(o + rcv._tab.Pos())
 	}
 	return nil
 }

--- a/tests/MyGame/Example/Referrable.go
+++ b/tests/MyGame/Example/Referrable.go
@@ -18,8 +18,7 @@ func GetRootAsReferrable(buf []byte, offset flatbuffers.UOffsetT) *Referrable {
 }
 
 func (rcv *Referrable) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *Referrable) Table() flatbuffers.Table {
@@ -29,7 +28,7 @@ func (rcv *Referrable) Table() flatbuffers.Table {
 func (rcv *Referrable) Id() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+		return rcv._tab.GetUint64(o + rcv._tab.Pos())
 	}
 	return 0
 }

--- a/tests/MyGame/Example/Stat.go
+++ b/tests/MyGame/Example/Stat.go
@@ -18,8 +18,7 @@ func GetRootAsStat(buf []byte, offset flatbuffers.UOffsetT) *Stat {
 }
 
 func (rcv *Stat) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *Stat) Table() flatbuffers.Table {
@@ -29,7 +28,7 @@ func (rcv *Stat) Table() flatbuffers.Table {
 func (rcv *Stat) Id() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+		return rcv._tab.ByteVector(o + rcv._tab.Pos())
 	}
 	return nil
 }
@@ -37,7 +36,7 @@ func (rcv *Stat) Id() []byte {
 func (rcv *Stat) Val() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
-		return rcv._tab.GetInt64(o + rcv._tab.Pos)
+		return rcv._tab.GetInt64(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -49,7 +48,7 @@ func (rcv *Stat) MutateVal(n int64) bool {
 func (rcv *Stat) Count() uint16 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
-		return rcv._tab.GetUint16(o + rcv._tab.Pos)
+		return rcv._tab.GetUint16(o + rcv._tab.Pos())
 	}
 	return 0
 }

--- a/tests/MyGame/Example/Test.go
+++ b/tests/MyGame/Example/Test.go
@@ -11,8 +11,7 @@ type Test struct {
 }
 
 func (rcv *Test) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *Test) Table() flatbuffers.Table {
@@ -20,17 +19,17 @@ func (rcv *Test) Table() flatbuffers.Table {
 }
 
 func (rcv *Test) A() int16 {
-	return rcv._tab.GetInt16(rcv._tab.Pos + flatbuffers.UOffsetT(0))
+	return rcv._tab.GetInt16(rcv._tab.Pos() + flatbuffers.UOffsetT(0))
 }
 func (rcv *Test) MutateA(n int16) bool {
-	return rcv._tab.MutateInt16(rcv._tab.Pos+flatbuffers.UOffsetT(0), n)
+	return rcv._tab.MutateInt16(rcv._tab.Pos()+flatbuffers.UOffsetT(0), n)
 }
 
 func (rcv *Test) B() int8 {
-	return rcv._tab.GetInt8(rcv._tab.Pos + flatbuffers.UOffsetT(2))
+	return rcv._tab.GetInt8(rcv._tab.Pos() + flatbuffers.UOffsetT(2))
 }
 func (rcv *Test) MutateB(n int8) bool {
-	return rcv._tab.MutateInt8(rcv._tab.Pos+flatbuffers.UOffsetT(2), n)
+	return rcv._tab.MutateInt8(rcv._tab.Pos()+flatbuffers.UOffsetT(2), n)
 }
 
 func CreateTest(builder *flatbuffers.Builder, a int16, b int8) flatbuffers.UOffsetT {

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.go
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.go
@@ -18,8 +18,7 @@ func GetRootAsTestSimpleTableWithEnum(buf []byte, offset flatbuffers.UOffsetT) *
 }
 
 func (rcv *TestSimpleTableWithEnum) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *TestSimpleTableWithEnum) Table() flatbuffers.Table {
@@ -29,7 +28,7 @@ func (rcv *TestSimpleTableWithEnum) Table() flatbuffers.Table {
 func (rcv *TestSimpleTableWithEnum) Color() Color {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		return rcv._tab.GetByte(o + rcv._tab.Pos())
 	}
 	return 2
 }

--- a/tests/MyGame/Example/TypeAliases.go
+++ b/tests/MyGame/Example/TypeAliases.go
@@ -18,8 +18,7 @@ func GetRootAsTypeAliases(buf []byte, offset flatbuffers.UOffsetT) *TypeAliases 
 }
 
 func (rcv *TypeAliases) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *TypeAliases) Table() flatbuffers.Table {
@@ -29,7 +28,7 @@ func (rcv *TypeAliases) Table() flatbuffers.Table {
 func (rcv *TypeAliases) I8() int8 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		return rcv._tab.GetInt8(o + rcv._tab.Pos)
+		return rcv._tab.GetInt8(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -41,7 +40,7 @@ func (rcv *TypeAliases) MutateI8(n int8) bool {
 func (rcv *TypeAliases) U8() byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		return rcv._tab.GetByte(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -53,7 +52,7 @@ func (rcv *TypeAliases) MutateU8(n byte) bool {
 func (rcv *TypeAliases) I16() int16 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
-		return rcv._tab.GetInt16(o + rcv._tab.Pos)
+		return rcv._tab.GetInt16(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -65,7 +64,7 @@ func (rcv *TypeAliases) MutateI16(n int16) bool {
 func (rcv *TypeAliases) U16() uint16 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
-		return rcv._tab.GetUint16(o + rcv._tab.Pos)
+		return rcv._tab.GetUint16(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -77,7 +76,7 @@ func (rcv *TypeAliases) MutateU16(n uint16) bool {
 func (rcv *TypeAliases) I32() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
-		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+		return rcv._tab.GetInt32(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -89,7 +88,7 @@ func (rcv *TypeAliases) MutateI32(n int32) bool {
 func (rcv *TypeAliases) U32() uint32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
 	if o != 0 {
-		return rcv._tab.GetUint32(o + rcv._tab.Pos)
+		return rcv._tab.GetUint32(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -101,7 +100,7 @@ func (rcv *TypeAliases) MutateU32(n uint32) bool {
 func (rcv *TypeAliases) I64() int64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
 	if o != 0 {
-		return rcv._tab.GetInt64(o + rcv._tab.Pos)
+		return rcv._tab.GetInt64(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -113,7 +112,7 @@ func (rcv *TypeAliases) MutateI64(n int64) bool {
 func (rcv *TypeAliases) U64() uint64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
 	if o != 0 {
-		return rcv._tab.GetUint64(o + rcv._tab.Pos)
+		return rcv._tab.GetUint64(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -125,7 +124,7 @@ func (rcv *TypeAliases) MutateU64(n uint64) bool {
 func (rcv *TypeAliases) F32() float32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
 	if o != 0 {
-		return rcv._tab.GetFloat32(o + rcv._tab.Pos)
+		return rcv._tab.GetFloat32(o + rcv._tab.Pos())
 	}
 	return 0.0
 }
@@ -137,7 +136,7 @@ func (rcv *TypeAliases) MutateF32(n float32) bool {
 func (rcv *TypeAliases) F64() float64 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
 	if o != 0 {
-		return rcv._tab.GetFloat64(o + rcv._tab.Pos)
+		return rcv._tab.GetFloat64(o + rcv._tab.Pos())
 	}
 	return 0.0
 }

--- a/tests/MyGame/Example/Vec3.go
+++ b/tests/MyGame/Example/Vec3.go
@@ -11,8 +11,7 @@ type Vec3 struct {
 }
 
 func (rcv *Vec3) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *Vec3) Table() flatbuffers.Table {
@@ -20,45 +19,45 @@ func (rcv *Vec3) Table() flatbuffers.Table {
 }
 
 func (rcv *Vec3) X() float32 {
-	return rcv._tab.GetFloat32(rcv._tab.Pos + flatbuffers.UOffsetT(0))
+	return rcv._tab.GetFloat32(rcv._tab.Pos() + flatbuffers.UOffsetT(0))
 }
 func (rcv *Vec3) MutateX(n float32) bool {
-	return rcv._tab.MutateFloat32(rcv._tab.Pos+flatbuffers.UOffsetT(0), n)
+	return rcv._tab.MutateFloat32(rcv._tab.Pos()+flatbuffers.UOffsetT(0), n)
 }
 
 func (rcv *Vec3) Y() float32 {
-	return rcv._tab.GetFloat32(rcv._tab.Pos + flatbuffers.UOffsetT(4))
+	return rcv._tab.GetFloat32(rcv._tab.Pos() + flatbuffers.UOffsetT(4))
 }
 func (rcv *Vec3) MutateY(n float32) bool {
-	return rcv._tab.MutateFloat32(rcv._tab.Pos+flatbuffers.UOffsetT(4), n)
+	return rcv._tab.MutateFloat32(rcv._tab.Pos()+flatbuffers.UOffsetT(4), n)
 }
 
 func (rcv *Vec3) Z() float32 {
-	return rcv._tab.GetFloat32(rcv._tab.Pos + flatbuffers.UOffsetT(8))
+	return rcv._tab.GetFloat32(rcv._tab.Pos() + flatbuffers.UOffsetT(8))
 }
 func (rcv *Vec3) MutateZ(n float32) bool {
-	return rcv._tab.MutateFloat32(rcv._tab.Pos+flatbuffers.UOffsetT(8), n)
+	return rcv._tab.MutateFloat32(rcv._tab.Pos()+flatbuffers.UOffsetT(8), n)
 }
 
 func (rcv *Vec3) Test1() float64 {
-	return rcv._tab.GetFloat64(rcv._tab.Pos + flatbuffers.UOffsetT(16))
+	return rcv._tab.GetFloat64(rcv._tab.Pos() + flatbuffers.UOffsetT(16))
 }
 func (rcv *Vec3) MutateTest1(n float64) bool {
-	return rcv._tab.MutateFloat64(rcv._tab.Pos+flatbuffers.UOffsetT(16), n)
+	return rcv._tab.MutateFloat64(rcv._tab.Pos()+flatbuffers.UOffsetT(16), n)
 }
 
 func (rcv *Vec3) Test2() Color {
-	return rcv._tab.GetByte(rcv._tab.Pos + flatbuffers.UOffsetT(24))
+	return rcv._tab.GetByte(rcv._tab.Pos() + flatbuffers.UOffsetT(24))
 }
 func (rcv *Vec3) MutateTest2(n Color) bool {
-	return rcv._tab.MutateByte(rcv._tab.Pos+flatbuffers.UOffsetT(24), n)
+	return rcv._tab.MutateByte(rcv._tab.Pos()+flatbuffers.UOffsetT(24), n)
 }
 
 func (rcv *Vec3) Test3(obj *Test) *Test {
 	if obj == nil {
 		obj = new(Test)
 	}
-	obj.Init(rcv._tab.Bytes, rcv._tab.Pos+26)
+	obj.Init(rcv._tab.Bytes(), rcv._tab.Pos()+26)
 	return obj
 }
 

--- a/tests/MyGame/Example2/Monster.go
+++ b/tests/MyGame/Example2/Monster.go
@@ -18,8 +18,7 @@ func GetRootAsMonster(buf []byte, offset flatbuffers.UOffsetT) *Monster {
 }
 
 func (rcv *Monster) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *Monster) Table() flatbuffers.Table {

--- a/tests/MyGame/InParentNamespace.go
+++ b/tests/MyGame/InParentNamespace.go
@@ -18,8 +18,7 @@ func GetRootAsInParentNamespace(buf []byte, offset flatbuffers.UOffsetT) *InPare
 }
 
 func (rcv *InParentNamespace) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *InParentNamespace) Table() flatbuffers.Table {

--- a/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.go
+++ b/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.go
@@ -11,8 +11,7 @@ type StructInNestedNS struct {
 }
 
 func (rcv *StructInNestedNS) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *StructInNestedNS) Table() flatbuffers.Table {
@@ -20,17 +19,17 @@ func (rcv *StructInNestedNS) Table() flatbuffers.Table {
 }
 
 func (rcv *StructInNestedNS) A() int32 {
-	return rcv._tab.GetInt32(rcv._tab.Pos + flatbuffers.UOffsetT(0))
+	return rcv._tab.GetInt32(rcv._tab.Pos() + flatbuffers.UOffsetT(0))
 }
 func (rcv *StructInNestedNS) MutateA(n int32) bool {
-	return rcv._tab.MutateInt32(rcv._tab.Pos+flatbuffers.UOffsetT(0), n)
+	return rcv._tab.MutateInt32(rcv._tab.Pos()+flatbuffers.UOffsetT(0), n)
 }
 
 func (rcv *StructInNestedNS) B() int32 {
-	return rcv._tab.GetInt32(rcv._tab.Pos + flatbuffers.UOffsetT(4))
+	return rcv._tab.GetInt32(rcv._tab.Pos() + flatbuffers.UOffsetT(4))
 }
 func (rcv *StructInNestedNS) MutateB(n int32) bool {
-	return rcv._tab.MutateInt32(rcv._tab.Pos+flatbuffers.UOffsetT(4), n)
+	return rcv._tab.MutateInt32(rcv._tab.Pos()+flatbuffers.UOffsetT(4), n)
 }
 
 func CreateStructInNestedNS(builder *flatbuffers.Builder, a int32, b int32) flatbuffers.UOffsetT {

--- a/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.go
+++ b/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.go
@@ -18,8 +18,7 @@ func GetRootAsTableInNestedNS(buf []byte, offset flatbuffers.UOffsetT) *TableInN
 }
 
 func (rcv *TableInNestedNS) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *TableInNestedNS) Table() flatbuffers.Table {
@@ -29,7 +28,7 @@ func (rcv *TableInNestedNS) Table() flatbuffers.Table {
 func (rcv *TableInNestedNS) Foo() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+		return rcv._tab.GetInt32(o + rcv._tab.Pos())
 	}
 	return 0
 }

--- a/tests/namespace_test/NamespaceA/SecondTableInA.go
+++ b/tests/namespace_test/NamespaceA/SecondTableInA.go
@@ -20,8 +20,7 @@ func GetRootAsSecondTableInA(buf []byte, offset flatbuffers.UOffsetT) *SecondTab
 }
 
 func (rcv *SecondTableInA) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *SecondTableInA) Table() flatbuffers.Table {
@@ -31,11 +30,11 @@ func (rcv *SecondTableInA) Table() flatbuffers.Table {
 func (rcv *SecondTableInA) ReferToC(obj *NamespaceC.TableInC) *NamespaceC.TableInC {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		x := rcv._tab.Indirect(o + rcv._tab.Pos)
+		x := rcv._tab.Indirect(o + rcv._tab.Pos())
 		if obj == nil {
 			obj = new(NamespaceC.TableInC)
 		}
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return obj
 	}
 	return nil

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.go
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.go
@@ -20,8 +20,7 @@ func GetRootAsTableInFirstNS(buf []byte, offset flatbuffers.UOffsetT) *TableInFi
 }
 
 func (rcv *TableInFirstNS) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *TableInFirstNS) Table() flatbuffers.Table {
@@ -31,11 +30,11 @@ func (rcv *TableInFirstNS) Table() flatbuffers.Table {
 func (rcv *TableInFirstNS) FooTable(obj *NamespaceA__NamespaceB.TableInNestedNS) *NamespaceA__NamespaceB.TableInNestedNS {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		x := rcv._tab.Indirect(o + rcv._tab.Pos)
+		x := rcv._tab.Indirect(o + rcv._tab.Pos())
 		if obj == nil {
 			obj = new(NamespaceA__NamespaceB.TableInNestedNS)
 		}
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return obj
 	}
 	return nil
@@ -44,7 +43,7 @@ func (rcv *TableInFirstNS) FooTable(obj *NamespaceA__NamespaceB.TableInNestedNS)
 func (rcv *TableInFirstNS) FooEnum() EnumInNestedNS {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
-		return rcv._tab.GetInt8(o + rcv._tab.Pos)
+		return rcv._tab.GetInt8(o + rcv._tab.Pos())
 	}
 	return 0
 }
@@ -56,11 +55,11 @@ func (rcv *TableInFirstNS) MutateFooEnum(n EnumInNestedNS) bool {
 func (rcv *TableInFirstNS) FooStruct(obj *NamespaceA__NamespaceB.StructInNestedNS) *NamespaceA__NamespaceB.StructInNestedNS {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
-		x := o + rcv._tab.Pos
+		x := o + rcv._tab.Pos()
 		if obj == nil {
 			obj = new(NamespaceA__NamespaceB.StructInNestedNS)
 		}
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return obj
 	}
 	return nil

--- a/tests/namespace_test/NamespaceC/TableInC.go
+++ b/tests/namespace_test/NamespaceC/TableInC.go
@@ -20,8 +20,7 @@ func GetRootAsTableInC(buf []byte, offset flatbuffers.UOffsetT) *TableInC {
 }
 
 func (rcv *TableInC) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
+	rcv._tab.Init(buf, i)
 }
 
 func (rcv *TableInC) Table() flatbuffers.Table {
@@ -31,11 +30,11 @@ func (rcv *TableInC) Table() flatbuffers.Table {
 func (rcv *TableInC) ReferToA1(obj *NamespaceA.TableInFirstNS) *NamespaceA.TableInFirstNS {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		x := rcv._tab.Indirect(o + rcv._tab.Pos)
+		x := rcv._tab.Indirect(o + rcv._tab.Pos())
 		if obj == nil {
 			obj = new(NamespaceA.TableInFirstNS)
 		}
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return obj
 	}
 	return nil
@@ -44,11 +43,11 @@ func (rcv *TableInC) ReferToA1(obj *NamespaceA.TableInFirstNS) *NamespaceA.Table
 func (rcv *TableInC) ReferToA2(obj *NamespaceA.SecondTableInA) *NamespaceA.SecondTableInA {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
-		x := rcv._tab.Indirect(o + rcv._tab.Pos)
+		x := rcv._tab.Indirect(o + rcv._tab.Pos())
 		if obj == nil {
 			obj = new(NamespaceA.SecondTableInA)
 		}
-		obj.Init(rcv._tab.Bytes, x)
+		obj.Init(rcv._tab.Bytes(), x)
 		return obj
 	}
 	return nil


### PR DESCRIPTION
This shrinks the size of Table (and therefore all FlatBuffers objects)
from 32 bytes to 24. We're not using the capacity of the given slice for
anything, since we never modify it, so we can pack the position in the
len field, and len in cap.

-----

I had this idea while thinking about some other aspects of the Go implementation. This might provide a performance improvement for programs that create many flatbuffers objects by reducing memory pressure and making it more appealing to pass objects by value where it makes sense.

Benchmark results (from my laptop, not very rigorous):
master:
```
BenchmarkParseGold-4                    20000000               281 ns/op         795.93 MB/s           0 B/op        0 allocs/op
BenchmarkParseGold-4                    20000000               285 ns/op         785.18 MB/s           0 B/op        0 allocs/op
BenchmarkParseGold-4                    20000000               281 ns/op         795.57 MB/s           0 B/op        0 allocs/op
```
this change:
```
BenchmarkParseGold-4                    20000000               279 ns/op         802.47 MB/s           0 B/op        0 allocs/op
BenchmarkParseGold-4                    20000000               280 ns/op         799.91 MB/s           0 B/op        0 allocs/op
BenchmarkParseGold-4                    20000000               282 ns/op         793.33 MB/s           0 B/op        0 allocs/op
```

As far as the public API, client code in the same package as generated flatbuffers code that accesses the `Bytes` and `Pos` fields directly will have to change to use `Bytes()`, `Pos()`, and `Init()`. Or code that uses `flatbuffers.Table` directly. I think those should be relatively rare.