### PR TITLE
Generate FlagsAttribute for C#

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -510,6 +510,11 @@ class GeneralGenerator : public BaseGenerator {
     std::string &code = *code_ptr;
     if (enum_def.generated) return;
 
+    // In C# this indicates enumeration values can be treated as bit flags.
+    if (lang_.language == IDLOptions::kCSharp && enum_def.attributes.Lookup("bit_flags")) {
+        code += "[System.FlagsAttribute]\n";
+    }
+
     // Generate enum definitions of the form:
     // public static (final) int name = value;
     // In Java, we use ints rather than the Enum feature, because we want them

--- a/tests/MyGame/Example/Color.cs
+++ b/tests/MyGame/Example/Color.cs
@@ -5,6 +5,7 @@
 namespace MyGame.Example
 {
 
+[System.FlagsAttribute]
 public enum Color : byte
 {
  Red = 1,


### PR DESCRIPTION
For schema enums with the bit_flags attribute, generate the
corresponding System.FlagsAttribute in generated C# code.
