### PR TITLE
Fix a warning on compiling with clang

### DIFF
--- a/include/flatbuffers/reflection_generated.h
+++ b/include/flatbuffers/reflection_generated.h
@@ -95,7 +95,7 @@ inline const char * const *EnumNamesBaseType() {
 
 inline const char *EnumNameBaseType(BaseType e) {
   if (e < None || e > Union) return "";
-  const size_t index = static_cast<int>(e);
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesBaseType()[index];
 }
 

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -56,7 +56,7 @@ inline const char * const *EnumNamesColor() {
 
 inline const char *EnumNameColor(Color e) {
   if (e < Color_Red || e > Color_Blue) return "";
-  const size_t index = static_cast<int>(e);
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesColor()[index];
 }
 
@@ -86,7 +86,7 @@ inline const char * const *EnumNamesEquipment() {
 
 inline const char *EnumNameEquipment(Equipment e) {
   if (e < Equipment_NONE || e > Equipment_Weapon) return "";
-  const size_t index = static_cast<int>(e);
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesEquipment()[index];
 }
 

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -1015,10 +1015,10 @@ class CppGenerator : public BaseGenerator {
                " || e > " + GetEnumValUse(enum_def, *enum_def.vals.vec.back()) +
                ") return \"\";";
 
-      code_ += "  const size_t index = static_cast<int>(e)\\";
+      code_ += "  const size_t index = static_cast<size_t>(e)\\";
       if (enum_def.vals.vec.front()->value) {
         auto vals = GetEnumValUse(enum_def, *enum_def.vals.vec.front());
-        code_ += " - static_cast<int>(" + vals + ")\\";
+        code_ += " - static_cast<size_t>(" + vals + ")\\";
       }
       code_ += ";";
 

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -123,7 +123,7 @@ inline const char * const *EnumNamesColor() {
 
 inline const char *EnumNameColor(Color e) {
   if (e < Color_Red || e > Color_Blue) return "";
-  const size_t index = static_cast<int>(e) - static_cast<int>(Color_Red);
+  const size_t index = static_cast<size_t>(e) - static_cast<size_t>(Color_Red);
   return EnumNamesColor()[index];
 }
 
@@ -159,7 +159,7 @@ inline const char * const *EnumNamesAny() {
 
 inline const char *EnumNameAny(Any e) {
   if (e < Any_NONE || e > Any_MyGame_Example2_Monster) return "";
-  const size_t index = static_cast<int>(e);
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesAny()[index];
 }
 
@@ -295,7 +295,7 @@ inline const char * const *EnumNamesAnyUniqueAliases() {
 
 inline const char *EnumNameAnyUniqueAliases(AnyUniqueAliases e) {
   if (e < AnyUniqueAliases_NONE || e > AnyUniqueAliases_M2) return "";
-  const size_t index = static_cast<int>(e);
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesAnyUniqueAliases()[index];
 }
 
@@ -431,7 +431,7 @@ inline const char * const *EnumNamesAnyAmbiguousAliases() {
 
 inline const char *EnumNameAnyAmbiguousAliases(AnyAmbiguousAliases e) {
   if (e < AnyAmbiguousAliases_NONE || e > AnyAmbiguousAliases_M3) return "";
-  const size_t index = static_cast<int>(e);
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesAnyAmbiguousAliases()[index];
 }
 

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -46,7 +46,7 @@ inline const char * const *EnumNamesEnumInNestedNS() {
 
 inline const char *EnumNameEnumInNestedNS(EnumInNestedNS e) {
   if (e < EnumInNestedNS_A || e > EnumInNestedNS_C) return "";
-  const size_t index = static_cast<int>(e);
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesEnumInNestedNS()[index];
 }
 

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -70,7 +70,7 @@ inline const char * const *EnumNamesCharacter() {
 
 inline const char *EnumNameCharacter(Character e) {
   if (e < Character_NONE || e > Character_Unused) return "";
-  const size_t index = static_cast<int>(e);
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesCharacter()[index];
 }
 


### PR DESCRIPTION
Fix code, which generates constructions like `const size_t index = static_cast<int>(e);` to avoid the warning `implicit conversion changes signedness: 'int' to 'const size_t' (aka 'const unsigned long')`

https://github.com/google/flatbuffers/issues/5253