### PR TITLE
Use integer as vtable hash key instead of layout tuple

### DIFF
--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -254,7 +254,10 @@ class Builder(object):
 
             # Finally, store this vtable in memory for future
             # deduplication:
-            self.vtables.setdefault(vtKeyHash, []).append(self.Offset())
+            vtables = self.vtables.get(vtKeyHash)
+            if vtables is None:
+                vtables = self.vtables[vtKeyHash] = []
+            vtables.append(objectOffset + vBytes)
         else:
             # Found a duplicate vtable.
             objectStart = SOffsetTFlags.py_type(len(self.Bytes) - objectOffset)


### PR DESCRIPTION
This reduces memory usage at the cost of having to subsequently check for equality.

See https://github.com/google/flatbuffers/pull/5314 for further reference.