### PR TITLE
[Python] Use qualified names to import schema types

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -36,7 +36,7 @@ class PythonGenerator : public BaseGenerator {
   PythonGenerator(const Parser &parser, const std::string &path,
                   const std::string &file_name)
       : BaseGenerator(parser, path, file_name, "" /* not used */,
-                      "" /* not used */),
+                      "."),
         float_const_gen_("float('nan')", "float('inf')", "float('-inf')") {
     static const char * const keywords[] = {
       "False",
@@ -239,7 +239,7 @@ class PythonGenerator : public BaseGenerator {
       code += "x = self._tab.Indirect(o + self._tab.Pos)\n";
     }
     code += Indent + Indent + Indent;
-    code += "from ." + TypeName(field) + " import " + TypeName(field) + "\n";
+    code += "from " + QualifiedTypeName(field) + " import " + TypeName(field) + "\n";
     code += Indent + Indent + Indent + "obj = " + TypeName(field) + "()\n";
     code += Indent + Indent + Indent + "obj.Init(self._tab.Bytes, x)\n";
     code += Indent + Indent + Indent + "return obj\n";
@@ -273,7 +273,7 @@ class PythonGenerator : public BaseGenerator {
       code += Indent + Indent + Indent + "from flatbuffers.table import Table\n";
     } else {
       code += Indent + Indent + Indent;
-      code += "from ." + TypeName(field) + " import " + TypeName(field) + "\n";
+      code += "from " + QualifiedTypeName(field) + " import " + TypeName(field) + "\n";
     }
     code += Indent + Indent + Indent + "obj = Table(bytearray(), 0)\n";
     code += Indent + Indent + Indent + GenGetter(field.value.type);
@@ -299,7 +299,7 @@ class PythonGenerator : public BaseGenerator {
       code += Indent + Indent + Indent + "x = self._tab.Indirect(x)\n";
     }
     code += Indent + Indent + Indent;
-    code += "from ." + TypeName(field) + " import " + TypeName(field) + "\n";
+    code += "from " + QualifiedTypeName(field) + " import " + TypeName(field) + "\n";
     code += Indent + Indent + Indent + "obj = " + TypeName(field) + "()\n";
     code += Indent + Indent + Indent + "obj.Init(self._tab.Bytes, x)\n";
     code += Indent + Indent + Indent + "return obj\n";
@@ -647,6 +647,11 @@ class PythonGenerator : public BaseGenerator {
 
   std::string TypeName(const FieldDef &field) {
     return GenTypeGet(field.value.type);
+  }
+
+  // Get the qualified name (including modules) of the given field's type
+  std::string QualifiedTypeName(const FieldDef &field) {
+    return WrapInNameSpace(field.value.type.struct_def->defined_namespace, TypeName(field));
   }
 
   // Create a struct with a builder and the struct's arguments.

--- a/tests/MyGame/Example/Monster.py
+++ b/tests/MyGame/Example/Monster.py
@@ -24,7 +24,7 @@ class Monster(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             x = o + self._tab.Pos
-            from .Vec3 import Vec3
+            from MyGame.Example.Vec3 import Vec3
             obj = Vec3()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -103,7 +103,7 @@ class Monster(object):
         if o != 0:
             x = self._tab.Vector(o)
             x += flatbuffers.number_types.UOffsetTFlags.py_type(j) * 4
-            from .Test import Test
+            from MyGame.Example.Test import Test
             obj = Test()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -140,7 +140,7 @@ class Monster(object):
             x = self._tab.Vector(o)
             x += flatbuffers.number_types.UOffsetTFlags.py_type(j) * 4
             x = self._tab.Indirect(x)
-            from .Monster import Monster
+            from MyGame.Example.Monster import Monster
             obj = Monster()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -158,7 +158,7 @@ class Monster(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(28))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .Monster import Monster
+            from MyGame.Example.Monster import Monster
             obj = Monster()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -191,7 +191,7 @@ class Monster(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(32))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .Stat import Stat
+            from MyGame.Example.Stat import Stat
             obj = Stat()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -324,7 +324,7 @@ class Monster(object):
         if o != 0:
             x = self._tab.Vector(o)
             x += flatbuffers.number_types.UOffsetTFlags.py_type(j) * 8
-            from .Ability import Ability
+            from MyGame.Example.Ability import Ability
             obj = Ability()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -365,7 +365,7 @@ class Monster(object):
         if o != 0:
             x = self._tab.Vector(o)
             x += flatbuffers.number_types.UOffsetTFlags.py_type(j) * 4
-            from .Test import Test
+            from MyGame.Example.Test import Test
             obj = Test()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -427,7 +427,7 @@ class Monster(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(72))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .InParentNamespace import InParentNamespace
+            from MyGame.InParentNamespace import InParentNamespace
             obj = InParentNamespace()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -440,7 +440,7 @@ class Monster(object):
             x = self._tab.Vector(o)
             x += flatbuffers.number_types.UOffsetTFlags.py_type(j) * 4
             x = self._tab.Indirect(x)
-            from .Referrable import Referrable
+            from MyGame.Example.Referrable import Referrable
             obj = Referrable()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -489,7 +489,7 @@ class Monster(object):
             x = self._tab.Vector(o)
             x += flatbuffers.number_types.UOffsetTFlags.py_type(j) * 4
             x = self._tab.Indirect(x)
-            from .Referrable import Referrable
+            from MyGame.Example.Referrable import Referrable
             obj = Referrable()
             obj.Init(self._tab.Bytes, x)
             return obj

--- a/tests/PythonTest.sh
+++ b/tests/PythonTest.sh
@@ -18,9 +18,13 @@ pushd "$(dirname $0)" >/dev/null
 test_dir="$(pwd)"
 gen_code_path=${test_dir}
 runtime_library_dir=${test_dir}/../python
+namespace_test_dir=${test_dir}/namespace_test
 
 # Emit Python code for the example schema in the test dir:
 ${test_dir}/../flatc -p -o ${gen_code_path} -I include_test monster_test.fbs
+
+# Emit Python code for the namespace schemas
+${test_dir}/../flatc -p -o ${namespace_test_dir} ${namespace_test_dir}/namespace_test1.fbs ${namespace_test_dir}/namespace_test2.fbs
 
 # Syntax: run_tests <interpreter> <benchmark vtable dedupes>
 #                   <benchmark read count> <benchmark build count>
@@ -30,8 +34,8 @@ function run_tests() {
     echo "Testing with interpreter: ${1}"
     PYTHONDONTWRITEBYTECODE=1 \
     JYTHONDONTWRITEBYTECODE=1 \
-    PYTHONPATH=${runtime_library_dir}:${gen_code_path} \
-    JYTHONPATH=${runtime_library_dir}:${gen_code_path} \
+    PYTHONPATH=${runtime_library_dir}:${gen_code_path}:${namespace_test_dir} \
+    JYTHONPATH=${runtime_library_dir}:${gen_code_path}:${namespace_test_dir} \
     COMPARE_GENERATED_TO_GO=0 \
     COMPARE_GENERATED_TO_JAVA=0 \
     $1 py_test.py $2 $3 $4
@@ -63,7 +67,7 @@ if $(which coverage >/dev/null); then
   echo 'Found coverage utility, running coverage with default Python:'
 
   PYTHONDONTWRITEBYTECODE=1 \
-  PYTHONPATH=${runtime_library_dir}:${gen_code_path} \
+  PYTHONPATH=${runtime_library_dir}:${gen_code_path}:${namespace_test_dir} \
   coverage run --source=flatbuffers,MyGame py_test.py 0 0 0 > /dev/null
 
   echo

--- a/tests/namespace_test/NamespaceA/SecondTableInA.py
+++ b/tests/namespace_test/NamespaceA/SecondTableInA.py
@@ -23,7 +23,7 @@ class SecondTableInA(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .TableInC import TableInC
+            from NamespaceC.TableInC import TableInC
             obj = TableInC()
             obj.Init(self._tab.Bytes, x)
             return obj

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.py
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.py
@@ -23,7 +23,7 @@ class TableInFirstNS(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .TableInNestedNS import TableInNestedNS
+            from NamespaceA.NamespaceB.TableInNestedNS import TableInNestedNS
             obj = TableInNestedNS()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -41,7 +41,7 @@ class TableInFirstNS(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             x = o + self._tab.Pos
-            from .StructInNestedNS import StructInNestedNS
+            from NamespaceA.NamespaceB.StructInNestedNS import StructInNestedNS
             obj = StructInNestedNS()
             obj.Init(self._tab.Bytes, x)
             return obj

--- a/tests/namespace_test/NamespaceC/TableInC.py
+++ b/tests/namespace_test/NamespaceC/TableInC.py
@@ -23,7 +23,7 @@ class TableInC(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .TableInFirstNS import TableInFirstNS
+            from NamespaceA.TableInFirstNS import TableInFirstNS
             obj = TableInFirstNS()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -34,7 +34,7 @@ class TableInC(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .SecondTableInA import SecondTableInA
+            from NamespaceA.SecondTableInA import SecondTableInA
             obj = SecondTableInA()
             obj.Init(self._tab.Bytes, x)
             return obj


### PR DESCRIPTION
Previously, the generated python sources would import types using a
relative module with only the type's name specified as part of the
current module. This doesn't work for fields in schemas with types
defined in a different namespace from the containing structure.

This change uses the full namespace of the type when importing it, which
should resolve fields no matter where their type is defined.