### PR TITLE
Ensure we don't subtract with underflow getting enum names

### DIFF
--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -698,14 +698,14 @@ class RustGenerator : public BaseGenerator {
       code_ += "pub fn enum_name_{{ENUM_NAME_SNAKE}}(e: {{ENUM_NAME}}) -> "
                "&'static str {";
 
-      code_ += "  let index: usize = e as usize\\";
+      code_ += "  let index = e as {{BASE_TYPE}}\\";
       if (enum_def.vals.vec.front()->value) {
         auto vals = GetEnumValUse(enum_def, *enum_def.vals.vec.front());
-        code_ += " - " + vals + " as usize\\";
+        code_ += " - " + vals + " as {{BASE_TYPE}}\\";
       }
       code_ += ";";
 
-      code_ += "  ENUM_NAMES_{{ENUM_NAME_CAPS}}[index]";
+      code_ += "  ENUM_NAMES_{{ENUM_NAME_CAPS}}[index as usize]";
       code_ += "}";
       code_ += "";
     }

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -227,8 +227,8 @@ const ENUM_NAMES_COLOR:[&'static str; 8] = [
 ];
 
 pub fn enum_name_color(e: Color) -> &'static str {
-  let index: usize = e as usize - Color::Red as usize;
-  ENUM_NAMES_COLOR[index]
+  let index = e as i8 - Color::Red as i8;
+  ENUM_NAMES_COLOR[index as usize]
 }
 
 #[allow(non_camel_case_types)]
@@ -293,8 +293,8 @@ const ENUM_NAMES_ANY:[&'static str; 4] = [
 ];
 
 pub fn enum_name_any(e: Any) -> &'static str {
-  let index: usize = e as usize;
-  ENUM_NAMES_ANY[index]
+  let index = e as u8;
+  ENUM_NAMES_ANY[index as usize]
 }
 
 pub struct AnyUnionTableOffset {}
@@ -360,8 +360,8 @@ const ENUM_NAMES_ANY_UNIQUE_ALIASES:[&'static str; 4] = [
 ];
 
 pub fn enum_name_any_unique_aliases(e: AnyUniqueAliases) -> &'static str {
-  let index: usize = e as usize;
-  ENUM_NAMES_ANY_UNIQUE_ALIASES[index]
+  let index = e as u8;
+  ENUM_NAMES_ANY_UNIQUE_ALIASES[index as usize]
 }
 
 pub struct AnyUniqueAliasesUnionTableOffset {}
@@ -427,8 +427,8 @@ const ENUM_NAMES_ANY_AMBIGUOUS_ALIASES:[&'static str; 4] = [
 ];
 
 pub fn enum_name_any_ambiguous_aliases(e: AnyAmbiguousAliases) -> &'static str {
-  let index: usize = e as usize;
-  ENUM_NAMES_ANY_AMBIGUOUS_ALIASES[index]
+  let index = e as u8;
+  ENUM_NAMES_ANY_AMBIGUOUS_ALIASES[index as usize]
 }
 
 pub struct AnyAmbiguousAliasesUnionTableOffset {}

--- a/tests/namespace_test/namespace_test1_generated.rs
+++ b/tests/namespace_test/namespace_test1_generated.rs
@@ -84,8 +84,8 @@ const ENUM_NAMES_ENUM_IN_NESTED_NS:[&'static str; 3] = [
 ];
 
 pub fn enum_name_enum_in_nested_ns(e: EnumInNestedNS) -> &'static str {
-  let index: usize = e as usize;
-  ENUM_NAMES_ENUM_IN_NESTED_NS[index]
+  let index = e as i8;
+  ENUM_NAMES_ENUM_IN_NESTED_NS[index as usize]
 }
 
 // struct StructInNestedNS, aligned to 4


### PR DESCRIPTION
Fixes #5245:

The code generated for enum names underflows when attempting to get an enum name for one of the negative values (`panicked at 'attempt to subtract with overflow'`):

```
pub fn enum_name_xyz(e: XYZ) -> &'static str {
  let index: usize = e as usize - XYZ::NEGATIVE_VALUE as usize;
  ENUM_NAMES_XYZ[index]
}
```

Instead, the code should cast the left and right to the underlying representation (ie: `i8`), then cast that result to `usize`:

```
pub fn enum_name_xyz(e: XYZ) -> &'static str {
  let index = e as i8 - XYZ::NEGATIVE_VALUE as i8;
  ENUM_NAMES_XYZ[index as usize]
}
```
