### PR TITLE
[Javascript] Remove newly introduced trailing whitespace in flatbuffer.js

### DIFF
--- a/js/flatbuffers.js
+++ b/js/flatbuffers.js
@@ -842,7 +842,7 @@ flatbuffers.ByteBuffer.allocate = function(byte_size) {
   return new flatbuffers.ByteBuffer(new Uint8Array(byte_size));
 };
 
-flatbuffers.ByteBuffer.prototype.clear = function() {  
+flatbuffers.ByteBuffer.prototype.clear = function() {
   this.position_ = 0;
 };
 

--- a/js/flatbuffers.js
+++ b/js/flatbuffers.js
@@ -829,7 +829,6 @@ flatbuffers.ByteBuffer = function(bytes) {
    * @private
    */
   this.position_ = 0;
-
 };
 
 /**


### PR DESCRIPTION
The newly introduced clear function has some trailing white space in an
otherwise whitespace clean file. Remove it.