### PR TITLE
[C++] Ran src/clang-format-all.sh

### DIFF
--- a/grpc/src/compiler/schema_interface.h
+++ b/grpc/src/compiler/schema_interface.h
@@ -34,10 +34,10 @@
 #ifndef GRPC_INTERNAL_COMPILER_SCHEMA_INTERFACE_H
 #define GRPC_INTERNAL_COMPILER_SCHEMA_INTERFACE_H
 
-#include "src/compiler/config.h"
-
 #include <memory>
 #include <vector>
+
+#include "src/compiler/config.h"
 
 #ifndef GRPC_CUSTOM_STRING
 #  include <string>

--- a/grpc/tests/grpctest.cpp
+++ b/grpc/tests/grpctest.cpp
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-#include <thread>
-
 #include <grpc++/grpc++.h>
+
+#include <thread>
 
 #include "monster_test.grpc.fb.h"
 #include "monster_test_generated.h"
 #include "test_assert.h"
 
 using namespace MyGame::Example;
-using flatbuffers::grpc::MessageBuilder;
 using flatbuffers::FlatBufferBuilder;
+using flatbuffers::grpc::MessageBuilder;
 
 void message_builder_tests();
 
@@ -97,8 +97,7 @@ void RunServer() {
   server_instance->Wait();
 }
 
