### PR TITLE
Add a docs section to explain running flatc with CMake.

### DIFF
--- a/docs/source/Building.md
+++ b/docs/source/Building.md
@@ -56,7 +56,7 @@ view the [Tutorial](@ref flatbuffers_guide_tutorial) and select your appropriate
 language using the radio buttons.
 
 ### Using in CMake-based projects
-If you want to use FlatBuffers in a project which already uses CMake, then a more
+If you want to use FlatBuffers in a project which already uses CMake then a more
 robust and flexible approach is to build FlatBuffers as part of that project directly.
 This is done by making the FlatBuffers source code available to the main build
 and adding it using CMake's `add_subdirectory()` command. This has the
@@ -65,8 +65,9 @@ between FlatBuffers and the rest of your project, so issues associated with usin
 incompatible libraries (eg debug/release), etc. are avoided. This is
 particularly useful on Windows.
 
-Suppose you put FlatBuffers source code in directory `${FLATBUFFERS_SRC_DIR}`.
-To build it as part of your project, add following code to your `CMakeLists.txt` file:
+Suppose you put FlatBuffers source code in the directory `${FLATBUFFERS_SRC_DIR}`.
+To build it as part of your project, add the following code to your
+`CMakeLists.txt` file:
 ```cmake
 # Add FlatBuffers directly to our build. This defines the `flatbuffers` target.
 add_subdirectory(${FLATBUFFERS_SRC_DIR}
@@ -74,11 +75,107 @@ add_subdirectory(${FLATBUFFERS_SRC_DIR}
                  EXCLUDE_FROM_ALL)
 
 # Now simply link against flatbuffers as needed to your already declared target.
-# The flatbuffers target carry header search path automatically if CMake > 2.8.11.
-target_link_libraries(own_project_target PRIVATE flatbuffers)
+# The flatbuffers target carries header search path information automatically
+# when using CMake version > 2.8.11.
+target_link_libraries(your_project_target PRIVATE flatbuffers)
 ```
-When build your project the `flatbuffers` library will be compiled and linked 
-to a target as part of your project.
+When building your project, the `flatbuffers` library will then be compiled and linked 
+to the target as part of your project.
+
+#### Automatically Running `flatc`
+
+In addition to the above you will also likely want to add custom CMake targets
+to automatically compile your `*.fbs` files when you build your project.  This
+has the advantage that you will not need to manually run the `flatc` compiler
+(or risk forgetting to do so) when you update your Flatbuffers schema files.
+
+If you've followed the recipe in this section to incorporate Flatbuffers into
+your project's build (recommended) then there will also be a new target called
+`flatc` visible to you; this is the target representing the `flatc` executable
+(compiler) that you will need to run to compile the schemas.  Ideally, whenever
+you build your project, this compiler will be run (and built first if necessary)
+to compile any `*.fbs` files that have changed since the last build.
+
+To set this up you will essentially need to add a series of CMake Custom
+Commands to your build and then make your target depend on the files generated
+by that target.  There are two examples of this in the Flatbuffers package:
+
+1. There is a function provided by the Flatbuffers package called `build_flatbuffers`
+in the file `${FLATBUFFERS_SRC_DIR}/CMake/BuildFlatBuffers.cmake` that does exactly this.
+See the comments at the top of that file for details.  Essentially, you call the function
+with a list of schema files and it will create all of the custom commands for you.
+2. There is also an example of directly adding such custom commands in Flatbuffers'
+own `CMakeLists.txt` file at the root of the source tree (see the function called
+`compile_flatbuffers_schema_to_cpp`).
+
+Since each project has slightly different build requirements, you may want to
+take those two examples and adapt them for your own project's needs, adding
+or removing as necessary.  The first option, if it satifies your project's needs,
+will likely be simpler; the second option will be more flexible.
+
+The following is an example of a simple starting point for the second approach:
+
+1. Create a folder called `flatbuffers` somewhere in your project's source tree.
+2. Place all of your `*.fbs` files in there, along with a `CMakeLists.txt` file.
+3. In the parent folder, add the `flatbuffers` folder via `add_subdirectory`.
+4. In the `flatbuffers/CMakeLists.txt` file put something like this:
+
+```cmake
+file( GLOB fbs "*.fbs" )
+
+# Agglomeration of generated include files (*_generated.h).
+set( generated_files "" )
+
+foreach( fb ${fbs} )
+  get_filename_component( stem ${fb} NAME_WE )
+  get_filename_component( name ${fb} NAME )
+  set( generated_include ${CMAKE_CURRENT_BINARY_DIR}/${stem}_generated.h )
+  add_custom_command(
+    OUTPUT ${generated_include}
+    COMMENT "Compiling flatbuffer for ${name}"
+    COMMAND flatc # This will be a target recognized by CMake.
+    --cpp
+    --scoped-enums          # (optional)
+    --reflect-types         # (optional)
+    --reflect-names         # (optional)
+    -o ${CMAKE_CURRENT_BINARY_DIR}
+    -I ${CMAKE_CURRENT_SOURCE_DIR}
+    ${fb}
+    DEPENDS flatc ${fb}
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+  list( APPEND generated_files ${generated_include} )
+endforeach()
+
+# Create a custom target that depends on all the generated files.
+# Depending on this will trigger all schemas to be compiled.
+add_custom_target( your_flatbuf_target DEPENDS ${generated_files} )
+
+set_property(
+  TARGET your_flatbuf_target
+  PROPERTY INCLUDE_DIR
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+```
+Then, in the parent folder's `CMakeLists.txt` file you can add a `flatbuffers`
+dependency as described at the start of this section, as well as:
+```cmake
+add_dependencies( your_project_target your_flatbuf_target )
+get_target_property( FLATBUFF_INCLUDE_DIR your_flatbuf_target INCLUDE_DIR )
+
+target_include_directories(
+    your_project_target
+    PRIVATE
+    ...
+    ${FLATBUFF_INCLUDE_DIR}
+    ...)
+```
+These will trigger the schema generation and allow your source files to
+include the generated files.  Finally, as mentioned above, the `build_flatbuffers`
+function in the `CMake/BuildFlatBuffers.cmake` file can also set this up
+for you; see the comments at the top of that file for an example.  Many users,
+however, will prefer to add the Custom Commands directly since it is ultimately
+more flexible.
 
 #### Override default depth limit of nested objects
 To override [the depth limit of recursion](@ref flatbuffers_guide_use_cpp), 

--- a/docs/source/Building.md
+++ b/docs/source/Building.md
@@ -177,6 +177,14 @@ for you; see the comments at the top of that file for an example.  Many users,
 however, will prefer to add the Custom Commands directly since it is ultimately
 more flexible.
 
+However, this is an important shortcoming of the above methodology: specifically,
+the custom targets are not aware of dependencies among schema files via include
+statements.  In other words, if schema file `A.fbs` includes `B.fbs` then the
+correct rebuilding process is to recompile both files when `B.fbs` changes.  The
+above method will not do this, and thus can lead to incorrect rebuilding.  One
+solution would be to hardcode the dependencies in the CMake file `DEPENDS` part
+of the custom command, though this is not ideal for reasons of maintenance.
+
 #### Override default depth limit of nested objects
 To override [the depth limit of recursion](@ref flatbuffers_guide_use_cpp), 
 add this directive:


### PR DESCRIPTION
Currently the docs explain how to build the Flatbuffers package
itself using CMake but they don't explain how to set up one's
project so that it invokes the flatc compiler as part of their
build (which most builds will want/need to do).

Tested by running Doxygen.

Fixes #5548 