### PR TITLE
Fix buildifier warnings found in new bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,7 @@
 licenses(["notice"])
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
     features = [
@@ -86,11 +88,11 @@ cc_binary(
         "src/idl_gen_cpp.cpp",
         "src/idl_gen_dart.cpp",
         "src/idl_gen_general.cpp",
-        "src/idl_gen_kotlin.cpp",
         "src/idl_gen_go.cpp",
         "src/idl_gen_grpc.cpp",
         "src/idl_gen_js_ts.cpp",
         "src/idl_gen_json_schema.cpp",
+        "src/idl_gen_kotlin.cpp",
         "src/idl_gen_lobster.cpp",
         "src/idl_gen_lua.cpp",
         "src/idl_gen_php.cpp",
@@ -137,8 +139,8 @@ cc_test(
         "src/util.cpp",
         "tests/namespace_test/namespace_test1_generated.h",
         "tests/namespace_test/namespace_test2_generated.h",
-        "tests/native_type_test_impl.h",
         "tests/native_type_test_impl.cpp",
+        "tests/native_type_test_impl.h",
         "tests/test.cpp",
         "tests/test_assert.cpp",
         "tests/test_assert.h",
@@ -152,12 +154,18 @@ cc_test(
         "-DBAZEL_TEST_DATA_PATH",
     ],
     data = [
+        ":tests/arrays_test.bfbs",
+        ":tests/arrays_test.fbs",
+        ":tests/arrays_test.golden",
         ":tests/include_test/include_test1.fbs",
         ":tests/include_test/sub/include_test2.fbs",
+        ":tests/monster_extra.fbs",
         ":tests/monster_test.bfbs",
         ":tests/monster_test.fbs",
+        ":tests/monsterdata_extra.json",
         ":tests/monsterdata_test.golden",
         ":tests/monsterdata_test.json",
+        ":tests/native_type_test.fbs",
         ":tests/prototest/imported.proto",
         ":tests/prototest/test.golden",
         ":tests/prototest/test.proto",
@@ -165,21 +173,15 @@ cc_test(
         ":tests/unicode_test.json",
         ":tests/union_vector/union_vector.fbs",
         ":tests/union_vector/union_vector.json",
-        ":tests/monster_extra.fbs",
-        ":tests/monsterdata_extra.json",
-        ":tests/arrays_test.bfbs",
-        ":tests/arrays_test.fbs",
-        ":tests/arrays_test.golden",
-        ":tests/native_type_test.fbs",
     ],
     includes = [
         "include/",
         "tests/",
     ],
     deps = [
+        ":arrays_test_cc_fbs",
         ":monster_extra_cc_fbs",
         ":monster_test_cc_fbs",
-        ":arrays_test_cc_fbs",
         ":native_type_test_cc_fbs",
     ],
 )
@@ -211,7 +213,8 @@ flatbuffer_cc_library(
         "--gen-mutable",
         "--reflect-names",
         "--cpp-ptr-type flatbuffers::unique_ptr",
-        "--scoped-enums" ],
+        "--scoped-enums",
+    ],
 )
 
 flatbuffer_cc_library(
@@ -220,6 +223,6 @@ flatbuffer_cc_library(
     flatc_args = [
         "--gen-object-api",
         "--gen-mutable",
-        "--cpp-ptr-type flatbuffers::unique_ptr" ],
+        "--cpp-ptr-type flatbuffers::unique_ptr",
+    ],
 )
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,11 +4,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
+    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
     urls = [
         "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
         "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
     ],
-    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -5,6 +5,8 @@
 Rules for building C++ flatbuffers with Bazel.
 """
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 flatc_path = "@com_github_google_flatbuffers//:flatc"
 
 DEFAULT_INCLUDE_PATHS = [
@@ -209,7 +211,7 @@ def flatbuffer_cc_library(
         reflection_name = reflection_name,
         reflection_visibility = visibility,
     )
-    native.cc_library(
+    cc_library(
         name = name,
         hdrs = [
             ":" + srcs_lib,


### PR DESCRIPTION
Fixes warnings caught in:
https://buildkite.com/bazel/flatbuffers/builds/863#cff87e1d-b976-4734-8157-4b6d88c7b5e1