### PR TITLE
Fix namespaced struct/field name collision detection (#5540)

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -677,7 +677,7 @@ CheckedError Parser::AddField(StructDef &struct_def, const std::string &name,
 CheckedError Parser::ParseField(StructDef &struct_def) {
   std::string name = attribute_;
 
-  if (LookupStruct(name))
+  if (LookupCreateStruct(name, false, false))
     return Error("field name can not be the same as table/struct name");
 
   std::vector<std::string> dc = doc_comment_;


### PR DESCRIPTION
Changes the use of `LookupStruct` to `LookupCreateStruct` in
`ParseField` to also detect when collisions happen in namespaces.

Solution as given by @aardappel. Fixes #5540.