### PR TITLE
[C#] Don't check ForceDefaults when adding Offset values

### DIFF
--- a/net/FlatBuffers/FlatBufferBuilder.cs
+++ b/net/FlatBuffers/FlatBufferBuilder.cs
@@ -540,9 +540,9 @@ namespace FlatBuffers
         /// </summary>
         /// <param name="o">The index into the vtable</param>
         /// <param name="x">The value to put into the buffer. If the value is equal to the default
-        /// and <see cref="ForceDefaults"/> is false, the value will be skipped.</param>
+        /// the value will be skipped.</param>
         /// <param name="d">The default value to compare the value against</param>
-        public void AddOffset(int o, int x, int d) { if (ForceDefaults || x != d) { AddOffset(x); Slot(o); } }
+        public void AddOffset(int o, int x, int d) { if (x != d) { AddOffset(x); Slot(o); } }
         /// @endcond
 
         /// <summary>


### PR DESCRIPTION
With ForceDefaults enabled 0 offsets will be added and the vtable populated. 0 offset values aren't handled while reading and will throw exceptions when accessing those members. I don't think there's any functional reason to force a 0 offset value to be written.