### PR TITLE
Print warnings from flatc to stdout

### DIFF
--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -30,8 +30,10 @@ void FlatCompiler::ParseFile(
   include_directories.push_back(local_include_directory.c_str());
   include_directories.push_back(nullptr);
   if (!parser.Parse(contents.c_str(), &include_directories[0],
-                    filename.c_str()))
+                    filename.c_str())) {
     Error(parser.error_, false, false);
+  }
+  if (!parser.error_.empty()) { Warn(parser.error_, false); }
   include_directories.pop_back();
   include_directories.pop_back();
 }

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -99,8 +99,10 @@ void DeserializeDoc( std::vector<std::string> &doc,
 }
 
 void Parser::Message(const std::string &msg) {
-  error_ = file_being_parsed_.length() ? AbsolutePath(file_being_parsed_) : "";
+  if (!error_.empty()) error_ += "\n";  // log all warnings and errors
+  error_ += file_being_parsed_.length() ? AbsolutePath(file_being_parsed_) : "";
   // clang-format off
+
   #ifdef _WIN32  // MSVC alike
     error_ +=
         "(" + NumToString(line_) + ", " + NumToString(CursorPosition()) + ")";


### PR DESCRIPTION
Adds warnings output from the flatc parser to the stdout stream.
Adds warnings accumulation to `Parser.error_` string.