### PR TITLE
[FlexBuffers][Java] WIP: Performance improvements on FlexBuffers Java

### DIFF
--- a/java/com/google/flatbuffers/ArrayReadBuf.java
+++ b/java/com/google/flatbuffers/ArrayReadBuf.java
@@ -1,0 +1,152 @@
+package com.google.flatbuffers;
+
+/**
+ * Implements {@code ReadBuf} using an array of bytes
+ * as a backing storage. Using array of bytes are
+ * usually faster than {@code ByteBuffer}.
+ */
+public class ArrayReadBuf implements ReadBuf {
+
+    // cache for converting UTF-8 codepoints into
+    // Java chars. Used to speed up String comparison
+    private final char[] comparisonBuffer = new char[2];
+    private final byte[] buffer;
+    private final int limit;
+    public ArrayReadBuf(byte[] buffer, int limit) {
+        this.buffer = buffer;
+        this.limit = limit;
+    }
+
+    @Override
+    public boolean getBoolean(int index) {
+        return buffer[index] != 0;
+    }
+
+    @Override
+    public byte get(int index) {
+        return buffer[index];
+    }
+
+    @Override
+    public short getShort(int index) {
+        return (short) ((buffer[index+ 1] << 8) | (buffer[index] & 0xff));
+    }
+
+    @Override
+    public int getInt(int index) {
+        return (((buffer[index + 3]) << 24) |
+                ((buffer[index + 2] & 0xff) << 16) |
+                ((buffer[index + 1] & 0xff) << 8) |
+                ((buffer[index] & 0xff)));
+    }
+
+    @Override
+    public long getLong(int index) {
+        return ((((long) buffer[index++] & 0xff)) |
+                (((long) buffer[index++] & 0xff) << 8) |
+                (((long) buffer[index++] & 0xff) << 16) |
+                (((long) buffer[index++] & 0xff) << 24) |
+                (((long) buffer[index++] & 0xff) << 32) |
+                (((long) buffer[index++] & 0xff) << 40) |
+                (((long) buffer[index++] & 0xff) << 48) |
+                (((long) buffer[index]) << 56));
+    }
+
+    @Override
+    public float getFloat(int index) {
+        return Float.intBitsToFloat(getInt(index));
+    }
+
+    @Override
+    public double getDouble(int index) {
+        return Double.longBitsToDouble(getLong(index));
+    }
+
+    @Override
+    public String getString(int start, int size) {
+        return Utf8.getDefault().decodeUtf8Array(buffer, start, size);
+    }
+
+    @Override
+    public byte[] data() {
+        return buffer;
+    }
+
+    @Override
+    public int limit() {
+        return limit;
+    }
+
+    @Override
+    public int compareBytes(int start, byte[] other) {
+        int l1 = start;
+        int l2 = 0;
+        byte c1, c2;
+        do {
+            c1 = buffer[l1];
+            c2 = other[l2];
+            if (c1 == '\0')
+                return c1 - c2;
+            l1++;
+            l2++;
+            if (l2 == other.length) {
+                // in our buffer we have an additional \0 byte
+                // but this does not exist in regular Java strings, so we return now
+                return c1 - c2;
+            }
+        }
+        while (c1 == c2);
+        return c1 - c2;
+    }
+
+    @Override
+    public int compareString(int start, String other) {
+        int l1 = start;
+        int l2 = 0;
+        int limit = other.length();
+        char c2;
+
+        // special loop for ASCII characters. Most of keys should be ASCII only, so this
+        // loop should be optimized for that.
+        // breaks if a multi-byte character is found
+        while (l2<limit) {
+            byte b = buffer[l1];
+            if (b == 0) {
+                return -1;
+            }
+            if (b < 0) {
+                break;
+            }
+            c2 = other.charAt(l2);
+            if ((char)b != c2) {
+                return b - c2;
+            }
+            l1++;
+            l2++;
+        }
+
+        while (l2<limit) {
+            int charSize = Utf8.getDefault().decodeCodePoint(this, l1, comparisonBuffer);
+            if (charSize == 0) {
+                return -1;
+            }
+            c2 = other.charAt(l2);
+            if (comparisonBuffer[0] != c2) {
+                return comparisonBuffer[0] - c2;
+            }
+
+            if (charSize == 4) {
+                c2 = other.charAt(l2++);
+                if (comparisonBuffer[1] != c2) {
+                    return comparisonBuffer[0] - c2;
+                }
+            }
+
+            l1 += charSize;
+            l2++;
+        }
+
+        return 0;
+    }
+
+}

