### PR TITLE
[C++] Verifier for evolved union fields should return true for unknown values.

### DIFF
--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -655,7 +655,7 @@ inline bool VerifyEquipment(flatbuffers::Verifier &verifier, const void *obj, Eq
       auto ptr = reinterpret_cast<const MyGame::Sample::Weapon *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    default: return false;
+    default: return true;
   }
 }
 

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -1295,7 +1295,7 @@ class CppGenerator : public BaseGenerator {
         code_ += "    }";
       }
     }
-    code_ += "    default: return false;";
+    code_ += "    default: return true;"; // unknown values are OK.
     code_ += "  }";
     code_ += "}";
     code_ += "";

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -2801,7 +2801,7 @@ inline bool VerifyAny(flatbuffers::Verifier &verifier, const void *obj, Any type
       auto ptr = reinterpret_cast<const MyGame::Example2::Monster *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    default: return false;
+    default: return true;
   }
 }
 
@@ -2912,7 +2912,7 @@ inline bool VerifyAnyUniqueAliases(flatbuffers::Verifier &verifier, const void *
       auto ptr = reinterpret_cast<const MyGame::Example2::Monster *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    default: return false;
+    default: return true;
   }
 }
 
@@ -3023,7 +3023,7 @@ inline bool VerifyAnyAmbiguousAliases(flatbuffers::Verifier &verifier, const voi
       auto ptr = reinterpret_cast<const MyGame::Example::Monster *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    default: return false;
+    default: return true;
   }
 }
 

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -563,7 +563,7 @@ inline bool VerifyCharacter(flatbuffers::Verifier &verifier, const void *obj, Ch
       auto ptr = reinterpret_cast<const flatbuffers::String *>(obj);
       return verifier.VerifyString(ptr);
     }
-    default: return false;
+    default: return true;
   }
 }
 


### PR DESCRIPTION
The C++ flatbuffer verifier returns `false` if it encounters an unknown union field. This should not be the case as unknown union fields are OK in a forward compatible evolution of the schema.

```
union Any_V1 { Monster, Weapon, Pickup }
union Any_V2 { Monster, Weapon, Pickup, Armor }
```

Generating a flatbuffer with an Any_V2 union will return 'false' in the verifier generated against the Any_V1 union schema. 

This change will now skip unknown union fields by returning `true` for them. This is fine since the older schema wouldn't known about these new union fields anyway and wouldn't 'parse' them.

Note: No tests were provided because there are no existing schema evolution tests. This is [known issue](https://github.com/google/flatbuffers/projects/16#card-28306986). The chance of this change breaking things is extremely low, since it is only in the verifier that is not required to be used.
