### PR TITLE
Fix compilation error in tests.

### DIFF
--- a/tests/native_type_test_impl.h
+++ b/tests/native_type_test_impl.h
@@ -8,7 +8,7 @@ namespace Native {
     float z;
 
     Vector3D() { x = 0; y = 0; z = 0; };
-    Vector3D(float x, float y, float z) { this->x = x; this->y = y; this->z = z; }
+    Vector3D(float _x, float _y, float _z) { this->x = _x; this->y = _y; this->z = _z; }
   };
 }
 


### PR DESCRIPTION
Local variables were shadowing member fields, causing errors.


