### PR TITLE
has_method support for primitive fields in java runtime. Changed: idl.h, FlatBufferBuilder.java ,  idl_gen_general.cpp, idl_parser.cpp, flatc.cpp

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -527,6 +527,7 @@ struct IDLOptions {
   bool size_prefixed;
   std::string root_type;
   bool force_defaults;
+  bool java_primitive_has_method;
   std::vector<std::string> cpp_includes;
 
   // Possible options for the more general generator below.
@@ -600,6 +601,7 @@ struct IDLOptions {
         protobuf_ascii_alike(false),
         size_prefixed(false),
         force_defaults(false),
+        java_primitive_has_method(false),
         lang(IDLOptions::kJava),
         mini_reflect(IDLOptions::kNone),
         lang_to_generate(0),
@@ -924,6 +926,8 @@ class Parser : public ParserState {
 // Utility functions for multiple generators:
 
 extern std::string MakeCamel(const std::string &in, bool first = true);
+
+extern std::string MakeScreamingCamel(const std::string &in);
 
 // Generate text (JSON) from a given FlatBuffer, and a given Parser
 // object that has been populated with the corresponding schema.

--- a/java/com/google/flatbuffers/FlatBufferBuilder.java
+++ b/java/com/google/flatbuffers/FlatBufferBuilder.java
@@ -199,6 +199,17 @@ public class FlatBufferBuilder {
         }
     }
 
+   /**
+   * Helper function to test if a field is present in the table
+   *
+   * @param table Flatbuffer table
+   * @param offset virtual table offset
+   * @return true if the filed is present
+   */
+   public static boolean isFieldPresent(Table table, int offset) {
+     return table.__offset(offset) != 0;
+   }
+
     /**
      * Reset the FlatBufferBuilder by purging all data that it holds.
      */

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -319,6 +319,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.force_defaults = true;
       } else if (arg == "--force-empty") {
         opts.set_empty_to_null = false;
+      } else if (arg == "--java_primitive_has_method") {
+        opts.java_primitive_has_method = true;
       } else {
         for (size_t i = 0; i < params_.num_generators; ++i) {
           if (arg == params_.generators[i].generator_opt_long ||

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -319,7 +319,7 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.force_defaults = true;
       } else if (arg == "--force-empty") {
         opts.set_empty_to_null = false;
-      } else if (arg == "--java_primitive_has_method") {
+      } else if (arg == "--java-primitive-has-method") {
         opts.java_primitive_has_method = true;
       } else {
         for (size_t i = 0; i < params_.num_generators; ++i) {

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -1323,6 +1323,15 @@ class GeneralGenerator : public BaseGenerator {
           }
         }
       }
+      if (parser_.opts.java_primitive_has_method &&
+          IsScalar(field.value.type.base_type) && !struct_def.fixed) {
+        auto vt_offset_constant = "  public static final int VT_" +
+                                  MakeScreamingCamel(field.name) + " = " +
+                                  NumToString(field.value.offset) + ";";
+
+        code += vt_offset_constant;
+        code += "\n";
+      }
     }
     code += "\n";
     flatbuffers::FieldDef *key_field = nullptr;

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -102,6 +102,18 @@ std::string MakeCamel(const std::string &in, bool first) {
   return s;
 }
 
+// Convert an underscore_based_identifier in to screaming snake case.
+std::string MakeScreamingCamel(const std::string &in) {
+  std::string s;
+  for (size_t i = 0; i < in.length(); i++) {
+    if (in[i] != '_')
+      s += static_cast<char>(toupper(in[i]));
+    else
+      s += in[i];
+  }
+  return s;
+}
+
 void DeserializeDoc( std::vector<std::string> &doc,
                      const Vector<Offset<String>> *documentation) {
   if (documentation == nullptr) return;


### PR DESCRIPTION
Adding a new  compile flag 
`--java_primitive_has_method
`
that generates get methods for the virtual table offset for the the primitive fields in java runtime.

If  `force_defaults` is set to true in FlatbufferBuilder, then we can check if the primitive filed is present:

**FlatbufferObject tableObject** [instance of Table]
``` 
if (FlatBufferBuilder.isFieldPresent(tableObject, FlatbufferObject.VT_INTEGER)) {
     tableObject.getInteger()
}
```
