### PR TITLE
[Kotlin] Fix union vector accessor after change in Java API

### DIFF
--- a/src/idl_gen_kotlin.cpp
+++ b/src/idl_gen_kotlin.cpp
@@ -975,9 +975,6 @@ class KotlinGenerator : public BaseGenerator {
                         params = "obj: " + field_type + ", j: Int";
                     }
 
-
-                    writer.SetValue("toType", "YYYYY");
-
                     auto ret_type = return_type + nullable;
                     GenerateFun(writer, field_name, params, ret_type, [&](){
                         auto inline_size = NumToString(InlineSize(vectortype));
@@ -1008,7 +1005,7 @@ class KotlinGenerator : public BaseGenerator {
                     GenerateFun(writer, field_name, "obj: " + field_type,
                                 return_type + "?", [&](){
                         writer += OffsetWrapperOneLine(offset_val,
-                                                       bbgetter + "(obj, o)",
+                                                       bbgetter + "(obj, o + bb_pos)",
                                                        "null");
                     });
                     break;

--- a/tests/MyGame/Example/Monster.kt
+++ b/tests/MyGame/Example/Monster.kt
@@ -116,7 +116,7 @@ class Monster : Table() {
         }
     }
     fun test(obj: Table) : Table? {
-        val o = __offset(20); return if (o != 0) __union(obj, o) else null
+        val o = __offset(20); return if (o != 0) __union(obj, o + bb_pos) else null
     }
     fun test4(j: Int) : MyGame.Example.Test? = test4(MyGame.Example.Test(), j)
     fun test4(obj: MyGame.Example.Test, j: Int) : MyGame.Example.Test? {
@@ -717,7 +717,7 @@ class Monster : Table() {
         }
     }
     fun anyUnique(obj: Table) : Table? {
-        val o = __offset(92); return if (o != 0) __union(obj, o) else null
+        val o = __offset(92); return if (o != 0) __union(obj, o + bb_pos) else null
     }
     val anyAmbiguousType : UByte
         get() {
@@ -734,7 +734,7 @@ class Monster : Table() {
         }
     }
     fun anyAmbiguous(obj: Table) : Table? {
-        val o = __offset(96); return if (o != 0) __union(obj, o) else null
+        val o = __offset(96); return if (o != 0) __union(obj, o + bb_pos) else null
     }
     fun vectorOfEnums(j: Int) : UByte {
         val o = __offset(98)

--- a/tests/union_vector/Movie.kt
+++ b/tests/union_vector/Movie.kt
@@ -30,7 +30,7 @@ class Movie : Table() {
         }
     }
     fun mainCharacter(obj: Table) : Table? {
-        val o = __offset(6); return if (o != 0) __union(obj, o) else null
+        val o = __offset(6); return if (o != 0) __union(obj, o + bb_pos) else null
     }
     fun charactersType(j: Int) : UByte {
         val o = __offset(8)


### PR DESCRIPTION
Kolin uses java library as dependency, which changed the way it access union vector recently (e365c502ffc659752f9b7a8d60b0052a07e33659).

 This changes updates kotlin code generation to match Java's changes.