### PR TITLE
Excluded crtdbg.h from non-MSVC compilation

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -23,7 +23,9 @@
 #  ifndef NOMINMAX
 #    define NOMINMAX
 #  endif
-#  include <crtdbg.h>
+#  ifdef _MSC_VER
+#    include <crtdbg.h>
+#  endif
 #  include <windows.h>  // Must be included before <direct.h>
 #  include <direct.h>
 #  include <winbase.h>


### PR DESCRIPTION
This PR fixes MinGW 32 bit compilation on Windows.

`crtdbg.h` is not available with the MinGW 32-bit compiler, so I have wrapped the `include` statement with a check for `_MSC_VER` to restrict its usage to Visual C++ compiler. This exact fix has already been implemented in `test_assert.cpp`.

https://github.com/google/flatbuffers/blob/4eb3efc221d66ef02928d1b1860e097ab2e4ce16/tests/test_assert.cpp#L5-L8

Also, the methods used from `crtdbg.h` are already surrounded by a similar check:

https://github.com/google/flatbuffers/blob/4eb3efc221d66ef02928d1b1860e097ab2e4ce16/src/util.cpp#L253-L268

Because of this, I do not believe this change will cause any side effects.

I have tested this on Visual C++ 2019 compiler and MinGW 32-bit GCC compiler on Windows 10 64-bit.
