### PR TITLE
[C++ ] Correctly serialize bit_flags enums to JSON with output_enum_identifiers option

### DIFF
--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -54,19 +54,17 @@ bool Print(T val, Type type, int /*indent*/, Type * /*union_type*/,
     std::vector<EnumVal const *> enum_values;
     if (auto ev = type.enum_def->ReverseLookup(static_cast<int64_t>(val))) {
       enum_values.push_back(ev);
-    }
-    else if (val && type.enum_def->attributes.Lookup("bit_flags")) {
+    } else if (val && type.enum_def->attributes.Lookup("bit_flags")) {
       for (auto it = type.enum_def->Vals().begin(),
                 e = type.enum_def->Vals().end();
            it != e; ++it) {
-        if ((*it)->GetAsInt64() & static_cast<int64_t>(val))
+        if ((*it)->GetAsUInt64() & static_cast<uint64_t>(val))
           enum_values.push_back(*it);
       }
     }
-
     if (!enum_values.empty()) {
       text += '\"';
-      for(auto it = enum_values.begin(), e = enum_values.end(); it != e; ++it)
+      for (auto it = enum_values.begin(), e = enum_values.end(); it != e; ++it)
         text += (*it)->name + ' ';
       text[text.length() - 1] = '\"';
       return true;

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -620,8 +620,7 @@ void JsonDefaultTest() {
   TEST_EQ(std::string::npos != jsongen.find("testf: 3.14159"), true);
 }
 
-void JsonEnumsTest() 
-{
+void JsonEnumsTest() {
   // load FlatBuffer schema (.fbs) from disk
   std::string schemafile;
   TEST_EQ(flatbuffers::LoadFile((test_data_path + "monster_test.fbs").c_str(),

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -620,6 +620,33 @@ void JsonDefaultTest() {
   TEST_EQ(std::string::npos != jsongen.find("testf: 3.14159"), true);
 }
 
+void JsonEnumsTest() 
+{
+  // load FlatBuffer schema (.fbs) from disk
+  std::string schemafile;
+  TEST_EQ(flatbuffers::LoadFile((test_data_path + "monster_test.fbs").c_str(),
+                                false, &schemafile),
+          true);
+  // parse schema first, so we can use it to parse the data after
+  flatbuffers::Parser parser;
+  auto include_test_path =
+      flatbuffers::ConCatPathFileName(test_data_path, "include_test");
+  const char *include_directories[] = { test_data_path.c_str(),
+                                        include_test_path.c_str(), nullptr };
+  parser.opts.output_enum_identifiers = true;
+  TEST_EQ(parser.Parse(schemafile.c_str(), include_directories), true);
+  flatbuffers::FlatBufferBuilder builder;
+  auto name = builder.CreateString("bitflag_enum");
+  MonsterBuilder color_monster(builder);
+  color_monster.add_name(name);
+  color_monster.add_color(Color(Color_Blue | Color_Red));
+  FinishMonsterBuffer(builder, color_monster.Finish());
+  std::string jsongen;
+  auto result = GenerateText(parser, builder.GetBufferPointer(), &jsongen);
+  TEST_EQ(result, true);
+  TEST_EQ(std::string::npos != jsongen.find("color: \"Red Blue\""), true);
+}
+
 #if defined(FLATBUFFERS_HAS_NEW_STRTOD) && (FLATBUFFERS_HAS_NEW_STRTOD > 0)
 // The IEEE-754 quiet_NaN is not simple binary constant.
 // All binary NaN bit strings have all the bits of the biased exponent field E
@@ -2975,6 +3002,7 @@ int FlatBufferTests() {
   EndianSwapTest();
   CreateSharedStringTest();
   JsonDefaultTest();
+  JsonEnumsTest();
   FlexBuffersTest();
   UninitializedVectorTest();
   EqualOperatorTest();


### PR DESCRIPTION
Correctly if we try to serialize bit_flags enum value with 2 or more values set, we will get numeric value in resulting JSON, despite **output_enum_identifiers**  option enabled:

```
auto name = builder.CreateString("bitflag_enum");
MonsterBuilder color_monster(builder);
color_monster.add_name(name);
color_monster.add_color(Color(Color_Blue | Color_Red)) 
```
serialized to
```
{
  name: "bitflag_enum",
  color: 9
}
```
while correct serialization with  **output_enum_identifiers**  option:
```
{
  name: "bitflag_enum",
  color: "Red Blue"
}
```

Adding separate test case (mostly copy-pasted from JsonDefaultTest) looks like an overkill, but I didn't find suitable place in existing tests 