--- a/java/com/google/flatbuffers/ByteBufferReadBuf.java
+++ b/java/com/google/flatbuffers/ByteBufferReadBuf.java
@@ -1,0 +1,138 @@
+package com.google.flatbuffers;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class ByteBufferReadBuf implements ReadBuf {
+
+    // cache for converting UTF-8 codepoints into
+    // Java chars. Used to speed up String comparison
+    private final char[] comparisonBuffer = new char[2];
+    private final ByteBuffer buffer;
+
+    public ByteBufferReadBuf(ByteBuffer bb) {
+        this.buffer = bb;
+    }
+
+    @Override
+    public boolean getBoolean(int index) {
+        return get(index) != 0;
+    }
+
+    @Override
+    public byte get(int index) {
+        return buffer.get(index);
+    }
+
+    @Override
+    public short getShort(int index) {
+        return buffer.getShort(index);
+    }
+
+    @Override
+    public int getInt(int index) {
+        return buffer.getInt(index);
+    }
+
+    @Override
+    public long getLong(int index) {
+        return buffer.getLong(index);
+    }
+
+    @Override
+    public float getFloat(int index) {
+        return buffer.getFloat(index);
+    }
+
+    @Override
+    public double getDouble(int index) {
+        return buffer.getDouble(index);
+    }
+
+    @Override
+    public String getString(int start, int size) {
+        return Utf8.getDefault().decodeUtf8(buffer, start, size);
+    }
+
+    @Override
+    public byte[] data() {
+        return buffer.array();
+    }
+
+    @Override
+    public int limit() {
+        return buffer.limit();
+    }
+
+    @Override
+    public int compareBytes(int start, byte[] other) {
+        int l1 = start;
+        int l2 = 0;
+        byte c1, c2;
+        do {
+            c1 = buffer.get(l1);
+            c2 = other[l2];
+            if (c1 == '\0')
+                return c1 - c2;
+            l1++;
+            l2++;
+            if (l2 == other.length) {
+                // in our buffer we have an additional \0 byte
+                // but this does not exist in regular Java strings, so we return now
+                return c1 - c2;
+            }
+        }
+        while (c1 == c2);
+        return c1 - c2;
+    }
+
+    @Override
+    public int compareString(int start, String other) {
+        int l1 = start;
+        int l2 = 0;
+        int limit = other.length();
+        char c2;
+
+        // special loop for ASCII characters. Most of keys should be ASCII only, so this
+        // loop should be optimized for that.
+        // breaks if a multi-byte character is found
+        while (l2<limit) {
+            byte b = buffer.get(l1);
+            if (b == 0) {
+                return -1;
+            }
+            if (b < 0) {
+                break;
+            }
+            c2 = other.charAt(l2);
+            if ((char)b != c2) {
+                return b - c2;
+            }
+            l1++;
+            l2++;
+        }
+
+        while (l2<limit) {
+            int charSize = Utf8.decodeCodePoint(this, l1, comparisonBuffer);
+            if (charSize == 0) {
+                return -1;
+            }
+            c2 = other.charAt(l2);
+            if (comparisonBuffer[0] != c2) {
+                return comparisonBuffer[0] - c2;
+            }
+
+            if (charSize == 4) {
+                c2 = other.charAt(l2++);
+                if (comparisonBuffer[1] != c2) {
+                    return comparisonBuffer[0] - c2;
+                }
+            }
+
+            l1 += charSize;
+            l2++;
+        }
+
+        return 0;
+    }
+}

