### PR TITLE
Add element size parameter to __vector_as_arraysegment [c#]

### DIFF
--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -89,7 +89,7 @@ namespace FlatBuffers
         // Get the data of a vector whoses offset is stored at "offset" in this object as an
         // Spant&lt;byte&gt;. If the vector is not present in the ByteBuffer,
         // then an empty span will be returned.
-        public Span<byte> __vector_as_span(int offset)
+        public Span<byte> __vector_as_span(int offset, int elementSize)
         {
             var o = this.__offset(offset);
             if (0 == o)
@@ -99,7 +99,7 @@ namespace FlatBuffers
 
             var pos = this.__vector(o);
             var len = this.__vector_len(o);
-            return bb.ToSpan(pos, len);
+            return bb.ToSpan(pos, len * elementSize);
         }
 #else
         // Get the data of a vector whoses offset is stored at "offset" in this object as an

--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Text;
+using System.Runtime.InteropServices;
 
 namespace FlatBuffers
 {
@@ -89,17 +90,23 @@ namespace FlatBuffers
         // Get the data of a vector whoses offset is stored at "offset" in this object as an
         // Spant&lt;byte&gt;. If the vector is not present in the ByteBuffer,
         // then an empty span will be returned.
-        public Span<byte> __vector_as_span(int offset, int elementSize)
+        public Span<T> __vector_as_span<T>(int offset, int elementSize) where T : struct
         {
+            if (!BitConverter.IsLittleEndian)
+            {
+               throw new NotSupportedException("Getting typed span on a Big Endian " +
+                                               "system is not support");
+            }
+
             var o = this.__offset(offset);
             if (0 == o)
             {
-                return new Span<byte>();
+                return new Span<T>();
             }
 
             var pos = this.__vector(o);
             var len = this.__vector_len(o);
-            return bb.ToSpan(pos, len * elementSize);
+            return MemoryMarshal.Cast<byte, T>(bb.ToSpan(pos, len * elementSize));
         }
 #else
         // Get the data of a vector whoses offset is stored at "offset" in this object as an

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -1218,12 +1218,11 @@ class GeneralGenerator : public BaseGenerator {
             break;
           case IDLOptions::kCSharp:
             code += "#if ENABLE_SPAN_T\n";
-            code += "  public Span<byte> Get";
+            code += "  public Span<" + GenTypeBasic(field.value.type.VectorType()) + "> Get";
             code += MakeCamel(field.name, lang_.first_camel_upper);
             code += "Bytes() { return ";
-            code += lang_.accessor_prefix + "__vector_as_span(";
+            code += lang_.accessor_prefix + "__vector_as_span<"+ GenTypeBasic(field.value.type.VectorType()) +">(";
             code += NumToString(field.value.offset);
-            code += ", " + NumToString(SizeOf(field.value.type.VectorType().base_type));
             code += "); }\n";
             code += "#else\n";
             code += "  public ArraySegment<byte>? Get";

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -1223,6 +1223,7 @@ class GeneralGenerator : public BaseGenerator {
             code += "Bytes() { return ";
             code += lang_.accessor_prefix + "__vector_as_span(";
             code += NumToString(field.value.offset);
+            code += ", " + NumToString(SizeOf(field.value.type.VectorType().base_type));
             code += "); }\n";
             code += "#else\n";
             code += "  public ArraySegment<byte>? Get";

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -1223,13 +1223,14 @@ class GeneralGenerator : public BaseGenerator {
             code += "Bytes() { return ";
             code += lang_.accessor_prefix + "__vector_as_span<"+ GenTypeBasic(field.value.type.VectorType()) +">(";
             code += NumToString(field.value.offset);
+            code += ", " + NumToString(SizeOf(field.value.type.VectorType().base_type));
             code += "); }\n";
             code += "#else\n";
             code += "  public ArraySegment<byte>? Get";
             code += MakeCamel(field.name, lang_.first_camel_upper);
             code += "Bytes() { return ";
             code += lang_.accessor_prefix + "__vector_as_arraysegment(";
-            code += NumToString(field.value.offset);
+            code += NumToString(field.value.offset);           
             code += "); }\n";
             code += "#endif\n";
 

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -260,6 +260,12 @@ namespace FlatBuffers.Test
             {
                 Assert.IsTrue(monster.GetTestarrayofboolsBytes().Length != 0);
             }
+
+            var longArrayBytes = monster.GetVectorOfLongsBytes();
+            Assert.IsTrue(monster.VectorOfLongsLength * 8 == longArrayBytes.Length);
+
+            var doubleArrayBytes = monster.GetVectorOfDoublesBytes();
+            Assert.IsTrue(monster.VectorOfDoublesLength * 8 == doubleArrayBytes.Length);
 #else
             var nameBytes = monster.GetNameBytes().Value;
             Assert.AreEqual("MyMonster", Encoding.UTF8.GetString(nameBytes.Array, nameBytes.Offset, nameBytes.Count));
@@ -273,7 +279,7 @@ namespace FlatBuffers.Test
                 Assert.IsTrue(monster.GetTestarrayofboolsBytes().HasValue);
             }
 #endif
-        }
+    }
 
         [FlatBuffersTestMethod]
         public void CanReadCppGeneratedWireFile()

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -27,7 +27,7 @@ public struct Monster : IFlatbufferObject
   public bool MutateHp(short hp) { int o = __p.__offset(8); if (o != 0) { __p.bb.PutShort(o + __p.bb_pos, hp); return true; } else { return false; } }
   public string Name { get { int o = __p.__offset(10); return o != 0 ? __p.__string(o + __p.bb_pos) : null; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetNameBytes() { return __p.__vector_as_span(10, 1); }
+  public Span<byte> GetNameBytes() { return __p.__vector_as_span<byte>(10, 1); }
 #else
   public ArraySegment<byte>? GetNameBytes() { return __p.__vector_as_arraysegment(10); }
 #endif
@@ -35,7 +35,7 @@ public struct Monster : IFlatbufferObject
   public byte Inventory(int j) { int o = __p.__offset(14); return o != 0 ? __p.bb.Get(__p.__vector(o) + j * 1) : (byte)0; }
   public int InventoryLength { get { int o = __p.__offset(14); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetInventoryBytes() { return __p.__vector_as_span(14, 1); }
+  public Span<byte> GetInventoryBytes() { return __p.__vector_as_span<byte>(14, 1); }
 #else
   public ArraySegment<byte>? GetInventoryBytes() { return __p.__vector_as_arraysegment(14); }
 #endif
@@ -59,7 +59,7 @@ public struct Monster : IFlatbufferObject
   public byte Testnestedflatbuffer(int j) { int o = __p.__offset(30); return o != 0 ? __p.bb.Get(__p.__vector(o) + j * 1) : (byte)0; }
   public int TestnestedflatbufferLength { get { int o = __p.__offset(30); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetTestnestedflatbufferBytes() { return __p.__vector_as_span(30, 1); }
+  public Span<byte> GetTestnestedflatbufferBytes() { return __p.__vector_as_span<byte>(30, 1); }
 #else
   public ArraySegment<byte>? GetTestnestedflatbufferBytes() { return __p.__vector_as_arraysegment(30); }
 #endif
@@ -88,7 +88,7 @@ public struct Monster : IFlatbufferObject
   public bool Testarrayofbools(int j) { int o = __p.__offset(52); return o != 0 ? 0!=__p.bb.Get(__p.__vector(o) + j * 1) : false; }
   public int TestarrayofboolsLength { get { int o = __p.__offset(52); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetTestarrayofboolsBytes() { return __p.__vector_as_span(52, 1); }
+  public Span<bool> GetTestarrayofboolsBytes() { return __p.__vector_as_span<bool>(52, 1); }
 #else
   public ArraySegment<byte>? GetTestarrayofboolsBytes() { return __p.__vector_as_arraysegment(52); }
 #endif
@@ -107,7 +107,7 @@ public struct Monster : IFlatbufferObject
   public byte Flex(int j) { int o = __p.__offset(64); return o != 0 ? __p.bb.Get(__p.__vector(o) + j * 1) : (byte)0; }
   public int FlexLength { get { int o = __p.__offset(64); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetFlexBytes() { return __p.__vector_as_span(64, 1); }
+  public Span<byte> GetFlexBytes() { return __p.__vector_as_span<byte>(64, 1); }
 #else
   public ArraySegment<byte>? GetFlexBytes() { return __p.__vector_as_arraysegment(64); }
 #endif
@@ -118,7 +118,7 @@ public struct Monster : IFlatbufferObject
   public long VectorOfLongs(int j) { int o = __p.__offset(68); return o != 0 ? __p.bb.GetLong(__p.__vector(o) + j * 8) : (long)0; }
   public int VectorOfLongsLength { get { int o = __p.__offset(68); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfLongsBytes() { return __p.__vector_as_span(68, 8); }
+  public Span<long> GetVectorOfLongsBytes() { return __p.__vector_as_span<long>(68, 8); }
 #else
   public ArraySegment<byte>? GetVectorOfLongsBytes() { return __p.__vector_as_arraysegment(68); }
 #endif
@@ -127,7 +127,7 @@ public struct Monster : IFlatbufferObject
   public double VectorOfDoubles(int j) { int o = __p.__offset(70); return o != 0 ? __p.bb.GetDouble(__p.__vector(o) + j * 8) : (double)0; }
   public int VectorOfDoublesLength { get { int o = __p.__offset(70); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfDoublesBytes() { return __p.__vector_as_span(70, 8); }
+  public Span<double> GetVectorOfDoublesBytes() { return __p.__vector_as_span<double>(70, 8); }
 #else
   public ArraySegment<byte>? GetVectorOfDoublesBytes() { return __p.__vector_as_arraysegment(70); }
 #endif
@@ -142,7 +142,7 @@ public struct Monster : IFlatbufferObject
   public ulong VectorOfWeakReferences(int j) { int o = __p.__offset(78); return o != 0 ? __p.bb.GetUlong(__p.__vector(o) + j * 8) : (ulong)0; }
   public int VectorOfWeakReferencesLength { get { int o = __p.__offset(78); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfWeakReferencesBytes() { return __p.__vector_as_span(78, 8); }
+  public Span<ulong> GetVectorOfWeakReferencesBytes() { return __p.__vector_as_span<ulong>(78, 8); }
 #else
   public ArraySegment<byte>? GetVectorOfWeakReferencesBytes() { return __p.__vector_as_arraysegment(78); }
 #endif
@@ -156,7 +156,7 @@ public struct Monster : IFlatbufferObject
   public ulong VectorOfCoOwningReferences(int j) { int o = __p.__offset(84); return o != 0 ? __p.bb.GetUlong(__p.__vector(o) + j * 8) : (ulong)0; }
   public int VectorOfCoOwningReferencesLength { get { int o = __p.__offset(84); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfCoOwningReferencesBytes() { return __p.__vector_as_span(84, 8); }
+  public Span<ulong> GetVectorOfCoOwningReferencesBytes() { return __p.__vector_as_span<ulong>(84, 8); }
 #else
   public ArraySegment<byte>? GetVectorOfCoOwningReferencesBytes() { return __p.__vector_as_arraysegment(84); }
 #endif
@@ -167,7 +167,7 @@ public struct Monster : IFlatbufferObject
   public ulong VectorOfNonOwningReferences(int j) { int o = __p.__offset(88); return o != 0 ? __p.bb.GetUlong(__p.__vector(o) + j * 8) : (ulong)0; }
   public int VectorOfNonOwningReferencesLength { get { int o = __p.__offset(88); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfNonOwningReferencesBytes() { return __p.__vector_as_span(88, 8); }
+  public Span<ulong> GetVectorOfNonOwningReferencesBytes() { return __p.__vector_as_span<ulong>(88, 8); }
 #else
   public ArraySegment<byte>? GetVectorOfNonOwningReferencesBytes() { return __p.__vector_as_arraysegment(88); }
 #endif
@@ -182,7 +182,7 @@ public struct Monster : IFlatbufferObject
   public MyGame.Example.Color VectorOfEnums(int j) { int o = __p.__offset(98); return o != 0 ? (MyGame.Example.Color)__p.bb.Get(__p.__vector(o) + j * 1) : (MyGame.Example.Color)0; }
   public int VectorOfEnumsLength { get { int o = __p.__offset(98); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfEnumsBytes() { return __p.__vector_as_span(98, 1); }
+  public Span<MyGame.Example.Color> GetVectorOfEnumsBytes() { return __p.__vector_as_span<MyGame.Example.Color>(98, 1); }
 #else
   public ArraySegment<byte>? GetVectorOfEnumsBytes() { return __p.__vector_as_arraysegment(98); }
 #endif

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -27,7 +27,7 @@ public struct Monster : IFlatbufferObject
   public bool MutateHp(short hp) { int o = __p.__offset(8); if (o != 0) { __p.bb.PutShort(o + __p.bb_pos, hp); return true; } else { return false; } }
   public string Name { get { int o = __p.__offset(10); return o != 0 ? __p.__string(o + __p.bb_pos) : null; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetNameBytes() { return __p.__vector_as_span(10); }
+  public Span<byte> GetNameBytes() { return __p.__vector_as_span(10, 1); }
 #else
   public ArraySegment<byte>? GetNameBytes() { return __p.__vector_as_arraysegment(10); }
 #endif
@@ -35,7 +35,7 @@ public struct Monster : IFlatbufferObject
   public byte Inventory(int j) { int o = __p.__offset(14); return o != 0 ? __p.bb.Get(__p.__vector(o) + j * 1) : (byte)0; }
   public int InventoryLength { get { int o = __p.__offset(14); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetInventoryBytes() { return __p.__vector_as_span(14); }
+  public Span<byte> GetInventoryBytes() { return __p.__vector_as_span(14, 1); }
 #else
   public ArraySegment<byte>? GetInventoryBytes() { return __p.__vector_as_arraysegment(14); }
 #endif
@@ -59,7 +59,7 @@ public struct Monster : IFlatbufferObject
   public byte Testnestedflatbuffer(int j) { int o = __p.__offset(30); return o != 0 ? __p.bb.Get(__p.__vector(o) + j * 1) : (byte)0; }
   public int TestnestedflatbufferLength { get { int o = __p.__offset(30); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetTestnestedflatbufferBytes() { return __p.__vector_as_span(30); }
+  public Span<byte> GetTestnestedflatbufferBytes() { return __p.__vector_as_span(30, 1); }
 #else
   public ArraySegment<byte>? GetTestnestedflatbufferBytes() { return __p.__vector_as_arraysegment(30); }
 #endif
@@ -88,7 +88,7 @@ public struct Monster : IFlatbufferObject
   public bool Testarrayofbools(int j) { int o = __p.__offset(52); return o != 0 ? 0!=__p.bb.Get(__p.__vector(o) + j * 1) : false; }
   public int TestarrayofboolsLength { get { int o = __p.__offset(52); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetTestarrayofboolsBytes() { return __p.__vector_as_span(52); }
+  public Span<byte> GetTestarrayofboolsBytes() { return __p.__vector_as_span(52, 1); }
 #else
   public ArraySegment<byte>? GetTestarrayofboolsBytes() { return __p.__vector_as_arraysegment(52); }
 #endif
@@ -107,7 +107,7 @@ public struct Monster : IFlatbufferObject
   public byte Flex(int j) { int o = __p.__offset(64); return o != 0 ? __p.bb.Get(__p.__vector(o) + j * 1) : (byte)0; }
   public int FlexLength { get { int o = __p.__offset(64); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetFlexBytes() { return __p.__vector_as_span(64); }
+  public Span<byte> GetFlexBytes() { return __p.__vector_as_span(64, 1); }
 #else
   public ArraySegment<byte>? GetFlexBytes() { return __p.__vector_as_arraysegment(64); }
 #endif
@@ -118,7 +118,7 @@ public struct Monster : IFlatbufferObject
   public long VectorOfLongs(int j) { int o = __p.__offset(68); return o != 0 ? __p.bb.GetLong(__p.__vector(o) + j * 8) : (long)0; }
   public int VectorOfLongsLength { get { int o = __p.__offset(68); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfLongsBytes() { return __p.__vector_as_span(68); }
+  public Span<byte> GetVectorOfLongsBytes() { return __p.__vector_as_span(68, 8); }
 #else
   public ArraySegment<byte>? GetVectorOfLongsBytes() { return __p.__vector_as_arraysegment(68); }
 #endif
@@ -127,7 +127,7 @@ public struct Monster : IFlatbufferObject
   public double VectorOfDoubles(int j) { int o = __p.__offset(70); return o != 0 ? __p.bb.GetDouble(__p.__vector(o) + j * 8) : (double)0; }
   public int VectorOfDoublesLength { get { int o = __p.__offset(70); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfDoublesBytes() { return __p.__vector_as_span(70); }
+  public Span<byte> GetVectorOfDoublesBytes() { return __p.__vector_as_span(70, 8); }
 #else
   public ArraySegment<byte>? GetVectorOfDoublesBytes() { return __p.__vector_as_arraysegment(70); }
 #endif
@@ -142,7 +142,7 @@ public struct Monster : IFlatbufferObject
   public ulong VectorOfWeakReferences(int j) { int o = __p.__offset(78); return o != 0 ? __p.bb.GetUlong(__p.__vector(o) + j * 8) : (ulong)0; }
   public int VectorOfWeakReferencesLength { get { int o = __p.__offset(78); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfWeakReferencesBytes() { return __p.__vector_as_span(78); }
+  public Span<byte> GetVectorOfWeakReferencesBytes() { return __p.__vector_as_span(78, 8); }
 #else
   public ArraySegment<byte>? GetVectorOfWeakReferencesBytes() { return __p.__vector_as_arraysegment(78); }
 #endif
@@ -156,7 +156,7 @@ public struct Monster : IFlatbufferObject
   public ulong VectorOfCoOwningReferences(int j) { int o = __p.__offset(84); return o != 0 ? __p.bb.GetUlong(__p.__vector(o) + j * 8) : (ulong)0; }
   public int VectorOfCoOwningReferencesLength { get { int o = __p.__offset(84); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfCoOwningReferencesBytes() { return __p.__vector_as_span(84); }
+  public Span<byte> GetVectorOfCoOwningReferencesBytes() { return __p.__vector_as_span(84, 8); }
 #else
   public ArraySegment<byte>? GetVectorOfCoOwningReferencesBytes() { return __p.__vector_as_arraysegment(84); }
 #endif
@@ -167,7 +167,7 @@ public struct Monster : IFlatbufferObject
   public ulong VectorOfNonOwningReferences(int j) { int o = __p.__offset(88); return o != 0 ? __p.bb.GetUlong(__p.__vector(o) + j * 8) : (ulong)0; }
   public int VectorOfNonOwningReferencesLength { get { int o = __p.__offset(88); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfNonOwningReferencesBytes() { return __p.__vector_as_span(88); }
+  public Span<byte> GetVectorOfNonOwningReferencesBytes() { return __p.__vector_as_span(88, 8); }
 #else
   public ArraySegment<byte>? GetVectorOfNonOwningReferencesBytes() { return __p.__vector_as_arraysegment(88); }
 #endif
@@ -182,7 +182,7 @@ public struct Monster : IFlatbufferObject
   public MyGame.Example.Color VectorOfEnums(int j) { int o = __p.__offset(98); return o != 0 ? (MyGame.Example.Color)__p.bb.Get(__p.__vector(o) + j * 1) : (MyGame.Example.Color)0; }
   public int VectorOfEnumsLength { get { int o = __p.__offset(98); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVectorOfEnumsBytes() { return __p.__vector_as_span(98); }
+  public Span<byte> GetVectorOfEnumsBytes() { return __p.__vector_as_span(98, 1); }
 #else
   public ArraySegment<byte>? GetVectorOfEnumsBytes() { return __p.__vector_as_arraysegment(98); }
 #endif

--- a/tests/MyGame/Example/Stat.cs
+++ b/tests/MyGame/Example/Stat.cs
@@ -20,7 +20,7 @@ public struct Stat : IFlatbufferObject
 
   public string Id { get { int o = __p.__offset(4); return o != 0 ? __p.__string(o + __p.bb_pos) : null; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetIdBytes() { return __p.__vector_as_span(4, 1); }
+  public Span<byte> GetIdBytes() { return __p.__vector_as_span<byte>(4, 1); }
 #else
   public ArraySegment<byte>? GetIdBytes() { return __p.__vector_as_arraysegment(4); }
 #endif

--- a/tests/MyGame/Example/Stat.cs
+++ b/tests/MyGame/Example/Stat.cs
@@ -20,7 +20,7 @@ public struct Stat : IFlatbufferObject
 
   public string Id { get { int o = __p.__offset(4); return o != 0 ? __p.__string(o + __p.bb_pos) : null; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetIdBytes() { return __p.__vector_as_span(4); }
+  public Span<byte> GetIdBytes() { return __p.__vector_as_span(4, 1); }
 #else
   public ArraySegment<byte>? GetIdBytes() { return __p.__vector_as_arraysegment(4); }
 #endif

--- a/tests/MyGame/Example/TypeAliases.cs
+++ b/tests/MyGame/Example/TypeAliases.cs
@@ -41,7 +41,7 @@ public struct TypeAliases : IFlatbufferObject
   public sbyte V8(int j) { int o = __p.__offset(24); return o != 0 ? __p.bb.GetSbyte(__p.__vector(o) + j * 1) : (sbyte)0; }
   public int V8Length { get { int o = __p.__offset(24); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetV8Bytes() { return __p.__vector_as_span(24, 1); }
+  public Span<sbyte> GetV8Bytes() { return __p.__vector_as_span<sbyte>(24, 1); }
 #else
   public ArraySegment<byte>? GetV8Bytes() { return __p.__vector_as_arraysegment(24); }
 #endif
@@ -50,7 +50,7 @@ public struct TypeAliases : IFlatbufferObject
   public double Vf64(int j) { int o = __p.__offset(26); return o != 0 ? __p.bb.GetDouble(__p.__vector(o) + j * 8) : (double)0; }
   public int Vf64Length { get { int o = __p.__offset(26); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVf64Bytes() { return __p.__vector_as_span(26, 8); }
+  public Span<double> GetVf64Bytes() { return __p.__vector_as_span<double>(26, 8); }
 #else
   public ArraySegment<byte>? GetVf64Bytes() { return __p.__vector_as_arraysegment(26); }
 #endif

--- a/tests/MyGame/Example/TypeAliases.cs
+++ b/tests/MyGame/Example/TypeAliases.cs
@@ -41,7 +41,7 @@ public struct TypeAliases : IFlatbufferObject
   public sbyte V8(int j) { int o = __p.__offset(24); return o != 0 ? __p.bb.GetSbyte(__p.__vector(o) + j * 1) : (sbyte)0; }
   public int V8Length { get { int o = __p.__offset(24); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetV8Bytes() { return __p.__vector_as_span(24); }
+  public Span<byte> GetV8Bytes() { return __p.__vector_as_span(24, 1); }
 #else
   public ArraySegment<byte>? GetV8Bytes() { return __p.__vector_as_arraysegment(24); }
 #endif
@@ -50,7 +50,7 @@ public struct TypeAliases : IFlatbufferObject
   public double Vf64(int j) { int o = __p.__offset(26); return o != 0 ? __p.bb.GetDouble(__p.__vector(o) + j * 8) : (double)0; }
   public int Vf64Length { get { int o = __p.__offset(26); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetVf64Bytes() { return __p.__vector_as_span(26); }
+  public Span<byte> GetVf64Bytes() { return __p.__vector_as_span(26, 8); }
 #else
   public ArraySegment<byte>? GetVf64Bytes() { return __p.__vector_as_arraysegment(26); }
 #endif

--- a/tests/MyGame/MonsterExtra.cs
+++ b/tests/MyGame/MonsterExtra.cs
@@ -38,7 +38,7 @@ public struct MonsterExtra : IFlatbufferObject
   public double Dvec(int j) { int o = __p.__offset(20); return o != 0 ? __p.bb.GetDouble(__p.__vector(o) + j * 8) : (double)0; }
   public int DvecLength { get { int o = __p.__offset(20); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetDvecBytes() { return __p.__vector_as_span(20, 8); }
+  public Span<double> GetDvecBytes() { return __p.__vector_as_span<double>(20, 8); }
 #else
   public ArraySegment<byte>? GetDvecBytes() { return __p.__vector_as_arraysegment(20); }
 #endif
@@ -47,7 +47,7 @@ public struct MonsterExtra : IFlatbufferObject
   public float Fvec(int j) { int o = __p.__offset(22); return o != 0 ? __p.bb.GetFloat(__p.__vector(o) + j * 4) : (float)0; }
   public int FvecLength { get { int o = __p.__offset(22); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetFvecBytes() { return __p.__vector_as_span(22, 4); }
+  public Span<float> GetFvecBytes() { return __p.__vector_as_span<float>(22, 4); }
 #else
   public ArraySegment<byte>? GetFvecBytes() { return __p.__vector_as_arraysegment(22); }
 #endif

--- a/tests/MyGame/MonsterExtra.cs
+++ b/tests/MyGame/MonsterExtra.cs
@@ -38,7 +38,7 @@ public struct MonsterExtra : IFlatbufferObject
   public double Dvec(int j) { int o = __p.__offset(20); return o != 0 ? __p.bb.GetDouble(__p.__vector(o) + j * 8) : (double)0; }
   public int DvecLength { get { int o = __p.__offset(20); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetDvecBytes() { return __p.__vector_as_span(20); }
+  public Span<byte> GetDvecBytes() { return __p.__vector_as_span(20, 8); }
 #else
   public ArraySegment<byte>? GetDvecBytes() { return __p.__vector_as_arraysegment(20); }
 #endif
@@ -47,7 +47,7 @@ public struct MonsterExtra : IFlatbufferObject
   public float Fvec(int j) { int o = __p.__offset(22); return o != 0 ? __p.bb.GetFloat(__p.__vector(o) + j * 4) : (float)0; }
   public int FvecLength { get { int o = __p.__offset(22); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetFvecBytes() { return __p.__vector_as_span(22); }
+  public Span<byte> GetFvecBytes() { return __p.__vector_as_span(22, 4); }
 #else
   public ArraySegment<byte>? GetFvecBytes() { return __p.__vector_as_arraysegment(22); }
 #endif

--- a/tests/union_vector/Movie.cs
+++ b/tests/union_vector/Movie.cs
@@ -22,7 +22,7 @@ public struct Movie : IFlatbufferObject
   public Character CharactersType(int j) { int o = __p.__offset(8); return o != 0 ? (Character)__p.bb.Get(__p.__vector(o) + j * 1) : (Character)0; }
   public int CharactersTypeLength { get { int o = __p.__offset(8); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetCharactersTypeBytes() { return __p.__vector_as_span(8, 1); }
+  public Span<Character> GetCharactersTypeBytes() { return __p.__vector_as_span<Character>(8, 1); }
 #else
   public ArraySegment<byte>? GetCharactersTypeBytes() { return __p.__vector_as_arraysegment(8); }
 #endif

--- a/tests/union_vector/Movie.cs
+++ b/tests/union_vector/Movie.cs
@@ -22,7 +22,7 @@ public struct Movie : IFlatbufferObject
   public Character CharactersType(int j) { int o = __p.__offset(8); return o != 0 ? (Character)__p.bb.Get(__p.__vector(o) + j * 1) : (Character)0; }
   public int CharactersTypeLength { get { int o = __p.__offset(8); return o != 0 ? __p.__vector_len(o) : 0; } }
 #if ENABLE_SPAN_T
-  public Span<byte> GetCharactersTypeBytes() { return __p.__vector_as_span(8); }
+  public Span<byte> GetCharactersTypeBytes() { return __p.__vector_as_span(8, 1); }
 #else
   public ArraySegment<byte>? GetCharactersTypeBytes() { return __p.__vector_as_arraysegment(8); }
 #endif


### PR DESCRIPTION
Add element size parameter to __vector_as_arraysegment fixing issue where VectorAsBytes returns incorrect size span for multibyte element types.

Potential solution for: https://github.com/google/flatbuffers/issues/5511
