### PR TITLE
[GO] enhance golang object API to add 3 shortcut

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -816,8 +816,7 @@ class GoGenerator : public BaseGenerator {
 
   void GenNativeUnionPack(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "func " + enum_def.name + "Pack(builder *flatbuffers.Builder, t *" +
-            NativeName(enum_def) + ") flatbuffers.UOffsetT {\n";
+    code += "func (t *" + NativeName(enum_def)  + ") Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {\n";
     code += "\tif t == nil {\n\t\treturn 0\n\t}\n";
 
     code += "\tswitch t.Type {\n";
@@ -833,6 +832,17 @@ class GoGenerator : public BaseGenerator {
     code += "\t}\n";
     code += "\treturn 0\n";
     code += "}\n\n";
+
+    code += "// " + enum_def.name + "Pack()  \n";
+    code += "// \n";
+    code +="// DEPRECATED: Use " + NativeName(enum_def)  + ".Park() instead.\n";
+    code += "func " + enum_def.name + "Pack(builder *flatbuffers.Builder, t *" +
+              NativeName(enum_def) + ") flatbuffers.UOffsetT {\n";
+    code += "\tif t == nil {\n\t\treturn 0\n\t}\n";
+    code += "\treturn t.Pack(builder)\n";
+    code += "}\n\n";
+
+
   }
 
   void GenNativeUnionUnPack(const EnumDef &enum_def, std::string *code_ptr) {

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -831,17 +831,6 @@ class GoGenerator : public BaseGenerator {
     code += "\t}\n";
     code += "\treturn 0\n";
     code += "}\n\n";
-
-    code += "// " + enum_def.name + "Pack()  \n";
-    code += "// \n";
-    code +="// DEPRECATED: Use " + NativeName(enum_def)  + ".Park() instead.\n";
-    code += "func " + enum_def.name + "Pack(builder *flatbuffers.Builder, t *" +
-              NativeName(enum_def) + ") flatbuffers.UOffsetT {\n";
-    code += "\tif t == nil {\n\t\treturn 0\n\t}\n";
-    code += "\treturn t.Pack(builder)\n";
-    code += "}\n\n";
-
-
   }
 
   void GenNativeUnionUnPack(const EnumDef &enum_def, std::string *code_ptr) {
@@ -981,16 +970,6 @@ class GoGenerator : public BaseGenerator {
     code += "\treturn " + struct_def.name + "End(builder)\n";
     code += "}\n\n";
 
-    // keep old style xxxxxPack() name
-    code += "// " + struct_def.name + "Pack()  \n";
-    code += "// \n";
-    code +="// DEPRECATED: Use " + NativeName(struct_def) + ".Park() instead.\n";
-    code += "func " + struct_def.name +
-              "Pack(builder *flatbuffers.Builder, t *" + NativeName(struct_def) +
-              ") flatbuffers.UOffsetT {\n";
-    code += "\treturn t.Pack(builder)\n";
-    code += "}\n\n";
-
     // shortcut of native object to flatbuffers Builder
     code += "func (rcv *" + NativeName(struct_def) +
             ") Builder() *flatbuffers.Builder {\n";
@@ -1099,13 +1078,6 @@ class GoGenerator : public BaseGenerator {
     StructPackArgs(struct_def, "", code_ptr);
     code += ")\n";
     code += "}\n";
-
-    code +="// DEPRECATED: Use "  + NativeName(struct_def) + ".Park instead.\n";
-    code += "func " + struct_def.name +
-              "Pack(builder *flatbuffers.Builder, t *" + NativeName(struct_def) +
-              ") flatbuffers.UOffsetT {\n";
-    code += "\treturn t.Pack(builder)\n";
-    code += "}\n\n";
   }
 
   void StructPackArgs(const StructDef &struct_def, const char *nameprefix,

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -872,9 +872,8 @@ class GoGenerator : public BaseGenerator {
   void GenNativeTablePack(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "func " + struct_def.name +
-            "Pack(builder *flatbuffers.Builder, t *" + NativeName(struct_def) +
-            ") flatbuffers.UOffsetT {\n";
+    code += "func (t *" + NativeName(struct_def) +
+            ") Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {\n";
     code += "\tif t == nil { return 0 }\n";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
@@ -986,18 +985,26 @@ class GoGenerator : public BaseGenerator {
     code += "\treturn " + struct_def.name + "End(builder)\n";
     code += "}\n\n";
 
+    code += "// " + struct_def.name + "Pack()  \n";
+    code += "// \n";
+    code +="// DEPRECATED: Use " + NativeName(struct_def) + ".Park() instead.\n";
+    code += "func " + struct_def.name +
+              "Pack(builder *flatbuffers.Builder, t *" + NativeName(struct_def) +
+              ") flatbuffers.UOffsetT {\n";
+    code += "\treturn t.Pack(builder)\n";
+    code += "}\n\n";
     // shortcut of native object to flatbuffers Builder
     code += "func (rcv *" + NativeName(struct_def) +
             ") Builder() *flatbuffers.Builder {\n";
     code += "\tb := flatbuffers.NewBuilder(0)\n";
-    code += "\tb.Finish(" + struct_def.name + "Pack(b, rcv))\n";
+    code += "\tb.Finish(rcv.Pack(b))\n";
     code += "\treturn b\n";
     code += "}\n\n";
 
     // shortcut of native object Pack, serialized object to binary array
     code += "func (rcv *" + NativeName(struct_def) + ") Marshal() []byte  {\n";
     code += "\t b := flatbuffers.NewBuilder(0)\n";
-    code += "\t b.Finish(" + struct_def.name + "Pack(b, rcv))\n";
+    code += "\t b.Finish(rcv.Pack(b))\n";
     code += "\treturn b.FinishedBytes()\n";
     code += "}\n\n";
 
@@ -1087,14 +1094,20 @@ class GoGenerator : public BaseGenerator {
   void GenNativeStructPack(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "func " + struct_def.name +
-            "Pack(builder *flatbuffers.Builder, t *" + NativeName(struct_def) +
-            ") flatbuffers.UOffsetT {\n";
+    code += "func (t *" + NativeName(struct_def) +
+            ") Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {\n";
     code += "\tif t == nil { return 0 }\n";
     code += "\treturn Create" + struct_def.name + "(builder";
     StructPackArgs(struct_def, "", code_ptr);
     code += ")\n";
     code += "}\n";
+
+    code +="// DEPRECATED: Use "  + NativeName(struct_def) + ".Park instead.\n";
+    code += "func " + struct_def.name +
+              "Pack(builder *flatbuffers.Builder, t *" + NativeName(struct_def) +
+              ") flatbuffers.UOffsetT {\n";
+    code += "\treturn t.Pack(builder)\n";
+    code += "}\n\n";
   }
 
   void StructPackArgs(const StructDef &struct_def, const char *nameprefix,

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -977,23 +977,25 @@ class GoGenerator : public BaseGenerator {
     code += "}\n\n";
 
     // shortcut of native object to flatbuffers Builder
-    code+= "func (rcv *" + NativeName(struct_def) + ") Builder() *flatbuffers.Builder {\n";
-    code+= "\tb := flatbuffers.NewBuilder(0)\n";
-    code+= "\tb.Finish(" + struct_def.name + "Pack(b, rcv))\n";
-    code+= "\treturn b\n";
-    code+= "}\n\n";
+    code += "func (rcv *" + NativeName(struct_def) +
+            ") Builder() *flatbuffers.Builder {\n";
+    code += "\tb := flatbuffers.NewBuilder(0)\n";
+    code += "\tb.Finish(" + struct_def.name + "Pack(b, rcv))\n";
+    code += "\treturn b\n";
+    code += "}\n\n";
 
     // shortcut of native object Pack, serialized object to binary array
-    code+= "func (rcv *" + NativeName(struct_def) + ") Marshal() []byte  {\n";
-    code+= "\t b := flatbuffers.NewBuilder(0)\n";
-    code+= "\t b.Finish(" + struct_def.name + "Pack(b, rcv))\n";
-    code+= "\treturn b.FinishedBytes()\n";
-    code+= "}\n\n";
+    code += "func (rcv *" + NativeName(struct_def) + ") Marshal() []byte  {\n";
+    code += "\t b := flatbuffers.NewBuilder(0)\n";
+    code += "\t b.Finish(" + struct_def.name + "Pack(b, rcv))\n";
+    code += "\treturn b.FinishedBytes()\n";
+    code += "}\n\n";
 
     // shortcut of native object UnPack , un-serialize from binary array
-    code+= "func Unmarshal"  + NativeName(struct_def) + " (b []byte) *" + NativeName(struct_def) + " {\n";
-    code+= "\treturn GetRootAs" + struct_def.name + "(b, 0).UnPack()\n";
-    code+= "}\n\n";
+    code += "func Unmarshal" + NativeName(struct_def) + " (b []byte) *" +
+            NativeName(struct_def) + " {\n";
+    code += "\treturn GetRootAs" + struct_def.name + "(b, 0).UnPack()\n";
+    code += "}\n\n";
   }
 
   void GenNativeTableUnPack(const StructDef &struct_def,

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -975,6 +975,25 @@ class GoGenerator : public BaseGenerator {
     }
     code += "\treturn " + struct_def.name + "End(builder)\n";
     code += "}\n\n";
+
+    // shortcut of native object to flatbuffers Builder
+    code+= "func (rcv *" + NativeName(struct_def) + ") Builder() *flatbuffers.Builder {\n";
+    code+= "\tb := flatbuffers.NewBuilder(0)\n";
+    code+= "\tb.Finish(" + struct_def.name + "Pack(b, rcv))\n";
+    code+= "\treturn b\n";
+    code+= "}\n\n";
+
+    // shortcut of native object Pack, serialized object to binary array
+    code+= "func (rcv *" + NativeName(struct_def) + ") Marshal() []byte  {\n";
+    code+= "\t b := flatbuffers.NewBuilder(0)\n";
+    code+= "\t b.Finish(" + struct_def.name + "Pack(b, rcv))\n";
+    code+= "\treturn b.FinishedBytes()\n";
+    code+= "}\n\n";
+
+    // shortcut of native object UnPack , un-serialize from binary array
+    code+= "func Unmarshal"  + NativeName(struct_def) + " (b []byte) *" + NativeName(struct_def) + " {\n";
+    code+= "\treturn GetRootAs" + struct_def.name + "(b, 0).UnPack()\n";
+    code+= "}\n\n";
   }
 
   void GenNativeTableUnPack(const StructDef &struct_def,

--- a/tests/MyGame/Example/Monster.go
+++ b/tests/MyGame/Example/Monster.go
@@ -295,6 +295,22 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 	return MonsterEnd(builder)
 }
 
+func (rcv *MonsterT) Builder() *flatbuffers.Builder {
+	b := flatbuffers.NewBuilder(0)
+	b.Finish(MonsterPack(b, rcv))
+	return b
+}
+
+func (rcv *MonsterT) Marshal() []byte  {
+	 b := flatbuffers.NewBuilder(0)
+	 b.Finish(MonsterPack(b, rcv))
+	return b.FinishedBytes()
+}
+
+func UnmarshalMonsterT (b []byte) *MonsterT {
+	return GetRootAsMonster(b, 0).UnPack()
+}
+
 func (rcv *Monster) UnPackTo(t *MonsterT) {
 	t.Pos = rcv.Pos(nil).UnPack()
 	t.Mana = rcv.Mana()

--- a/tests/MyGame/Example/Referrable.go
+++ b/tests/MyGame/Example/Referrable.go
@@ -17,6 +17,22 @@ func ReferrablePack(builder *flatbuffers.Builder, t *ReferrableT) flatbuffers.UO
 	return ReferrableEnd(builder)
 }
 
+func (rcv *ReferrableT) Builder() *flatbuffers.Builder {
+	b := flatbuffers.NewBuilder(0)
+	b.Finish(ReferrablePack(b, rcv))
+	return b
+}
+
+func (rcv *ReferrableT) Marshal() []byte  {
+	 b := flatbuffers.NewBuilder(0)
+	 b.Finish(ReferrablePack(b, rcv))
+	return b.FinishedBytes()
+}
+
+func UnmarshalReferrableT (b []byte) *ReferrableT {
+	return GetRootAsReferrable(b, 0).UnPack()
+}
+
 func (rcv *Referrable) UnPackTo(t *ReferrableT) {
 	t.Id = rcv.Id()
 }

--- a/tests/MyGame/Example/Stat.go
+++ b/tests/MyGame/Example/Stat.go
@@ -22,6 +22,22 @@ func StatPack(builder *flatbuffers.Builder, t *StatT) flatbuffers.UOffsetT {
 	return StatEnd(builder)
 }
 
+func (rcv *StatT) Builder() *flatbuffers.Builder {
+	b := flatbuffers.NewBuilder(0)
+	b.Finish(StatPack(b, rcv))
+	return b
+}
+
+func (rcv *StatT) Marshal() []byte  {
+	 b := flatbuffers.NewBuilder(0)
+	 b.Finish(StatPack(b, rcv))
+	return b.FinishedBytes()
+}
+
+func UnmarshalStatT (b []byte) *StatT {
+	return GetRootAsStat(b, 0).UnPack()
+}
+
 func (rcv *Stat) UnPackTo(t *StatT) {
 	t.Id = string(rcv.Id())
 	t.Val = rcv.Val()

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.go
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.go
@@ -17,6 +17,22 @@ func TestSimpleTableWithEnumPack(builder *flatbuffers.Builder, t *TestSimpleTabl
 	return TestSimpleTableWithEnumEnd(builder)
 }
 
+func (rcv *TestSimpleTableWithEnumT) Builder() *flatbuffers.Builder {
+	b := flatbuffers.NewBuilder(0)
+	b.Finish(TestSimpleTableWithEnumPack(b, rcv))
+	return b
+}
+
+func (rcv *TestSimpleTableWithEnumT) Marshal() []byte  {
+	 b := flatbuffers.NewBuilder(0)
+	 b.Finish(TestSimpleTableWithEnumPack(b, rcv))
+	return b.FinishedBytes()
+}
+
+func UnmarshalTestSimpleTableWithEnumT (b []byte) *TestSimpleTableWithEnumT {
+	return GetRootAsTestSimpleTableWithEnum(b, 0).UnPack()
+}
+
 func (rcv *TestSimpleTableWithEnum) UnPackTo(t *TestSimpleTableWithEnumT) {
 	t.Color = rcv.Color()
 }

--- a/tests/MyGame/Example/TypeAliases.go
+++ b/tests/MyGame/Example/TypeAliases.go
@@ -57,6 +57,22 @@ func TypeAliasesPack(builder *flatbuffers.Builder, t *TypeAliasesT) flatbuffers.
 	return TypeAliasesEnd(builder)
 }
 
+func (rcv *TypeAliasesT) Builder() *flatbuffers.Builder {
+	b := flatbuffers.NewBuilder(0)
+	b.Finish(TypeAliasesPack(b, rcv))
+	return b
+}
+
+func (rcv *TypeAliasesT) Marshal() []byte  {
+	 b := flatbuffers.NewBuilder(0)
+	 b.Finish(TypeAliasesPack(b, rcv))
+	return b.FinishedBytes()
+}
+
+func UnmarshalTypeAliasesT (b []byte) *TypeAliasesT {
+	return GetRootAsTypeAliases(b, 0).UnPack()
+}
+
 func (rcv *TypeAliases) UnPackTo(t *TypeAliasesT) {
 	t.I8 = rcv.I8()
 	t.U8 = rcv.U8()

--- a/tests/MyGame/Example2/Monster.go
+++ b/tests/MyGame/Example2/Monster.go
@@ -15,6 +15,22 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 	return MonsterEnd(builder)
 }
 
+func (rcv *MonsterT) Builder() *flatbuffers.Builder {
+	b := flatbuffers.NewBuilder(0)
+	b.Finish(MonsterPack(b, rcv))
+	return b
+}
+
+func (rcv *MonsterT) Marshal() []byte  {
+	 b := flatbuffers.NewBuilder(0)
+	 b.Finish(MonsterPack(b, rcv))
+	return b.FinishedBytes()
+}
+
+func UnmarshalMonsterT (b []byte) *MonsterT {
+	return GetRootAsMonster(b, 0).UnPack()
+}
+
 func (rcv *Monster) UnPackTo(t *MonsterT) {
 }
 

--- a/tests/MyGame/InParentNamespace.go
+++ b/tests/MyGame/InParentNamespace.go
@@ -15,6 +15,22 @@ func InParentNamespacePack(builder *flatbuffers.Builder, t *InParentNamespaceT) 
 	return InParentNamespaceEnd(builder)
 }
 
+func (rcv *InParentNamespaceT) Builder() *flatbuffers.Builder {
+	b := flatbuffers.NewBuilder(0)
+	b.Finish(InParentNamespacePack(b, rcv))
+	return b
+}
+
+func (rcv *InParentNamespaceT) Marshal() []byte  {
+	 b := flatbuffers.NewBuilder(0)
+	 b.Finish(InParentNamespacePack(b, rcv))
+	return b.FinishedBytes()
+}
+
+func UnmarshalInParentNamespaceT (b []byte) *InParentNamespaceT {
+	return GetRootAsInParentNamespace(b, 0).UnPack()
+}
+
 func (rcv *InParentNamespace) UnPackTo(t *InParentNamespaceT) {
 }
 

--- a/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.go
+++ b/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.go
@@ -17,6 +17,22 @@ func TableInNestedNSPack(builder *flatbuffers.Builder, t *TableInNestedNST) flat
 	return TableInNestedNSEnd(builder)
 }
 
+func (rcv *TableInNestedNST) Builder() *flatbuffers.Builder {
+	b := flatbuffers.NewBuilder(0)
+	b.Finish(TableInNestedNSPack(b, rcv))
+	return b
+}
+
+func (rcv *TableInNestedNST) Marshal() []byte  {
+	 b := flatbuffers.NewBuilder(0)
+	 b.Finish(TableInNestedNSPack(b, rcv))
+	return b.FinishedBytes()
+}
+
+func UnmarshalTableInNestedNST (b []byte) *TableInNestedNST {
+	return GetRootAsTableInNestedNS(b, 0).UnPack()
+}
+
 func (rcv *TableInNestedNS) UnPackTo(t *TableInNestedNST) {
 	t.Foo = rcv.Foo()
 }

--- a/tests/namespace_test/NamespaceA/SecondTableInA.go
+++ b/tests/namespace_test/NamespaceA/SecondTableInA.go
@@ -20,6 +20,22 @@ func SecondTableInAPack(builder *flatbuffers.Builder, t *SecondTableInAT) flatbu
 	return SecondTableInAEnd(builder)
 }
 
+func (rcv *SecondTableInAT) Builder() *flatbuffers.Builder {
+	b := flatbuffers.NewBuilder(0)
+	b.Finish(SecondTableInAPack(b, rcv))
+	return b
+}
+
+func (rcv *SecondTableInAT) Marshal() []byte  {
+	 b := flatbuffers.NewBuilder(0)
+	 b.Finish(SecondTableInAPack(b, rcv))
+	return b.FinishedBytes()
+}
+
+func UnmarshalSecondTableInAT (b []byte) *SecondTableInAT {
+	return GetRootAsSecondTableInA(b, 0).UnPack()
+}
+
 func (rcv *SecondTableInA) UnPackTo(t *SecondTableInAT) {
 	t.ReferToC = rcv.ReferToC(nil).UnPack()
 }

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.go
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.go
@@ -25,6 +25,22 @@ func TableInFirstNSPack(builder *flatbuffers.Builder, t *TableInFirstNST) flatbu
 	return TableInFirstNSEnd(builder)
 }
 
+func (rcv *TableInFirstNST) Builder() *flatbuffers.Builder {
+	b := flatbuffers.NewBuilder(0)
+	b.Finish(TableInFirstNSPack(b, rcv))
+	return b
+}
+
+func (rcv *TableInFirstNST) Marshal() []byte  {
+	 b := flatbuffers.NewBuilder(0)
+	 b.Finish(TableInFirstNSPack(b, rcv))
+	return b.FinishedBytes()
+}
+
+func UnmarshalTableInFirstNST (b []byte) *TableInFirstNST {
+	return GetRootAsTableInFirstNS(b, 0).UnPack()
+}
+
 func (rcv *TableInFirstNS) UnPackTo(t *TableInFirstNST) {
 	t.FooTable = rcv.FooTable(nil).UnPack()
 	t.FooEnum = rcv.FooEnum()

--- a/tests/namespace_test/NamespaceC/TableInC.go
+++ b/tests/namespace_test/NamespaceC/TableInC.go
@@ -23,6 +23,22 @@ func TableInCPack(builder *flatbuffers.Builder, t *TableInCT) flatbuffers.UOffse
 	return TableInCEnd(builder)
 }
 
+func (rcv *TableInCT) Builder() *flatbuffers.Builder {
+	b := flatbuffers.NewBuilder(0)
+	b.Finish(TableInCPack(b, rcv))
+	return b
+}
+
+func (rcv *TableInCT) Marshal() []byte  {
+	 b := flatbuffers.NewBuilder(0)
+	 b.Finish(TableInCPack(b, rcv))
+	return b.FinishedBytes()
+}
+
+func UnmarshalTableInCT (b []byte) *TableInCT {
+	return GetRootAsTableInC(b, 0).UnPack()
+}
+
 func (rcv *TableInC) UnPackTo(t *TableInCT) {
 	t.ReferToA1 = rcv.ReferToA1(nil).UnPack()
 	t.ReferToA2 = rcv.ReferToA2(nil).UnPack()


### PR DESCRIPTION
1.  object.Builder()  --- shortcat of native object to flatbuffers Builder ( go method )
2. object.Marshal() --- shortcut of native object Pack  ( serialize method )
3. UnmarshalObjectT(b []byte) *ObjectT --- shortcut of object UnPack ( un-serialize  function  )

