### PR TITLE
[C++] Fix for printing of enum in case output_enum_identifiers=1.

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -283,6 +283,11 @@ template<typename T> class Vector {
     return reinterpret_cast<const void *>(Data() + o);
   }
 
+  template<typename S>
+  const void *GetAsStruct(const S &sd, uoffset_t i) const {
+    return reinterpret_cast<const void *>(Data() + sd.bytesize * i);
+  }
+
   iterator begin() { return iterator(Data(), 0); }
   const_iterator begin() const { return const_iterator(Data(), 0); }
 
@@ -443,6 +448,13 @@ template<typename T, uint16_t length> class Array {
 
   return_type operator[](uoffset_t i) const { return Get(i); }
 
+  // If this is a Vector of enums, T will be its storage type, not the enum
+  // type. This function makes it convenient to retrieve value with enum
+  // type E.
+  template<typename E> E GetEnum(uoffset_t i) const {
+    return static_cast<E>(Get(i));
+  }
+
   const_iterator begin() const { return const_iterator(Data(), 0); }
   const_iterator end() const { return const_iterator(Data(), size()); }
 
@@ -518,12 +530,19 @@ template<typename T, uint16_t length> class Array<Offset<T>, length> {
   static_assert(flatbuffers::is_same<T, void>::value, "unexpected type T");
 
  public:
+  typedef const void* return_type;
+
   const uint8_t *Data() const { return data_; }
 
   // Make idl_gen_text.cpp::PrintContainer happy.
-  const void *operator[](uoffset_t) const {
+  return_type operator[](uoffset_t) const {
     FLATBUFFERS_ASSERT(false);
     return nullptr;
+  }
+
+  template<typename S>
+  const void *GetAsStruct(const S &sd, uoffset_t i) const {
+    return reinterpret_cast<const void *>(Data() + sd.bytesize * i);
   }
 
  private:

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -283,11 +283,6 @@ template<typename T> class Vector {
     return reinterpret_cast<const void *>(Data() + o);
   }
 
-  template<typename S>
-  const void *GetAsStruct(const S &sd, uoffset_t i) const {
-    return reinterpret_cast<const void *>(Data() + sd.bytesize * i);
-  }
-
   iterator begin() { return iterator(Data(), 0); }
   const_iterator begin() const { return const_iterator(Data(), 0); }
 
@@ -538,11 +533,6 @@ template<typename T, uint16_t length> class Array<Offset<T>, length> {
   return_type operator[](uoffset_t) const {
     FLATBUFFERS_ASSERT(false);
     return nullptr;
-  }
-
-  template<typename S>
-  const void *GetAsStruct(const S &sd, uoffset_t i) const {
-    return reinterpret_cast<const void *>(Data() + sd.bytesize * i);
   }
 
  private:

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -132,7 +132,9 @@ struct JsonPrinter {
         AddNewLine();
       }
       AddIndent(elem_indent);
-      auto ptr = is_struct ? c.GetAsStruct(*type.struct_def, i) : c[i];
+      auto ptr = is_struct ? reinterpret_cast<const void *>(
+                                 c.Data() + type.struct_def->bytesize * i)
+                           : c[i];
       if (!PrintOffset(ptr, type, elem_indent, prev_val,
                        static_cast<soffset_t>(i))) {
         return false;

--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -23,356 +23,335 @@
 
 namespace flatbuffers {
 
-static bool GenStruct(const StructDef &struct_def, const Table *table,
-                      int indent, const IDLOptions &opts, std::string *_text);
-
-static bool PrintOffset(const void *val, const Type &type, int indent,
-                        const IDLOptions &opts, std::string *_text,
-                        const uint8_t *prev_val, soffset_t vector_index);
-
-// If indentation is less than 0, that indicates we don't want any newlines
-// either.
-inline static void AddNewLine(const IDLOptions &opts, std::string *_text) {
-  if (opts.indent_step >= 0) *_text += '\n';
-}
-
-inline static void AddIndent(int ident, std::string *_text) {
-  _text->append(ident, ' ');
-}
-
-inline static int Indent(const IDLOptions &opts) {
-  return std::max(opts.indent_step, 0);
-}
-
-// Output an identifier with or without quotes depending on strictness.
-static void OutputIdentifier(const std::string &name, const IDLOptions &opts,
-                             std::string *_text) {
-  std::string &text = *_text;
-  if (opts.strict_json) text += '\"';
-  text += name;
-  if (opts.strict_json) text += '\"';
-}
-
-// Print (and its template specialization below for pointers) generate text
-// for a single FlatBuffer value into JSON format.
-// The general case for scalars:
-template<typename T>
-static bool PrintScalar(T val, const Type &type, int /*indent*/,
-                        const IDLOptions &opts, std::string *_text) {
-  std::string &text = *_text;
-  if (IsBool(type.base_type)) {
-    text += val != 0 ? "true" : "false";
-    return true;  // done
-  }
-
-  if (opts.output_enum_identifiers && type.enum_def) {
-    const auto &enum_def = *type.enum_def;
-    if (auto ev = enum_def.ReverseLookup(static_cast<int64_t>(val))) {
-      text += '\"';
-      text += ev->name;
-      text += '\"';
-      return true;  // done
-    } else if (val && enum_def.attributes.Lookup("bit_flags")) {
-      const auto entry_len = text.length();
-      const auto u64 = static_cast<uint64_t>(val);
-      uint64_t mask = 0;
-      text += '\"';
-      for (auto it = enum_def.Vals().begin(), e = enum_def.Vals().end();
-           it != e; ++it) {
-        auto f = (*it)->GetAsUInt64();
-        if (f & u64) {
-          mask |= f;
-          text += (*it)->name;
-          text += ' ';
-        }
-      }
-      // Don't slice if (u64 != mask)
-      if (mask && (u64 == mask)) {
-        text[text.length() - 1] = '\"';
-        return true;  // done
-      }
-      text.resize(entry_len);  // restore
-    }
-    // print as numeric value
-  }
-
-  text += NumToString(val);
-  return true;
-}
-
 struct PrintScalarTag {};
 struct PrintPointerTag {};
 template<typename T> struct PrintTag { typedef PrintScalarTag type; };
 template<> struct PrintTag<const void *> { typedef PrintPointerTag type; };
 
-// Print a vector or an array of JSON values, comma seperated, wrapped in "[]".
-template<typename Container>
-static bool PrintContainer(PrintScalarTag, const Container &c, size_t size,
-                           const Type &type, int indent, const IDLOptions &opts,
-                           std::string *_text, const uint8_t *) {
-  const auto elem_ident = indent + Indent(opts);
-  std::string &text = *_text;
-  text += '[';
-  AddNewLine(opts, &text);
-  for (uoffset_t i = 0; i < size; i++) {
-    if (i) {
-      if (!opts.protobuf_ascii_alike) text += ',';
-      AddNewLine(opts, &text);
-    }
-    AddIndent(elem_ident, &text);
-    if (!PrintScalar(c[i], type, elem_ident, opts, _text)) { return false; }
+struct JsonPrinter {
+  // If indentation is less than 0, that indicates we don't want any newlines
+  // either.
+  void AddNewLine() {
+    if (opts.indent_step >= 0) text += '\n';
   }
-  AddNewLine(opts, &text);
-  AddIndent(indent, &text);
-  text += ']';
-  return true;
-}
 
-// Print a vector or an array of JSON values, comma seperated, wrapped in "[]".
-template<typename Container>
-static bool PrintContainer(PrintPointerTag, const Container &c, size_t size,
-                           const Type &type, int indent, const IDLOptions &opts,
-                           std::string *_text, const uint8_t *prev_val) {
-  const auto is_struct = IsStruct(type);
-  const auto elem_ident = indent + Indent(opts);
-  std::string &text = *_text;
-  text += '[';
-  AddNewLine(opts, &text);
-  for (uoffset_t i = 0; i < size; i++) {
-    if (i) {
-      if (!opts.protobuf_ascii_alike) text += ',';
-      AddNewLine(opts, &text);
-    }
-    AddIndent(elem_ident, &text);
-    auto ptr = is_struct ? c.GetAsStruct(*type.struct_def, i) : c[i];
-    if (!PrintOffset(ptr, type, elem_ident, opts, _text, prev_val,
-                     static_cast<soffset_t>(i))) {
-      return false;
-    }
+  void AddIndent(int ident) { text.append(ident, ' '); }
+
+  int Indent() const { return std::max(opts.indent_step, 0); }
+
+  // Output an identifier with or without quotes depending on strictness.
+  void OutputIdentifier(const std::string &name) {
+    if (opts.strict_json) text += '\"';
+    text += name;
+    if (opts.strict_json) text += '\"';
   }
-  AddNewLine(opts, &text);
-  AddIndent(indent, &text);
-  text += ']';
-  return true;
-}
 
-template<typename T>
-static bool PrintVector(const void *val, const Type &type, int indent,
-                        const IDLOptions &opts, std::string *_text,
-                        const uint8_t *prev_val) {
-  typedef Vector<T> Container;
-  typedef typename PrintTag<typename Container::return_type>::type tag;
-  auto &vec = *reinterpret_cast<const Container *>(val);
-  return PrintContainer<Container>(tag(), vec, vec.size(), type, indent, opts,
-                                   _text, prev_val);
-}
+  // Print (and its template specialization below for pointers) generate text
+  // for a single FlatBuffer value into JSON format.
+  // The general case for scalars:
+  template<typename T>
+  bool PrintScalar(T val, const Type &type, int /*indent*/) {
+    if (IsBool(type.base_type)) {
+      text += val != 0 ? "true" : "false";
+      return true;  // done
+    }
 
-// Print an array a sequence of JSON values, comma separated, wrapped in "[]".
-template<typename T>
-static bool PrintArray(const void *val, size_t size, const Type &type,
-                       int indent, const IDLOptions &opts, std::string *_text) {
-  typedef Array<T, 0xFFFF> Container;
-  typedef typename PrintTag<typename Container::return_type>::type tag;
-  auto &arr = *reinterpret_cast<const Container *>(val);
-  return PrintContainer<Container>(tag(), arr, size, type, indent, opts, _text,
-                                   nullptr);
-}
-
-static bool PrintOffset(const void *val, const Type &type, int indent,
-                        const IDLOptions &opts, std::string *_text,
-                        const uint8_t *prev_val, soffset_t vector_index) {
-  switch (type.base_type) {
-    case BASE_TYPE_UNION: {
-      // If this assert hits, you have an corrupt buffer, a union type field
-      // was not present or was out of range.
-      FLATBUFFERS_ASSERT(prev_val);
-      auto union_type_byte = *prev_val;  // Always a uint8_t.
-      if (vector_index >= 0) {
-        auto type_vec = reinterpret_cast<const Vector<uint8_t> *>(
-            prev_val + ReadScalar<uoffset_t>(prev_val));
-        union_type_byte = type_vec->Get(static_cast<uoffset_t>(vector_index));
+    if (opts.output_enum_identifiers && type.enum_def) {
+      const auto &enum_def = *type.enum_def;
+      if (auto ev = enum_def.ReverseLookup(static_cast<int64_t>(val))) {
+        text += '\"';
+        text += ev->name;
+        text += '\"';
+        return true;  // done
+      } else if (val && enum_def.attributes.Lookup("bit_flags")) {
+        const auto entry_len = text.length();
+        const auto u64 = static_cast<uint64_t>(val);
+        uint64_t mask = 0;
+        text += '\"';
+        for (auto it = enum_def.Vals().begin(), e = enum_def.Vals().end();
+             it != e; ++it) {
+          auto f = (*it)->GetAsUInt64();
+          if (f & u64) {
+            mask |= f;
+            text += (*it)->name;
+            text += ' ';
+          }
+        }
+        // Don't slice if (u64 != mask)
+        if (mask && (u64 == mask)) {
+          text[text.length() - 1] = '\"';
+          return true;  // done
+        }
+        text.resize(entry_len);  // restore
       }
-      auto enum_val = type.enum_def->ReverseLookup(union_type_byte, true);
-      if (enum_val) {
-        return PrintOffset(val, enum_val->union_type, indent, opts, _text,
-                           nullptr, -1);
-      } else {
+      // print as numeric value
+    }
+
+    text += NumToString(val);
+    return true;
+  }
+
+  void AddComma() {
+    if (!opts.protobuf_ascii_alike) text += ',';
+  }
+
+  // Print a vector or an array of JSON values, comma seperated, wrapped in
+  // "[]".
+  template<typename Container>
+  bool PrintContainer(PrintScalarTag, const Container &c, size_t size,
+                      const Type &type, int indent, const uint8_t *) {
+    const auto elem_indent = indent + Indent();
+    text += '[';
+    AddNewLine();
+    for (uoffset_t i = 0; i < size; i++) {
+      if (i) {
+        AddComma();
+        AddNewLine();
+      }
+      AddIndent(elem_indent);
+      if (!PrintScalar(c[i], type, elem_indent)) { return false; }
+    }
+    AddNewLine();
+    AddIndent(indent);
+    text += ']';
+    return true;
+  }
+
+  // Print a vector or an array of JSON values, comma seperated, wrapped in
+  // "[]".
+  template<typename Container>
+  bool PrintContainer(PrintPointerTag, const Container &c, size_t size,
+                      const Type &type, int indent, const uint8_t *prev_val) {
+    const auto is_struct = IsStruct(type);
+    const auto elem_indent = indent + Indent();
+    text += '[';
+    AddNewLine();
+    for (uoffset_t i = 0; i < size; i++) {
+      if (i) {
+        AddComma();
+        AddNewLine();
+      }
+      AddIndent(elem_indent);
+      auto ptr = is_struct ? c.GetAsStruct(*type.struct_def, i) : c[i];
+      if (!PrintOffset(ptr, type, elem_indent, prev_val,
+                       static_cast<soffset_t>(i))) {
         return false;
       }
     }
-    case BASE_TYPE_STRUCT:
-      return GenStruct(*type.struct_def, reinterpret_cast<const Table *>(val),
-                       indent, opts, _text);
-    case BASE_TYPE_STRING: {
-      auto s = reinterpret_cast<const String *>(val);
-      return EscapeString(s->c_str(), s->size(), _text, opts.allow_non_utf8,
-                          opts.natural_utf8);
-    }
-    case BASE_TYPE_VECTOR: {
-      const auto vec_type = type.VectorType();
-      // Call PrintVector above specifically for each element type:
-      // clang-format off
-      switch (vec_type.base_type) {
+    AddNewLine();
+    AddIndent(indent);
+    text += ']';
+    return true;
+  }
+
+  template<typename T>
+  bool PrintVector(const void *val, const Type &type, int indent,
+                   const uint8_t *prev_val) {
+    typedef Vector<T> Container;
+    typedef typename PrintTag<typename Container::return_type>::type tag;
+    auto &vec = *reinterpret_cast<const Container *>(val);
+    return PrintContainer<Container>(tag(), vec, vec.size(), type, indent,
+                                     prev_val);
+  }
+
+  // Print an array a sequence of JSON values, comma separated, wrapped in "[]".
+  template<typename T>
+  bool PrintArray(const void *val, size_t size, const Type &type, int indent) {
+    typedef Array<T, 0xFFFF> Container;
+    typedef typename PrintTag<typename Container::return_type>::type tag;
+    auto &arr = *reinterpret_cast<const Container *>(val);
+    return PrintContainer<Container>(tag(), arr, size, type, indent, nullptr);
+  }
+
+  bool PrintOffset(const void *val, const Type &type, int indent,
+                   const uint8_t *prev_val, soffset_t vector_index) {
+    switch (type.base_type) {
+      case BASE_TYPE_UNION: {
+        // If this assert hits, you have an corrupt buffer, a union type field
+        // was not present or was out of range.
+        FLATBUFFERS_ASSERT(prev_val);
+        auto union_type_byte = *prev_val;  // Always a uint8_t.
+        if (vector_index >= 0) {
+          auto type_vec = reinterpret_cast<const Vector<uint8_t> *>(
+              prev_val + ReadScalar<uoffset_t>(prev_val));
+          union_type_byte = type_vec->Get(static_cast<uoffset_t>(vector_index));
+        }
+        auto enum_val = type.enum_def->ReverseLookup(union_type_byte, true);
+        if (enum_val) {
+          return PrintOffset(val, enum_val->union_type, indent, nullptr, -1);
+        } else {
+          return false;
+        }
+      }
+      case BASE_TYPE_STRUCT:
+        return GenStruct(*type.struct_def, reinterpret_cast<const Table *>(val),
+                         indent);
+      case BASE_TYPE_STRING: {
+        auto s = reinterpret_cast<const String *>(val);
+        return EscapeString(s->c_str(), s->size(), &text, opts.allow_non_utf8,
+                            opts.natural_utf8);
+      }
+      case BASE_TYPE_VECTOR: {
+        const auto vec_type = type.VectorType();
+        // Call PrintVector above specifically for each element type:
+        // clang-format off
+        switch (vec_type.base_type) {
         #define FLATBUFFERS_TD(ENUM, IDLTYPE, CTYPE, ...) \
           case BASE_TYPE_ ## ENUM: \
             if (!PrintVector<CTYPE>( \
-                  val, vec_type, indent, opts, _text, prev_val)) { \
+                  val, vec_type, indent, prev_val)) { \
               return false; \
             } \
             break;
           FLATBUFFERS_GEN_TYPES(FLATBUFFERS_TD)
         #undef FLATBUFFERS_TD
+        }
+        // clang-format on
+        return true;
       }
-      // clang-format on
-      return true;
-    }
-    case BASE_TYPE_ARRAY: {
-      const auto vec_type = type.VectorType();
-      // Call PrintArray above specifically for each element type:
-      // clang-format off
-      switch (vec_type.base_type) {
-        #define FLATBUFFERS_TD(ENUM, IDLTYPE, CTYPE, ...) \
-        case BASE_TYPE_ ## ENUM: \
-          if (!PrintArray<CTYPE>( \
-              val, type.fixed_length, \
-              vec_type, indent, opts, _text)) { \
-          return false; \
-          } \
-          break;
-        FLATBUFFERS_GEN_TYPES_SCALAR(FLATBUFFERS_TD)
-        // Arrays of scalars or structs are only possible.
-        FLATBUFFERS_GEN_TYPES_POINTER(FLATBUFFERS_TD)
-        #undef FLATBUFFERS_TD
-        case BASE_TYPE_ARRAY: FLATBUFFERS_ASSERT(0);
-      }
-      // clang-format on
-      return true;
-    }
-    default: FLATBUFFERS_ASSERT(0); return false;
-  }
-}
-
-template<typename T> static T GetFieldDefault(const FieldDef &fd) {
-  T val;
-  auto check = StringToNumber(fd.value.constant.c_str(), &val);
-  (void)check;
-  FLATBUFFERS_ASSERT(check);
-  return val;
-}
-
-// Generate text for a scalar field.
-template<typename T>
-static bool GenField(const FieldDef &fd, const Table *table, bool fixed,
-                     const IDLOptions &opts, int indent, std::string *_text) {
-  return PrintScalar(
-      fixed ? reinterpret_cast<const Struct *>(table)->GetField<T>(
-                  fd.value.offset)
-            : table->GetField<T>(fd.value.offset, GetFieldDefault<T>(fd)),
-      fd.value.type, indent, opts, _text);
-}
-
-static bool GenStruct(const StructDef &struct_def, const Table *table,
-                      int indent, const IDLOptions &opts, std::string *_text);
-
-// Generate text for non-scalar field.
-static bool GenFieldOffset(const FieldDef &fd, const Table *table, bool fixed,
-                           int indent, const IDLOptions &opts,
-                           std::string *_text, const uint8_t *prev_val) {
-  const void *val = nullptr;
-  if (fixed) {
-    // The only non-scalar fields in structs are structs or arrays.
-    FLATBUFFERS_ASSERT(IsStruct(fd.value.type) || IsArray(fd.value.type));
-    val = reinterpret_cast<const Struct *>(table)->GetStruct<const void *>(
-        fd.value.offset);
-  } else if (fd.flexbuffer) {
-    auto vec = table->GetPointer<const Vector<uint8_t> *>(fd.value.offset);
-    auto root = flexbuffers::GetRoot(vec->data(), vec->size());
-    root.ToString(true, opts.strict_json, *_text);
-    return true;
-  } else if (fd.nested_flatbuffer) {
-    auto vec = table->GetPointer<const Vector<uint8_t> *>(fd.value.offset);
-    auto root = GetRoot<Table>(vec->data());
-    return GenStruct(*fd.nested_flatbuffer, root, indent, opts, _text);
-  } else {
-    val = IsStruct(fd.value.type)
-              ? table->GetStruct<const void *>(fd.value.offset)
-              : table->GetPointer<const void *>(fd.value.offset);
-  }
-  return PrintOffset(val, fd.value.type, indent, opts, _text, prev_val, -1);
-}
-
-// Generate text for a struct or table, values separated by commas, indented,
-// and bracketed by "{}"
-static bool GenStruct(const StructDef &struct_def, const Table *table,
-                      int indent, const IDLOptions &opts, std::string *_text) {
-  std::string &text = *_text;
-  text += '{';
-  int fieldout = 0;
-  const uint8_t *prev_val = nullptr;
-  const auto elem_ident = indent + Indent(opts);
-  for (auto it = struct_def.fields.vec.begin();
-       it != struct_def.fields.vec.end(); ++it) {
-    FieldDef &fd = **it;
-    auto is_present = struct_def.fixed || table->CheckField(fd.value.offset);
-    auto output_anyway = opts.output_default_scalars_in_json &&
-                         IsScalar(fd.value.type.base_type) && !fd.deprecated;
-    if (is_present || output_anyway) {
-      if (fieldout++) {
-        if (!opts.protobuf_ascii_alike) text += ',';
-      }
-      AddNewLine(opts, &text);
-      AddIndent(elem_ident, &text);
-      OutputIdentifier(fd.name, opts, _text);
-      if (!opts.protobuf_ascii_alike ||
-          (fd.value.type.base_type != BASE_TYPE_STRUCT &&
-           fd.value.type.base_type != BASE_TYPE_VECTOR))
-        text += ':';
-      text += ' ';
-      switch (fd.value.type.base_type) {
-// clang-format off
+      case BASE_TYPE_ARRAY: {
+        const auto vec_type = type.VectorType();
+        // Call PrintArray above specifically for each element type:
+        // clang-format off
+        switch (vec_type.base_type) {
         #define FLATBUFFERS_TD(ENUM, IDLTYPE, CTYPE, ...) \
           case BASE_TYPE_ ## ENUM: \
-            if (!GenField<CTYPE>(fd, table, struct_def.fixed, \
-                                  opts, elem_ident, _text)) { \
+            if (!PrintArray<CTYPE>( \
+                val, type.fixed_length, vec_type, indent)) { \
+            return false; \
+            } \
+            break;
+            FLATBUFFERS_GEN_TYPES_SCALAR(FLATBUFFERS_TD)
+              // Arrays of scalars or structs are only possible.
+              FLATBUFFERS_GEN_TYPES_POINTER(FLATBUFFERS_TD)
+        #undef FLATBUFFERS_TD
+          case BASE_TYPE_ARRAY: FLATBUFFERS_ASSERT(0);
+        }
+        // clang-format on
+        return true;
+      }
+      default: FLATBUFFERS_ASSERT(0); return false;
+    }
+  }
+
+  template<typename T> static T GetFieldDefault(const FieldDef &fd) {
+    T val;
+    auto check = StringToNumber(fd.value.constant.c_str(), &val);
+    (void)check;
+    FLATBUFFERS_ASSERT(check);
+    return val;
+  }
+
+  // Generate text for a scalar field.
+  template<typename T>
+  bool GenField(const FieldDef &fd, const Table *table, bool fixed,
+                int indent) {
+    return PrintScalar(
+        fixed ? reinterpret_cast<const Struct *>(table)->GetField<T>(
+                    fd.value.offset)
+              : table->GetField<T>(fd.value.offset, GetFieldDefault<T>(fd)),
+        fd.value.type, indent);
+  }
+
+  // Generate text for non-scalar field.
+  bool GenFieldOffset(const FieldDef &fd, const Table *table, bool fixed,
+                      int indent, const uint8_t *prev_val) {
+    const void *val = nullptr;
+    if (fixed) {
+      // The only non-scalar fields in structs are structs or arrays.
+      FLATBUFFERS_ASSERT(IsStruct(fd.value.type) || IsArray(fd.value.type));
+      val = reinterpret_cast<const Struct *>(table)->GetStruct<const void *>(
+          fd.value.offset);
+    } else if (fd.flexbuffer) {
+      auto vec = table->GetPointer<const Vector<uint8_t> *>(fd.value.offset);
+      auto root = flexbuffers::GetRoot(vec->data(), vec->size());
+      root.ToString(true, opts.strict_json, text);
+      return true;
+    } else if (fd.nested_flatbuffer) {
+      auto vec = table->GetPointer<const Vector<uint8_t> *>(fd.value.offset);
+      auto root = GetRoot<Table>(vec->data());
+      return GenStruct(*fd.nested_flatbuffer, root, indent);
+    } else {
+      val = IsStruct(fd.value.type)
+                ? table->GetStruct<const void *>(fd.value.offset)
+                : table->GetPointer<const void *>(fd.value.offset);
+    }
+    return PrintOffset(val, fd.value.type, indent, prev_val, -1);
+  }
+
+  // Generate text for a struct or table, values separated by commas, indented,
+  // and bracketed by "{}"
+  bool GenStruct(const StructDef &struct_def, const Table *table, int indent) {
+    text += '{';
+    int fieldout = 0;
+    const uint8_t *prev_val = nullptr;
+    const auto elem_indent = indent + Indent();
+    for (auto it = struct_def.fields.vec.begin();
+         it != struct_def.fields.vec.end(); ++it) {
+      FieldDef &fd = **it;
+      auto is_present = struct_def.fixed || table->CheckField(fd.value.offset);
+      auto output_anyway = opts.output_default_scalars_in_json &&
+                           IsScalar(fd.value.type.base_type) && !fd.deprecated;
+      if (is_present || output_anyway) {
+        if (fieldout++) { AddComma(); }
+        AddNewLine();
+        AddIndent(elem_indent);
+        OutputIdentifier(fd.name);
+        if (!opts.protobuf_ascii_alike ||
+            (fd.value.type.base_type != BASE_TYPE_STRUCT &&
+             fd.value.type.base_type != BASE_TYPE_VECTOR))
+          text += ':';
+        text += ' ';
+        // clang-format off
+        switch (fd.value.type.base_type) {
+        #define FLATBUFFERS_TD(ENUM, IDLTYPE, CTYPE, ...) \
+          case BASE_TYPE_ ## ENUM: \
+            if (!GenField<CTYPE>(fd, table, struct_def.fixed, elem_indent)) { \
               return false; \
             } \
             break;
-          FLATBUFFERS_GEN_TYPES_SCALAR(FLATBUFFERS_TD)
+            FLATBUFFERS_GEN_TYPES_SCALAR(FLATBUFFERS_TD)
         #undef FLATBUFFERS_TD
         // Generate drop-thru case statements for all pointer types:
         #define FLATBUFFERS_TD(ENUM, ...) \
           case BASE_TYPE_ ## ENUM:
-          FLATBUFFERS_GEN_TYPES_POINTER(FLATBUFFERS_TD)
-          FLATBUFFERS_GEN_TYPE_ARRAY(FLATBUFFERS_TD)
+              FLATBUFFERS_GEN_TYPES_POINTER(FLATBUFFERS_TD)
+              FLATBUFFERS_GEN_TYPE_ARRAY(FLATBUFFERS_TD)
         #undef FLATBUFFERS_TD
-            if (!GenFieldOffset(fd, table, struct_def.fixed, elem_ident,
-                                opts, _text, prev_val)) {
-              return false;
-            }
+              if (!GenFieldOffset(fd, table, struct_def.fixed, elem_indent, prev_val)) {
+                return false;
+              }
             break;
+        }
         // clang-format on
-      }
-      // Track prev val for use with union types.
-      if (struct_def.fixed) {
-        prev_val = reinterpret_cast<const uint8_t *>(table) + fd.value.offset;
-      } else {
-        prev_val = table->GetAddressOf(fd.value.offset);
+        // Track prev val for use with union types.
+        if (struct_def.fixed) {
+          prev_val = reinterpret_cast<const uint8_t *>(table) + fd.value.offset;
+        } else {
+          prev_val = table->GetAddressOf(fd.value.offset);
+        }
       }
     }
+    AddNewLine();
+    AddIndent(indent);
+    text += '}';
+    return true;
   }
-  AddNewLine(opts, &text);
-  AddIndent(indent, &text);
-  text += '}';
-  return true;
-}
+
+  JsonPrinter(const Parser &parser, std::string &dest)
+      : opts(parser.opts), text(dest) {
+    text.reserve(1024);  // Reduce amount of inevitable reallocs.
+  }
+
+  const IDLOptions &opts;
+  std::string &text;
+};
 
 static bool GenerateTextImpl(const Parser &parser, const Table *table,
                              const StructDef &struct_def, std::string *_text) {
-  auto &text = *_text;
-  text.reserve(1024);  // Reduce amount of inevitable reallocs.
-  auto root = static_cast<const Table *>(table);
-  if (!GenStruct(struct_def, root, 0, parser.opts, &text)) { return false; }
-  AddNewLine(parser.opts, &text);
+  JsonPrinter printer(parser, *_text);
+  if (!printer.GenStruct(struct_def, table, 0)) { return false; }
+  printer.AddNewLine();
   return true;
 }
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -650,6 +650,19 @@ void JsonEnumsTest() {
   auto result = GenerateText(parser, builder.GetBufferPointer(), &jsongen);
   TEST_EQ(result, true);
   TEST_EQ(std::string::npos != jsongen.find("color: \"Red Blue\""), true);
+  // Test forward compatibility with 'output_enum_identifiers = true'.
+  // Current Color doesn't have '(1u << 2)' field, let's add it.
+  builder.Clear();
+  std::string future_json;
+  auto future_name = builder.CreateString("future bitflag_enum");
+  MonsterBuilder future_color(builder);
+  future_color.add_name(future_name);
+  future_color.add_color(
+      static_cast<Color>((1u << 2) | Color_Blue | Color_Red));
+  FinishMonsterBuffer(builder, future_color.Finish());
+  result = GenerateText(parser, builder.GetBufferPointer(), &future_json);
+  TEST_EQ(result, true);
+  TEST_EQ(std::string::npos != future_json.find("color: 13"), true);
 }
 
 #if defined(FLATBUFFERS_HAS_NEW_STRTOD) && (FLATBUFFERS_HAS_NEW_STRTOD > 0)


### PR DESCRIPTION
This PR fixes the printing of bit_flags enum in case output_enum_identifiers=1.
Support of `bit_flags`+`case output_enum_identifiers` was added by #5454 (@ll-antn).
Unfortunately, we missed that #5454 didn't take into account a possible forward evolution of enums.
Numerical result of conversion `binary->json->binary` might depend on flag `output_enum_identifiers` and enum value.
The first commit adds a simple test case.
Let's imagine we receive a binary message with `color=(1u << 2) | Color_Blue | Color_Red)`.
If `output_enum_identifiers=false`, json output will be correct: `color: 13`.
But for `case output_enum_identifiers=true` it will be: `color: "Red Blue"`.
If convert this wrong JSON back into a binary message, the `(1u << 2)` flag will be lost.
This PR fixes it (function `PrintScalar`).

Other changes are refactoring to improve readability and performance.