### PR TITLE
[Python] Fix accessor generation for nested/neighbor namespaces

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,6 +71,7 @@ test_script:
   - "..\\%CONFIGURATION%\\flatc -b -I include_test monster_test.fbs unicode_test.json"
   - "node JavaScriptTest ./monster_test_generated"
   - rem "-------------- Python ---------------"
+  - set PYTHONPATH=namespace_test
   - where python
   - python --version
   - where pip

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -36,8 +36,7 @@ class PythonGenerator : public BaseGenerator {
  public:
   PythonGenerator(const Parser &parser, const std::string &path,
                   const std::string &file_name)
-      : BaseGenerator(parser, path, file_name, "" /* not used */,
-                      "" /* not used */),
+      : BaseGenerator(parser, path, file_name, "" /* not used */, "."),
         float_const_gen_("float('nan')", "float('inf')", "float('-inf')") {
     static const char * const keywords[] = {
       "False",
@@ -241,7 +240,8 @@ class PythonGenerator : public BaseGenerator {
       code += "x = self._tab.Indirect(o + self._tab.Pos)\n";
     }
     code += Indent + Indent + Indent;
-    code += "from ." + TypeName(field) + " import " + TypeName(field) + "\n";
+    code += "from " + WrapInNameSpace(*field.value.type.struct_def);
+    code += " import " + TypeName(field) + "\n";
     code += Indent + Indent + Indent + "obj = " + TypeName(field) + "()\n";
     code += Indent + Indent + Indent + "obj.Init(self._tab.Bytes, x)\n";
     code += Indent + Indent + Indent + "return obj\n";

--- a/tests/MyGame/Example/Monster.py
+++ b/tests/MyGame/Example/Monster.py
@@ -24,7 +24,7 @@ class Monster(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             x = o + self._tab.Pos
-            from .Vec3 import Vec3
+            from MyGame.Example.Vec3 import Vec3
             obj = Vec3()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -158,7 +158,7 @@ class Monster(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(28))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .Monster import Monster
+            from MyGame.Example.Monster import Monster
             obj = Monster()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -191,7 +191,7 @@ class Monster(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(32))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .Stat import Stat
+            from MyGame.Example.Stat import Stat
             obj = Stat()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -427,7 +427,7 @@ class Monster(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(72))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .InParentNamespace import InParentNamespace
+            from MyGame.InParentNamespace import InParentNamespace
             obj = InParentNamespace()
             obj.Init(self._tab.Bytes, x)
             return obj

--- a/tests/PythonTest.sh
+++ b/tests/PythonTest.sh
@@ -30,8 +30,8 @@ function run_tests() {
     echo "Testing with interpreter: ${1}"
     PYTHONDONTWRITEBYTECODE=1 \
     JYTHONDONTWRITEBYTECODE=1 \
-    PYTHONPATH=${runtime_library_dir}:${gen_code_path} \
-    JYTHONPATH=${runtime_library_dir}:${gen_code_path} \
+    PYTHONPATH=${runtime_library_dir}:${gen_code_path}:${gen_code_path}/namespace_test \
+    JYTHONPATH=${runtime_library_dir}:${gen_code_path}:${gen_code_path}/namespace_test \
     COMPARE_GENERATED_TO_GO=0 \
     COMPARE_GENERATED_TO_JAVA=0 \
     $1 py_test.py $2 $3 $4
@@ -63,7 +63,7 @@ if $(which coverage >/dev/null); then
   echo 'Found coverage utility, running coverage with default Python:'
 
   PYTHONDONTWRITEBYTECODE=1 \
-  PYTHONPATH=${runtime_library_dir}:${gen_code_path} \
+  PYTHONPATH=${runtime_library_dir}:${gen_code_path}:${gen_code_path}/namespace_test \
   coverage run --source=flatbuffers,MyGame py_test.py 0 0 0 > /dev/null
 
   echo

--- a/tests/namespace_test/NamespaceA/SecondTableInA.py
+++ b/tests/namespace_test/NamespaceA/SecondTableInA.py
@@ -23,7 +23,7 @@ class SecondTableInA(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .TableInC import TableInC
+            from NamespaceC.TableInC import TableInC
             obj = TableInC()
             obj.Init(self._tab.Bytes, x)
             return obj

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.cs
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.cs
@@ -17,15 +17,18 @@ public struct TableInFirstNS : IFlatbufferObject
   public void __init(int _i, ByteBuffer _bb) { __p.bb_pos = _i; __p.bb = _bb; }
   public TableInFirstNS __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public NamespaceA.NamespaceB.TableInNestedNS? FooTable { get { int o = __p.__offset(4); return o != 0 ? (NamespaceA.NamespaceB.TableInNestedNS?)(new NamespaceA.NamespaceB.TableInNestedNS()).__assign(__p.__indirect(o + __p.bb_pos), __p.bb) : null; } }
-  public NamespaceA.NamespaceB.EnumInNestedNS FooEnum { get { int o = __p.__offset(6); return o != 0 ? (NamespaceA.NamespaceB.EnumInNestedNS)__p.bb.GetSbyte(o + __p.bb_pos) : NamespaceA.NamespaceB.EnumInNestedNS.A; } }
-  public bool MutateFooEnum(NamespaceA.NamespaceB.EnumInNestedNS foo_enum) { int o = __p.__offset(6); if (o != 0) { __p.bb.PutSbyte(o + __p.bb_pos, (sbyte)foo_enum); return true; } else { return false; } }
-  public NamespaceA.NamespaceB.StructInNestedNS? FooStruct { get { int o = __p.__offset(8); return o != 0 ? (NamespaceA.NamespaceB.StructInNestedNS?)(new NamespaceA.NamespaceB.StructInNestedNS()).__assign(o + __p.bb_pos, __p.bb) : null; } }
+  public int X { get { int o = __p.__offset(4); return o != 0 ? __p.bb.GetInt(o + __p.bb_pos) : (int)0; } }
+  public bool MutateX(int x) { int o = __p.__offset(4); if (o != 0) { __p.bb.PutInt(o + __p.bb_pos, x); return true; } else { return false; } }
+  public NamespaceA.NamespaceB.TableInNestedNS? FooTable { get { int o = __p.__offset(6); return o != 0 ? (NamespaceA.NamespaceB.TableInNestedNS?)(new NamespaceA.NamespaceB.TableInNestedNS()).__assign(__p.__indirect(o + __p.bb_pos), __p.bb) : null; } }
+  public NamespaceA.NamespaceB.EnumInNestedNS FooEnum { get { int o = __p.__offset(8); return o != 0 ? (NamespaceA.NamespaceB.EnumInNestedNS)__p.bb.GetSbyte(o + __p.bb_pos) : NamespaceA.NamespaceB.EnumInNestedNS.A; } }
+  public bool MutateFooEnum(NamespaceA.NamespaceB.EnumInNestedNS foo_enum) { int o = __p.__offset(8); if (o != 0) { __p.bb.PutSbyte(o + __p.bb_pos, (sbyte)foo_enum); return true; } else { return false; } }
+  public NamespaceA.NamespaceB.StructInNestedNS? FooStruct { get { int o = __p.__offset(10); return o != 0 ? (NamespaceA.NamespaceB.StructInNestedNS?)(new NamespaceA.NamespaceB.StructInNestedNS()).__assign(o + __p.bb_pos, __p.bb) : null; } }
 
-  public static void StartTableInFirstNS(FlatBufferBuilder builder) { builder.StartTable(3); }
-  public static void AddFooTable(FlatBufferBuilder builder, Offset<NamespaceA.NamespaceB.TableInNestedNS> fooTableOffset) { builder.AddOffset(0, fooTableOffset.Value, 0); }
-  public static void AddFooEnum(FlatBufferBuilder builder, NamespaceA.NamespaceB.EnumInNestedNS fooEnum) { builder.AddSbyte(1, (sbyte)fooEnum, 0); }
-  public static void AddFooStruct(FlatBufferBuilder builder, Offset<NamespaceA.NamespaceB.StructInNestedNS> fooStructOffset) { builder.AddStruct(2, fooStructOffset.Value, 0); }
+  public static void StartTableInFirstNS(FlatBufferBuilder builder) { builder.StartTable(4); }
+  public static void AddX(FlatBufferBuilder builder, int x) { builder.AddInt(0, x, 0); }
+  public static void AddFooTable(FlatBufferBuilder builder, Offset<NamespaceA.NamespaceB.TableInNestedNS> fooTableOffset) { builder.AddOffset(1, fooTableOffset.Value, 0); }
+  public static void AddFooEnum(FlatBufferBuilder builder, NamespaceA.NamespaceB.EnumInNestedNS fooEnum) { builder.AddSbyte(2, (sbyte)fooEnum, 0); }
+  public static void AddFooStruct(FlatBufferBuilder builder, Offset<NamespaceA.NamespaceB.StructInNestedNS> fooStructOffset) { builder.AddStruct(3, fooStructOffset.Value, 0); }
   public static Offset<NamespaceA.TableInFirstNS> EndTableInFirstNS(FlatBufferBuilder builder) {
     int o = builder.EndTable();
     return new Offset<NamespaceA.TableInFirstNS>(o);

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.go
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.go
@@ -28,8 +28,20 @@ func (rcv *TableInFirstNS) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *TableInFirstNS) FooTable(obj *NamespaceA__NamespaceB.TableInNestedNS) *NamespaceA__NamespaceB.TableInNestedNS {
+func (rcv *TableInFirstNS) X() int32 {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
+	if o != 0 {
+		return rcv._tab.GetInt32(o + rcv._tab.Pos)
+	}
+	return 0
+}
+
+func (rcv *TableInFirstNS) MutateX(n int32) bool {
+	return rcv._tab.MutateInt32Slot(4, n)
+}
+
+func (rcv *TableInFirstNS) FooTable(obj *NamespaceA__NamespaceB.TableInNestedNS) *NamespaceA__NamespaceB.TableInNestedNS {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
 	if o != 0 {
 		x := rcv._tab.Indirect(o + rcv._tab.Pos)
 		if obj == nil {
@@ -42,7 +54,7 @@ func (rcv *TableInFirstNS) FooTable(obj *NamespaceA__NamespaceB.TableInNestedNS)
 }
 
 func (rcv *TableInFirstNS) FooEnum() NamespaceA__NamespaceB.EnumInNestedNS {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
 	if o != 0 {
 		return NamespaceA__NamespaceB.EnumInNestedNS(rcv._tab.GetInt8(o + rcv._tab.Pos))
 	}
@@ -50,11 +62,11 @@ func (rcv *TableInFirstNS) FooEnum() NamespaceA__NamespaceB.EnumInNestedNS {
 }
 
 func (rcv *TableInFirstNS) MutateFooEnum(n NamespaceA__NamespaceB.EnumInNestedNS) bool {
-	return rcv._tab.MutateInt8Slot(6, int8(n))
+	return rcv._tab.MutateInt8Slot(8, int8(n))
 }
 
 func (rcv *TableInFirstNS) FooStruct(obj *NamespaceA__NamespaceB.StructInNestedNS) *NamespaceA__NamespaceB.StructInNestedNS {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		x := o + rcv._tab.Pos
 		if obj == nil {
@@ -67,16 +79,19 @@ func (rcv *TableInFirstNS) FooStruct(obj *NamespaceA__NamespaceB.StructInNestedN
 }
 
 func TableInFirstNSStart(builder *flatbuffers.Builder) {
-	builder.StartObject(3)
+	builder.StartObject(4)
+}
+func TableInFirstNSAddX(builder *flatbuffers.Builder, x int32) {
+	builder.PrependInt32Slot(0, x, 0)
 }
 func TableInFirstNSAddFooTable(builder *flatbuffers.Builder, fooTable flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(fooTable), 0)
+	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(fooTable), 0)
 }
 func TableInFirstNSAddFooEnum(builder *flatbuffers.Builder, fooEnum NamespaceA__NamespaceB.EnumInNestedNS) {
-	builder.PrependInt8Slot(1, int8(fooEnum), 0)
+	builder.PrependInt8Slot(2, int8(fooEnum), 0)
 }
 func TableInFirstNSAddFooStruct(builder *flatbuffers.Builder, fooStruct flatbuffers.UOffsetT) {
-	builder.PrependStructSlot(2, flatbuffers.UOffsetT(fooStruct), 0)
+	builder.PrependStructSlot(3, flatbuffers.UOffsetT(fooStruct), 0)
 }
 func TableInFirstNSEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.java
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.java
@@ -14,17 +14,20 @@ public final class TableInFirstNS extends Table {
   public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; vtable_start = bb_pos - bb.getInt(bb_pos); vtable_size = bb.getShort(vtable_start); }
   public TableInFirstNS __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
+  public int x() { int o = __offset(4); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
+  public boolean mutateX(int x) { int o = __offset(4); if (o != 0) { bb.putInt(o + bb_pos, x); return true; } else { return false; } }
   public NamespaceA.NamespaceB.TableInNestedNS fooTable() { return fooTable(new NamespaceA.NamespaceB.TableInNestedNS()); }
-  public NamespaceA.NamespaceB.TableInNestedNS fooTable(NamespaceA.NamespaceB.TableInNestedNS obj) { int o = __offset(4); return o != 0 ? obj.__assign(__indirect(o + bb_pos), bb) : null; }
-  public byte fooEnum() { int o = __offset(6); return o != 0 ? bb.get(o + bb_pos) : 0; }
-  public boolean mutateFooEnum(byte foo_enum) { int o = __offset(6); if (o != 0) { bb.put(o + bb_pos, foo_enum); return true; } else { return false; } }
+  public NamespaceA.NamespaceB.TableInNestedNS fooTable(NamespaceA.NamespaceB.TableInNestedNS obj) { int o = __offset(6); return o != 0 ? obj.__assign(__indirect(o + bb_pos), bb) : null; }
+  public byte fooEnum() { int o = __offset(8); return o != 0 ? bb.get(o + bb_pos) : 0; }
+  public boolean mutateFooEnum(byte foo_enum) { int o = __offset(8); if (o != 0) { bb.put(o + bb_pos, foo_enum); return true; } else { return false; } }
   public NamespaceA.NamespaceB.StructInNestedNS fooStruct() { return fooStruct(new NamespaceA.NamespaceB.StructInNestedNS()); }
-  public NamespaceA.NamespaceB.StructInNestedNS fooStruct(NamespaceA.NamespaceB.StructInNestedNS obj) { int o = __offset(8); return o != 0 ? obj.__assign(o + bb_pos, bb) : null; }
+  public NamespaceA.NamespaceB.StructInNestedNS fooStruct(NamespaceA.NamespaceB.StructInNestedNS obj) { int o = __offset(10); return o != 0 ? obj.__assign(o + bb_pos, bb) : null; }
 
-  public static void startTableInFirstNS(FlatBufferBuilder builder) { builder.startTable(3); }
-  public static void addFooTable(FlatBufferBuilder builder, int fooTableOffset) { builder.addOffset(0, fooTableOffset, 0); }
-  public static void addFooEnum(FlatBufferBuilder builder, byte fooEnum) { builder.addByte(1, fooEnum, 0); }
-  public static void addFooStruct(FlatBufferBuilder builder, int fooStructOffset) { builder.addStruct(2, fooStructOffset, 0); }
+  public static void startTableInFirstNS(FlatBufferBuilder builder) { builder.startTable(4); }
+  public static void addX(FlatBufferBuilder builder, int x) { builder.addInt(0, x, 0); }
+  public static void addFooTable(FlatBufferBuilder builder, int fooTableOffset) { builder.addOffset(1, fooTableOffset, 0); }
+  public static void addFooEnum(FlatBufferBuilder builder, byte fooEnum) { builder.addByte(2, fooEnum, 0); }
+  public static void addFooStruct(FlatBufferBuilder builder, int fooStructOffset) { builder.addStruct(3, fooStructOffset, 0); }
   public static int endTableInFirstNS(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.lua
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.lua
@@ -21,8 +21,15 @@ end
 function TableInFirstNS_mt:Init(buf, pos)
     self.view = flatbuffers.view.New(buf, pos)
 end
-function TableInFirstNS_mt:FooTable()
+function TableInFirstNS_mt:X()
     local o = self.view:Offset(4)
+    if o ~= 0 then
+        return self.view:Get(flatbuffers.N.Int32, o + self.view.pos)
+    end
+    return 0
+end
+function TableInFirstNS_mt:FooTable()
+    local o = self.view:Offset(6)
     if o ~= 0 then
         local x = self.view:Indirect(o + self.view.pos)
         local obj = require('NamespaceA.NamespaceB.TableInNestedNS').New()
@@ -31,14 +38,14 @@ function TableInFirstNS_mt:FooTable()
     end
 end
 function TableInFirstNS_mt:FooEnum()
-    local o = self.view:Offset(6)
+    local o = self.view:Offset(8)
     if o ~= 0 then
         return self.view:Get(flatbuffers.N.Int8, o + self.view.pos)
     end
     return 0
 end
 function TableInFirstNS_mt:FooStruct()
-    local o = self.view:Offset(8)
+    local o = self.view:Offset(10)
     if o ~= 0 then
         local x = o + self.view.pos
         local obj = require('NamespaceA.NamespaceB.StructInNestedNS').New()
@@ -46,10 +53,11 @@ function TableInFirstNS_mt:FooStruct()
         return obj
     end
 end
-function TableInFirstNS.Start(builder) builder:StartObject(3) end
-function TableInFirstNS.AddFooTable(builder, fooTable) builder:PrependUOffsetTRelativeSlot(0, fooTable, 0) end
-function TableInFirstNS.AddFooEnum(builder, fooEnum) builder:PrependInt8Slot(1, fooEnum, 0) end
-function TableInFirstNS.AddFooStruct(builder, fooStruct) builder:PrependStructSlot(2, fooStruct, 0) end
+function TableInFirstNS.Start(builder) builder:StartObject(4) end
+function TableInFirstNS.AddX(builder, x) builder:PrependInt32Slot(0, x, 0) end
+function TableInFirstNS.AddFooTable(builder, fooTable) builder:PrependUOffsetTRelativeSlot(1, fooTable, 0) end
+function TableInFirstNS.AddFooEnum(builder, fooEnum) builder:PrependInt8Slot(2, fooEnum, 0) end
+function TableInFirstNS.AddFooStruct(builder, fooStruct) builder:PrependStructSlot(3, fooStruct, 0) end
 function TableInFirstNS.End(builder) return builder:EndObject() end
 
 return TableInFirstNS -- return the module

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.php
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.php
@@ -32,10 +32,19 @@ class TableInFirstNS extends Table
         return $this;
     }
 
+    /**
+     * @return int
+     */
+    public function getX()
+    {
+        $o = $this->__offset(4);
+        return $o != 0 ? $this->bb->getInt($o + $this->bb_pos) : 0;
+    }
+
     public function getFooTable()
     {
         $obj = new TableInNestedNS();
-        $o = $this->__offset(4);
+        $o = $this->__offset(6);
         return $o != 0 ? $obj->init($this->__indirect($o + $this->bb_pos), $this->bb) : 0;
     }
 
@@ -44,14 +53,14 @@ class TableInFirstNS extends Table
      */
     public function getFooEnum()
     {
-        $o = $this->__offset(6);
+        $o = $this->__offset(8);
         return $o != 0 ? $this->bb->getSbyte($o + $this->bb_pos) : \NamespaceA\NamespaceB\EnumInNestedNS::A;
     }
 
     public function getFooStruct()
     {
         $obj = new StructInNestedNS();
-        $o = $this->__offset(8);
+        $o = $this->__offset(10);
         return $o != 0 ? $obj->init($o + $this->bb_pos, $this->bb) : 0;
     }
 
@@ -61,16 +70,17 @@ class TableInFirstNS extends Table
      */
     public static function startTableInFirstNS(FlatBufferBuilder $builder)
     {
-        $builder->StartObject(3);
+        $builder->StartObject(4);
     }
 
     /**
      * @param FlatBufferBuilder $builder
      * @return TableInFirstNS
      */
-    public static function createTableInFirstNS(FlatBufferBuilder $builder, $foo_table, $foo_enum, $foo_struct)
+    public static function createTableInFirstNS(FlatBufferBuilder $builder, $x, $foo_table, $foo_enum, $foo_struct)
     {
-        $builder->startObject(3);
+        $builder->startObject(4);
+        self::addX($builder, $x);
         self::addFooTable($builder, $foo_table);
         self::addFooEnum($builder, $foo_enum);
         self::addFooStruct($builder, $foo_struct);
@@ -83,9 +93,19 @@ class TableInFirstNS extends Table
      * @param int
      * @return void
      */
+    public static function addX(FlatBufferBuilder $builder, $x)
+    {
+        $builder->addIntX(0, $x, 0);
+    }
+
+    /**
+     * @param FlatBufferBuilder $builder
+     * @param int
+     * @return void
+     */
     public static function addFooTable(FlatBufferBuilder $builder, $fooTable)
     {
-        $builder->addOffsetX(0, $fooTable, 0);
+        $builder->addOffsetX(1, $fooTable, 0);
     }
 
     /**
@@ -95,7 +115,7 @@ class TableInFirstNS extends Table
      */
     public static function addFooEnum(FlatBufferBuilder $builder, $fooEnum)
     {
-        $builder->addSbyteX(1, $fooEnum, 0);
+        $builder->addSbyteX(2, $fooEnum, 0);
     }
 
     /**
@@ -105,7 +125,7 @@ class TableInFirstNS extends Table
      */
     public static function addFooStruct(FlatBufferBuilder $builder, $fooStruct)
     {
-        $builder->addStructX(2, $fooStruct, 0);
+        $builder->addStructX(3, $fooStruct, 0);
     }
 
     /**

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.py
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.py
@@ -19,11 +19,18 @@ class TableInFirstNS(object):
         self._tab = flatbuffers.table.Table(buf, pos)
 
     # TableInFirstNS
-    def FooTable(self):
+    def X(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return 0
+
+    # TableInFirstNS
+    def FooTable(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .TableInNestedNS import TableInNestedNS
+            from NamespaceA.NamespaceB.TableInNestedNS import TableInNestedNS
             obj = TableInNestedNS()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -31,24 +38,25 @@ class TableInFirstNS(object):
 
     # TableInFirstNS
     def FooEnum(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
         return 0
 
     # TableInFirstNS
     def FooStruct(self):
-        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             x = o + self._tab.Pos
-            from .StructInNestedNS import StructInNestedNS
+            from NamespaceA.NamespaceB.StructInNestedNS import StructInNestedNS
             obj = StructInNestedNS()
             obj.Init(self._tab.Bytes, x)
             return obj
         return None
 
-def TableInFirstNSStart(builder): builder.StartObject(3)
-def TableInFirstNSAddFooTable(builder, fooTable): builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(fooTable), 0)
-def TableInFirstNSAddFooEnum(builder, fooEnum): builder.PrependInt8Slot(1, fooEnum, 0)
-def TableInFirstNSAddFooStruct(builder, fooStruct): builder.PrependStructSlot(2, flatbuffers.number_types.UOffsetTFlags.py_type(fooStruct), 0)
+def TableInFirstNSStart(builder): builder.StartObject(4)
+def TableInFirstNSAddX(builder, x): builder.PrependInt32Slot(0, x, 0)
+def TableInFirstNSAddFooTable(builder, fooTable): builder.PrependUOffsetTRelativeSlot(1, flatbuffers.number_types.UOffsetTFlags.py_type(fooTable), 0)
+def TableInFirstNSAddFooEnum(builder, fooEnum): builder.PrependInt8Slot(2, fooEnum, 0)
+def TableInFirstNSAddFooStruct(builder, fooStruct): builder.PrependStructSlot(3, flatbuffers.number_types.UOffsetTFlags.py_type(fooStruct), 0)
 def TableInFirstNSEnd(builder): return builder.EndObject()

--- a/tests/namespace_test/NamespaceC/TableInC.py
+++ b/tests/namespace_test/NamespaceC/TableInC.py
@@ -23,7 +23,7 @@ class TableInC(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .TableInFirstNS import TableInFirstNS
+            from NamespaceA.TableInFirstNS import TableInFirstNS
             obj = TableInFirstNS()
             obj.Init(self._tab.Bytes, x)
             return obj
@@ -34,7 +34,7 @@ class TableInC(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             x = self._tab.Indirect(o + self._tab.Pos)
-            from .SecondTableInA import SecondTableInA
+            from NamespaceA.SecondTableInA import SecondTableInA
             obj = SecondTableInA()
             obj.Init(self._tab.Bytes, x)
             return obj

--- a/tests/namespace_test/namespace_test2.fbs
+++ b/tests/namespace_test/namespace_test2.fbs
@@ -4,6 +4,7 @@ namespace NamespaceA;
 
 table TableInFirstNS
 {
+    x:int;
     foo_table:NamespaceB.TableInNestedNS;
 	foo_enum:NamespaceB.EnumInNestedNS;
 	foo_struct:NamespaceB.StructInNestedNS;

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -43,10 +43,17 @@ struct TableInFirstNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return TableInFirstNSTypeTable();
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_FOO_TABLE = 4,
-    VT_FOO_ENUM = 6,
-    VT_FOO_STRUCT = 8
+    VT_X = 4,
+    VT_FOO_TABLE = 6,
+    VT_FOO_ENUM = 8,
+    VT_FOO_STRUCT = 10
   };
+  int32_t x() const {
+    return GetField<int32_t>(VT_X, 0);
+  }
+  bool mutate_x(int32_t _x) {
+    return SetField<int32_t>(VT_X, _x, 0);
+  }
   const NamespaceA::NamespaceB::TableInNestedNS *foo_table() const {
     return GetPointer<const NamespaceA::NamespaceB::TableInNestedNS *>(VT_FOO_TABLE);
   }
@@ -67,6 +74,7 @@ struct TableInFirstNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
+           VerifyField<int32_t>(verifier, VT_X) &&
            VerifyOffset(verifier, VT_FOO_TABLE) &&
            verifier.VerifyTable(foo_table()) &&
            VerifyField<int8_t>(verifier, VT_FOO_ENUM) &&
@@ -78,6 +86,9 @@ struct TableInFirstNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct TableInFirstNSBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
+  void add_x(int32_t x) {
+    fbb_.AddElement<int32_t>(TableInFirstNS::VT_X, x, 0);
+  }
   void add_foo_table(flatbuffers::Offset<NamespaceA::NamespaceB::TableInNestedNS> foo_table) {
     fbb_.AddOffset(TableInFirstNS::VT_FOO_TABLE, foo_table);
   }
@@ -101,12 +112,14 @@ struct TableInFirstNSBuilder {
 
 inline flatbuffers::Offset<TableInFirstNS> CreateTableInFirstNS(
     flatbuffers::FlatBufferBuilder &_fbb,
+    int32_t x = 0,
     flatbuffers::Offset<NamespaceA::NamespaceB::TableInNestedNS> foo_table = 0,
     NamespaceA::NamespaceB::EnumInNestedNS foo_enum = NamespaceA::NamespaceB::EnumInNestedNS_A,
     const NamespaceA::NamespaceB::StructInNestedNS *foo_struct = 0) {
   TableInFirstNSBuilder builder_(_fbb);
   builder_.add_foo_struct(foo_struct);
   builder_.add_foo_table(foo_table);
+  builder_.add_x(x);
   builder_.add_foo_enum(foo_enum);
   return builder_.Finish();
 }
@@ -237,6 +250,7 @@ namespace NamespaceA {
 
 inline const flatbuffers::TypeTable *TableInFirstNSTypeTable() {
   static const flatbuffers::TypeCode type_codes[] = {
+    { flatbuffers::ET_INT, 0, -1 },
     { flatbuffers::ET_SEQUENCE, 0, 0 },
     { flatbuffers::ET_CHAR, 0, 1 },
     { flatbuffers::ET_SEQUENCE, 0, 2 }
@@ -247,12 +261,13 @@ inline const flatbuffers::TypeTable *TableInFirstNSTypeTable() {
     NamespaceA::NamespaceB::StructInNestedNSTypeTable
   };
   static const char * const names[] = {
+    "x",
     "foo_table",
     "foo_enum",
     "foo_struct"
   };
   static const flatbuffers::TypeTable tt = {
-    flatbuffers::ST_TABLE, 3, type_codes, type_refs, nullptr, names
+    flatbuffers::ST_TABLE, 4, type_codes, type_refs, nullptr, names
   };
   return &tt;
 }

--- a/tests/namespace_test/namespace_test2_generated.js
+++ b/tests/namespace_test/namespace_test2_generated.js
@@ -63,11 +63,34 @@ NamespaceA.TableInFirstNS.getSizePrefixedRootAsTableInFirstNS = function(bb, obj
 };
 
 /**
+ * @returns {number}
+ */
+NamespaceA.TableInFirstNS.prototype.x = function() {
+  var offset = this.bb.__offset(this.bb_pos, 4);
+  return offset ? this.bb.readInt32(this.bb_pos + offset) : 0;
+};
+
+/**
+ * @param {number} value
+ * @returns {boolean}
+ */
+NamespaceA.TableInFirstNS.prototype.mutate_x = function(value) {
+  var offset = this.bb.__offset(this.bb_pos, 4);
+
+  if (offset === 0) {
+    return false;
+  }
+
+  this.bb.writeInt32(this.bb_pos + offset, value);
+  return true;
+};
+
+/**
  * @param {NamespaceA.NamespaceB.TableInNestedNS=} obj
  * @returns {NamespaceA.NamespaceB.TableInNestedNS|null}
  */
 NamespaceA.TableInFirstNS.prototype.fooTable = function(obj) {
-  var offset = this.bb.__offset(this.bb_pos, 4);
+  var offset = this.bb.__offset(this.bb_pos, 6);
   return offset ? (obj || new NamespaceA.NamespaceB.TableInNestedNS).__init(this.bb.__indirect(this.bb_pos + offset), this.bb) : null;
 };
 
@@ -75,7 +98,7 @@ NamespaceA.TableInFirstNS.prototype.fooTable = function(obj) {
  * @returns {NamespaceA.NamespaceB.EnumInNestedNS}
  */
 NamespaceA.TableInFirstNS.prototype.fooEnum = function() {
-  var offset = this.bb.__offset(this.bb_pos, 6);
+  var offset = this.bb.__offset(this.bb_pos, 8);
   return offset ? /** @type {NamespaceA.NamespaceB.EnumInNestedNS} */ (this.bb.readInt8(this.bb_pos + offset)) : NamespaceA.NamespaceB.EnumInNestedNS.A;
 };
 
@@ -84,7 +107,7 @@ NamespaceA.TableInFirstNS.prototype.fooEnum = function() {
  * @returns {boolean}
  */
 NamespaceA.TableInFirstNS.prototype.mutate_foo_enum = function(value) {
-  var offset = this.bb.__offset(this.bb_pos, 6);
+  var offset = this.bb.__offset(this.bb_pos, 8);
 
   if (offset === 0) {
     return false;
@@ -99,7 +122,7 @@ NamespaceA.TableInFirstNS.prototype.mutate_foo_enum = function(value) {
  * @returns {NamespaceA.NamespaceB.StructInNestedNS|null}
  */
 NamespaceA.TableInFirstNS.prototype.fooStruct = function(obj) {
-  var offset = this.bb.__offset(this.bb_pos, 8);
+  var offset = this.bb.__offset(this.bb_pos, 10);
   return offset ? (obj || new NamespaceA.NamespaceB.StructInNestedNS).__init(this.bb_pos + offset, this.bb) : null;
 };
 
@@ -107,7 +130,15 @@ NamespaceA.TableInFirstNS.prototype.fooStruct = function(obj) {
  * @param {flatbuffers.Builder} builder
  */
 NamespaceA.TableInFirstNS.startTableInFirstNS = function(builder) {
-  builder.startObject(3);
+  builder.startObject(4);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
+ * @param {number} x
+ */
+NamespaceA.TableInFirstNS.addX = function(builder, x) {
+  builder.addFieldInt32(0, x, 0);
 };
 
 /**
@@ -115,7 +146,7 @@ NamespaceA.TableInFirstNS.startTableInFirstNS = function(builder) {
  * @param {flatbuffers.Offset} fooTableOffset
  */
 NamespaceA.TableInFirstNS.addFooTable = function(builder, fooTableOffset) {
-  builder.addFieldOffset(0, fooTableOffset, 0);
+  builder.addFieldOffset(1, fooTableOffset, 0);
 };
 
 /**
@@ -123,7 +154,7 @@ NamespaceA.TableInFirstNS.addFooTable = function(builder, fooTableOffset) {
  * @param {NamespaceA.NamespaceB.EnumInNestedNS} fooEnum
  */
 NamespaceA.TableInFirstNS.addFooEnum = function(builder, fooEnum) {
-  builder.addFieldInt8(1, fooEnum, NamespaceA.NamespaceB.EnumInNestedNS.A);
+  builder.addFieldInt8(2, fooEnum, NamespaceA.NamespaceB.EnumInNestedNS.A);
 };
 
 /**
@@ -131,7 +162,7 @@ NamespaceA.TableInFirstNS.addFooEnum = function(builder, fooEnum) {
  * @param {flatbuffers.Offset} fooStructOffset
  */
 NamespaceA.TableInFirstNS.addFooStruct = function(builder, fooStructOffset) {
-  builder.addFieldStruct(2, fooStructOffset, 0);
+  builder.addFieldStruct(3, fooStructOffset, 0);
 };
 
 /**
@@ -145,13 +176,15 @@ NamespaceA.TableInFirstNS.endTableInFirstNS = function(builder) {
 
 /**
  * @param {flatbuffers.Builder} builder
+ * @param {number} x
  * @param {flatbuffers.Offset} fooTableOffset
  * @param {NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS} fooEnum
  * @param {flatbuffers.Offset} fooStructOffset
  * @returns {flatbuffers.Offset}
  */
-NamespaceA.TableInFirstNS.createTableInFirstNS = function(builder, fooTableOffset, fooEnum, fooStructOffset) {
+NamespaceA.TableInFirstNS.createTableInFirstNS = function(builder, x, fooTableOffset, fooEnum, fooStructOffset) {
   NamespaceA.TableInFirstNS.startTableInFirstNS(builder);
+  NamespaceA.TableInFirstNS.addX(builder, x);
   NamespaceA.TableInFirstNS.addFooTable(builder, fooTableOffset);
   NamespaceA.TableInFirstNS.addFooEnum(builder, fooEnum);
   NamespaceA.TableInFirstNS.addFooStruct(builder, fooStructOffset);

--- a/tests/namespace_test/namespace_test2_generated.lobster
+++ b/tests/namespace_test/namespace_test2_generated.lobster
@@ -14,13 +14,15 @@ namespace NamespaceA
 class SecondTableInA
 
 class TableInFirstNS : flatbuffers_handle
+    def x():
+        return buf_.flatbuffers_field_int32(pos_, 4, 0)
     def foo_table():
-        let o = buf_.flatbuffers_field_table(pos_, 4)
+        let o = buf_.flatbuffers_field_table(pos_, 6)
         return if o: NamespaceA_NamespaceB_TableInNestedNS { buf_, o } else: nil
     def foo_enum():
-        return EnumInNestedNS(buf_.flatbuffers_field_int8(pos_, 6, 0))
+        return EnumInNestedNS(buf_.flatbuffers_field_int8(pos_, 8, 0))
     def foo_struct():
-        let o = buf_.flatbuffers_field_struct(pos_, 8)
+        let o = buf_.flatbuffers_field_struct(pos_, 10)
         return if o: NamespaceA_NamespaceB_StructInNestedNS { buf_, o } else: nil
 
 def GetRootAsTableInFirstNS(buf:string): return TableInFirstNS { buf, buf.flatbuffers_indirect(0) }
@@ -28,16 +30,19 @@ def GetRootAsTableInFirstNS(buf:string): return TableInFirstNS { buf, buf.flatbu
 struct TableInFirstNSBuilder:
     b_:flatbuffers_builder
     def start():
-        b_.StartObject(3)
+        b_.StartObject(4)
+        return this
+    def add_x(x:int):
+        b_.PrependInt32Slot(0, x, 0)
         return this
     def add_foo_table(foo_table:flatbuffers_offset):
-        b_.PrependUOffsetTRelativeSlot(0, foo_table)
+        b_.PrependUOffsetTRelativeSlot(1, foo_table)
         return this
     def add_foo_enum(foo_enum:EnumInNestedNS):
-        b_.PrependInt8Slot(1, foo_enum, 0)
+        b_.PrependInt8Slot(2, foo_enum, 0)
         return this
     def add_foo_struct(foo_struct:flatbuffers_offset):
-        b_.PrependStructSlot(2, foo_struct)
+        b_.PrependStructSlot(3, foo_struct)
         return this
     def end():
         return b_.EndObject()

--- a/tests/namespace_test/namespace_test2_generated.rs
+++ b/tests/namespace_test/namespace_test2_generated.rs
@@ -48,14 +48,20 @@ impl<'a> TableInFirstNS<'a> {
       let mut builder = TableInFirstNSBuilder::new(_fbb);
       if let Some(x) = args.foo_struct { builder.add_foo_struct(x); }
       if let Some(x) = args.foo_table { builder.add_foo_table(x); }
+      builder.add_x(args.x);
       builder.add_foo_enum(args.foo_enum);
       builder.finish()
     }
 
-    pub const VT_FOO_TABLE: flatbuffers::VOffsetT = 4;
-    pub const VT_FOO_ENUM: flatbuffers::VOffsetT = 6;
-    pub const VT_FOO_STRUCT: flatbuffers::VOffsetT = 8;
+    pub const VT_X: flatbuffers::VOffsetT = 4;
+    pub const VT_FOO_TABLE: flatbuffers::VOffsetT = 6;
+    pub const VT_FOO_ENUM: flatbuffers::VOffsetT = 8;
+    pub const VT_FOO_STRUCT: flatbuffers::VOffsetT = 10;
 
+  #[inline]
+  pub fn x(&self) -> i32 {
+    self._tab.get::<i32>(TableInFirstNS::VT_X, Some(0)).unwrap()
+  }
   #[inline]
   pub fn foo_table(&self) -> Option<namespace_b::TableInNestedNS<'a>> {
     self._tab.get::<flatbuffers::ForwardsUOffset<namespace_b::TableInNestedNS<'a>>>(TableInFirstNS::VT_FOO_TABLE, None)
@@ -71,6 +77,7 @@ impl<'a> TableInFirstNS<'a> {
 }
 
 pub struct TableInFirstNSArgs<'a> {
+    pub x: i32,
     pub foo_table: Option<flatbuffers::WIPOffset<namespace_b::TableInNestedNS<'a >>>,
     pub foo_enum: namespace_b::EnumInNestedNS,
     pub foo_struct: Option<&'a  namespace_b::StructInNestedNS>,
@@ -79,6 +86,7 @@ impl<'a> Default for TableInFirstNSArgs<'a> {
     #[inline]
     fn default() -> Self {
         TableInFirstNSArgs {
+            x: 0,
             foo_table: None,
             foo_enum: namespace_b::EnumInNestedNS::A,
             foo_struct: None,
@@ -90,6 +98,10 @@ pub struct TableInFirstNSBuilder<'a: 'b, 'b> {
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> TableInFirstNSBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_x(&mut self, x: i32) {
+    self.fbb_.push_slot::<i32>(TableInFirstNS::VT_X, x, 0);
+  }
   #[inline]
   pub fn add_foo_table(&mut self, foo_table: flatbuffers::WIPOffset<namespace_b::TableInNestedNS<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<namespace_b::TableInNestedNS>>(TableInFirstNS::VT_FOO_TABLE, foo_table);

--- a/tests/namespace_test/namespace_test2_generated.ts
+++ b/tests/namespace_test/namespace_test2_generated.ts
@@ -39,11 +39,34 @@ static getSizePrefixedRootAsTableInFirstNS(bb:flatbuffers.ByteBuffer, obj?:Table
 };
 
 /**
+ * @returns number
+ */
+x():number {
+  var offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.readInt32(this.bb_pos + offset) : 0;
+};
+
+/**
+ * @param number value
+ * @returns boolean
+ */
+mutate_x(value:number):boolean {
+  var offset = this.bb!.__offset(this.bb_pos, 4);
+
+  if (offset === 0) {
+    return false;
+  }
+
+  this.bb!.writeInt32(this.bb_pos + offset, value);
+  return true;
+};
+
+/**
  * @param NamespaceA.NamespaceB.TableInNestedNS= obj
  * @returns NamespaceA.NamespaceB.TableInNestedNS|null
  */
 fooTable(obj?:NS8755221360535654258.NamespaceA.NamespaceB.TableInNestedNS):NS8755221360535654258.NamespaceA.NamespaceB.TableInNestedNS|null {
-  var offset = this.bb!.__offset(this.bb_pos, 4);
+  var offset = this.bb!.__offset(this.bb_pos, 6);
   return offset ? (obj || new NS8755221360535654258.NamespaceA.NamespaceB.TableInNestedNS).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
 };
 
@@ -51,7 +74,7 @@ fooTable(obj?:NS8755221360535654258.NamespaceA.NamespaceB.TableInNestedNS):NS875
  * @returns NamespaceA.NamespaceB.EnumInNestedNS
  */
 fooEnum():NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS {
-  var offset = this.bb!.__offset(this.bb_pos, 6);
+  var offset = this.bb!.__offset(this.bb_pos, 8);
   return offset ? /**  */ (this.bb!.readInt8(this.bb_pos + offset)) : NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS.A;
 };
 
@@ -60,7 +83,7 @@ fooEnum():NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS {
  * @returns boolean
  */
 mutate_foo_enum(value:NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS):boolean {
-  var offset = this.bb!.__offset(this.bb_pos, 6);
+  var offset = this.bb!.__offset(this.bb_pos, 8);
 
   if (offset === 0) {
     return false;
@@ -75,7 +98,7 @@ mutate_foo_enum(value:NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS
  * @returns NamespaceA.NamespaceB.StructInNestedNS|null
  */
 fooStruct(obj?:NS8755221360535654258.NamespaceA.NamespaceB.StructInNestedNS):NS8755221360535654258.NamespaceA.NamespaceB.StructInNestedNS|null {
-  var offset = this.bb!.__offset(this.bb_pos, 8);
+  var offset = this.bb!.__offset(this.bb_pos, 10);
   return offset ? (obj || new NS8755221360535654258.NamespaceA.NamespaceB.StructInNestedNS).__init(this.bb_pos + offset, this.bb!) : null;
 };
 
@@ -83,7 +106,15 @@ fooStruct(obj?:NS8755221360535654258.NamespaceA.NamespaceB.StructInNestedNS):NS8
  * @param flatbuffers.Builder builder
  */
 static startTableInFirstNS(builder:flatbuffers.Builder) {
-  builder.startObject(3);
+  builder.startObject(4);
+};
+
+/**
+ * @param flatbuffers.Builder builder
+ * @param number x
+ */
+static addX(builder:flatbuffers.Builder, x:number) {
+  builder.addFieldInt32(0, x, 0);
 };
 
 /**
@@ -91,7 +122,7 @@ static startTableInFirstNS(builder:flatbuffers.Builder) {
  * @param flatbuffers.Offset fooTableOffset
  */
 static addFooTable(builder:flatbuffers.Builder, fooTableOffset:flatbuffers.Offset) {
-  builder.addFieldOffset(0, fooTableOffset, 0);
+  builder.addFieldOffset(1, fooTableOffset, 0);
 };
 
 /**
@@ -99,7 +130,7 @@ static addFooTable(builder:flatbuffers.Builder, fooTableOffset:flatbuffers.Offse
  * @param NamespaceA.NamespaceB.EnumInNestedNS fooEnum
  */
 static addFooEnum(builder:flatbuffers.Builder, fooEnum:NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS) {
-  builder.addFieldInt8(1, fooEnum, NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS.A);
+  builder.addFieldInt8(2, fooEnum, NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS.A);
 };
 
 /**
@@ -107,7 +138,7 @@ static addFooEnum(builder:flatbuffers.Builder, fooEnum:NS8755221360535654258.Nam
  * @param flatbuffers.Offset fooStructOffset
  */
 static addFooStruct(builder:flatbuffers.Builder, fooStructOffset:flatbuffers.Offset) {
-  builder.addFieldStruct(2, fooStructOffset, 0);
+  builder.addFieldStruct(3, fooStructOffset, 0);
 };
 
 /**
@@ -119,8 +150,9 @@ static endTableInFirstNS(builder:flatbuffers.Builder):flatbuffers.Offset {
   return offset;
 };
 
-static createTableInFirstNS(builder:flatbuffers.Builder, fooTableOffset:flatbuffers.Offset, fooEnum:NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS, fooStructOffset:flatbuffers.Offset):flatbuffers.Offset {
+static createTableInFirstNS(builder:flatbuffers.Builder, x:number, fooTableOffset:flatbuffers.Offset, fooEnum:NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS, fooStructOffset:flatbuffers.Offset):flatbuffers.Offset {
   TableInFirstNS.startTableInFirstNS(builder);
+  TableInFirstNS.addX(builder, x);
   TableInFirstNS.addFooTable(builder, fooTableOffset);
   TableInFirstNS.addFooEnum(builder, fooEnum);
   TableInFirstNS.addFooStruct(builder, fooStructOffset);

--- a/tests/namespace_test/namespace_test2_namespace_a_generated.dart
+++ b/tests/namespace_test/namespace_test2_namespace_a_generated.dart
@@ -21,13 +21,14 @@ class TableInFirstNS {
   final fb.BufferContext _bc;
   final int _bcOffset;
 
-  namespace_a_namespace_b.TableInNestedNS get fooTable => namespace_a_namespace_b.TableInNestedNS.reader.vTableGet(_bc, _bcOffset, 4, null);
-  EnumInNestedNS get fooEnum => new EnumInNestedNS.fromValue(const fb.Int8Reader().vTableGet(_bc, _bcOffset, 6, 0));
-  namespace_a_namespace_b.StructInNestedNS get fooStruct => namespace_a_namespace_b.StructInNestedNS.reader.vTableGet(_bc, _bcOffset, 8, null);
+  int get x => const fb.Int32Reader().vTableGet(_bc, _bcOffset, 4, 0);
+  namespace_a_namespace_b.TableInNestedNS get fooTable => namespace_a_namespace_b.TableInNestedNS.reader.vTableGet(_bc, _bcOffset, 6, null);
+  EnumInNestedNS get fooEnum => new EnumInNestedNS.fromValue(const fb.Int8Reader().vTableGet(_bc, _bcOffset, 8, 0));
+  namespace_a_namespace_b.StructInNestedNS get fooStruct => namespace_a_namespace_b.StructInNestedNS.reader.vTableGet(_bc, _bcOffset, 10, null);
 
   @override
   String toString() {
-    return 'TableInFirstNS{fooTable: $fooTable, fooEnum: $fooEnum, fooStruct: $fooStruct}';
+    return 'TableInFirstNS{x: $x, fooTable: $fooTable, fooEnum: $fooEnum, fooStruct: $fooStruct}';
   }
 }
 
@@ -50,16 +51,20 @@ class TableInFirstNSBuilder {
     fbBuilder.startTable();
   }
 
+  int addX(int x) {
+    fbBuilder.addInt32(0, x);
+    return fbBuilder.offset;
+  }
   int addFooTableOffset(int offset) {
-    fbBuilder.addOffset(0, offset);
+    fbBuilder.addOffset(1, offset);
     return fbBuilder.offset;
   }
   int addFooEnum(EnumInNestedNS fooEnum) {
-    fbBuilder.addInt8(1, fooEnum?.value);
+    fbBuilder.addInt8(2, fooEnum?.value);
     return fbBuilder.offset;
   }
   int addFooStruct(int offset) {
-    fbBuilder.addStruct(2, offset);
+    fbBuilder.addStruct(3, offset);
     return fbBuilder.offset;
   }
 
@@ -69,16 +74,19 @@ class TableInFirstNSBuilder {
 }
 
 class TableInFirstNSObjectBuilder extends fb.ObjectBuilder {
+  final int _x;
   final namespace_a_namespace_b.TableInNestedNSObjectBuilder _fooTable;
   final EnumInNestedNS _fooEnum;
   final namespace_a_namespace_b.StructInNestedNSObjectBuilder _fooStruct;
 
   TableInFirstNSObjectBuilder({
+    int x,
     namespace_a_namespace_b.TableInNestedNSObjectBuilder fooTable,
     EnumInNestedNS fooEnum,
     namespace_a_namespace_b.StructInNestedNSObjectBuilder fooStruct,
   })
-      : _fooTable = fooTable,
+      : _x = x,
+        _fooTable = fooTable,
         _fooEnum = fooEnum,
         _fooStruct = fooStruct;
 
@@ -90,12 +98,13 @@ class TableInFirstNSObjectBuilder extends fb.ObjectBuilder {
     final int fooTableOffset = _fooTable?.getOrCreateOffset(fbBuilder);
 
     fbBuilder.startTable();
+    fbBuilder.addInt32(0, _x);
     if (fooTableOffset != null) {
-      fbBuilder.addOffset(0, fooTableOffset);
+      fbBuilder.addOffset(1, fooTableOffset);
     }
-    fbBuilder.addInt8(1, _fooEnum?.value);
+    fbBuilder.addInt8(2, _fooEnum?.value);
     if (_fooStruct != null) {
-      fbBuilder.addStruct(2, _fooStruct.finish(fbBuilder));
+      fbBuilder.addStruct(3, _fooStruct.finish(fbBuilder));
     }
     return fbBuilder.endTable();
   }


### PR DESCRIPTION
For non-scalar (struct/table) fields, the compiler generates accessors that import the module where the type of that field is defined in this form:

`from .<type-name> import <type-name>`

This relative import works if the type is defined in the same namespace, but when the type is defined in another namespace or a nested namespace, it fails.

The fix is simply to use `BaseGenerator::WrapInNameSpace` to get the _absolute_ module name instead of `PythonGenerator::TypeName`.

I also added 2 tests to verify.
