### PR TITLE
[Dart]fix: segment fault with empty namespace when generating dart file

### DIFF
--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -71,7 +71,7 @@ class DartGenerator : public BaseGenerator {
              "// ignore_for_file: unused_import, unused_field, "
              "unused_local_variable\n\n";
 
-      if (kv->first != "") {
+      if (!kv->first.empty()) {
         code += "library " + kv->first + ";\n\n";
       }
 
@@ -87,7 +87,7 @@ class DartGenerator : public BaseGenerator {
            ++kv2) {
         if (kv2->first != kv->first) {
           code += "import '" +
-                  GeneratedFileName("./", file_name_ + (kv2->first != "" ? "_" + kv2->first : "")) +
+                  GeneratedFileName("./", file_name_ + (!kv2->first.empty() ? "_" + kv2->first : "")) +
                   "' as " + ImportAliasName(kv2->first) + ";\n";
         }
       }
@@ -95,7 +95,7 @@ class DartGenerator : public BaseGenerator {
       code += kv->second;
 
       if (!SaveFile(
-              GeneratedFileName(path_, file_name_ + (kv->first != "" ? "_" + kv->first : "")).c_str(),
+              GeneratedFileName(path_, file_name_ + (!kv->first.empty() ? "_" + kv->first : "")).c_str(),
               code, false)) {
         return false;
       }

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -87,7 +87,7 @@ class DartGenerator : public BaseGenerator {
            ++kv2) {
         if (kv2->first != kv->first) {
           code += "import '" +
-                  GeneratedFileName("./", file_name_ + (kv->first != "" ? "_" + kv2->first : "") +
+                  GeneratedFileName("./", file_name_ + (kv2->first != "" ? "_" + kv2->first : "") +
                   "' as " + ImportAliasName(kv2->first) + ";\n");
         }
       }
@@ -147,7 +147,7 @@ class DartGenerator : public BaseGenerator {
       auto noext = flatbuffers::StripExtension(it->second);
       auto basename = flatbuffers::StripPath(noext);
 
-      *code += "import '" + GeneratedFileName("", basename + "_" + the_namespace) + "';\n";
+      *code += "import '" + GeneratedFileName("", basename + (the_namespace == "" ? "" : "_" + the_namespace)) + "';\n";
     }
   }
 

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -95,7 +95,7 @@ class DartGenerator : public BaseGenerator {
       code += kv->second;
 
       if (!SaveFile(
-              GeneratedFileName(path_, file_name_ + (kv->first != "" ? "_" + kv2->first : ""),
+              GeneratedFileName(path_, file_name_ + (kv->first != "" ? "_" + kv->first : ""),
               code, false)) {
         return false;
       }

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -95,7 +95,7 @@ class DartGenerator : public BaseGenerator {
       code += kv->second;
 
       if (!SaveFile(
-              GeneratedFileName(path_, file_name_ + (kv->first != "" ? "_" + kv->first : ""),
+              GeneratedFileName(path_, file_name_ + (kv->first != "" ? "_" + kv->first : "")).c_str(),
               code, false)) {
         return false;
       }

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -71,7 +71,9 @@ class DartGenerator : public BaseGenerator {
              "// ignore_for_file: unused_import, unused_field, "
              "unused_local_variable\n\n";
 
-      code += "library " + kv->first + ";\n\n";
+      if (kv->first != "") {
+        code += "library " + kv->first + ";\n\n";
+      }
 
       code += "import 'dart:typed_data' show Uint8List;\n";
       code += "import 'package:flat_buffers/flat_buffers.dart' as " + _kFb +
@@ -85,15 +87,15 @@ class DartGenerator : public BaseGenerator {
            ++kv2) {
         if (kv2->first != kv->first) {
           code += "import '" +
-                  GeneratedFileName("./", file_name_ + "_" + kv2->first) +
-                  "' as " + ImportAliasName(kv2->first) + ";\n";
+                  GeneratedFileName("./", file_name_ + (kv->first != "" ? "_" + kv2->first : "") +
+                  "' as " + ImportAliasName(kv2->first) + ";\n");
         }
       }
       code += "\n";
       code += kv->second;
 
       if (!SaveFile(
-              GeneratedFileName(path_, file_name_ + "_" + kv->first).c_str(),
+              GeneratedFileName(path_, file_name_ + (kv->first != "" ? "_" + kv2->first : ""),
               code, false)) {
         return false;
       }
@@ -115,6 +117,9 @@ class DartGenerator : public BaseGenerator {
   }
 
   static std::string BuildNamespaceName(const Namespace &ns) {
+    if (ns.components.empty()) {
+      return "";
+    }
     std::stringstream sstream;
     std::copy(ns.components.begin(), ns.components.end() - 1,
               std::ostream_iterator<std::string>(sstream, "."));

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -87,8 +87,8 @@ class DartGenerator : public BaseGenerator {
            ++kv2) {
         if (kv2->first != kv->first) {
           code += "import '" +
-                  GeneratedFileName("./", file_name_ + (kv2->first != "" ? "_" + kv2->first : "") +
-                  "' as " + ImportAliasName(kv2->first) + ";\n");
+                  GeneratedFileName("./", file_name_ + (kv2->first != "" ? "_" + kv2->first : "")) +
+                  "' as " + ImportAliasName(kv2->first) + ";\n";
         }
       }
       code += "\n";


### PR DESCRIPTION
A segmentation fault occurred when trying to use flatc generate a .dart file with scheme file with out namespace(which works properly on other languages). Here is the fix