### PR TITLE
add check for root_type specified for json schema generation

### DIFF
--- a/src/idl_gen_json_schema.cpp
+++ b/src/idl_gen_json_schema.cpp
@@ -122,6 +122,7 @@ class JsonSchemaGenerator : public BaseGenerator {
       : BaseGenerator(base_generator) {}
 
   bool generate() {
+    if (parser_.root_struct_def_ == nullptr) { return false; }
     code_.Clear();
     code_ += "{";
     code_ += "  \"$schema\": \"http://json-schema.org/draft-04/schema#\",";


### PR DESCRIPTION
Hi! As recommended [here](https://github.com/google/flatbuffers/issues/5615) I've added simple check to avoid segfault. In my opinion this solution currently misses user friendly error message, but I dont see any example near this place in codebase for propagating error message. Can you advise me how to properly do this? Also I'll be glad to add test for change I made, so the question is what is the best place for such test? Can I simply add fbs file without root_type and test return code of flatc in generate_code.sh or something else?

Also recommendations for PR says:
> For any C++ changes, please make sure to run `sh src/clang-format-git.sh`

Firstly script is renamed to just `clang-format.sh` and after I launched it there are format related changes to code that is not related to my changes. So definetly this check should be in CI to protect the health of the codebase. 
