### PR TITLE
C++: Change usage of std::string's .at() to more widely-compatible [].

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1327,7 +1327,7 @@ CheckedError Parser::TryTypedValue(const std::string *name, int dtoken,
       const auto &s = e.constant;
       const auto k = s.find_first_of("0123456789.");
       if ((std::string::npos != k) && (s.length() > (k + 1)) &&
-          (s.at(k) == '0' && is_alpha_char(s.at(k + 1), 'X')) &&
+          (s[k] == '0' && is_alpha_char(s[k + 1], 'X')) &&
           (std::string::npos == s.find_first_of("pP", k + 2))) {
         return Error(
             "invalid number, the exponent suffix of hexadecimal "


### PR DESCRIPTION
Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