-template <class Builder>
-void StoreRPC(MonsterStorage::Stub *stub) {
+template<class Builder> void StoreRPC(MonsterStorage::Stub *stub) {
   Builder fbb;
   grpc::ClientContext context;
   // Build a request with the name set.
@@ -119,8 +118,7 @@ void StoreRPC(MonsterStorage::Stub *stub) {
   }
 }
 
-template <class Builder>
-void RetrieveRPC(MonsterStorage::Stub *stub) {
+template<class Builder> void RetrieveRPC(MonsterStorage::Stub *stub) {
   Builder fbb;
   grpc::ClientContext context;
   fbb.Clear();
@@ -155,7 +153,6 @@ int grpc_server_test() {
   RetrieveRPC<MessageBuilder>(stub.get());
   RetrieveRPC<FlatBufferBuilder>(stub.get());
 
-
 #if !FLATBUFFERS_GRPC_DISABLE_AUTO_VERIFICATION
   {
     // Test that an invalid request errors out correctly
@@ -181,7 +178,7 @@ int grpc_server_test() {
   return 0;
 }
 
-int main(int /*argc*/, const char * /*argv*/ []) {
+int main(int /*argc*/, const char * /*argv*/[]) {
   message_builder_tests();
   grpc_server_test();
 
@@ -193,4 +190,3 @@ int main(int /*argc*/, const char * /*argv*/ []) {
     return 1;
   }
 }
-

--- a/grpc/tests/message_builder_test.cpp
+++ b/grpc/tests/message_builder_test.cpp
@@ -3,22 +3,27 @@
 #include "test_assert.h"
 #include "test_builder.h"
 
-using MyGame::Example::Vec3;
-using MyGame::Example::CreateStat;
 using MyGame::Example::Any_NONE;
+using MyGame::Example::CreateStat;
+using MyGame::Example::Vec3;
 
-bool verify(flatbuffers::grpc::Message<Monster> &msg, const std::string &expected_name, Color color) {
+bool verify(flatbuffers::grpc::Message<Monster> &msg,
+            const std::string &expected_name, Color color) {
   const Monster *monster = msg.GetRoot();
-  return (monster->name()->str() == expected_name) && (monster->color() == color);
+  return (monster->name()->str() == expected_name) &&
+         (monster->color() == color);
 }
 
-bool release_n_verify(flatbuffers::grpc::MessageBuilder &mbb, const std::string &expected_name, Color color) {
+bool release_n_verify(flatbuffers::grpc::MessageBuilder &mbb,
+                      const std::string &expected_name, Color color) {
   flatbuffers::grpc::Message<Monster> msg = mbb.ReleaseMessage<Monster>();
   const Monster *monster = msg.GetRoot();
-  return (monster->name()->str() == expected_name) && (monster->color() == color);
+  return (monster->name()->str() == expected_name) &&
+         (monster->color() == color);
 }
 
-void builder_move_assign_after_releaseraw_test(flatbuffers::grpc::MessageBuilder dst) {
+void builder_move_assign_after_releaseraw_test(
+    flatbuffers::grpc::MessageBuilder dst) {
   auto root_offset1 = populate1(dst);
   dst.Finish(root_offset1);
   size_t size, offset;
@@ -36,12 +41,11 @@ void builder_move_assign_after_releaseraw_test(flatbuffers::grpc::MessageBuilder
   grpc_slice_unref(slice);
 }
 
-template <class SrcBuilder>
+template<class SrcBuilder>
 struct BuilderReuseTests<flatbuffers::grpc::MessageBuilder, SrcBuilder> {
-  static void builder_reusable_after_release_message_test(TestSelector selector) {
-    if (!selector.count(REUSABLE_AFTER_RELEASE_MESSAGE)) {
-      return;
-    }
+  static void builder_reusable_after_release_message_test(
+      TestSelector selector) {
+    if (!selector.count(REUSABLE_AFTER_RELEASE_MESSAGE)) { return; }
 
     flatbuffers::grpc::MessageBuilder mb;
     std::vector<flatbuffers::grpc::Message<Monster>> buffers;
@@ -54,12 +58,10 @@ struct BuilderReuseTests<flatbuffers::grpc::MessageBuilder, SrcBuilder> {
   }
 
   static void builder_reusable_after_release_test(TestSelector selector) {
-    if (!selector.count(REUSABLE_AFTER_RELEASE)) {
-      return;
-    }
+    if (!selector.count(REUSABLE_AFTER_RELEASE)) { return; }
 
-    // FIXME: Populate-Release loop fails assert(GRPC_SLICE_IS_EMPTY(slice_)) in SliceAllocator::allocate
-    // in the second iteration.
+    // FIXME: Populate-Release loop fails assert(GRPC_SLICE_IS_EMPTY(slice_)) in
+    // SliceAllocator::allocate in the second iteration.
 
     flatbuffers::grpc::MessageBuilder mb;
     std::vector<flatbuffers::DetachedBuffer> buffers;
@@ -72,9 +74,7 @@ struct BuilderReuseTests<flatbuffers::grpc::MessageBuilder, SrcBuilder> {
   }
 
   static void builder_reusable_after_releaseraw_test(TestSelector selector) {
-    if (!selector.count(REUSABLE_AFTER_RELEASE_RAW)) {
-      return;
-    }
+    if (!selector.count(REUSABLE_AFTER_RELEASE_RAW)) { return; }
 
     flatbuffers::grpc::MessageBuilder mb;
     for (int i = 0; i < 5; ++i) {
@@ -88,13 +88,13 @@ struct BuilderReuseTests<flatbuffers::grpc::MessageBuilder, SrcBuilder> {
     }
   }
 
-  static void builder_reusable_after_release_and_move_assign_test(TestSelector selector) {
-    if (!selector.count(REUSABLE_AFTER_RELEASE_AND_MOVE_ASSIGN)) {
-      return;
-    }
+  static void builder_reusable_after_release_and_move_assign_test(
+      TestSelector selector) {
+    if (!selector.count(REUSABLE_AFTER_RELEASE_AND_MOVE_ASSIGN)) { return; }
 
-    // FIXME: Release-move_assign loop fails assert(p == GRPC_SLICE_START_PTR(slice_))
-    // in DetachedBuffer destructor after all the iterations
+    // FIXME: Release-move_assign loop fails assert(p ==
+    // GRPC_SLICE_START_PTR(slice_)) in DetachedBuffer destructor after all the
+    // iterations
 
     flatbuffers::grpc::MessageBuilder dst;
     std::vector<flatbuffers::DetachedBuffer> buffers;
@@ -113,7 +113,8 @@ struct BuilderReuseTests<flatbuffers::grpc::MessageBuilder, SrcBuilder> {
     }
   }
 
-  static void builder_reusable_after_release_message_and_move_assign_test(TestSelector selector) {
+  static void builder_reusable_after_release_message_and_move_assign_test(
+      TestSelector selector) {
     if (!selector.count(REUSABLE_AFTER_RELEASE_MESSAGE_AND_MOVE_ASSIGN)) {
       return;
     }
@@ -135,10 +136,9 @@ struct BuilderReuseTests<flatbuffers::grpc::MessageBuilder, SrcBuilder> {
     }
   }
 
-  static void builder_reusable_after_releaseraw_and_move_assign_test(TestSelector selector) {
-    if (!selector.count(REUSABLE_AFTER_RELEASE_RAW_AND_MOVE_ASSIGN)) {
-      return;
-    }
+  static void builder_reusable_after_releaseraw_and_move_assign_test(
+      TestSelector selector) {
+    if (!selector.count(REUSABLE_AFTER_RELEASE_RAW_AND_MOVE_ASSIGN)) { return; }
 
     flatbuffers::grpc::MessageBuilder dst;
     for (int i = 0; i < 5; ++i) {
@@ -175,11 +175,11 @@ void slice_allocator_tests() {
     uint8_t *buf = sa1.allocate(size);
     TEST_ASSERT_FUNC(buf != 0);
     buf[0] = 100;
-    buf[size-1] = 200;
+    buf[size - 1] = 200;
     flatbuffers::grpc::SliceAllocator sa2(std::move(sa1));
     // buf should not be deleted after move-construct
     TEST_EQ_FUNC(buf[0], 100);
-    TEST_EQ_FUNC(buf[size-1], 200);
+    TEST_EQ_FUNC(buf[size - 1], 200);
     // buf is freed here
   }
 
@@ -194,13 +194,16 @@ void slice_allocator_tests() {
   }
 }
 
-/// This function does not populate exactly the first half of the table. But it could.
-void populate_first_half(MyGame::Example::MonsterBuilder &wrapper, flatbuffers::Offset<flatbuffers::String> name_offset) {
+/// This function does not populate exactly the first half of the table. But it
+/// could.
+void populate_first_half(MyGame::Example::MonsterBuilder &wrapper,
+                         flatbuffers::Offset<flatbuffers::String> name_offset) {
   wrapper.add_name(name_offset);
   wrapper.add_color(m1_color);
 }
 
-/// This function does not populate exactly the second half of the table. But it could.
+/// This function does not populate exactly the second half of the table. But it
+/// could.
 void populate_second_half(MyGame::Example::MonsterBuilder &wrapper) {
   wrapper.add_hp(77);
   wrapper.add_mana(88);
@@ -208,83 +211,97 @@ void populate_second_half(MyGame::Example::MonsterBuilder &wrapper) {
   wrapper.add_pos(&vec3);
 }
 
-/// This function is a hack to update the FlatBufferBuilder reference (fbb_) in the MonsterBuilder object.
-/// This function will break if fbb_ is not the first member in MonsterBuilder. In that case, some offset must be added.
-/// This function is used exclusively for testing correctness of move operations between FlatBufferBuilders.
-/// If MonsterBuilder had a fbb_ pointer, this hack would be unnecessary. That involves a code-generator change though.
-void test_only_hack_update_fbb_reference(MyGame::Example::MonsterBuilder &monsterBuilder,
-                                         flatbuffers::grpc::MessageBuilder &mb) {
+/// This function is a hack to update the FlatBufferBuilder reference (fbb_) in
+/// the MonsterBuilder object. This function will break if fbb_ is not the first
+/// member in MonsterBuilder. In that case, some offset must be added. This
+/// function is used exclusively for testing correctness of move operations
+/// between FlatBufferBuilders. If MonsterBuilder had a fbb_ pointer, this hack
+/// would be unnecessary. That involves a code-generator change though.
+void test_only_hack_update_fbb_reference(
+    MyGame::Example::MonsterBuilder &monsterBuilder,
+    flatbuffers::grpc::MessageBuilder &mb) {
   *reinterpret_cast<flatbuffers::FlatBufferBuilder **>(&monsterBuilder) = &mb;
 }
 
-/// This test validates correctness of move conversion of FlatBufferBuilder to a MessageBuilder DURING
-/// a table construction. Half of the table is constructed using FlatBufferBuilder and the other half
-/// of the table is constructed using a MessageBuilder.
+/// This test validates correctness of move conversion of FlatBufferBuilder to a
+/// MessageBuilder DURING a table construction. Half of the table is constructed
+/// using FlatBufferBuilder and the other half of the table is constructed using
+/// a MessageBuilder.
 void builder_move_ctor_conversion_before_finish_half_n_half_table_test() {
-  for (size_t initial_size = 4 ; initial_size <= 2048; initial_size *= 2) {
+  for (size_t initial_size = 4; initial_size <= 2048; initial_size *= 2) {
     flatbuffers::FlatBufferBuilder fbb(initial_size);
     auto name_offset = fbb.CreateString(m1_name);
-    MyGame::Example::MonsterBuilder monsterBuilder(fbb);     // starts a table in FlatBufferBuilder
+    MyGame::Example::MonsterBuilder monsterBuilder(
+        fbb);  // starts a table in FlatBufferBuilder
     populate_first_half(monsterBuilder, name_offset);
     flatbuffers::grpc::MessageBuilder mb(std::move(fbb));
-    test_only_hack_update_fbb_reference(monsterBuilder, mb); // hack
+    test_only_hack_update_fbb_reference(monsterBuilder, mb);  // hack
     populate_second_half(monsterBuilder);
-    mb.Finish(monsterBuilder.Finish());                      // ends the table in MessageBuilder
+    mb.Finish(monsterBuilder.Finish());  // ends the table in MessageBuilder
     TEST_ASSERT_FUNC(release_n_verify(mb, m1_name, m1_color));
     TEST_EQ_FUNC(fbb.GetSize(), 0);
   }
 }
 
-/// This test populates a COMPLETE inner table before move conversion and later populates more members in the outer table.
+/// This test populates a COMPLETE inner table before move conversion and later
+/// populates more members in the outer table.
 void builder_move_ctor_conversion_before_finish_test() {
-  for (size_t initial_size = 4 ; initial_size <= 2048; initial_size *= 2) {
+  for (size_t initial_size = 4; initial_size <= 2048; initial_size *= 2) {
     flatbuffers::FlatBufferBuilder fbb(initial_size);
     auto stat_offset = CreateStat(fbb, fbb.CreateString("SomeId"), 0, 0);
     flatbuffers::grpc::MessageBuilder mb(std::move(fbb));
-    auto monster_offset = CreateMonster(mb, 0, 150, 100, mb.CreateString(m1_name), 0, m1_color, Any_NONE, 0, 0, 0, 0, 0, 0, stat_offset);
+    auto monster_offset =
+        CreateMonster(mb, 0, 150, 100, mb.CreateString(m1_name), 0, m1_color,
+                      Any_NONE, 0, 0, 0, 0, 0, 0, stat_offset);
     mb.Finish(monster_offset);
     TEST_ASSERT_FUNC(release_n_verify(mb, m1_name, m1_color));
     TEST_EQ_FUNC(fbb.GetSize(), 0);
   }
 }
 
-/// This test validates correctness of move conversion of FlatBufferBuilder to a MessageBuilder DURING
-/// a table construction. Half of the table is constructed using FlatBufferBuilder and the other half
-/// of the table is constructed using a MessageBuilder.
+/// This test validates correctness of move conversion of FlatBufferBuilder to a
+/// MessageBuilder DURING a table construction. Half of the table is constructed
+/// using FlatBufferBuilder and the other half of the table is constructed using
+/// a MessageBuilder.
 void builder_move_assign_conversion_before_finish_half_n_half_table_test() {
   flatbuffers::FlatBufferBuilder fbb;
   flatbuffers::grpc::MessageBuilder mb;
 
-  for (int i = 0;i < 5; ++i) {
+  for (int i = 0; i < 5; ++i) {
     flatbuffers::FlatBufferBuilder fbb;
     auto name_offset = fbb.CreateString(m1_name);
-    MyGame::Example::MonsterBuilder monsterBuilder(fbb);     // starts a table in FlatBufferBuilder
+    MyGame::Example::MonsterBuilder monsterBuilder(
+        fbb);  // starts a table in FlatBufferBuilder
     populate_first_half(monsterBuilder, name_offset);
     mb = std::move(fbb);
-    test_only_hack_update_fbb_reference(monsterBuilder, mb); // hack
+    test_only_hack_update_fbb_reference(monsterBuilder, mb);  // hack
     populate_second_half(monsterBuilder);
-    mb.Finish(monsterBuilder.Finish());                      // ends the table in MessageBuilder
+    mb.Finish(monsterBuilder.Finish());  // ends the table in MessageBuilder
     TEST_ASSERT_FUNC(release_n_verify(mb, m1_name, m1_color));
     TEST_EQ_FUNC(fbb.GetSize(), 0);
   }
 }
 
-/// This test populates a COMPLETE inner table before move conversion and later populates more members in the outer table.
+/// This test populates a COMPLETE inner table before move conversion and later
+/// populates more members in the outer table.
 void builder_move_assign_conversion_before_finish_test() {
   flatbuffers::FlatBufferBuilder fbb;
   flatbuffers::grpc::MessageBuilder mb;
 
-  for (int i = 0;i < 5; ++i) {
+  for (int i = 0; i < 5; ++i) {
     auto stat_offset = CreateStat(fbb, fbb.CreateString("SomeId"), 0, 0);
     mb = std::move(fbb);
-    auto monster_offset = CreateMonster(mb, 0, 150, 100, mb.CreateString(m1_name), 0, m1_color, Any_NONE, 0, 0, 0, 0, 0, 0, stat_offset);
+    auto monster_offset =
+        CreateMonster(mb, 0, 150, 100, mb.CreateString(m1_name), 0, m1_color,
+                      Any_NONE, 0, 0, 0, 0, 0, 0, stat_offset);
     mb.Finish(monster_offset);
     TEST_ASSERT_FUNC(release_n_verify(mb, m1_name, m1_color));
     TEST_EQ_FUNC(fbb.GetSize(), 0);
   }
 }
 
-/// This test populates data, finishes the buffer, and does move conversion after.
+/// This test populates data, finishes the buffer, and does move conversion
+/// after.
 void builder_move_ctor_conversion_after_finish_test() {
   flatbuffers::FlatBufferBuilder fbb;
   fbb.Finish(populate1(fbb));
@@ -293,12 +310,13 @@ void builder_move_ctor_conversion_after_finish_test() {
   TEST_EQ_FUNC(fbb.GetSize(), 0);
 }
 
-/// This test populates data, finishes the buffer, and does move conversion after.
+/// This test populates data, finishes the buffer, and does move conversion
+/// after.
 void builder_move_assign_conversion_after_finish_test() {
   flatbuffers::FlatBufferBuilder fbb;
   flatbuffers::grpc::MessageBuilder mb;
 
-  for (int i = 0;i < 5; ++i) {
+  for (int i = 0; i < 5; ++i) {
     fbb.Finish(populate1(fbb));
     mb = std::move(fbb);
     TEST_ASSERT_FUNC(release_n_verify(mb, m1_name, m1_color));
@@ -307,15 +325,15 @@ void builder_move_assign_conversion_after_finish_test() {
 }
 
 void message_builder_tests() {
-  using flatbuffers::grpc::MessageBuilder;
   using flatbuffers::FlatBufferBuilder;
+  using flatbuffers::grpc::MessageBuilder;
 
   slice_allocator_tests();
 
 #ifndef __APPLE__
   builder_move_ctor_conversion_before_finish_half_n_half_table_test();
   builder_move_assign_conversion_before_finish_half_n_half_table_test();
-#endif // __APPLE__
+#endif  // __APPLE__
   builder_move_ctor_conversion_before_finish_test();
   builder_move_assign_conversion_before_finish_test();
 
@@ -326,15 +344,18 @@ void message_builder_tests() {
   BuilderTests<MessageBuilder, FlatBufferBuilder>::all_tests();
 
   BuilderReuseTestSelector tests[6] = {
-    //REUSABLE_AFTER_RELEASE,                 // Assertion failed: (GRPC_SLICE_IS_EMPTY(slice_))
-    //REUSABLE_AFTER_RELEASE_AND_MOVE_ASSIGN, // Assertion failed: (p == GRPC_SLICE_START_PTR(slice_)
+    // REUSABLE_AFTER_RELEASE,                 // Assertion failed:
+    // (GRPC_SLICE_IS_EMPTY(slice_))
+    // REUSABLE_AFTER_RELEASE_AND_MOVE_ASSIGN, // Assertion failed: (p ==
+    // GRPC_SLICE_START_PTR(slice_)
 
-    REUSABLE_AFTER_RELEASE_RAW,
-    REUSABLE_AFTER_RELEASE_MESSAGE,
+    REUSABLE_AFTER_RELEASE_RAW, REUSABLE_AFTER_RELEASE_MESSAGE,
     REUSABLE_AFTER_RELEASE_MESSAGE_AND_MOVE_ASSIGN,
     REUSABLE_AFTER_RELEASE_RAW_AND_MOVE_ASSIGN
   };
 
-  BuilderReuseTests<MessageBuilder, MessageBuilder>::run_tests(TestSelector(tests, tests+6));
-  BuilderReuseTests<MessageBuilder, FlatBufferBuilder>::run_tests(TestSelector(tests, tests+6));
+  BuilderReuseTests<MessageBuilder, MessageBuilder>::run_tests(
+      TestSelector(tests, tests + 6));
+  BuilderReuseTests<MessageBuilder, FlatBufferBuilder>::run_tests(
+      TestSelector(tests, tests + 6));
 }

--- a/include/flatbuffers/reflection.h
+++ b/include/flatbuffers/reflection.h
@@ -228,7 +228,7 @@ inline std::string GetAnyVectorElemS(const VectorOfAny *vec,
 template<typename T>
 T *GetAnyVectorElemPointer(const VectorOfAny *vec, size_t i) {
   auto elem_ptr = vec->Data() + sizeof(uoffset_t) * i;
-  return reinterpret_cast<T*>(elem_ptr + ReadScalar<uoffset_t>(elem_ptr));
+  return reinterpret_cast<T *>(elem_ptr + ReadScalar<uoffset_t>(elem_ptr));
 }
 
 // Get the inline-address of a vector element. Useful for Structs (pass Struct

--- a/samples/sample_bfbs.cpp
+++ b/samples/sample_bfbs.cpp
@@ -16,8 +16,7 @@
 
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
-
-#include "monster_generated.h" // Already includes "flatbuffers/flatbuffers.h".
+#include "monster_generated.h"  // Already includes "flatbuffers/flatbuffers.h".
 
 using namespace MyGame::Sample;
 
@@ -30,7 +29,8 @@ int main(int /*argc*/, const char * /*argv*/[]) {
   std::string bfbs_file;
   bool ok =
       flatbuffers::LoadFile("tests/monster_test.fbs", false, &schema_file) &&
-      flatbuffers::LoadFile("tests/monsterdata_test.golden", false, &json_file) &&
+      flatbuffers::LoadFile("tests/monsterdata_test.golden", false,
+                            &json_file) &&
       flatbuffers::LoadFile("tests/monster_test.bfbs", true, &bfbs_file);
   if (!ok) {
     printf("couldn't load files!\n");

--- a/samples/sample_binary.cpp
+++ b/samples/sample_binary.cpp
@@ -20,7 +20,7 @@ using namespace MyGame::Sample;
 
 // Example how to use FlatBuffers to create and read binary buffers.
 
-int main(int /*argc*/, const char * /*argv*/ []) {
+int main(int /*argc*/, const char * /*argv*/[]) {
   // Build up a serialized buffer algorithmically:
   flatbuffers::FlatBufferBuilder builder;
 

--- a/samples/sample_text.cpp
+++ b/samples/sample_text.cpp
@@ -16,14 +16,13 @@
 
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
-
 #include "monster_generated.h"  // Already includes "flatbuffers/flatbuffers.h".
 
 using namespace MyGame::Sample;
 
 // This is an example of parsing text straight into a buffer and then
 // generating flatbuffer (JSON) text from the buffer.
-int main(int /*argc*/, const char * /*argv*/ []) {
+int main(int /*argc*/, const char * /*argv*/[]) {
   // load FlatBuffer schema (.fbs) and JSON from disk
   std::string schemafile;
   std::string jsonfile;

--- a/src/idl_gen_js_ts.cpp
+++ b/src/idl_gen_js_ts.cpp
@@ -1014,7 +1014,8 @@ class JsTsGenerator : public BaseGenerator {
       }
 
       // Adds the mutable scalar value to the output
-      if (IsScalar(field.value.type.base_type) && parser.opts.mutable_buffer && !IsUnion(field.value.type)) {
+      if (IsScalar(field.value.type.base_type) && parser.opts.mutable_buffer &&
+          !IsUnion(field.value.type)) {
         std::string annotations = GenTypeAnnotation(
             kParam, GenTypeName(field.value.type, true), "value");
         GenDocComment(

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -2308,7 +2308,6 @@ void InvalidNestedFlatbufferTest() {
   TEST_EQ(parser1.Parse("{ name: \"Bender\", testnestedflatbuffer: { name: "
                         "\"Leela\", color: \"nonexistent\"}}"),
           false);
-  // Check that Parser is destroyed correctly after parsing invalid json
 }
 
 void UnionVectorTest() {


### PR DESCRIPTION
Ran the `src/clang-format-all.sh` on a clean branch to fix any outstanding format issues.

Oddly, I had to delete a rouge? comment at then end of `test/test.cpp#InvalidNestedFlatbufferTest` that caused running `clang-format` to produce a non-buildable source. Another bug with clang-format? (clang-format v.5).

Ran both `flattests` and `test/generate_code.sh`.