### PR TITLE
[Lua] Library improvements

### DIFF
--- a/lua/flatbuffers/builder.lua
+++ b/lua/flatbuffers/builder.lua
@@ -29,12 +29,12 @@ local getAlignSize = compat.GetAlignSize
 
 local function vtableEqual(a, objectStart, b)
     UOffsetT:EnforceNumber(objectStart)
-    if (#a * VOffsetT.bytewidth) ~= #b then
+    if (#a * 2) ~= #b then
         return false
     end
 
     for i, elem in ipairs(a) do
-        local x = string.unpack(VOffsetT.packFmt, b, 1 + (i - 1) * VOffsetT.bytewidth)
+        local x = string.unpack(VOffsetT.packFmt, b, 1 + (i - 1) * 2)
         if x ~= 0 or elem ~= 0 then
             local y = objectStart - elem
             if x ~= y then
@@ -121,7 +121,7 @@ function mt:WriteVtable()
         local vt2lenstr = self.bytes:Slice(vt2Start, vt2Start+1)
         local vt2Len = string.unpack(VOffsetT.packFmt, vt2lenstr, 1)
 
-        local metadata = VtableMetadataFields * VOffsetT.bytewidth
+        local metadata = VtableMetadataFields * 2
         local vt2End = vt2Start + vt2Len
         local vt2 = self.bytes:Slice(vt2Start+metadata,vt2End)
 
@@ -150,7 +150,7 @@ function mt:WriteVtable()
         self:PrependVOffsetT(objectSize)
 
         local vBytes = #self.currentVTable + VtableMetadataFields
-        vBytes = vBytes * VOffsetT.bytewidth
+        vBytes = vBytes * 2
         self:PrependVOffsetT(vBytes)
 
         local objectStart = #self.bytes - objectOffset
@@ -225,17 +225,17 @@ function mt:Prep(size, additionalBytes)
 end
 
 function mt:PrependSOffsetTRelative(off)
-    self:Prep(SOffsetT.bytewidth, 0)
+    self:Prep(4, 0)
     assert(off <= self:Offset(), "Offset arithmetic error")
-    local off2 = self:Offset() - off + SOffsetT.bytewidth
+    local off2 = self:Offset() - off + 4
     self:Place(off2, SOffsetT)
 end
 
 function mt:PrependUOffsetTRelative(off)
-    self:Prep(UOffsetT.bytewidth, 0)
+    self:Prep(4, 0)
     local soffset = self:Offset()
     if off <= soffset then
-        local off2 = soffset - off + UOffsetT.bytewidth
+        local off2 = soffset - off + 4
         self:Place(off2, UOffsetT)
     else
         error("Offset arithmetic error")
@@ -245,8 +245,9 @@ end
 function mt:StartVector(elemSize, numElements, alignment)
     assert(not self.nested)
     self.nested = true
-    self:Prep(Uint32.bytewidth, elemSize * numElements)
-    self:Prep(alignment, elemSize * numElements)
+    local elementSize = elemSize * numElements
+    self:Prep(4, elementSize) -- Uint32 length
+    self:Prep(alignment, elementSize)
     return self:Offset()
 end
 
@@ -263,7 +264,7 @@ function mt:CreateString(s)
 
     assert(type(s) == "string")
 
-    self:Prep(UOffsetT.bytewidth, (#s + 1)*Uint8.bytewidth)
+    self:Prep(4, #s + 1)
     self:Place(0, Uint8)
 
     local l = #s
@@ -271,20 +272,21 @@ function mt:CreateString(s)
 
     self.bytes:Set(s, self.head, self.head + l)
 
-    return self:EndVector(#s)
+    return self:EndVector(l)
 end
 
 function mt:CreateByteVector(x)
     assert(not self.nested)
     self.nested = true
-    self:Prep(UOffsetT.bytewidth, #x*Uint8.bytewidth)
 
     local l = #x
+    self:Prep(4, l)
+
     self.head = self.head - l
 
     self.bytes:Set(x, self.head, self.head + l)
 
-    return self:EndVector(#x)
+    return self:EndVector(l)
 end
 
 function mt:Slot(slotnum)
@@ -295,12 +297,7 @@ end
 
 local function finish(self, rootTable, sizePrefix)
     UOffsetT:EnforceNumber(rootTable)
-    local prepSize = UOffsetT.bytewidth
-    if sizePrefix then
-        prepSize = prepSize + Int32.bytewidth
-    end
-
-    self:Prep(self.minalign, prepSize)
+    self:Prep(self.minalign, sizePrefix and 8 or 4)
     self:PrependUOffsetTRelative(rootTable)
     if sizePrefix then
         local size = #self.bytes - self.head
@@ -325,8 +322,9 @@ function mt:Prepend(flags, off)
 end
 
 function mt:PrependSlot(flags, o, x, d)
-    flags:EnforceNumber(x)
-    flags:EnforceNumber(d)
+    flags:EnforceNumbers(x,d)
+--    flags:EnforceNumber(x)
+--    flags:EnforceNumber(d)
     if x ~= d then
         self:Prepend(flags, x)
         self:Slot(o)

--- a/lua/flatbuffers/numTypes.lua
+++ b/lua/flatbuffers/numTypes.lua
@@ -34,6 +34,20 @@ function type_mt:EnforceNumber(n)
     error("Number is not in the valid range") 
 end
 
+function type_mt:EnforceNumbers(a,b)
+   -- duplicate code since the overhead of function calls
+    -- for such a popular method is time consuming
+    if not self.min_value and not self.max_value then
+        return
+    end
+
+    if self.min_value <= a and a <= self.max_value and self.min_value <= b and b <= self.max_value then
+        return
+    end
+
+    error("Number is not in the valid range")
+end
+
 function type_mt:EnforceNumberAndPack(n)
     return bpack(self.packFmt, n)    
 end
@@ -58,6 +72,7 @@ local bool_mt =
     Unpack = function(self, buf, pos) return buf[pos] == "1" end,
     ValidNumber = function(self, n) return true end, -- anything is a valid boolean in Lua
     EnforceNumber = function(self, n) end, -- anything is a valid boolean in Lua
+    EnforceNumbers = function(self, a, b) end, -- anything is a valid boolean in Lua
     EnforceNumberAndPack = function(self, n) return self:Pack(value) end,
 }
 

--- a/lua/flatbuffers/view.lua
+++ b/lua/flatbuffers/view.lua
@@ -6,69 +6,83 @@ local mt_name = "flatbuffers.view.mt"
 local N = require("flatbuffers.numTypes")
 local binaryarray = require("flatbuffers.binaryarray")
 
+local function enforceOffset(off)
+    if off < 0 or off > 42949672951 then
+        error("Offset is not valid")
+    end
+end
+
+local unpack = string.unpack
+local function unPackUoffset(bytes, off)
+    return unpack("<I4", bytes.str, off + 1)
+end
+
+local function unPackVoffset(bytes, off)
+    return unpack("<I2", bytes.str, off + 1)
+end
+
 function m.New(buf, pos)
-    N.UOffsetT:EnforceNumber(pos)
-    
+    enforceOffset(pos)
     -- need to convert from a string buffer into
     -- a binary array
 
     local o = {
         bytes = type(buf) == "string" and binaryarray.New(buf) or buf,
-        pos = pos
+        pos = pos,
     }
     setmetatable(o, {__index = mt, __metatable = mt_name})
     return o
 end
 
 function mt:Offset(vtableOffset)
-    local vtable = self.pos - self:Get(N.SOffsetT, self.pos)
-    local vtableEnd = self:Get(N.VOffsetT, vtable)
-    if vtableOffset < vtableEnd then
-        return self:Get(N.VOffsetT, vtable + vtableOffset)
+    local vtable = self.vtable
+    if not vtable then
+        vtable = self.pos - self:Get(N.SOffsetT, self.pos)
+        self.vtable = vtable
+        self.vtableEnd = self:Get(N.VOffsetT, vtable)
+    end
+    if vtableOffset < self.vtableEnd then
+        return unPackVoffset(self.bytes, vtable + vtableOffset)
     end
     return 0
 end
 
 function mt:Indirect(off)
-    N.UOffsetT:EnforceNumber(off)
-    return off + N.UOffsetT:Unpack(self.bytes, off)
+    enforceOffset(off)
+    return off + unPackUoffset(self.bytes, off)
 end
 
 function mt:String(off)
-    N.UOffsetT:EnforceNumber(off)
-    off = off + N.UOffsetT:Unpack(self.bytes, off)
-    local start = off + N.UOffsetT.bytewidth
-    local length = N.UOffsetT:Unpack(self.bytes, off)
+    enforceOffset(off)
+    off = off + unPackUoffset(self.bytes, off)
+    local start = off + 4
+    local length = unPackUoffset(self.bytes, off)
     return self.bytes:Slice(start, start+length)
 end
 
 function mt:VectorLen(off)
-    N.UOffsetT:EnforceNumber(off)
+    enforceOffset(off)
     off = off + self.pos
-    off = off + N.UOffsetT:Unpack(self.bytes, off)
-    return N.UOffsetT:Unpack(self.bytes, off)
+    off = off + unPackUoffset(self.bytes, off)
+    return unPackUoffset(self.bytes, off)
 end
 
 function mt:Vector(off)
-    N.UOffsetT:EnforceNumber(off)
-    
+    enforceOffset(off)
     off = off + self.pos
-    local x = off + self:Get(N.UOffsetT, off)
-    x = x + N.UOffsetT.bytewidth
-    return x
+    return off + self:Get(N.UOffsetT, off) + 4
 end
 
 function mt:Union(t2, off)
     assert(getmetatable(t2) == mt_name)
-    N.UOffsetT:EnforceNumber(off)
-    
+    enforceOffset(off)
     off = off + self.pos
     t2.pos = off + self:Get(N.UOffsetT, off)
     t2.bytes = self.bytes
 end
 
 function mt:Get(flags, off)
-    N.UOffsetT:EnforceNumber(off)
+    enforceOffset(off)
     return flags:Unpack(self.bytes, off)
 end
 
@@ -85,8 +99,7 @@ function mt:GetSlot(slot, d, validatorFlags)
 end
 
 function mt:GetVOffsetTSlot(slot, d)
-    N.VOffsetT:EnforceNumber(slot)
-    N.VOffsetT:EnforceNumber(d)
+    N.VOffsetT:EnforceNumbers(slot, d)
     local off = self:Offset(slot)
     if off == 0 then
         return d

--- a/tests/luatest.lua
+++ b/tests/luatest.lua
@@ -82,6 +82,7 @@ local function checkReadBuffer(buf, offset, sizePrefix)
 end
 
 local function generateMonster(sizePrefix, b)
+    if b then b:Clear() end
     b = b or flatbuffers.Builder(0)
     local str = b:CreateString("MyMonster")
     local test1 = b:CreateString("test1")
@@ -208,26 +209,16 @@ local function testCanonicalData()
     checkReadBuffer(wireData)  
 end    
     
-local function benchmarkMakeMonster(count)
-    local length = #(generateMonster())
-    
-    --require("flatbuffers.profiler")
-    --profiler = newProfiler("call")
-    --profiler:start()
-    
+local function benchmarkMakeMonster(count, reuseBuilder)
+    local fbb = reuseBuilder and flatbuffers.Builder(0)
+    local length = #(generateMonster(false, fbb))
+
     local s = os.clock()
     for i=1,count do
-        generateMonster()
+        generateMonster(false, fbb)
     end
     local e = os.clock()    
-    
-    --profiler:stop()
 
-    --local outfile = io.open( "profile.txt", "w+" )
-    --profiler:report( outfile, true)
-    --outfile:close()
-    
-    
     local dur = (e - s)
     local rate = count / (dur * 1000)
     local data = (length * count) / (1024 * 1024)
@@ -279,6 +270,7 @@ local tests =
             {100}, 
             {1000},
             {10000},
+            {10000, true}
         }
     },   
     {
@@ -290,7 +282,7 @@ local tests =
             {10000},
             -- uncomment following to run 1 million to compare. 
             -- Took ~141 seconds on my machine
-            --{1000000}, 
+            --{1000000},
         }
     }, 
 }


### PR DESCRIPTION
Realized `view.lua#Offset()` is in a hot path and optimized it to avoid a bunch of needless lookups. I first cache the location to the vtable (instead of calculating it everytime) and inlined the unpacking function. 

This lead me to optimized most of the `view.lua` file to reduce lookups and use local functions as much as possible. I also hardcoded a lot of values that will never change, again to avoid lookups.

The profiling tests show almost a 2x improvement in traversing the flatbuffer data.

**Before**:

```
built 100 512-byte flatbuffers in 0.03sec: 3.67/msec, 1.79MB/sec
built 1000 512-byte flatbuffers in 0.22sec: 4.62/msec, 2.26MB/sec
built 10000 512-byte flatbuffers in 2.17sec: 4.61/msec, 2.25MB/sec
traversed 100 440-byte flatbuffers in 0.01sec: 15.10/msec, 6.34MB/sec
traversed 1000 440-byte flatbuffers in 0.07sec: 14.80/msec, 6.21MB/sec
traversed 10000 440-byte flatbuffers in 0.69sec: 14.40/msec, 6.04MB/sec
Number of test passed: 10 / 10 (100.00%)
```

**After**:

```
built 100 512-byte flatbuffers in 0.03sec: 2.95/msec, 1.44MB/sec
built 1000 512-byte flatbuffers in 0.20sec: 4.96/msec, 2.42MB/sec
built 10000 512-byte flatbuffers in 1.93sec: 5.17/msec, 2.53MB/sec
built 10000 512-byte flatbuffers in 1.52sec: 6.59/msec, 3.22MB/sec
traversed 100 440-byte flatbuffers in 0.00sec: 26.85/msec, 11.27MB/sec
traversed 1000 440-byte flatbuffers in 0.04sec: 26.30/msec, 11.03MB/sec
traversed 10000 440-byte flatbuffers in 0.36sec: 27.40/msec, 11.50MB/sec
Number of test passed: 11 / 11 (100.00%)

```