### PR TITLE
Fix issue #5557

### DIFF
--- a/samples/sample_bfbs.cpp
+++ b/samples/sample_bfbs.cpp
@@ -17,7 +17,6 @@
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
 
-#include "monster_test_generated.h"
 #include "monster_generated.h" // Already includes "flatbuffers/flatbuffers.h".
 
 using namespace MyGame::Sample;


### PR DESCRIPTION
This PR remove not necessary dependency from the `sample bfbs.cpp` file.

The `sample bfbs.cpp` includes not necessary file `monster_test generated.h`.
But this file isn't part of the corresponding source list (`${FlatBuffers_Sample_BFBS_SRCS}`).
This unexpected inclusion is not taken into account by the dependency resolution system.
If this file is really needed, then it should be part of the `sample_bfbs` target.
