### PR TITLE
[C++] Dereference of null pointer #5353

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -1445,6 +1445,7 @@ class GeneralGenerator : public BaseGenerator {
     // Only generate key compare function for table,
     // because `key_field` is not set for struct
     if (struct_def.has_key && !struct_def.fixed) {
+      FLATBUFFERS_ASSERT(key_field);
       if (lang_.language == IDLOptions::kJava) {
         code += "\n  @Override\n  protected int keysCompare(";
         code += "Integer o1, Integer o2, ByteBuffer _bb) {";


### PR DESCRIPTION
add an assert to make sure that `key_field` is not a null pointer.

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
