### PR TITLE
Fix typos in comments

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -99,7 +99,7 @@
 #if !defined(__clang__) && \
     defined(__GNUC__) && \
     (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__ < 40600)
-  // Backwards compatability for g++ 4.4, and 4.5 which don't have the nullptr
+  // Backwards compatibility for g++ 4.4, and 4.5 which don't have the nullptr
   // and constexpr keywords. Note the __clang__ check is needed, because clang
   // presents itself as an older GNUC compiler.
   #ifndef nullptr_t

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -2235,7 +2235,7 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
     // Check the vtable offset.
     auto tableo = static_cast<size_t>(table - buf_);
     if (!Verify<soffset_t>(tableo)) return false;
-    // This offset may be signed, but doing the substraction unsigned always
+    // This offset may be signed, but doing the subtraction unsigned always
     // gives the result we want.
     auto vtableo = tableo - static_cast<size_t>(ReadScalar<soffset_t>(table));
     // Check the vtable size field, then check vtable fits in its entirety.

--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -1054,7 +1054,7 @@ class Builder FLATBUFFERS_FINAL_CLASS {
     for (auto key = start; key < stack_.size(); key += 2) {
       FLATBUFFERS_ASSERT(stack_[key].type_ == FBT_KEY);
     }
-    // Now sort values, so later we can do a binary seach lookup.
+    // Now sort values, so later we can do a binary search lookup.
     // We want to sort 2 array elements at a time.
     struct TwoValue {
       Value key;

--- a/include/flatbuffers/grpc.h
+++ b/include/flatbuffers/grpc.h
@@ -274,7 +274,7 @@ template<class T> class SerializationTraits<flatbuffers::grpc::Message<T>> {
                                 grpc_byte_buffer **buffer, bool *own_buffer) {
     // We are passed in a `Message<T>`, which is a wrapper around a
     // `grpc_slice`. We extract it here using `BorrowSlice()`. The const cast
-    // is necesary because the `grpc_raw_byte_buffer_create` func expects
+    // is necessary because the `grpc_raw_byte_buffer_create` func expects
     // non-const slices in order to increment their refcounts.
     grpc_slice *slice = const_cast<grpc_slice *>(&msg.BorrowSlice());
     // Now use `grpc_raw_byte_buffer_create` to package the single slice into a
@@ -306,7 +306,7 @@ template<class T> class SerializationTraits<flatbuffers::grpc::Message<T>> {
       grpc_byte_buffer_reader_init(&reader, buffer);
       grpc_slice slice = grpc_byte_buffer_reader_readall(&reader);
       grpc_byte_buffer_reader_destroy(&reader);
-      // We wrap a `Message<T>` around the slice, but dont increment refcount
+      // We wrap a `Message<T>` around the slice, but don't increment refcount
       *msg = flatbuffers::grpc::Message<T>(slice, false);
     }
     grpc_byte_buffer_destroy(buffer);


### PR DESCRIPTION
Found by the https://github.com/OSGeo/gdal/blob/master/gdal/scripts/fix_typos.sh
script on the internal copy of flatbuffers inside GDAL