### PR TITLE
Split parsing of empty enums and union-NONE into different paths

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2067,9 +2067,13 @@ CheckedError Parser::ParseEnum(const bool is_union, EnumDef **dest) {
   const auto strict_ascending = (false == opts.proto_mode);
   EnumValBuilder evb(*this, *enum_def, strict_ascending);
   EXPECT('{');
-  // A lot of code generatos expect that an enum is not-empty.
-  if ((is_union || Is('}')) && !opts.proto_mode) {
-    evb.CreateEnumerator("NONE");
+  if(is_union && !opts.proto_mode) {
+    // Every union has the NONE field, mapped to a special `void` type.
+    evb.CreateEnumerator("NONE", BASE_TYPE_NONE);
+    ECHECK(evb.AcceptEnumerator());
+  } else if (Is('}') && !opts.proto_mode) {
+    // Most code generators expect that an enum is not-empty.
+    evb.CreateEnumerator("NONE", 0);
     ECHECK(evb.AcceptEnumerator());
   }
   std::set<std::pair<BaseType, StructDef *>> union_types;


### PR DESCRIPTION
This is micro-review of `idl_parcer.cpp`.
The PR makes parsing of enums a little bit clear. 
Any union has the documented field **NONE* which mapped into BASE_TYPE_NONE.
Before PR, a value of NONE was implicitly mapped to BASE_TYPE_NONE by matching with 0-value.
Now this relationship is explicit.

Question:
Are any union must has NONE even if `opts. proto_mode` is set?
I'm right?