### PR TITLE
include/flatbuffers/base.h: fix no_sanitize issue with old clang

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -242,7 +242,7 @@ namespace flatbuffers {
 // Suppress Undefined Behavior Sanitizer (recoverable only). Usage:
 // - __supress_ubsan__("undefined")
 // - __supress_ubsan__("signed-integer-overflow")
-#if defined(__clang__)
+#if defined(__clang__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >=7))
   #define __supress_ubsan__(type) __attribute__((no_sanitize(type)))
 #elif defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 409)
   #define __supress_ubsan__(type) __attribute__((no_sanitize_undefined))


### PR DESCRIPTION
Older clang versions raise:
```
./flatbuffers/base.h:365:1: error: unknown attribute 'no_sanitize' ignored [-Werror,-Wattributes]
__supress_ubsan__("alignment")
^
./flatbuffers/base.h:246:50: note: expanded from macro '__supress_ubsan__'
  #define __supress_ubsan__(type) __attribute__((no_sanitize(type)))
                                                 ^
```

Comparing https://releases.llvm.org/3.6.0/tools/clang/docs/AttributeReference.html
with https://releases.llvm.org/3.7.0/tools/clang/docs/AttributeReference.html
shows that __attribute__((no_sanitize(type))) is available since 3.7.0
