### PR TITLE
Allow enums (and unions) to be used before declaration.

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2594,8 +2594,8 @@ CheckedError Parser::ParseRoot(const char *source, const char **include_paths,
   for (auto it = structs_.vec.begin(); it != structs_.vec.end();) {
     auto &struct_def = **it;
     if (struct_def.predecl) {
-      if (opts.proto_mode) {
-        // Protos allow enums to be used before declaration, so check if that
+      
+        // Allow enums to be used before declaration, so check if that
         // is the case here.
         EnumDef *enum_def = nullptr;
         for (size_t components =
@@ -2638,7 +2638,6 @@ CheckedError Parser::ParseRoot(const char *source, const char **include_paths,
           delete &struct_def;
           continue;  // Skip error.
         }
-      }
       auto err = "type referenced but not defined (check namespace): " +
                  struct_def.name;
       if (struct_def.original_location)


### PR DESCRIPTION

flatc failed to compile a standalone enum/union fbs file, which then includes a fbs file containing a table which includes that enum/union. In that case, it complains about 'type referenced, but not defined'. Checking the code, this exception was handled for proto files but not for the normal fbs case. This PR removes the exception for proto, and it solves the error described above.
