### PR TITLE
[Rust] Fixed broken compilation for required unions

### DIFF
--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1327,9 +1327,14 @@ class RustGenerator : public BaseGenerator {
             "Option<{{U_ELEMENT_TABLE_TYPE}}<'a>> {";
         code_ +=
             "    if self.{{FIELD_NAME}}_type() == {{U_ELEMENT_ENUM_TYPE}} {";
-        code_ +=
+        if (field.required) {
+          code_ +=
+            "      Some({{U_ELEMENT_TABLE_TYPE}}::init_from_table( self.{{FIELD_NAME}}()))";
+        } else {
+          code_ +=
             "      self.{{FIELD_NAME}}().map(|u| "
             "{{U_ELEMENT_TABLE_TYPE}}::init_from_table(u))";
+        }
         code_ += "    } else {";
         code_ += "      None";
         code_ += "    }";


### PR DESCRIPTION
Simply check if the field is required and avoid Option usage

$ sh src/clang-format-git.sh
changed files:
    src/idl_gen_rust.cpp
clang-format did not modify any files
Updated 0 paths from the index
davide@gentoo ~/git/flatbuffers 
$ cd tests && sh generate_code.sh
../flatc: warning: GRPC interface generator not implemented for binary
../flatc: warning: GRPC interface generator not implemented for JavaScript
../flatc: warning: GRPC interface generator not implemented for Dart
../flatc: warning: GRPC interface generator not implemented for TypeScript
../flatc: warning: GRPC interface generator not implemented for C#
../flatc: warning: GRPC interface generator not implemented for Python
../flatc: warning: GRPC interface generator not implemented for Lobster
../flatc: warning: GRPC interface generator not implemented for Lua
../flatc: warning: GRPC interface generator not implemented for Rust
../flatc: warning: GRPC interface generator not implemented for PHP
../flatc: warning: GRPC interface generator not implemented for Kotlin
../flatc: warning: GRPC interface generator not implemented for binary
../flatc: warning: GRPC interface generator not implemented for JavaScript
../flatc: warning: GRPC interface generator not implemented for Dart
../flatc: warning: GRPC interface generator not implemented for TypeScript
../flatc: warning: GRPC interface generator not implemented for C#
../flatc: warning: GRPC interface generator not implemented for Python
../flatc: warning: GRPC interface generator not implemented for Lobster
../flatc: warning: GRPC interface generator not implemented for Lua
../flatc: warning: GRPC interface generator not implemented for Rust
../flatc: warning: GRPC interface generator not implemented for PHP
../flatc: warning: GRPC interface generator not implemented for Kotlin
