### PR TITLE
[Go] Add UnPackTo functions

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -983,10 +983,8 @@ class GoGenerator : public BaseGenerator {
     const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "func (rcv *" + struct_def.name + ") UnPack() *" +
-            NativeName(struct_def) + " {\n";
-    code += "\tif rcv == nil { return nil }\n";
-    code += "\tt := &" + NativeName(struct_def) + "{}\n";
+    code += "func (rcv *" + struct_def.name + ") UnPackTo(t *" +
+            NativeName(struct_def) + ") {\n";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
       const FieldDef &field = **it;
@@ -1046,6 +1044,13 @@ class GoGenerator : public BaseGenerator {
         FLATBUFFERS_ASSERT(0);
       }
     }
+    code += "}\n\n";
+
+    code += "func (rcv *" + struct_def.name + ") UnPack() *" +
+            NativeName(struct_def) + " {\n";
+    code += "\tif rcv == nil { return nil }\n";
+    code += "\tt := &" + NativeName(struct_def) + "{}\n";
+    code += "\trcv.UnPackTo(t)\n";
     code += "\treturn t\n";
     code += "}\n\n";
   }
@@ -1083,10 +1088,8 @@ class GoGenerator : public BaseGenerator {
     const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "func (rcv *" + struct_def.name + ") UnPack() *" +
-            NativeName(struct_def) + " {\n";
-    code += "\tif rcv == nil { return nil }\n";
-    code += "\tt := &" + NativeName(struct_def) + "{}\n";
+    code += "func (rcv *" + struct_def.name + ") UnPackTo(t *" +
+            NativeName(struct_def) + ") {\n";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
       const FieldDef &field = **it;
@@ -1098,6 +1101,13 @@ class GoGenerator : public BaseGenerator {
                 MakeCamel(field.name) + "()\n";
       }
     }
+    code += "}\n\n";
+
+    code += "func (rcv *" + struct_def.name + ") UnPack() *" +
+            NativeName(struct_def) + " {\n";
+    code += "\tif rcv == nil { return nil }\n";
+    code += "\tt := &" + NativeName(struct_def) + "{}\n";
+    code += "\trcv.UnPackTo(t)\n";
     code += "\treturn t\n";
     code += "}\n\n";
   }

--- a/tests/MyGame/Example/Ability.go
+++ b/tests/MyGame/Example/Ability.go
@@ -15,11 +15,15 @@ func AbilityPack(builder *flatbuffers.Builder, t *AbilityT) flatbuffers.UOffsetT
 	if t == nil { return 0 }
 	return CreateAbility(builder, t.Id, t.Distance)
 }
+func (rcv *Ability) UnPackTo(t *AbilityT) {
+	t.Id = rcv.Id()
+	t.Distance = rcv.Distance()
+}
+
 func (rcv *Ability) UnPack() *AbilityT {
 	if rcv == nil { return nil }
 	t := &AbilityT{}
-	t.Id = rcv.Id()
-	t.Distance = rcv.Distance()
+	rcv.UnPackTo(t)
 	return t
 }
 

--- a/tests/MyGame/Example/Monster.go
+++ b/tests/MyGame/Example/Monster.go
@@ -295,9 +295,7 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 	return MonsterEnd(builder)
 }
 
-func (rcv *Monster) UnPack() *MonsterT {
-	if rcv == nil { return nil }
-	t := &MonsterT{}
+func (rcv *Monster) UnPackTo(t *MonsterT) {
 	t.Pos = rcv.Pos(nil).UnPack()
 	t.Mana = rcv.Mana()
 	t.Hp = rcv.Hp()
@@ -424,6 +422,12 @@ func (rcv *Monster) UnPack() *MonsterT {
 		t.VectorOfEnums[j] = rcv.VectorOfEnums(j)
 	}
 	t.SignedEnum = rcv.SignedEnum()
+}
+
+func (rcv *Monster) UnPack() *MonsterT {
+	if rcv == nil { return nil }
+	t := &MonsterT{}
+	rcv.UnPackTo(t)
 	return t
 }
 

--- a/tests/MyGame/Example/Referrable.go
+++ b/tests/MyGame/Example/Referrable.go
@@ -17,10 +17,14 @@ func ReferrablePack(builder *flatbuffers.Builder, t *ReferrableT) flatbuffers.UO
 	return ReferrableEnd(builder)
 }
 
+func (rcv *Referrable) UnPackTo(t *ReferrableT) {
+	t.Id = rcv.Id()
+}
+
 func (rcv *Referrable) UnPack() *ReferrableT {
 	if rcv == nil { return nil }
 	t := &ReferrableT{}
-	t.Id = rcv.Id()
+	rcv.UnPackTo(t)
 	return t
 }
 

--- a/tests/MyGame/Example/Stat.go
+++ b/tests/MyGame/Example/Stat.go
@@ -22,12 +22,16 @@ func StatPack(builder *flatbuffers.Builder, t *StatT) flatbuffers.UOffsetT {
 	return StatEnd(builder)
 }
 
