### PR TITLE
[go]add Name() for ForceCodec  interface

### DIFF
--- a/go/grpc.go
+++ b/go/grpc.go
@@ -27,6 +27,8 @@ func (FlatbuffersCodec) String() string {
 // Name returns the name of the Codec implementation. The returned string
 // will be used as part of content type in transmission.  The result must be
 // static; the result cannot change between calls.
+//
+// add Name() for ForceCodec interface
 func (FlatbuffersCodec) Name() string {
 	return Codec
 }

--- a/go/grpc.go
+++ b/go/grpc.go
@@ -3,18 +3,31 @@ package flatbuffers
 // Codec implements gRPC-go Codec which is used to encode and decode messages.
 var Codec = "flatbuffers"
 
+// FlatbuffersCodec defines the interface gRPC uses to encode and decode messages.  Note
+// that implementations of this interface must be thread safe; a Codec's
+// methods can be called from concurrent goroutines.
 type FlatbuffersCodec struct{}
 
+// Marshal returns the wire format of v.
 func (FlatbuffersCodec) Marshal(v interface{}) ([]byte, error) {
 	return v.(*Builder).FinishedBytes(), nil
 }
 
+// Unmarshal parses the wire format into v.
 func (FlatbuffersCodec) Unmarshal(data []byte, v interface{}) error {
 	v.(flatbuffersInit).Init(data, GetUOffsetT(data))
 	return nil
 }
 
+// String  old gRPC Codec interface func
 func (FlatbuffersCodec) String() string {
+	return Codec
+}
+
+// Name returns the name of the Codec implementation. The returned string
+// will be used as part of content type in transmission.  The result must be
+// static; the result cannot change between calls.
+func (FlatbuffersCodec) Name() string {
 	return Codec
 }
 


### PR DESCRIPTION
// ForceCodec returns a CallOption that will set the given Codec to be
// used for all request and response messages for a call. The result of calling
// String() will be used as the content-subtype in a case-insensitive manner.
//

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
