### PR TITLE
Make Rust constants public

### DIFF
--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -558,9 +558,9 @@ class RustGenerator : public BaseGenerator {
     code_.SetValue("ENUM_MAX_BASE_VALUE", enum_def.ToString(*maxv));
 
     // Generate enum constants, and impls for Follow, EndianScalar, and Push.
-    code_ += "const ENUM_MIN_{{ENUM_NAME_CAPS}}: {{BASE_TYPE}} = \\";
+    code_ += "pub const ENUM_MIN_{{ENUM_NAME_CAPS}}: {{BASE_TYPE}} = \\";
     code_ += "{{ENUM_MIN_BASE_VALUE}};";
-    code_ += "const ENUM_MAX_{{ENUM_NAME_CAPS}}: {{BASE_TYPE}} = \\";
+    code_ += "pub const ENUM_MAX_{{ENUM_NAME_CAPS}}: {{BASE_TYPE}} = \\";
     code_ += "{{ENUM_MAX_BASE_VALUE}};";
     code_ += "";
     code_ += "impl<'a> flatbuffers::Follow<'a> for {{ENUM_NAME}} {";
@@ -600,7 +600,7 @@ class RustGenerator : public BaseGenerator {
     // Generate an array of all enumeration values.
     auto num_fields = NumToString(enum_def.size());
     code_ += "#[allow(non_camel_case_types)]";
-    code_ += "const ENUM_VALUES_{{ENUM_NAME_CAPS}}:[{{ENUM_NAME}}; " +
+    code_ += "pub const ENUM_VALUES_{{ENUM_NAME_CAPS}}:[{{ENUM_NAME}}; " +
              num_fields + "] = [";
     for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
       const auto &ev = **it;

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -177,8 +177,8 @@ pub enum Color {
 
 }
 
-const ENUM_MIN_COLOR: u8 = 1;
-const ENUM_MAX_COLOR: u8 = 8;
+pub const ENUM_MIN_COLOR: u8 = 1;
+pub const ENUM_MAX_COLOR: u8 = 8;
 
 impl<'a> flatbuffers::Follow<'a> for Color {
   type Inner = Self;
@@ -212,7 +212,7 @@ impl flatbuffers::Push for Color {
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_COLOR:[Color; 3] = [
+pub const ENUM_VALUES_COLOR:[Color; 3] = [
   Color::Red,
   Color::Green,
   Color::Blue
@@ -246,8 +246,8 @@ pub enum Race {
 
 }
 
-const ENUM_MIN_RACE: i8 = -1;
-const ENUM_MAX_RACE: i8 = 2;
+pub const ENUM_MIN_RACE: i8 = -1;
+pub const ENUM_MAX_RACE: i8 = 2;
 
 impl<'a> flatbuffers::Follow<'a> for Race {
   type Inner = Self;
@@ -281,7 +281,7 @@ impl flatbuffers::Push for Race {
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_RACE:[Race; 4] = [
+pub const ENUM_VALUES_RACE:[Race; 4] = [
   Race::None,
   Race::Human,
   Race::Dwarf,
@@ -312,8 +312,8 @@ pub enum Any {
 
 }
 
-const ENUM_MIN_ANY: u8 = 0;
-const ENUM_MAX_ANY: u8 = 3;
+pub const ENUM_MIN_ANY: u8 = 0;
+pub const ENUM_MAX_ANY: u8 = 3;
 
 impl<'a> flatbuffers::Follow<'a> for Any {
   type Inner = Self;
@@ -347,7 +347,7 @@ impl flatbuffers::Push for Any {
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_ANY:[Any; 4] = [
+pub const ENUM_VALUES_ANY:[Any; 4] = [
   Any::NONE,
   Any::Monster,
   Any::TestSimpleTableWithEnum,
@@ -379,8 +379,8 @@ pub enum AnyUniqueAliases {
 
 }
 
-const ENUM_MIN_ANY_UNIQUE_ALIASES: u8 = 0;
-const ENUM_MAX_ANY_UNIQUE_ALIASES: u8 = 3;
+pub const ENUM_MIN_ANY_UNIQUE_ALIASES: u8 = 0;
+pub const ENUM_MAX_ANY_UNIQUE_ALIASES: u8 = 3;
 
 impl<'a> flatbuffers::Follow<'a> for AnyUniqueAliases {
   type Inner = Self;
@@ -414,7 +414,7 @@ impl flatbuffers::Push for AnyUniqueAliases {
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_ANY_UNIQUE_ALIASES:[AnyUniqueAliases; 4] = [
+pub const ENUM_VALUES_ANY_UNIQUE_ALIASES:[AnyUniqueAliases; 4] = [
   AnyUniqueAliases::NONE,
   AnyUniqueAliases::M,
   AnyUniqueAliases::TS,
@@ -446,8 +446,8 @@ pub enum AnyAmbiguousAliases {
 
 }
 
-const ENUM_MIN_ANY_AMBIGUOUS_ALIASES: u8 = 0;
-const ENUM_MAX_ANY_AMBIGUOUS_ALIASES: u8 = 3;
+pub const ENUM_MIN_ANY_AMBIGUOUS_ALIASES: u8 = 0;
+pub const ENUM_MAX_ANY_AMBIGUOUS_ALIASES: u8 = 3;
 
 impl<'a> flatbuffers::Follow<'a> for AnyAmbiguousAliases {
   type Inner = Self;
@@ -481,7 +481,7 @@ impl flatbuffers::Push for AnyAmbiguousAliases {
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_ANY_AMBIGUOUS_ALIASES:[AnyAmbiguousAliases; 4] = [
+pub const ENUM_VALUES_ANY_AMBIGUOUS_ALIASES:[AnyAmbiguousAliases; 4] = [
   AnyAmbiguousAliases::NONE,
   AnyAmbiguousAliases::M1,
   AnyAmbiguousAliases::M2,

--- a/tests/namespace_test/namespace_test1_generated.rs
+++ b/tests/namespace_test/namespace_test1_generated.rs
@@ -35,8 +35,8 @@ pub enum EnumInNestedNS {
 
 }
 
-const ENUM_MIN_ENUM_IN_NESTED_NS: i8 = 0;
-const ENUM_MAX_ENUM_IN_NESTED_NS: i8 = 2;
+pub const ENUM_MIN_ENUM_IN_NESTED_NS: i8 = 0;
+pub const ENUM_MAX_ENUM_IN_NESTED_NS: i8 = 2;
 
 impl<'a> flatbuffers::Follow<'a> for EnumInNestedNS {
   type Inner = Self;
@@ -70,7 +70,7 @@ impl flatbuffers::Push for EnumInNestedNS {
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_ENUM_IN_NESTED_NS:[EnumInNestedNS; 3] = [
+pub const ENUM_VALUES_ENUM_IN_NESTED_NS:[EnumInNestedNS; 3] = [
   EnumInNestedNS::A,
   EnumInNestedNS::B,
   EnumInNestedNS::C

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -235,6 +235,53 @@ mod generated_constants {
     fn monster_file_extension() {
         assert_eq!("mon", my_game::example::MONSTER_EXTENSION);
     }
+
+    #[test]
+    fn enum_constants_are_public() {
+        assert_eq!(1, my_game::example::ENUM_MIN_COLOR);
+        assert_eq!(8, my_game::example::ENUM_MAX_COLOR);
+        assert_eq!(my_game::example::ENUM_VALUES_COLOR, [
+            my_game::example::Color::Red,
+            my_game::example::Color::Green,
+            my_game::example::Color::Blue,
+        ]);
+
+        assert_eq!(-1, my_game::example::ENUM_MIN_RACE);
+        assert_eq!(2, my_game::example::ENUM_MAX_RACE);
+        assert_eq!(my_game::example::ENUM_VALUES_RACE, [
+            my_game::example::Race::None,
+            my_game::example::Race::Human,
+            my_game::example::Race::Dwarf,
+            my_game::example::Race::Elf,
+        ]);
+
+        assert_eq!(0, my_game::example::ENUM_MIN_ANY);
+        assert_eq!(3, my_game::example::ENUM_MAX_ANY);
+        assert_eq!(my_game::example::ENUM_VALUES_ANY, [
+            my_game::example::Any::NONE,
+            my_game::example::Any::Monster,
+            my_game::example::Any::TestSimpleTableWithEnum,
+            my_game::example::Any::MyGame_Example2_Monster,
+        ]);
+
+        assert_eq!(0, my_game::example::ENUM_MIN_ANY_UNIQUE_ALIASES);
+        assert_eq!(3, my_game::example::ENUM_MAX_ANY_UNIQUE_ALIASES);
+        assert_eq!(my_game::example::ENUM_VALUES_ANY_UNIQUE_ALIASES, [
+            my_game::example::AnyUniqueAliases::NONE,
+            my_game::example::AnyUniqueAliases::M,
+            my_game::example::AnyUniqueAliases::TS,
+            my_game::example::AnyUniqueAliases::M2,
+        ]);
+
+        assert_eq!(0, my_game::example::ENUM_MIN_ANY_AMBIGUOUS_ALIASES);
+        assert_eq!(3, my_game::example::ENUM_MAX_ANY_AMBIGUOUS_ALIASES);
+        assert_eq!(my_game::example::ENUM_VALUES_ANY_AMBIGUOUS_ALIASES, [
+            my_game::example::AnyAmbiguousAliases::NONE,
+            my_game::example::AnyAmbiguousAliases::M1,
+            my_game::example::AnyAmbiguousAliases::M2,
+            my_game::example::AnyAmbiguousAliases::M3,
+        ]);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Otherwise they cannot be accessed by code that consumes the generated bindings.