### PR TITLE
Set default CRTReportMode for the `flatc` target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -96,6 +96,7 @@ cc_binary(
         "src/idl_gen_python.cpp",
         "src/idl_gen_rust.cpp",
         "src/idl_gen_text.cpp",
+        "src/util.cpp",
     ],
     includes = [
         "grpc/",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,8 @@ set(FlatBuffers_Sample_BFBS_SRCS
 set(FlatBuffers_GRPCTest_SRCS
   include/flatbuffers/flatbuffers.h
   include/flatbuffers/grpc.h
+  include/util.h
+  src/util.cpp
   tests/monster_test.grpc.fb.h
   tests/test_assert.h
   tests/test_builder.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ set(FlatBuffers_Sample_BFBS_SRCS
 set(FlatBuffers_GRPCTest_SRCS
   include/flatbuffers/flatbuffers.h
   include/flatbuffers/grpc.h
-  include/util.h
+  include/flatbuffers/util.h
   src/util.cpp
   tests/monster_test.grpc.fb.h
   tests/test_assert.h

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -649,6 +649,9 @@ bool SetGlobalTestLocale(const char *locale_name,
 bool ReadEnvironmentVariable(const char *var_name,
                              std::string *_value = nullptr);
 
+// MSVC specific: Send all assert reports to STDOUT to prevent CI hangs.
+void SetupDefaultCRTReportMode();
+
 }  // namespace flatbuffers
 
 #endif  // FLATBUFFERS_UTIL_H_

--- a/src/flatc_main.cpp
+++ b/src/flatc_main.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "flatbuffers/flatc.h"
+#include "flatbuffers/util.h"
 
 static const char *g_program_name = nullptr;
 
@@ -34,6 +35,9 @@ static void Error(const flatbuffers::FlatCompiler *flatc,
 }
 
 int main(int argc, const char *argv[]) {
+  // Prevent Appveyor-CI hangs.
+  flatbuffers::SetupDefaultCRTReportMode();
+
   g_program_name = argv[0];
 
   const flatbuffers::FlatCompiler::Generator generators[] = {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -23,6 +23,7 @@
 #  ifndef NOMINMAX
 #    define NOMINMAX
 #  endif
+#  include <crtdbg.h>
 #  include <windows.h>  // Must be included before <direct.h>
 #  include <direct.h>
 #  include <winbase.h>
@@ -235,6 +236,7 @@ bool SetGlobalTestLocale(const char *locale_name, std::string *_value) {
   if (_value) *_value = std::string(the_locale);
   return true;
 }
+
 bool ReadEnvironmentVariable(const char *var_name, std::string *_value) {
   #ifdef _MSC_VER
   __pragma(warning(disable : 4996)); // _CRT_SECURE_NO_WARNINGS
@@ -243,6 +245,29 @@ bool ReadEnvironmentVariable(const char *var_name, std::string *_value) {
   if (!env_str) return false;
   if (_value) *_value = std::string(env_str);
   return true;
+}
+
+void SetupDefaultCRTReportMode() {
+  // clang-format off
+
+  #ifdef _MSC_VER
+    // By default, send all reports to STDOUT to prevent CI hangs.
+    // Enable assert report box [Abort|Retry|Ignore] if a debugger is present.
+    const int dbg_mode = (_CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG) |
+                         (IsDebuggerPresent() ? _CRTDBG_MODE_WNDW : 0);
+    (void)dbg_mode; // release mode fix
+    // CrtDebug reports to _CRT_WARN channel.
+    _CrtSetReportMode(_CRT_WARN, dbg_mode);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDOUT);
+    // The assert from <assert.h> reports to _CRT_ERROR channel
+    _CrtSetReportMode(_CRT_ERROR, dbg_mode);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDOUT);
+    // Internal CRT assert channel?
+    _CrtSetReportMode(_CRT_ASSERT, dbg_mode);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDOUT);
+  #endif
+
+  // clang-format on
 }
 
 }  // namespace flatbuffers

--- a/tests/test_assert.cpp
+++ b/tests/test_assert.cpp
@@ -41,24 +41,9 @@ void InitTestEngine(TestFailEventListener listener) {
   setvbuf(stdout, NULL, _IONBF, 0);
   setvbuf(stderr, NULL, _IONBF, 0);
 
-  // clang-format off
+  flatbuffers::SetupDefaultCRTReportMode();
 
-  #ifdef _MSC_VER
-    // By default, send all reports to STDOUT to prevent CI hangs.
-    // Enable assert report box [Abort|Retry|Ignore] if a debugger is present.
-    const int dbg_mode = (_CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG) |
-                         (IsDebuggerPresent() ? _CRTDBG_MODE_WNDW : 0);
-    (void)dbg_mode; // release mode fix
-    // CrtDebug reports to _CRT_WARN channel.
-    _CrtSetReportMode(_CRT_WARN, dbg_mode);
-    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDOUT);
-    // The assert from <assert.h> reports to _CRT_ERROR channel
-    _CrtSetReportMode(_CRT_ERROR, dbg_mode);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDOUT);
-    // Internal CRT assert channel?
-    _CrtSetReportMode(_CRT_ASSERT, dbg_mode);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDOUT);
-  #endif
+  // clang-format off
 
   #if defined(FLATBUFFERS_MEMORY_LEAK_TRACKING_MSVC)
     // For more thorough checking:


### PR DESCRIPTION
Issue: an assertion in the `flatc` halts Appveyor-CI until timeout expired (1 hour).