### PR TITLE
Disable lint check to workaround broken Android build tools.

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,1 @@
+gradle=build -x lint -x lintVitalRelease

--- a/samples/android/gradle.properties
+++ b/samples/android/gradle.properties
@@ -1,0 +1,1 @@
+gradle=build -x lint -x lintVitalRelease


### PR DESCRIPTION
Android builds started to fail during lint checks displaying the
following...

The value of attribute "name" associated with an element type "item" must not contain the '<' character.
Could not read /usr/local/android-sdk/platform-tools/api/annotations.zip
java.io.IOException: Could not parse XML from android/accounts/annotations.xml
... long stack trace ...

This disables the lint check to workaround
https://issuetracker.google.com/issues/116182838

Thank you for submitting a PR!

Please make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

Include other details as appropriate.

Thanks!
