### PR TITLE
Fix out-of-range error (MSVC2010) in idl_gen_dart.cpp

### DIFF
--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -120,7 +120,7 @@ class DartGenerator : public BaseGenerator {
               std::ostream_iterator<std::string>(sstream, "."));
 
     auto ret = sstream.str() + ns.components.back();
-    for (int i = 0; ret[i]; i++) {
+    for (size_t i = 0; i < ret.size(); i++) {
       auto lower = tolower(ret[i]);
       if (lower != ret[i]) {
         ret[i] = static_cast<char>(lower);


### PR DESCRIPTION
MSVC2010 doesn't support indexed access to \0-terminator.