### PR TITLE
[Lua] Fix for boolean PrependSlot (#5379)

### DIFF
--- a/lua/flatbuffers/numTypes.lua
+++ b/lua/flatbuffers/numTypes.lua
@@ -53,7 +53,12 @@ local bool_mt =
     max_value = true,
     lua_type = type(true),
     name = "bool",
-    packFmt = "<b"
+    packFmt = "<I1",
+    Pack = function(self, value) return value and "1" or "0" end,
+    Unpack = function(self, buf, pos) return buf[pos] == "1" end,
+    ValidNumber = function(self, n) return true end, -- anything is a valid boolean in Lua
+    EnforceNumber = function(self, n) end, -- anything is a valid boolean in Lua
+    EnforceNumberAndPack = function(self, n) return self:Pack(value) end,
 }
 
 local uint8_mt = 
@@ -170,7 +175,6 @@ setmetatable(float32_mt, {__index = type_mt})
 setmetatable(float64_mt, {__index = type_mt})
 
 
-m.Bool      = bool_mt
 m.Uint8     = uint8_mt
 m.Uint16    = uint16_mt
 m.Uint32    = uint32_mt
@@ -186,7 +190,7 @@ m.UOffsetT  = uint32_mt
 m.VOffsetT  = uint16_mt
 m.SOffsetT  = int32_mt
 
-function GenerateTypes(listOfTypes)
+local GenerateTypes = function(listOfTypes)
     for _,t in pairs(listOfTypes) do
         t.Pack = function(self, value) return bpack(self.packFmt, value) end
         t.Unpack = function(self, buf, pos) return bunpack(self.packFmt, buf, pos) end
@@ -195,4 +199,6 @@ end
 
 GenerateTypes(m)
 
+-- explicitly execute after GenerateTypes call, as we don't want to define a Pack/Unpack function for it.
+m.Bool      = bool_mt
 return m

--- a/tests/LuaTest.sh
+++ b/tests/LuaTest.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+#
+# Copyright 2019 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pushd "$(dirname $0)" >/dev/null
+test_dir="$(pwd)"
+
+${test_dir}/../flatc --lua -I include_test monster_test.fbs
+
+lua5.3 luatest.lua

--- a/tests/luatest.lua
+++ b/tests/luatest.lua
@@ -9,9 +9,7 @@ local function checkReadBuffer(buf, offset, sizePrefix)
     
     if sizePrefix then               
         local size = flatbuffers.N.Int32:Unpack(buf, offset)
-        -- no longer matches python tests, but the latest 'monsterdata_test.mon'
-        -- is 448 bytes, minus 4 to arrive at the 444
-        assert(size == 444)
+        assert(size == #buf - offset - 4)
         offset = offset + flatbuffers.N.Int32.bytewidth
     end    
     
@@ -136,6 +134,10 @@ local function generateMonster(sizePrefix)
     monster.AddTestType(b, 1)
     monster.AddTest(b, mon2)
     monster.AddTest4(b, test4)
+    monster.AddTestbool(b, true)
+    monster.AddTestbool(b, false)
+    monster.AddTestbool(b, null)
+    monster.AddTestbool(b,"true")
     monster.AddTestarrayofstring(b, testArrayOfString)
     monster.AddVectorOfLongs(b, vectorOfLongs)
     monster.AddVectorOfDoubles(b, vectorOfDoubles)


### PR DESCRIPTION
The packing/unpacking steps for Boolean values was failing because the
code expected numerical values. I overrode the functions for the Boolean
metatable to account for this. I also had to exclude the Boolean
metatable from the GenerateTypes helper function, as that was overriding
the Pack/Unpack functions defined in its metatable.

Added Linux bash script to run Lua tests from the command line.

Bug: google/flatbuffers#5379

Tested: Added Lua tests that were failing with reported error and are now fixed with the
code changes herein.
