### PR TITLE
[Java] Replace Table.UTF8_CHARSET with StandardCharsets.UTF_8

### DIFF
--- a/java/com/google/flatbuffers/Table.java
+++ b/java/com/google/flatbuffers/Table.java
@@ -19,7 +19,6 @@ package com.google.flatbuffers;
 import static com.google.flatbuffers.Constants.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
 
 /// @cond FLATBUFFERS_INTERNAL
 
@@ -27,12 +26,6 @@ import java.nio.charset.Charset;
  * All tables in the generated code derive from this class, and add their own accessors.
  */
 public class Table {
-  public final static ThreadLocal<Charset> UTF8_CHARSET = new ThreadLocal<Charset>() {
-    @Override
-    protected Charset initialValue() {
-      return Charset.forName("UTF-8");
-    }
-  };
   /** Used to hold the position of the `bb` buffer. */
   protected int bb_pos;
   /** The underlying ByteBuffer to hold the data of the Table. */

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -1134,7 +1134,7 @@ class JavaGenerator : public BaseGenerator {
       code += " key, ByteBuffer bb) {\n";
       if (key_field->value.type.base_type == BASE_TYPE_STRING) {
         code += "    byte[] byteKey = ";
-        code += "key.getBytes(Table.UTF8_CHARSET.get());\n";
+        code += "key.getBytes(java.nio.charset.StandardCharsets.UTF_8);\n";
       }
       code += "    int span = ";
       code += "bb.getInt(vectorLocation - 4);\n";

--- a/src/idl_gen_kotlin.cpp
+++ b/src/idl_gen_kotlin.cpp
@@ -522,7 +522,7 @@ class KotlinGenerator : public BaseGenerator {
       if (base_type == BASE_TYPE_STRING) {
         writer +=
             "val byteKey = key."
-            "toByteArray(Table.UTF8_CHARSET.get()!!)";
+            "toByteArray(java.nio.charset.StandardCharsets.UTF_8)";
       }
       writer += "var span = bb.getInt(vectorLocation - 4)";
       writer += "var start = 0";

--- a/tests/MyGame/Example/Monster.java
+++ b/tests/MyGame/Example/Monster.java
@@ -293,7 +293,7 @@ public final class Monster extends Table {
   protected int keysCompare(Integer o1, Integer o2, ByteBuffer _bb) { return compareStrings(__offset(10, o1, _bb), __offset(10, o2, _bb), _bb); }
 
   public static Monster __lookup_by_key(Monster obj, int vectorLocation, String key, ByteBuffer bb) {
-    byte[] byteKey = key.getBytes(Table.UTF8_CHARSET.get());
+    byte[] byteKey = key.getBytes(java.nio.charset.StandardCharsets.UTF_8);
     int span = bb.getInt(vectorLocation - 4);
     int start = 0;
     while (span != 0) {

--- a/tests/MyGame/Example/Monster.kt
+++ b/tests/MyGame/Example/Monster.kt
@@ -964,7 +964,7 @@ class Monster : Table() {
         fun finishMonsterBuffer(builder: FlatBufferBuilder, offset: Int) = builder.finish(offset, "MONS")
         fun finishSizePrefixedMonsterBuffer(builder: FlatBufferBuilder, offset: Int) = builder.finishSizePrefixed(offset, "MONS")
         fun __lookup_by_key(obj: Monster?, vectorLocation: Int, key: String, bb: ByteBuffer) : Monster? {
-            val byteKey = key.toByteArray(Table.UTF8_CHARSET.get()!!)
+            val byteKey = key.toByteArray(java.nio.charset.StandardCharsets.UTF_8)
             var span = bb.getInt(vectorLocation - 4)
             var start = 0
             while (span != 0) {


### PR DESCRIPTION
I am trying to use flatbuffers generated java code in GWT and is blocked by GWT's missing support for ThreadLocal.initialValue. Since StandardCharsets.UTF_8 is already used in other places and Charset is thread-safe this PR just removes Table.UTF8_CHARSET and replace all references to it with StandardCharsets.UTF_8.
