### PR TITLE
[Docs] Remove out-dated -S option from flatc syntax

### DIFF
--- a/docs/source/Compiler.md
+++ b/docs/source/Compiler.md
@@ -3,7 +3,7 @@ Using the schema compiler    {#flatbuffers_guide_using_schema_compiler}
 
 Usage:
 
-    flatc [ GENERATOR OPTIONS ] [ -o PATH ] [ -I PATH ] [ -S ] FILES...
+    flatc [ GENERATOR OPTIONS ] [ -o PATH ] [ -I PATH ] FILES...
           [ -- FILES...]
 
 The files are read and parsed in order, and can contain either schemas


### PR DESCRIPTION
Looks like it's an older syntax for --strict-json which was long-ago removed in https://github.com/google/flatbuffers/commit/d38b9af243d8dcfc53ab69c79e0ce404759240d4