### PR TITLE
[Go] Generate imports with fixed order

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -233,7 +233,7 @@ struct Namespace {
 
 inline bool operator<(const Namespace &a, const Namespace &b) {
   size_t min_size = std::min(a.components.size(), b.components.size());
-  for (int i = 0; i < min_size; ++i) {
+  for (size_t i = 0; i < min_size; ++i) {
     if (a.components[i] != b.components[i])
       return a.components[i] < b.components[i];
   }

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -231,6 +231,15 @@ struct Namespace {
   size_t from_table;  // Part of the namespace corresponds to a message/table.
 };
 
+inline bool operator<(const Namespace &a, const Namespace &b) {
+  size_t min_size = std::min(a.components.size(), b.components.size());
+  for (int i = 0; i < min_size; ++i) {
+    if (a.components[i] != b.components[i])
+      return a.components[i] < b.components[i];
+  }
+  return a.components.size() < b.components.size();
+}
+
 // Base class for all definition types (fields, structs_, enums_).
 struct Definition {
   Definition()

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -113,7 +113,13 @@ class GoGenerator : public BaseGenerator {
  private:
   Namespace go_namespace_;
   Namespace *cur_name_space_;
-  std::set<const Namespace*> tracked_imported_namespaces_;
+
+  struct NamespacePtrLess {
+    bool operator()(const Namespace *a, const Namespace *b) const {
+      return *a < *b;
+    }
+  };
+  std::set<const Namespace *, NamespacePtrLess> tracked_imported_namespaces_;
 
   // Most field accessors need to retrieve and test the field offset first,
   // this is the prefix code for that.


### PR DESCRIPTION
A counterexample can be found at https://travis-ci.org/google/flatbuffers/jobs/531091896 :

```
diff --git a/tests/MyGame/Example/Monster.go b/tests/MyGame/Example/Monster.go
index f37c103..078249a 100644
--- a/tests/MyGame/Example/Monster.go
+++ b/tests/MyGame/Example/Monster.go
@@ -5,8 +5,8 @@ package Example
 import (
 	flatbuffers "github.com/google/flatbuffers/go"
 
-	MyGame "MyGame"
 	MyGame__Example2 "MyGame/Example2"
+	MyGame "MyGame"
 )
```