### PR TITLE
[FlexBuffers][Java] Fix wrong access to a string using Reference::asS…

### DIFF
--- a/java/com/google/flatbuffers/FlexBuffers.java
+++ b/java/com/google/flatbuffers/FlexBuffers.java
@@ -481,7 +481,7 @@ public class FlexBuffers {
          */
         public String asString() {
             if (isString()) {
-                int start = indirect(bb, end, byteWidth);
+                int start = indirect(bb, end, parentWidth);
                 int size = readInt(bb, start - byteWidth, byteWidth);
                 return Utf8.getDefault().decodeUtf8(bb, start, size);
             }

--- a/java/com/google/flatbuffers/FlexBuffersBuilder.java
+++ b/java/com/google/flatbuffers/FlexBuffersBuilder.java
@@ -64,7 +64,7 @@ public class FlexBuffersBuilder {
      * But serialization performance might be slower and consumes more memory. This is ideal if you expect many repeated
      * strings on the message.
      */
-    public static final int BUILDER_FLAG_SHARE_STRINGS = 1;
+    public static final int BUILDER_FLAG_SHARE_STRINGS = 2;
     /**
      * Strings and keys will be shared between elements.
      */


### PR DESCRIPTION
…tring().

The real position of a string is  calculated by using the indirect() method,
which should be based on parentWidth and not byteWidth, as it was implemented.

We are also fixing the flag BUILDER_FLAG_SHARE_STRINGS on FlexBuffersBuilder
that was set as '1', the same value as BUILDER_FLAG_SHARE_KEYS.

Fix issue #5528
