### PR TITLE
[C++] read vtable size through ReadScalar()

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1364,7 +1364,7 @@ class FlatBufferBuilder {
            it += sizeof(uoffset_t)) {
         auto vt_offset_ptr = reinterpret_cast<uoffset_t *>(it);
         auto vt2 = reinterpret_cast<voffset_t *>(buf_.data_at(*vt_offset_ptr));
-        auto vt2_size = *vt2;
+        auto vt2_size = ReadScalar<voffset_t>(vt2);
         if (vt1_size != vt2_size || 0 != memcmp(vt2, vt1, vt1_size)) continue;
         vt_use = *vt_offset_ptr;
         buf_.pop(GetSize() - vtableoffsetloc);


### PR DESCRIPTION
Use ReadScalar() to read vtable size in order to avoid getting wrong value on big endian machine.