### PR TITLE
Add method GenerateTextFromTable issue #5249

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -834,6 +834,10 @@ extern std::string MakeCamel(const std::string &in, bool first = true);
 // strict_json adds "quotes" around field names if true.
 // If the flatbuffer cannot be encoded in JSON (e.g., it contains non-UTF-8
 // byte arrays in String values), returns false.
+extern bool GenerateTextFromTable(const Parser &parser,
+                                  const void *table,
+                                  const std::string &tablename,
+                                  std::string *text);
 extern bool GenerateText(const Parser &parser,
                          const void *flatbuffer,
                          std::string *text);

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -263,6 +263,24 @@ static bool GenStruct(const StructDef &struct_def, const Table *table,
 }
 
 // Generate a text representation of a flatbuffer in JSON format.
+bool GenerateTextFromTable(const Parser &parser, const void *table,
+                           const std::string& tablename,
+                           std::string *_text) {
+  StructDef* struct_def = parser.LookupStruct(tablename);
+  if (struct_def == nullptr) {
+    return false;
+  }
+  std::string &text = *_text;
+  text.reserve(1024);               // Reduce amount of inevitable reallocs.
+  auto root = static_cast<const Table*>(table);
+  if (!GenStruct(*struct_def, root, 0, parser.opts, _text)) {
+    return false;
+  }
+  text += NewLine(parser.opts);
+  return true;
+}
+
+// Generate a text representation of a flatbuffer in JSON format.
 bool GenerateText(const Parser &parser, const void *flatbuffer,
                   std::string *_text) {
   std::string &text = *_text;

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -266,11 +266,11 @@ static bool GenStruct(const StructDef &struct_def, const Table *table,
 bool GenerateTextFromTable(const Parser &parser, const void *table,
                            const std::string &table_name,
                            std::string *_text) {
-  StructDef *struct_def = parser.LookupStruct(table_name);
+  auto struct_def = parser.LookupStruct(table_name);
   if (struct_def == nullptr) {
     return false;
   }
-  std::string &text = *_text;
+  auto text = *_text;
   text.reserve(1024);               // Reduce amount of inevitable reallocs.
   auto root = static_cast<const Table*>(table);
   if (!GenStruct(*struct_def, root, 0, parser.opts, _text)) {

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -264,9 +264,9 @@ static bool GenStruct(const StructDef &struct_def, const Table *table,
 
 // Generate a text representation of a flatbuffer in JSON format.
 bool GenerateTextFromTable(const Parser &parser, const void *table,
-                           const std::string& tablename,
+                           const std::string &table_name,
                            std::string *_text) {
-  StructDef* struct_def = parser.LookupStruct(tablename);
+  StructDef *struct_def = parser.LookupStruct(table_name);
   if (struct_def == nullptr) {
     return false;
   }

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -264,15 +264,14 @@ static bool GenStruct(const StructDef &struct_def, const Table *table,
 
 // Generate a text representation of a flatbuffer in JSON format.
 bool GenerateTextFromTable(const Parser &parser, const void *table,
-                           const std::string &table_name,
-                           std::string *_text) {
+                           const std::string &table_name, std::string *_text) {
   auto struct_def = parser.LookupStruct(table_name);
   if (struct_def == nullptr) {
     return false;
   }
   auto text = *_text;
-  text.reserve(1024);               // Reduce amount of inevitable reallocs.
-  auto root = static_cast<const Table*>(table);
+  text.reserve(1024);  // Reduce amount of inevitable reallocs.
+  auto root = static_cast<const Table *>(table);
   if (!GenStruct(*struct_def, root, 0, parser.opts, _text)) {
     return false;
   }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1684,17 +1684,17 @@ void InvalidFloatTest() {
 void GenerateTableTextTest() {
   std::string schemafile;
   std::string jsonfile;
-  bool ok = flatbuffers::LoadFile((test_data_path + "monster_test.fbs").c_str(),
-                                  false, &schemafile) &&
-            flatbuffers::LoadFile((test_data_path + "monsterdata_test.json").c_str(),
-                                  false, &jsonfile);
+  bool ok = flatbuffers::LoadFile((test_data_path + "monster_test.fbs").c_str(),false, &schemafile) &&
+            flatbuffers::LoadFile((test_data_path + "monsterdata_test.json").c_str(), false, &jsonfile);
+  TEST_EQ(ok, true);
   auto include_test_path = flatbuffers::ConCatPathFileName(test_data_path, "include_test");
   const char *include_directories[] = { test_data_path.c_str(), include_test_path.c_str(), nullptr };
   flatbuffers::IDLOptions opt;
   opt.indent_step = -1;
   flatbuffers::Parser parser(opt);
   ok = parser.Parse(schemafile.c_str(), include_directories) &&
-  parser.Parse(jsonfile.c_str(), include_directories);
+       parser.Parse(jsonfile.c_str(), include_directories);
+  TEST_EQ(ok, true);
   // Test root table
   const Monster* monster = GetMonster(parser.builder_.GetBufferPointer());
   std::string jsongen;

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1681,6 +1681,43 @@ void InvalidFloatTest() {
   TestError("table T { F:float; } root_type T; { F:null }", invalid_msg);
 }
 
+void GenerateTableTextTest() {
+  std::string schemafile;
+  std::string jsonfile;
+  bool ok = flatbuffers::LoadFile((test_data_path + "monster_test.fbs").c_str(),
+                                  false, &schemafile) &&
+            flatbuffers::LoadFile((test_data_path + "monsterdata_test.json").c_str(),
+                                  false, &jsonfile);
+  auto include_test_path = flatbuffers::ConCatPathFileName(test_data_path, "include_test");
+  const char *include_directories[] = { test_data_path.c_str(), include_test_path.c_str(), nullptr };
+  flatbuffers::IDLOptions opt;
+  opt.indent_step = -1;
+  flatbuffers::Parser parser(opt);
+  ok = parser.Parse(schemafile.c_str(), include_directories) &&
+  parser.Parse(jsonfile.c_str(), include_directories);
+  // Test root table
+  const Monster* monster = GetMonster(parser.builder_.GetBufferPointer());
+  std::string jsongen;
+  auto result = GenerateTextFromTable(parser, monster, "MyGame.Example.Monster", &jsongen);
+  TEST_EQ(result, true);
+  // Test sub table
+  const Vec3* pos = monster->pos();
+  jsongen.clear();
+  result = GenerateTextFromTable(parser, pos, "MyGame.Example.Vec3", &jsongen);
+  TEST_EQ(result, true);
+  TEST_EQ_STR(jsongen.c_str(),"{x: 1.0,y: 2.0,z: 3.0,test1: 3.0,test2: \"Green\",test3: {a: 5,b: 6}}");
+  const Test& test3 = pos->test3();
+  jsongen.clear();
+  result = GenerateTextFromTable(parser, &test3, "MyGame.Example.Test", &jsongen);
+  TEST_EQ(result, true);
+  TEST_EQ_STR(jsongen.c_str(),"{a: 5,b: 6}");
+  const Test* test4 = monster->test4()->Get(0);
+  jsongen.clear();
+  result = GenerateTextFromTable(parser, test4, "MyGame.Example.Test", &jsongen);
+  TEST_EQ(result, true);
+  TEST_EQ_STR(jsongen.c_str(),"{a: 10,b: 20}");
+}
+
 template<typename T>
 void NumericUtilsTestInteger(const char *lower, const char *upper) {
   T x;
@@ -2581,6 +2618,7 @@ int FlatBufferTests() {
   IsAsciiUtilsTest();
   ValidFloatTest();
   InvalidFloatTest();
+  GenerateTableTextTest();
   return 0;
 }
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1684,11 +1684,16 @@ void InvalidFloatTest() {
 void GenerateTableTextTest() {
   std::string schemafile;
   std::string jsonfile;
-  bool ok = flatbuffers::LoadFile((test_data_path + "monster_test.fbs").c_str(),false, &schemafile) &&
-            flatbuffers::LoadFile((test_data_path + "monsterdata_test.json").c_str(), false, &jsonfile);
+  bool ok =
+      flatbuffers::LoadFile((test_data_path + "monster_test.fbs").c_str(),
+                            false, &schemafile) &&
+      flatbuffers::LoadFile((test_data_path + "monsterdata_test.json").c_str(),
+                            false, &jsonfile);
   TEST_EQ(ok, true);
-  auto include_test_path = flatbuffers::ConCatPathFileName(test_data_path, "include_test");
-  const char *include_directories[] = { test_data_path.c_str(), include_test_path.c_str(), nullptr };
+  auto include_test_path =
+      flatbuffers::ConCatPathFileName(test_data_path, "include_test");
+  const char *include_directories[] = {test_data_path.c_str(),
+                                       include_test_path.c_str(), nullptr};
   flatbuffers::IDLOptions opt;
   opt.indent_step = -1;
   flatbuffers::Parser parser(opt);
@@ -1696,26 +1701,31 @@ void GenerateTableTextTest() {
        parser.Parse(jsonfile.c_str(), include_directories);
   TEST_EQ(ok, true);
   // Test root table
-  const Monster* monster = GetMonster(parser.builder_.GetBufferPointer());
+  const Monster *monster = GetMonster(parser.builder_.GetBufferPointer());
   std::string jsongen;
-  auto result = GenerateTextFromTable(parser, monster, "MyGame.Example.Monster", &jsongen);
+  auto result = GenerateTextFromTable(parser, monster, "MyGame.Example.Monster",
+                                      &jsongen);
   TEST_EQ(result, true);
   // Test sub table
-  const Vec3* pos = monster->pos();
+  const Vec3 *pos = monster->pos();
   jsongen.clear();
   result = GenerateTextFromTable(parser, pos, "MyGame.Example.Vec3", &jsongen);
   TEST_EQ(result, true);
-  TEST_EQ_STR(jsongen.c_str(),"{x: 1.0,y: 2.0,z: 3.0,test1: 3.0,test2: \"Green\",test3: {a: 5,b: 6}}");
-  const Test& test3 = pos->test3();
+  TEST_EQ_STR(
+      jsongen.c_str(),
+      "{x: 1.0,y: 2.0,z: 3.0,test1: 3.0,test2: \"Green\",test3: {a: 5,b: 6}}");
+  const Test &test3 = pos->test3();
   jsongen.clear();
-  result = GenerateTextFromTable(parser, &test3, "MyGame.Example.Test", &jsongen);
+  result =
+      GenerateTextFromTable(parser, &test3, "MyGame.Example.Test", &jsongen);
   TEST_EQ(result, true);
-  TEST_EQ_STR(jsongen.c_str(),"{a: 5,b: 6}");
-  const Test* test4 = monster->test4()->Get(0);
+  TEST_EQ_STR(jsongen.c_str(), "{a: 5,b: 6}");
+  const Test *test4 = monster->test4()->Get(0);
   jsongen.clear();
-  result = GenerateTextFromTable(parser, test4, "MyGame.Example.Test", &jsongen);
+  result =
+      GenerateTextFromTable(parser, test4, "MyGame.Example.Test", &jsongen);
   TEST_EQ(result, true);
-  TEST_EQ_STR(jsongen.c_str(),"{a: 10,b: 20}");
+  TEST_EQ_STR(jsongen.c_str(), "{a: 10,b: 20}");
 }
 
 template<typename T>


### PR DESCRIPTION
Add method GenerateTextFromTable in order to create a json of a subtable issue #5249

Signed-off-by: Anthony Liot <anthony.liot@gmail.com>

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!