### PR TITLE
[Rust] Bump smallvec version to 1.0

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["flatbuffers", "serialization", "zero-copy"]
 categories = ["encoding", "data-structures", "memory-management"]
 
 [dependencies]
-smallvec = "0.6"
+smallvec = "1.0"


### PR DESCRIPTION
See https://github.com/servo/rust-smallvec/pull/175 for changelog.