### PR TITLE
Fix Buildifier "native-cc" warning

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,3 +16,13 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains()
+
+http_archive(
+    name = "rules_cc",
+    sha256 = "b4b2a2078bdb7b8328d843e8de07d7c13c80e6c89e86a09d6c4b424cfd1aaa19",
+    strip_prefix = "rules_cc-cb2dfba6746bfa3c3705185981f3109f0ae1b893",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/cb2dfba6746bfa3c3705185981f3109f0ae1b893.zip",
+        "https://github.com/bazelbuild/rules_cc/archive/cb2dfba6746bfa3c3705185981f3109f0ae1b893.zip",
+    ],
+)

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -5,6 +5,8 @@
 Rules for building C++ flatbuffers with Bazel.
 """
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 flatc_path = "@com_github_google_flatbuffers//:flatc"
 
 DEFAULT_INCLUDE_PATHS = [
@@ -209,7 +211,7 @@ def flatbuffer_cc_library(
         reflection_name = reflection_name,
         reflection_visibility = visibility,
     )
-    native.cc_library(
+    cc_library(
         name = name,
         hdrs = [
             ":" + srcs_lib,


### PR DESCRIPTION
Fix warning:

    build_defs.bzl:212: native-cc: Function "cc_library" is not global anymore and needs to be loaded from "@rules_cc//cc:defs.bzl". (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#native-cc)

See https://buildkite.com/bazel/flatbuffers/builds/864#_
