### PR TITLE
docs: Fix where to find the Typescript typings

### DIFF
--- a/docs/source/TypeScriptUsage.md
+++ b/docs/source/TypeScriptUsage.md
@@ -17,7 +17,7 @@ documentation to build `flatc` and should be familiar with
 ## FlatBuffers TypeScript library code location
 
 The code for the FlatBuffers TypeScript library can be found at
-`flatbuffers/js` with typings available at @types/flatubffers.
+`flatbuffers/js` with typings available at `@types/flatbuffers`.
 
 ## Testing the FlatBuffers TypeScript library
 


### PR DESCRIPTION
This is what currently rendered:

  /flatubffers

in https://google.github.io/flatbuffers/flatbuffers_guide_use_typescript.html

Besides the typo, @types is being swallowed, the hope is that puting it between
backticks will improve the situation.