--- a/java/com/google/flatbuffers/ReadBuf.java
+++ b/java/com/google/flatbuffers/ReadBuf.java
@@ -1,0 +1,99 @@
+package com.google.flatbuffers;
+
+/**
+ *  Represent a chunk of data, where FlexBuffers will read from.
+ */
+interface ReadBuf {
+
+    /**
+     * Read boolean from data. Booleans as stored as single byte
+     * @param index position of the element in ReadBuf
+     * @return boolean element
+     */
+    boolean getBoolean(int index);
+
+    /**
+     * Read a byte from data.
+     * @param index position of the element in ReadBuf
+     * @return a byte
+     */
+    byte get(int index);
+
+    /**
+     * Read a short from data.
+     * @param index position of the element in ReadBuf
+     * @return a short
+     */
+    short getShort(int index);
+
+    /**
+     * Read a 32-bit int from data.
+     * @param index position of the element in ReadBuf
+     * @return an int
+     */
+    int getInt(int index);
+
+    /**
+     * Read a 64-bit long from data.
+     * @param index position of the element in ReadBuf
+     * @return a long
+     */
+    long getLong(int index);
+
+    /**
+     * Read a 32-bit float from data.
+     * @param index position of the element in ReadBuf
+     * @return a float
+     */
+    float getFloat(int index);
+
+    /**
+     * Read a 64-bit float from data.
+     * @param index position of the element in ReadBuf
+     * @return a double
+     */
+    double getDouble(int index);
+
+    /**
+     * Read an UTF-8 string from data.
+     * @param start initial element of the string
+     * @param size size of the string in bytes.
+     * @return a {@code String}
+     */
+    String getString(int start, int size);
+
+    /**
+     * Expose ReadBuf as an array of bytes.
+     * This method is meant to be as efficient as possible, so for a array-backed ReadBuf, it should
+     * return its own internal data. In case access to internal data is not possible,
+     * a copy of the data into an array of bytes might occur.
+     * @return ReadBuf as an array of bytes
+     */
+    byte[] data();
+
+    /**
+     * Size of  the ReadBuf in bytes
+     * @return size
+     */
+    int limit();
+
+    /**
+     * Compare a segment of ReadBuf against a given array.
+     * @param start start position of the comparison
+     * @param data array of bytes to be compared to
+     * @return {@code 0} if ReadBuf segment is equal to data; less than {@code 0} if the ReadBuf
+     *      segment is lexicographically less than data; and greater than {@code 0} if this ReadBuf
+     *      segment is lexicographically greater than data.
+     */
+    int compareBytes(int start, byte[] data);
+
+    /**
+     * Compare a segment of ReadBuf against a given {@code String}.
+     * @param start start position of the comparison
+     * @param data a String to be compared to
+     * @return {@code 0} if ReadBuf segment is equal to data; less than {@code 0} if the ReadBuf
+     *      segment is lexicographically less than data; and greater than {@code 0} if this ReadBuf
+     *      segment is lexicographically greater than data.
+     */
+    int compareString(int start, String data);
+}

