### PR TITLE
(C++) Change deprecated vector Length() to size() in tutorial

### DIFF
--- a/docs/source/Tutorial.md
+++ b/docs/source/Tutorial.md
@@ -2555,7 +2555,7 @@ FlatBuffers `vector`.
 <div class="language-cpp">
 ~~~{.cpp}
   auto inv = monster->inventory(); // A pointer to a `flatbuffers::Vector<>`.
-  auto inv_len = inv->Length();
+  auto inv_len = inv->size();
   auto third_item = inv->Get(2);
 ~~~
 </div>
@@ -2650,7 +2650,7 @@ except your need to handle the result as a FlatBuffer `table`:
 <div class="language-cpp">
 ~~~{.cpp}
   auto weapons = monster->weapons(); // A pointer to a `flatbuffers::Vector<>`.
-  auto weapon_len = weapons->Length();
+  auto weapon_len = weapons->size();
   auto second_weapon_name = weapons->Get(1)->name()->str();
   auto second_weapon_damage = weapons->Get(1)->damage()
 ~~~


### PR DESCRIPTION
Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
