### PR TITLE
Added a CPP UnPackSizePrefixed<struct_name> generated helper function

### DIFF
--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -865,6 +865,12 @@ inline flatbuffers::unique_ptr<MonsterT> UnPackMonster(
   return flatbuffers::unique_ptr<MonsterT>(GetMonster(buf)->UnPack(res));
 }
 
+inline flatbuffers::unique_ptr<MonsterT> UnPackSizePrefixedMonster(
+    const void *buf,
+    const flatbuffers::resolver_function_t *res = nullptr) {
+  return flatbuffers::unique_ptr<MonsterT>(GetSizePrefixedMonster(buf)->UnPack(res));
+}
+
 }  // namespace Sample
 }  // namespace MyGame
 

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -474,6 +474,14 @@ class CppGenerator : public BaseGenerator {
         code_ += "(Get{{STRUCT_NAME}}(buf)->UnPack(res));";
         code_ += "}";
         code_ += "";
+
+        code_ += "inline {{UNPACK_RETURN}} UnPackSizePrefixed{{STRUCT_NAME}}(";
+        code_ += "    const void *buf,";
+        code_ += "    const flatbuffers::resolver_function_t *res = nullptr) {";
+        code_ += "  return {{UNPACK_TYPE}}\\";
+        code_ += "(GetSizePrefixed{{STRUCT_NAME}}(buf)->UnPack(res));";
+        code_ += "}";
+        code_ += "";
       }
     }
 

--- a/tests/monster_extra_generated.h
+++ b/tests/monster_extra_generated.h
@@ -349,6 +349,12 @@ inline std::unique_ptr<MonsterExtraT> UnPackMonsterExtra(
   return std::unique_ptr<MonsterExtraT>(GetMonsterExtra(buf)->UnPack(res));
 }
 
+inline std::unique_ptr<MonsterExtraT> UnPackSizePrefixedMonsterExtra(
+    const void *buf,
+    const flatbuffers::resolver_function_t *res = nullptr) {
+  return std::unique_ptr<MonsterExtraT>(GetSizePrefixedMonsterExtra(buf)->UnPack(res));
+}
+
 }  // namespace MyGame
 
 #endif  // FLATBUFFERS_GENERATED_MONSTEREXTRA_MYGAME_H_

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -3483,6 +3483,12 @@ inline flatbuffers::unique_ptr<MonsterT> UnPackMonster(
   return flatbuffers::unique_ptr<MonsterT>(GetMonster(buf)->UnPack(res));
 }
 
+inline flatbuffers::unique_ptr<MonsterT> UnPackSizePrefixedMonster(
+    const void *buf,
+    const flatbuffers::resolver_function_t *res = nullptr) {
+  return flatbuffers::unique_ptr<MonsterT>(GetSizePrefixedMonster(buf)->UnPack(res));
+}
+
 }  // namespace Example
 }  // namespace MyGame
 

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -850,4 +850,10 @@ inline flatbuffers::unique_ptr<MovieT> UnPackMovie(
   return flatbuffers::unique_ptr<MovieT>(GetMovie(buf)->UnPack(res));
 }
 
+inline flatbuffers::unique_ptr<MovieT> UnPackSizePrefixedMovie(
+    const void *buf,
+    const flatbuffers::resolver_function_t *res = nullptr) {
+  return flatbuffers::unique_ptr<MovieT>(GetSizePrefixedMovie(buf)->UnPack(res));
+}
+
 #endif  // FLATBUFFERS_GENERATED_UNIONVECTOR_H_


### PR DESCRIPTION
Missing helper function added to the cpp API generator for unpacking size prefixed structures
Added generated test files