### PR TITLE
[rust] Add rusfmt check to CI

### DIFF
--- a/tests/RustTest.sh
+++ b/tests/RustTest.sh
@@ -21,7 +21,13 @@ if [[ "$1" == "mips-unknown-linux-gnu" ]]; then
     export CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="qemu-mips -L /usr/mips-linux-gnu"
 fi
 
-cd ./rust_usage_test
+# Add rustup to tool chain.
+rustup component add rustfmt
+
+# Run lint checks
+rustfmt ../rust/flatbuffers/src/lib.rs --check
+cd ../tests/rust_usage_test
+
 cargo test $TARGET_FLAG -- --quiet
 TEST_RESULT=$?
 if [[ $TEST_RESULT  == 0 ]]; then

--- a/tests/docker/languages/Dockerfile.testing.rust.1_35_0
+++ b/tests/docker/languages/Dockerfile.testing.rust.1_35_0
@@ -1,4 +1,4 @@
-FROM rust:1.30.1-slim-stretch as base
+FROM rust:1.35.0-slim-stretch as base
 WORKDIR /code
 ADD . .
 RUN cp flatc_debian_stretch flatc

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_35_0
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_35_0
@@ -1,4 +1,4 @@
-FROM rust:1.30.1-slim-stretch as base
+FROM rust:1.35.0-slim-stretch as base
 RUN apt -qq update -y && apt -qq install -y \
     gcc-mips-linux-gnu \
     libexpat1 \


### PR DESCRIPTION
This adds a `rustfmt` against `rust/flatbuffers`. However this does not check the `tests/rust_usage_test` crate since I can't find a way to exclude the generated code.

Since the rust 1.30.1 toolchain does not support rustfmt, the dockerfile version was bumped.