### PR TITLE
Correct inverted logic around include prefixes.

### DIFF
--- a/src/idl_gen_fbs.cpp
+++ b/src/idl_gen_fbs.cpp
@@ -76,10 +76,10 @@ std::string GenerateFBS(const Parser &parser, const std::string &file_name) {
         continue;
       std::string basename;
       if(parser.opts.keep_include_path) {
+        basename = flatbuffers::StripExtension(it->second);
+      } else {
         basename = flatbuffers::StripPath(
                 flatbuffers::StripExtension(it->second));
-      } else {
-        basename = flatbuffers::StripExtension(it->second);
       }
       schema += "include \"" + basename + ".fbs\";\n";
       num_includes++;


### PR DESCRIPTION
4d1a9f8d9eab9fc6762e03cd862576965a0c6920 inverted the logic around
keeping the include prefix. This change fixes the error.