### PR TITLE
wrap multiple statements in do {} while(!IsConstTrue(true))

### DIFF
--- a/tests/test_assert.h
+++ b/tests/test_assert.h
@@ -13,7 +13,7 @@
   #define FLATBUFFERS_NO_FILE_TESTS
 #else
   #define TEST_OUTPUT_LINE(...) \
-      { printf(__VA_ARGS__); printf("\n"); }
+      do { printf(__VA_ARGS__); printf("\n"); } while(!IsConstTrue(true))
 #endif
 
 #define TEST_EQ(exp, val) TestEq(exp, val, "'" #exp "' != '" #val "'", __FILE__, __LINE__, "")


### PR DESCRIPTION
To avoid problems mentioned in https://stackoverflow.com/questions/257418/do-while-0-what-is-it-good-for. Use `!IsConstTrue(true)` instead of `0` to avoid warning C4127.