### PR TITLE
Adds XOPEN_SOURCE for PATH_MAX and POSIX 1993 for stat

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -16,7 +16,7 @@
 
 // clang-format off
 // Dont't remove `format off`, it prevent reordering of win-includes.
-#define _POSIX_C_SOURCE 199309L // For stat from stat/stat.h (POSIX extension).
+#define _POSIX_C_SOURCE 200112L // For stat from stat/stat.h and fseeko() (POSIX extensions).
 #ifdef _WIN32
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN
@@ -32,7 +32,7 @@
 #  include <winbase.h>
 #  undef interface  // This is also important because of reasons
 #else
-#  define _XOPEN_SOURCE 500 // For PATH_MAX from limits.h (SUSv2 extension) 
+#  define _XOPEN_SOURCE 600 // For PATH_MAX from limits.h (SUSv2 extension) 
 #  include <limits.h>
 #endif
 // clang-format on

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -16,6 +16,7 @@
 
 // clang-format off
 // Dont't remove `format off`, it prevent reordering of win-includes.
+#define _POSIX_C_SOURCE 199309L // For stat from stat/stat.h (POSIX extension).
 #ifdef _WIN32
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN
@@ -31,6 +32,7 @@
 #  include <winbase.h>
 #  undef interface  // This is also important because of reasons
 #else
+#  define _XOPEN_SOURCE 500 // For PATH_MAX from limits.h (SUSv2 extension) 
 #  include <limits.h>
 #endif
 // clang-format on


### PR DESCRIPTION
These are the only two required extension for compilation of flatbuffers using -std=c++11 instead of gnu++11. This makes it explicit where and why these extensions are required.
