### PR TITLE
Supress unsigned-integer-overflow for PaddingBytes

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -382,6 +382,7 @@ template<typename T> __supress_ubsan__("alignment") void WriteScalar(void *p, Of
 // Computes how many bytes you'd have to pad to be able to write an
 // "scalar_size" scalar if the buffer had grown to "buf_size" (downwards in
 // memory).
+__supress_ubsan__("unsigned-integer-overflow")
 inline size_t PaddingBytes(size_t buf_size, size_t scalar_size) {
   return ((~buf_size) + 1) & (scalar_size - 1);
 }


### PR DESCRIPTION
Can't pinpoint but seen in the wild:

flatbuffers/base.h:386:23: runtime error: unsigned integer overflow: 18446744073709551615 + 1 cannot be represented in type 'unsigned long'

Which leads me to believe that this is not wrong input for this function and should be sanitizer supressed. But it's more of a guess than anything. @aardappel asked me to ping @vglavnyy for this issue.