### PR TITLE
Fix echo not interpret \n in GoTest.sh

### DIFF
--- a/tests/GoTest.sh
+++ b/tests/GoTest.sh
@@ -67,7 +67,9 @@ fi
 
 NOT_FMT_FILES=$(gofmt -l MyGame)
 if [[ ${NOT_FMT_FILES} != "" ]]; then
-    echo "These files are not well gofmt'ed:\n\n${NOT_FMT_FILES}"
+    echo "These files are not well gofmt'ed:"
+    echo
+    echo "${NOT_FMT_FILES}"
     # enable this when enums are properly formated
     # exit 1
 fi


### PR DESCRIPTION
When running GoTest.sh, the last step that checking go format files
are print \n instead of new line:

These files are not well gofmt'ed:\n\nMyGame/Example/Color.go
MyGame/Example/MonsterStorage_grpc.go

This changes fix it by echo NOT_FMT_FILES in separate line.