### PR TITLE
Remove a static_assert

### DIFF
--- a/tests/fuzzer/test_init.h
+++ b/tests/fuzzer/test_init.h
@@ -5,10 +5,6 @@
 #include "fuzzer_assert.h"
 #include "test_assert.h"
 
-static_assert(__has_feature(memory_sanitizer) ||
-                  __has_feature(address_sanitizer),
-              "sanitizer disabled");
-
 // Utility for test run.
 struct OneTimeTestInit {
   // Declare trap for the Flatbuffers test engine.


### PR DESCRIPTION
Having a static_assert on MSAN and ASAN prevents the fuzzers from being used with different engines, like TSAN, UBSAN, … but also with fuzzers that aren't using MSAN/ASAN like afl for example.
