### PR TITLE
Use no_sanitize_address for clang

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -243,7 +243,7 @@ namespace flatbuffers {
 // - __supress_ubsan__("undefined")
 // - __supress_ubsan__("signed-integer-overflow")
 #if defined(__clang__)
-  #define __supress_ubsan__(type) __attribute__((no_sanitize(type)))
+  #define __supress_ubsan__(type) __attribute__((no_sanitize_address))
 #elif defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 409)
   #define __supress_ubsan__(type) __attribute__((no_sanitize_undefined))
 #else


### PR DESCRIPTION
Found to work on a broader range on architectures/clang versions.