### PR TITLE
[Go] bazel default target for gazelle

### DIFF
--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -1,5 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+alias(
+    name = "go_default_library",
+    actual = ":go",
+)
+
 go_library(
     name = "go",
     srcs = [


### PR DESCRIPTION
Automatic build file generation for Go using Gazelle assumes the presence of a default target with the name `:go_default_library` (see [documentation](https://github.com/bazelbuild/bazel-gazelle#dependency-resolution)).

An alias with this name referencing the actual target helps Gazelle, without the need for user side patches to the BUILD file.