### PR TITLE
[Bazel] Fix --incompatible_load_cc_rules_from_bzl

### DIFF
--- a/grpc/src/compiler/BUILD
+++ b/grpc/src/compiler/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,6 +1,6 @@
-package(
-    default_visibility = ["//visibility:private"],
-)
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+package(default_visibility = ["//visibility:private"])
 
 # Test binary.
 cc_test(


### PR DESCRIPTION
Incompatible flag --incompatible_load_cc_rules_from_bzl will break
FlatBuffers once Bazel 1.2.1 is released.

Fixes #5671