### PR TITLE
[C++] Add `--cpp-extra` flatc flag and add new generic table creation methods.

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -533,6 +533,7 @@ struct IDLOptions {
   std::string cpp_object_api_pointer_type;
   std::string cpp_object_api_string_type;
   bool cpp_object_api_string_flexible_constructor;
+  int cpp_extra_language_standard;
   bool gen_nullable;
   bool java_checkerframework;
   bool gen_generated;
@@ -619,6 +620,7 @@ struct IDLOptions {
         gen_compare(false),
         cpp_object_api_pointer_type("std::unique_ptr"),
         cpp_object_api_string_flexible_constructor(false),
+        cpp_extra_language_standard(0),
         gen_nullable(false),
         java_checkerframework(false),
         gen_generated(false),

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2186,6 +2186,19 @@ class CppGenerator : public BaseGenerator {
     code_ += "}";
     code_ += "";
 
+    // Generate a convenient CreateByTagType function that allows creating
+    // tables in a generic way by specifying only their type.
+    if (parser_.opts.cpp_extra_language_standard >= 14) {
+      code_ += "template<typename... Args>";
+      code_ += "auto CreateByTagType({{STRUCT_NAME}}*, "
+               "flatbuffers::FlatBufferBuilder &_fbb,";
+      code_ += "                     Args&&... args\\";
+      code_ += ") {";
+      code_ += "  return Create{{STRUCT_NAME}}(_fbb, std::forward<Args>(args)...);";
+      code_ += "}";
+      code_ += "";
+    }
+
     // Generate a CreateXDirect function with vector types as parameters
     if (has_string_or_vector_fields) {
       code_ +=


### PR DESCRIPTION
1. Add `--cpp-extra` flatc flag that allows the user to enable new (experimental) modern C++ features in the generated C++ code.  Valid values are 11, 14, 17, 20, and so on.  Default is 0, meaning no additional generated code.

2. Add a new feature guarded by the `--cpp-extra >= 14` flag: emit new generic table creation methods (with type-independent name) that take the Flatbuffers table type as a tag.  This makes the Flatbuffers generated C++ code more friendly to use cases involving template metaprogramming.

Note: `generate_code.sh` output results in no diffs for this CL since the new `--cpp-extra` flag defaults to `0`, which implies the current `-std=c++0x` feature set in the generator.

To see the new changes, add `--cpp-extra 14` to the `flatc` invocations in `generate_code.sh` and compile with `-std=c++14` (or MSVC equivalent).