### PR TITLE
Enable MSVC assert report box [Abort|Retry|Ignore] if a debugger is p…

### DIFF
--- a/tests/test_assert.cpp
+++ b/tests/test_assert.cpp
@@ -4,6 +4,7 @@
 
 #ifdef _MSC_VER
 #  include <crtdbg.h>
+#  include <windows.h>
 #endif
 
 int testing_fails = 0;
@@ -43,15 +44,19 @@ void InitTestEngine(TestFailEventListener listener) {
   // clang-format off
 
   #ifdef _MSC_VER
-    // Send all reports to STDOUT.
+    // By default, send all reports to STDOUT to prevent CI hangs.
+    // Enable assert report box [Abort|Retry|Ignore] if a debugger is present.
+    const int dbg_mode = (_CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG) |
+                         (IsDebuggerPresent() ? _CRTDBG_MODE_WNDW : 0);
+    (void)dbg_mode; // release mode fix
     // CrtDebug reports to _CRT_WARN channel.
-    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportMode(_CRT_WARN, dbg_mode);
     _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDOUT);
     // The assert from <assert.h> reports to _CRT_ERROR channel
-    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportMode(_CRT_ERROR, dbg_mode);
     _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDOUT);
     // Internal CRT assert channel?
-    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportMode(_CRT_ASSERT, dbg_mode);
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDOUT);
   #endif
 


### PR DESCRIPTION
MSVC only.
Proposed message box was disabled by #4952 to prevent Appveyor hangs until timeout expired (1 hour)
This PR enables the `[Abort|Retry|Ignore]` report message box if `fltatests` target runs under a debugger.