-func (rcv *Stat) UnPack() *StatT {
-	if rcv == nil { return nil }
-	t := &StatT{}
+func (rcv *Stat) UnPackTo(t *StatT) {
 	t.Id = string(rcv.Id())
 	t.Val = rcv.Val()
 	t.Count = rcv.Count()
+}
+
+func (rcv *Stat) UnPack() *StatT {
+	if rcv == nil { return nil }
+	t := &StatT{}
+	rcv.UnPackTo(t)
 	return t
 }
 

--- a/tests/MyGame/Example/Test.go
+++ b/tests/MyGame/Example/Test.go
@@ -15,11 +15,15 @@ func TestPack(builder *flatbuffers.Builder, t *TestT) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	return CreateTest(builder, t.A, t.B)
 }
+func (rcv *Test) UnPackTo(t *TestT) {
+	t.A = rcv.A()
+	t.B = rcv.B()
+}
+
 func (rcv *Test) UnPack() *TestT {
 	if rcv == nil { return nil }
 	t := &TestT{}
-	t.A = rcv.A()
-	t.B = rcv.B()
+	rcv.UnPackTo(t)
 	return t
 }
 

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.go
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.go
@@ -17,10 +17,14 @@ func TestSimpleTableWithEnumPack(builder *flatbuffers.Builder, t *TestSimpleTabl
 	return TestSimpleTableWithEnumEnd(builder)
 }
 
+func (rcv *TestSimpleTableWithEnum) UnPackTo(t *TestSimpleTableWithEnumT) {
+	t.Color = rcv.Color()
+}
+
 func (rcv *TestSimpleTableWithEnum) UnPack() *TestSimpleTableWithEnumT {
 	if rcv == nil { return nil }
 	t := &TestSimpleTableWithEnumT{}
-	t.Color = rcv.Color()
+	rcv.UnPackTo(t)
 	return t
 }
 

--- a/tests/MyGame/Example/TypeAliases.go
+++ b/tests/MyGame/Example/TypeAliases.go
@@ -57,9 +57,7 @@ func TypeAliasesPack(builder *flatbuffers.Builder, t *TypeAliasesT) flatbuffers.
 	return TypeAliasesEnd(builder)
 }
 
-func (rcv *TypeAliases) UnPack() *TypeAliasesT {
-	if rcv == nil { return nil }
-	t := &TypeAliasesT{}
+func (rcv *TypeAliases) UnPackTo(t *TypeAliasesT) {
 	t.I8 = rcv.I8()
 	t.U8 = rcv.U8()
 	t.I16 = rcv.I16()
@@ -80,6 +78,12 @@ func (rcv *TypeAliases) UnPack() *TypeAliasesT {
 	for j := 0; j < vf64Length; j++ {
 		t.Vf64[j] = rcv.Vf64(j)
 	}
+}
+
+func (rcv *TypeAliases) UnPack() *TypeAliasesT {
+	if rcv == nil { return nil }
+	t := &TypeAliasesT{}
+	rcv.UnPackTo(t)
 	return t
 }
 

--- a/tests/MyGame/Example/Vec3.go
+++ b/tests/MyGame/Example/Vec3.go
@@ -19,15 +19,19 @@ func Vec3Pack(builder *flatbuffers.Builder, t *Vec3T) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	return CreateVec3(builder, t.X, t.Y, t.Z, t.Test1, t.Test2, t.Test3.A, t.Test3.B)
 }
-func (rcv *Vec3) UnPack() *Vec3T {
-	if rcv == nil { return nil }
-	t := &Vec3T{}
+func (rcv *Vec3) UnPackTo(t *Vec3T) {
 	t.X = rcv.X()
 	t.Y = rcv.Y()
 	t.Z = rcv.Z()
 	t.Test1 = rcv.Test1()
 	t.Test2 = rcv.Test2()
 	t.Test3 = rcv.Test3(nil).UnPack()
+}
+
+func (rcv *Vec3) UnPack() *Vec3T {
+	if rcv == nil { return nil }
+	t := &Vec3T{}
+	rcv.UnPackTo(t)
 	return t
 }
 

--- a/tests/MyGame/Example2/Monster.go
+++ b/tests/MyGame/Example2/Monster.go
@@ -15,9 +15,13 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 	return MonsterEnd(builder)
 }
 
+func (rcv *Monster) UnPackTo(t *MonsterT) {
+}
+
 func (rcv *Monster) UnPack() *MonsterT {
 	if rcv == nil { return nil }
 	t := &MonsterT{}
+	rcv.UnPackTo(t)
 	return t
 }
 

--- a/tests/MyGame/InParentNamespace.go
+++ b/tests/MyGame/InParentNamespace.go
@@ -15,9 +15,13 @@ func InParentNamespacePack(builder *flatbuffers.Builder, t *InParentNamespaceT) 
 	return InParentNamespaceEnd(builder)
 }
 
+func (rcv *InParentNamespace) UnPackTo(t *InParentNamespaceT) {
+}
+
 func (rcv *InParentNamespace) UnPack() *InParentNamespaceT {
 	if rcv == nil { return nil }
 	t := &InParentNamespaceT{}
+	rcv.UnPackTo(t)
 	return t
 }
 


### PR DESCRIPTION
This adds an `UnPackTo` function to the Go object API, analogous to the C++ one, that unpacks into an existing object.  The `UnPack` functions use this to do the heavy lifting.
