### PR TITLE
Generate a dummy value for proto enums missing the default 0 value.

### DIFF
--- a/tests/prototest/test.golden
+++ b/tests/prototest/test.golden
@@ -10,6 +10,13 @@ enum ProtoEnum : int {
   BAR = 5,
 }
 
+enum ProtoEnumMissingDefault : int {
+  ///flatc-added default enum entry added to ensure a valid schema was generated.
+  ProtoEnumMissingDefault_FLATBUFFERS_DEFAULT_VALUE = 0,
+  FOO = 1,
+  BAR = 2,
+}
+
 table ImportedMessage {
   a:int;
 }

--- a/tests/prototest/test.proto
+++ b/tests/prototest/test.proto
@@ -57,3 +57,10 @@ message ProtoMessage {
     OtherMessage t = 18;
   }
 }
+
+enum ProtoEnumMissingDefault {
+  FOO = 1;
+  BAR = 2;
+}
+
+

--- a/tests/prototest/test_include.golden
+++ b/tests/prototest/test_include.golden
@@ -12,6 +12,13 @@ enum ProtoEnum : int {
   BAR = 5,
 }
 
+enum ProtoEnumMissingDefault : int {
+  ///flatc-added default enum entry added to ensure a valid schema was generated.
+  ProtoEnumMissingDefault_FLATBUFFERS_DEFAULT_VALUE = 0,
+  FOO = 1,
+  BAR = 2,
+}
+
 /// 2nd table doc comment with
 /// many lines.
 table ProtoMessage {

--- a/tests/prototest/test_suffix.golden
+++ b/tests/prototest/test_suffix.golden
@@ -10,6 +10,13 @@ enum ProtoEnum : int {
   BAR = 5,
 }
 
+enum ProtoEnumMissingDefault : int {
+  ///flatc-added default enum entry added to ensure a valid schema was generated.
+  ProtoEnumMissingDefault_FLATBUFFERS_DEFAULT_VALUE = 0,
+  FOO = 1,
+  BAR = 2,
+}
+
 table ImportedMessage {
   a:int;
 }

--- a/tests/prototest/test_union.golden
+++ b/tests/prototest/test_union.golden
@@ -22,6 +22,13 @@ union RUnion {
 
 namespace proto.test;
 
+enum ProtoEnumMissingDefault : int {
+  ///flatc-added default enum entry added to ensure a valid schema was generated.
+  ProtoEnumMissingDefault_FLATBUFFERS_DEFAULT_VALUE = 0,
+  FOO = 1,
+  BAR = 2,
+}
+
 table ImportedMessage {
   a:int;
 }

--- a/tests/prototest/test_union_include.golden
+++ b/tests/prototest/test_union_include.golden
@@ -24,6 +24,13 @@ union RUnion {
 
 namespace proto.test;
 
+enum ProtoEnumMissingDefault : int {
+  ///flatc-added default enum entry added to ensure a valid schema was generated.
+  ProtoEnumMissingDefault_FLATBUFFERS_DEFAULT_VALUE = 0,
+  FOO = 1,
+  BAR = 2,
+}
+
 /// 2nd table doc comment with
 /// many lines.
 table ProtoMessage {

--- a/tests/prototest/test_union_suffix.golden
+++ b/tests/prototest/test_union_suffix.golden
@@ -22,6 +22,13 @@ union RUnion {
 
 namespace proto.test.test_namespace_suffix;
 
+enum ProtoEnumMissingDefault : int {
+  ///flatc-added default enum entry added to ensure a valid schema was generated.
+  ProtoEnumMissingDefault_FLATBUFFERS_DEFAULT_VALUE = 0,
+  FOO = 1,
+  BAR = 2,
+}
+
 table ImportedMessage {
   a:int;
 }


### PR DESCRIPTION
In the Protobuf IDL, enums are not required to contain the value 0. The
flatbuffers IDL does require this value. When generating fbs files from
Proto IDL, include the 0 value if it is missing.