### PR TITLE
Add missing test data file to BUILD file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -159,6 +159,7 @@ cc_test(
         ":tests/prototest/test_union.golden",
         ":tests/unicode_test.json",
         ":tests/union_vector/union_vector.fbs",
+        ":tests/union_vector/union_vector.json",
     ],
     includes = ["include/"],
     deps = [


### PR DESCRIPTION
$ cat
/home/austin/.cache/bazel/_bazel_austin/4b3182bfa237d7e256d9f18ffe58322f/execroot/com_github_google_flatbuffers/bazel-out/k8-opt/testlogs/flatbuffers_test/test.log
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //:flatbuffers_test
-----------------------------------------------------------------------------
VALUE: "0"
EXPECTED: "1"
TEST FAILED: tests/test.cpp:2029, flatbuffers::LoadFile( (test_data_path
+ "union_vector/union_vector.json").c_str(), false, &jsonfile) in
VALUE: "0"
EXPECTED: "1"
TEST FAILED: tests/test.cpp:2100, parser.Parse(jsonfile.c_str()) in
VALUE: "0"
EXPECTED: "1"
TEST FAILED: tests/test.cpp:2103, VerifyMovieBuffer(jverifier) in