### PR TITLE
[C#] Add support to copy an arraysegment into flatbuffer

### DIFF
--- a/net/FlatBuffers/ByteBuffer.cs
+++ b/net/FlatBuffers/ByteBuffer.cs
@@ -229,6 +229,11 @@ namespace FlatBuffers
         {
             return SizeOf<T>() * x.Length;
         }
+#else
+        public static int ArraySize<T>(ArraySegment<T> x)
+        {
+            return SizeOf<T>() * x.Count;
+        }
 #endif
 
         // Get a portion of the buffer casted into an array of type T, given
@@ -873,6 +878,60 @@ namespace FlatBuffers
                 AssertOffsetAndLength(offset, numBytes);
                 // if we are LE, just do a block copy
                 MemoryMarshal.Cast<T, byte>(x).CopyTo(_buffer.Span.Slice(offset, numBytes));
+            }
+            else
+            {
+                throw new NotImplementedException("Big Endian Support not implemented yet " +
+                    "for putting typed arrays");
+                // if we are BE, we have to swap each element by itself
+                //for(int i = x.Length - 1; i >= 0; i--)
+                //{
+                //  todo: low priority, but need to genericize the Put<T>() functions
+                //}
+            }
+            return offset;
+        }
+#else
+        /// <summary>
+        /// Copies an array segment of type T into this buffer, ending at the given
+        /// offset into this buffer. The starting offset is calculated based on the length
+        /// of the array segment and is the value returned.
+        /// </summary>
+        /// <typeparam name="T">The type of the input data (must be a struct)</typeparam>
+        /// <param name="offset">The offset into this buffer where the copy will end</param>
+        /// <param name="x">The array to copy data from</param>
+        /// <returns>The 'start' location of this buffer now, after the copy completed</returns>
+        public int Put<T>(int offset, ArraySegment<T> x)
+          where T : struct
+        {
+            if (x == null)
+            {
+                throw new ArgumentNullException("Cannot put a null array segment");
+            }
+
+            if (x.Array == null)
+            {
+                throw new ArgumentException("Array segment can not contain null array");
+            }
+
+            if (x.Count == 0)
+            {
+                throw new ArgumentException("Cannot put an empty array segment");
+            }
+
+            if (!IsSupportedType<T>())
+            {
+                throw new ArgumentException("Cannot put an array segment of type "
+                    + typeof(T) + " into this buffer");
+            }
+
+            if (BitConverter.IsLittleEndian)
+            {
+                int numBytes = ByteBuffer.ArraySize(x);
+                offset -= numBytes;
+                AssertOffsetAndLength(offset, numBytes);
+                // if we are LE, just do a block copy
+                Buffer.BlockCopy(x.Array, x.Offset * SizeOf<T>(), _buffer.Buffer, offset, numBytes);
             }
             else
             {

--- a/net/FlatBuffers/FlatBufferBuilder.cs
+++ b/net/FlatBuffers/FlatBufferBuilder.cs
@@ -218,6 +218,18 @@ namespace FlatBuffers
         {
             _space = _bb.Put(_space, x);
         }
+#else
+        /// <summary>
+        /// Puts a ArraySegment of type T into this builder at the 
+        /// current offset
+        /// </summary>
+        /// <typeparam name="T">The type of the input data </typeparam>
+        /// <param name="x">The array segment to copy data from</param>
+        public void Put<T>(ArraySegment<T> x)
+            where T : struct
+        {
+            _space = _bb.Put(_space, x);
+        }
 #endif
 
         public void PutDouble(double x)
@@ -335,6 +347,37 @@ namespace FlatBuffers
             // Need to prep on size (for data alignment) and then we pass the
             // rest of the length (minus 1) as additional bytes
             Prep(size, size * (x.Length - 1));
+            Put(x);
+        }
+#else
+        /// <summary>
+        /// Add an array segment of type T to the buffer (aligns the data and grows if necessary).
+        /// </summary>
+        /// <typeparam name="T">The type of the input data</typeparam>
+        /// <param name="x">The array segment to copy data from</param>
+        public void Add<T>(ArraySegment<T> x)
+            where T : struct
+        {
+            if (x == null)
+            {
+                throw new ArgumentNullException("Cannot add a null array segment");
+            }
+
+            if (x.Count == 0)
+            {
+                // don't do anything if the array is empty
+                return;
+            }
+
+            if (!ByteBuffer.IsSupportedType<T>())
+            {
+                throw new ArgumentException("Cannot add this Type array segments to the builder");
+            }
+
+            int size = ByteBuffer.SizeOf<T>();
+            // Need to prep on size (for data alignment) and then we pass the
+            // rest of the length (minus 1) as additional bytes
+            Prep(size, size * (x.Count - 1));
             Put(x);
         }
 #endif


### PR DESCRIPTION
Currently when not compiled with `Span `enabled there is no way to add a segment of an array in a performant manner. `ArraySegment` is utilized as the alternative to `Span` in most cases throughout the library and generated code, but Add/Put aren't replicated when 'Span' is not enabled. This is specifically  useful for nested flatbuffers where just the used segment of a ByteBuffer can be copied into the parent flatbuffer without an intermediate copy.