### PR TITLE
[Go] Fix namespaces on enums

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -143,7 +143,7 @@ class GoGenerator : public BaseGenerator {
 
   // Construct the name of the type for this enum.
   std::string GetEnumTypeName(const EnumDef &enum_def) {
-    return WrapInNameSpaceAndTrack(cur_name_space_, GoIdentity(enum_def.name));
+    return WrapInNameSpaceAndTrack(enum_def.defined_namespace, GoIdentity(enum_def.name));
   }
 
   // Create a type for the enum values.

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.go
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.go
@@ -41,15 +41,15 @@ func (rcv *TableInFirstNS) FooTable(obj *NamespaceA__NamespaceB.TableInNestedNS)
 	return nil
 }
 
-func (rcv *TableInFirstNS) FooEnum() EnumInNestedNS {
+func (rcv *TableInFirstNS) FooEnum() NamespaceA__NamespaceB.EnumInNestedNS {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
-		return EnumInNestedNS(rcv._tab.GetInt8(o + rcv._tab.Pos))
+		return NamespaceA__NamespaceB.EnumInNestedNS(rcv._tab.GetInt8(o + rcv._tab.Pos))
 	}
 	return 0
 }
 
-func (rcv *TableInFirstNS) MutateFooEnum(n EnumInNestedNS) bool {
+func (rcv *TableInFirstNS) MutateFooEnum(n NamespaceA__NamespaceB.EnumInNestedNS) bool {
 	return rcv._tab.MutateInt8Slot(6, int8(n))
 }
 
@@ -72,7 +72,7 @@ func TableInFirstNSStart(builder *flatbuffers.Builder) {
 func TableInFirstNSAddFooTable(builder *flatbuffers.Builder, fooTable flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(fooTable), 0)
 }
-func TableInFirstNSAddFooEnum(builder *flatbuffers.Builder, fooEnum EnumInNestedNS) {
+func TableInFirstNSAddFooEnum(builder *flatbuffers.Builder, fooEnum NamespaceA__NamespaceB.EnumInNestedNS) {
 	builder.PrependInt8Slot(1, int8(fooEnum), 0)
 }
 func TableInFirstNSAddFooStruct(builder *flatbuffers.Builder, fooStruct flatbuffers.UOffsetT) {


### PR DESCRIPTION
Enums in Go weren't registering their namespaces, which then wouldn't be included in the `import()` block and wouldn't be referenced in the generated code.

Here's a schema that demonstrates the issue:

```
namespace Types;

enum TransitionType:byte {
	Fade = 0,
	Move = 1
}

namespace Data;

table SomeTransition {
	transition:Types.TransitionType;
	// other fields stripped out
}
```