--- a/java/com/google/flatbuffers/Utf8.java
+++ b/java/com/google/flatbuffers/Utf8.java
@@ -52,6 +52,51 @@ public abstract class Utf8 {
    */
   public abstract String decodeUtf8(ByteBuffer buffer, int offset, int length);
 
+  /**
+   * Decodes the given UTF-8 portion of the byte array into a {@link String}.
+   *
+   * @throws IllegalArgumentException if the input is not valid UTF-8.
+   */
+  public abstract String decodeUtf8Array(byte[] bytes, int index, int size);
+
+    // Read a UTF-8 codepoint starting at position start.
+    // it will be saved in out.
+    //
+    // Useful for reading a codepoint and compare against Java's char,
+    // instead of converting the whole data into a String
+    // Returns the size in bytes of the codepoint
+  public static int decodeCodePoint(ReadBuf buffer, int start, char[] out) {
+    byte b = buffer.get(start);
+    int size = 4;
+    if (b == 0) {
+        size = 0;
+    } else if (DecodeUtil.isOneByte(b)) {
+        size = 1;
+        out[0] = (char) b;
+    } else if (DecodeUtil.isTwoBytes(b)) {
+        size = 2;
+        DecodeUtil.handleTwoBytes(b, buffer.get(start + 1), out, 0);
+    } else if (DecodeUtil.isThreeBytes(b)) {
+        size = 3;
+        Utf8.DecodeUtil.handleThreeBytes(
+            b,
+            buffer.get(start + 1),
+            buffer.get(start + 2),
+            out,
+            0);
+    } else {
+        DecodeUtil.handleFourBytes(
+            b,
+            buffer.get(start + 1),
+            buffer.get(start + 2),
+            buffer.get(start + 3),
+            out,
+            0);
+    }
+
+    return size;
+  }
+
   private static Utf8 DEFAULT;
 
   /**

--- a/java/com/google/flatbuffers/Utf8Safe.java
+++ b/java/com/google/flatbuffers/Utf8Safe.java
@@ -123,7 +123,8 @@ final public class Utf8Safe extends Utf8 {
     return utf8Length;
   }
 
-  private static String decodeUtf8Array(byte[] bytes, int index, int size) {
+  @Override
+  public String decodeUtf8Array(byte[] bytes, int index, int size) {
     // Bitwise OR combines the sign bits so any negative value fails the check.
     if ((index | size | bytes.length - index - size) < 0) {
       throw new ArrayIndexOutOfBoundsException(
@@ -292,7 +293,6 @@ final public class Utf8Safe extends Utf8 {
       return decodeUtf8Buffer(buffer, offset, length);
     }
   }
-
 
   private static void encodeUtf8Buffer(CharSequence in, ByteBuffer out) {
     final int inLength = in.length();

--- a/tests/JavaTest.java
+++ b/tests/JavaTest.java
@@ -722,9 +722,9 @@ class JavaTest {
 
     public static void testSingleElementLong() {
         FlexBuffersBuilder builder = new FlexBuffersBuilder();
-        builder.putInt(Long.MAX_VALUE);
+        builder.putInt( 0x00000000_ffffffffL);
         ByteBuffer b = builder.finish();
-        TestEq(Long.MAX_VALUE, FlexBuffers.getRoot(b).asLong());
+        TestEq(0x00000000_ffffffffL, FlexBuffers.getRoot(b).asLong());
     }
 
     public static void testSingleElementFloat() {


### PR DESCRIPTION
A series of micro-optimizations to improve FlexBuffer read performance.
It is not the final solution (and testing), but I decided to share already
in order to avoid unused work in case of changes.

1: create a ReadBuf interface to avoid extra work on ByteBuffer.
It seems ByteBuffer has a lot of overhead due to checking bounds
twice (one time on ByteBuffer, second on backing byte[]). Also, there
is a lot of Buffer implementations from different libraries, like Netty
and Okio. So we are creating an interface to be able to plug different
buffer strategies.

The naked array implementation ArrayReadBuf provides a performance Buffer
over regular ByteBuffers due to the fact, ByteBuffers mostly check buffer
bounds twice.

2: cache key position on Map objects.
Read the real position of each key of a map can become very expensive, because
due to binary search, `indirect()` is called several times. Caching this data
is relatively cheap (array of ints with the size of n. of keys). And provides a very good performance boost.

3: Avoid temporary allocations on Map.binarySearch().
Original implementation naively allocates a KeyVector than perform a binary search over it.
We are using the already cache positions to perform the key comparison without that additional
allocation.

4: Optimize String vs buffer comparison for Keys
The original implementation we convert Key to string and do a comparison against the tested key.

We change the implementation to perform a check codepoint by codepoint, instead
of allocating the whole string. So avoid reducing most of the String allocations during
binarySearch().

That PR is not ready and is meant to get feedback. Current benchmark on the matter is the following:
```
benchmark:    45,563,192 ns AsteroidTest.deserializeFlexBuffer
benchmark:     8,699,808 ns AsteroidTest.deserializeFlexBufferReadBuf
benchmark:    37,635,615 ns AsteroidTest.deserializeGson
benchmark:    32,069,347 ns AsteroidTest.deserializeMoshi
```

AsteroidTest.deserializeFlexBufferReadBuf is the proposed version and AsteroidTest.deserializeFlexBuffer
is the original.

I added Moshi and Gson, two most used Json libraries android to use as a comparison.

for more details about the benchmark, check:
https://github.com/paulovap/android-serial-benchmark
