### PR TITLE
[C#] Fix retrieving enumeration vectors as arrays

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -1486,26 +1486,20 @@ class GeneralGenerator : public BaseGenerator {
             code += "); return ";
             code += "builder." + FunctionStart('E') + "ndVector(); }\n";
             // For C#, include a block copy method signature.
-            if (lang_.language == IDLOptions::kCSharp) {
+            // Skip if the vector is of enums, because builder.Add
+            // throws an exception when supplied an enum array.
+            if (lang_.language == IDLOptions::kCSharp &&
+                !IsEnum(vector_type)) {
               code += "  public static " + GenVectorOffsetType() + " ";
               code += FunctionStart('C') + "reate";
               code += MakeCamel(field.name);
               code += "VectorBlock(FlatBufferBuilder builder, ";
               code += GenTypeBasic(vector_type) + "[] data) ";
-              if (IsEnum(vector_type)) {
-                // Since builder.Add does not work for enum types,
-                // delegate to the non-block method. Block method is
-                // still produced for strict backward compatibility.
-                code += "{ return " + FunctionStart('C') + "reate";
-                code += MakeCamel(field.name) + "Vector(builder, data);";
-              } else {
-                code += "{ builder." + FunctionStart('S') + "tartVector(";
-                code += NumToString(elem_size);
-                code += ", data." + FunctionStart('L') + "ength, ";
-                code += NumToString(alignment);
-                code += "); builder.Add(data); return builder.EndVector();";
-              }
-              code += " }\n";
+              code += "{ builder." + FunctionStart('S') + "tartVector(";
+              code += NumToString(elem_size);
+              code += ", data." + FunctionStart('L') + "ength, ";
+              code += NumToString(alignment);
+              code += "); builder.Add(data); return builder.EndVector(); }\n";
             }
           }
           // Generate a method to start a vector, data to be added manually

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -312,25 +312,6 @@ namespace FlatBuffers.Test
         }
 
         [FlatBuffersTestMethod]
-        public void TestVectorOfEnumsUsingBlockCreate()
-        {
-            const string monsterName = "TestVectorBlockOfEnumsMonster";
-            var colorVec = new Color[] { Color.Red, Color.Green, Color.Blue };
-            var fbb = new FlatBufferBuilder(32);
-            var str1 = fbb.CreateString(monsterName);
-            var vec1 = Monster.CreateVectorOfEnumsVectorBlock(fbb, colorVec);
-            Monster.StartMonster(fbb);
-            Monster.AddName(fbb, str1);
-            Monster.AddVectorOfEnums(fbb, vec1);
-            var monster1 = Monster.EndMonster(fbb);
-            Monster.FinishMonsterBuffer(fbb, monster1);
-
-            var mons = Monster.GetRootAsMonster(fbb.DataBuffer);
-            var colors = mons.GetVectorOfEnumsArray();
-            Assert.ArrayEqual(colorVec, colors);
-        }
-
-        [FlatBuffersTestMethod]
         public void TestNestedFlatBuffer()
         {
             const string nestedMonsterName = "NestedMonsterName";

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -293,6 +293,44 @@ namespace FlatBuffers.Test
         }
 
         [FlatBuffersTestMethod]
+        public void TestVectorOfEnums()
+        {
+            const string monsterName = "TestVectorOfEnumsMonster";
+            var colorVec = new Color[] { Color.Red, Color.Green, Color.Blue };
+            var fbb = new FlatBufferBuilder(32);
+            var str1 = fbb.CreateString(monsterName);
+            var vec1 = Monster.CreateVectorOfEnumsVector(fbb, colorVec);
+            Monster.StartMonster(fbb);
+            Monster.AddName(fbb, str1);
+            Monster.AddVectorOfEnums(fbb, vec1);
+            var monster1 = Monster.EndMonster(fbb);
+            Monster.FinishMonsterBuffer(fbb, monster1);
+
+            var mons = Monster.GetRootAsMonster(fbb.DataBuffer);
+            var colors = mons.GetVectorOfEnumsArray();
+            Assert.ArrayEqual(colorVec, colors);
+        }
+
+        [FlatBuffersTestMethod]
+        public void TestVectorOfEnumsUsingBlockCreate()
+        {
+            const string monsterName = "TestVectorBlockOfEnumsMonster";
+            var colorVec = new Color[] { Color.Red, Color.Green, Color.Blue };
+            var fbb = new FlatBufferBuilder(32);
+            var str1 = fbb.CreateString(monsterName);
+            var vec1 = Monster.CreateVectorOfEnumsVectorBlock(fbb, colorVec);
+            Monster.StartMonster(fbb);
+            Monster.AddName(fbb, str1);
+            Monster.AddVectorOfEnums(fbb, vec1);
+            var monster1 = Monster.EndMonster(fbb);
+            Monster.FinishMonsterBuffer(fbb, monster1);
+
+            var mons = Monster.GetRootAsMonster(fbb.DataBuffer);
+            var colors = mons.GetVectorOfEnumsArray();
+            Assert.ArrayEqual(colorVec, colors);
+        }
+
+        [FlatBuffersTestMethod]
         public void TestNestedFlatBuffer()
         {
             const string nestedMonsterName = "NestedMonsterName";

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -283,7 +283,6 @@ public struct Monster : IFlatbufferObject
   public static void AddAnyAmbiguous(FlatBufferBuilder builder, int anyAmbiguousOffset) { builder.AddOffset(46, anyAmbiguousOffset, 0); }
   public static void AddVectorOfEnums(FlatBufferBuilder builder, VectorOffset vectorOfEnumsOffset) { builder.AddOffset(47, vectorOfEnumsOffset.Value, 0); }
   public static VectorOffset CreateVectorOfEnumsVector(FlatBufferBuilder builder, MyGame.Example.Color[] data) { builder.StartVector(1, data.Length, 1); for (int i = data.Length - 1; i >= 0; i--) builder.AddByte((byte)data[i]); return builder.EndVector(); }
-  public static VectorOffset CreateVectorOfEnumsVectorBlock(FlatBufferBuilder builder, MyGame.Example.Color[] data) { return CreateVectorOfEnumsVector(builder, data); }
   public static void StartVectorOfEnumsVector(FlatBufferBuilder builder, int numElems) { builder.StartVector(1, numElems, 1); }
   public static Offset<MyGame.Example.Monster> EndMonster(FlatBufferBuilder builder) {
     int o = builder.EndTable();

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -186,7 +186,7 @@ public struct Monster : IFlatbufferObject
 #else
   public ArraySegment<byte>? GetVectorOfEnumsBytes() { return __p.__vector_as_arraysegment(98); }
 #endif
-  public MyGame.Example.Color[] GetVectorOfEnumsArray() { return __p.__vector_as_array<MyGame.Example.Color>(98); }
+  public MyGame.Example.Color[] GetVectorOfEnumsArray() { int o = __p.__offset(98); if (o == 0) return null; int p = __p.__vector(o); int l = __p.__vector_len(o); MyGame.Example.Color[] a = new MyGame.Example.Color[l]; for (int i = 0; i < l; i++) { a[i] = (MyGame.Example.Color)__p.bb.Get(p + i * 1); } return a; }
   public bool MutateVectorOfEnums(int j, MyGame.Example.Color vector_of_enums) { int o = __p.__offset(98); if (o != 0) { __p.bb.Put(__p.__vector(o) + j * 1, (byte)vector_of_enums); return true; } else { return false; } }
 
   public static void StartMonster(FlatBufferBuilder builder) { builder.StartTable(48); }
@@ -283,7 +283,7 @@ public struct Monster : IFlatbufferObject
   public static void AddAnyAmbiguous(FlatBufferBuilder builder, int anyAmbiguousOffset) { builder.AddOffset(46, anyAmbiguousOffset, 0); }
   public static void AddVectorOfEnums(FlatBufferBuilder builder, VectorOffset vectorOfEnumsOffset) { builder.AddOffset(47, vectorOfEnumsOffset.Value, 0); }
   public static VectorOffset CreateVectorOfEnumsVector(FlatBufferBuilder builder, MyGame.Example.Color[] data) { builder.StartVector(1, data.Length, 1); for (int i = data.Length - 1; i >= 0; i--) builder.AddByte((byte)data[i]); return builder.EndVector(); }
-  public static VectorOffset CreateVectorOfEnumsVectorBlock(FlatBufferBuilder builder, MyGame.Example.Color[] data) { builder.StartVector(1, data.Length, 1); builder.Add(data); return builder.EndVector(); }
+  public static VectorOffset CreateVectorOfEnumsVectorBlock(FlatBufferBuilder builder, MyGame.Example.Color[] data) { return CreateVectorOfEnumsVector(builder, data); }
   public static void StartVectorOfEnumsVector(FlatBufferBuilder builder, int numElems) { builder.StartVector(1, numElems, 1); }
   public static Offset<MyGame.Example.Monster> EndMonster(FlatBufferBuilder builder) {
     int o = builder.EndTable();

--- a/tests/union_vector/Movie.cs
+++ b/tests/union_vector/Movie.cs
@@ -26,7 +26,7 @@ public struct Movie : IFlatbufferObject
 #else
   public ArraySegment<byte>? GetCharactersTypeBytes() { return __p.__vector_as_arraysegment(8); }
 #endif
-  public Character[] GetCharactersTypeArray() { return __p.__vector_as_array<Character>(8); }
+  public Character[] GetCharactersTypeArray() { int o = __p.__offset(8); if (o == 0) return null; int p = __p.__vector(o); int l = __p.__vector_len(o); Character[] a = new Character[l]; for (int i = 0; i < l; i++) { a[i] = (Character)__p.bb.Get(p + i * 1); } return a; }
   public bool MutateCharactersType(int j, Character characters_type) { int o = __p.__offset(8); if (o != 0) { __p.bb.Put(__p.__vector(o) + j * 1, (byte)characters_type); return true; } else { return false; } }
   public TTable? Characters<TTable>(int j) where TTable : struct, IFlatbufferObject { int o = __p.__offset(10); return o != 0 ? (TTable?)__p.__union<TTable>(__p.__vector(o) + j * 4 - __p.bb_pos) : null; }
   public int CharactersLength { get { int o = __p.__offset(10); return o != 0 ? __p.__vector_len(o) : 0; } }
@@ -49,7 +49,7 @@ public struct Movie : IFlatbufferObject
   public static void AddMainCharacter(FlatBufferBuilder builder, int mainCharacterOffset) { builder.AddOffset(1, mainCharacterOffset, 0); }
   public static void AddCharactersType(FlatBufferBuilder builder, VectorOffset charactersTypeOffset) { builder.AddOffset(2, charactersTypeOffset.Value, 0); }
   public static VectorOffset CreateCharactersTypeVector(FlatBufferBuilder builder, Character[] data) { builder.StartVector(1, data.Length, 1); for (int i = data.Length - 1; i >= 0; i--) builder.AddByte((byte)data[i]); return builder.EndVector(); }
-  public static VectorOffset CreateCharactersTypeVectorBlock(FlatBufferBuilder builder, Character[] data) { builder.StartVector(1, data.Length, 1); builder.Add(data); return builder.EndVector(); }
+  public static VectorOffset CreateCharactersTypeVectorBlock(FlatBufferBuilder builder, Character[] data) { return CreateCharactersTypeVector(builder, data); }
   public static void StartCharactersTypeVector(FlatBufferBuilder builder, int numElems) { builder.StartVector(1, numElems, 1); }
   public static void AddCharacters(FlatBufferBuilder builder, VectorOffset charactersOffset) { builder.AddOffset(3, charactersOffset.Value, 0); }
   public static VectorOffset CreateCharactersVector(FlatBufferBuilder builder, int[] data) { builder.StartVector(4, data.Length, 4); for (int i = data.Length - 1; i >= 0; i--) builder.AddOffset(data[i]); return builder.EndVector(); }

--- a/tests/union_vector/Movie.cs
+++ b/tests/union_vector/Movie.cs
@@ -49,7 +49,6 @@ public struct Movie : IFlatbufferObject
   public static void AddMainCharacter(FlatBufferBuilder builder, int mainCharacterOffset) { builder.AddOffset(1, mainCharacterOffset, 0); }
   public static void AddCharactersType(FlatBufferBuilder builder, VectorOffset charactersTypeOffset) { builder.AddOffset(2, charactersTypeOffset.Value, 0); }
   public static VectorOffset CreateCharactersTypeVector(FlatBufferBuilder builder, Character[] data) { builder.StartVector(1, data.Length, 1); for (int i = data.Length - 1; i >= 0; i--) builder.AddByte((byte)data[i]); return builder.EndVector(); }
-  public static VectorOffset CreateCharactersTypeVectorBlock(FlatBufferBuilder builder, Character[] data) { return CreateCharactersTypeVector(builder, data); }
   public static void StartCharactersTypeVector(FlatBufferBuilder builder, int numElems) { builder.StartVector(1, numElems, 1); }
   public static void AddCharacters(FlatBufferBuilder builder, VectorOffset charactersOffset) { builder.AddOffset(3, charactersOffset.Value, 0); }
   public static VectorOffset CreateCharactersVector(FlatBufferBuilder builder, int[] data) { builder.StartVector(4, data.Length, 4); for (int i = data.Length - 1; i >= 0; i--) builder.AddOffset(data[i]); return builder.EndVector(); }


### PR DESCRIPTION
Follow-up to #5419

The C# `ByteBuffer` class features a number of generic methods which are employed mostly when dealing with vectors. The generic methods work using a static table of type sizes, and do not support any type not in the table, including the enum types generated from flatbuffer schemas. They also use the `Buffer.BlockCopy` method to copy directly between the backing byte array and strongly typed arrays returned to or supplied from the user, and this method does not work with enum-typed arrays.

The C# code generator works around `ByteBuffer`'s lack of support for enum types by casting to/from the generated enum types when using the various `Get*`/`Put*` methods for reading/writing individual integer values. But for some generated code this work-around is not applicable, and flatc generates code which invokes the generic `ByteBuffer` methods using enum types, which will always throw at runtime.

I considered first attempting to address the limitations in `ByteBuffer` instead, but saw no way to do this without negatively impacting either performance or compatibility.

My solution modifies the generator to avoid calling the generic methods with enum types:

- Generated static `Create*VectorBlock()` methods now delegate to their `Create*Vector()` counterparts, which are semantically identical but slower. They should really be removed but I kept them there for backwards compatibility.
- Generated `Get*Array()` methods now directly create an array and copy data into it in a loop instead of calling `__vector_as_array<T>()`. Data is read into the array the same way the standard accessors for enum vectors read from the buffer, by using a specific `Get*()` method and casting to the enum type. The loop is roughly modelled after similar loops generated in `Create*Vector()` methods.