### PR TITLE
Add Linux Snap Packaging

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ summary: FlatBuffers compiler
 description: |
   FlatBuffers compiler
 
-grade: stable
+grade: devel
 confinement: strict
 
 parts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: flatc
+base: core18
+version: git
+summary: FlatBuffers compiler
+description: |
+  FlatBuffers compiler
+
+grade: stable
+confinement: strict
+
+parts:
+  flatc:
+    plugin: cmake
+    source: .
+    configflags:
+      - -GUnix Makefiles
+      - -DCMAKE_BUILD_TYPE=Release
+    build-packages:
+      - g++
+
+apps:
+  flatc:
+    command: flatc
+    plugs:
+      - home

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,11 +1,21 @@
 name: flatc
 base: core18
-version: git
+version: latest
+version-script: git describe --always | sed -e 's/-/+git/;y/-/./' | tail -c +2
 summary: FlatBuffers compiler
 description: |
   FlatBuffers compiler
 
-grade: devel
+  NOTE: This snap also ships the necessary header files required to compile
+  projects using flatbuffers, however, for the compilation to work, you have
+  to manually add the following path in your project's configuration:
+
+  /snap/flatc/current/include
+
+  If you need to use flatbuffers headers from a location other than the above
+  path, it is recommended to not use this snap as that could cause a mismatch.
+
+grade: stable
 confinement: strict
 
 parts:
@@ -17,6 +27,8 @@ parts:
       - -DCMAKE_BUILD_TYPE=Release
     build-packages:
       - g++
+      # used to set version number
+      - git
 
 apps:
   flatc:


### PR DESCRIPTION
Adds snap packaging for `flatc`. Once merged and published to snap store it will make installation of flatc on Linux based distros just one command away.