### PR TITLE
Bazel CI: fix bad value in yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,5 @@
 ---
-buildifier: true
+buildifier: latest
 platforms:
   ubuntu1404:
     build_targets:


### PR DESCRIPTION
Use the "simple format" defined here:
https://github.com/bazelbuild/continuous-integration/blob/69cf7ec23d984dcbb41fffe946e07ebf5ab7e0f1/buildkite/bazelci.py#L1453

This will unbreak the "Bazel / FlatBuffers"
pipeline on Bazel CI, see
https://buildkite.com/bazel/flatbuffers

Motivation: fix Buildtools pipeline's tests with
the Windows-native test wrapper.
See https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/844#ebe8cc26-473d-4c6c-ac4f-83a61f026b90

