### PR TITLE
Add files generated by CMake to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@
 **/install_manifest.txt
 **/CMakeCache.txt
 **/CMakeTestfile.cmake
+**/CPackConfig.cmake
+**/CPackSourceConfig.cmake
+**/compile_commands.json
 **/Debug/**
 **/Release/**
 **/RelWithDebInfo/**


### PR DESCRIPTION
After executing `cmake .` under the flatbuffers root directory, my CMake generates 3 additional files in the same directory:

```
CPackConfig.cmake
CPackSourceConfig.cmake
compile_commands.json
```

I am not sure what they are, but I am pretty sure they can be ignored.

My CMake version is:

```
cmake version 3.13.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```