### PR TITLE
[Go] Replace references to hardcoded ”Monster" etc with idiomatic go wherever possible

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -837,9 +837,10 @@ class GoGenerator : public BaseGenerator {
   void GenNativeUnionUnPack(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "func " + enum_def.name + "UnPack(t " + enum_def.name +
-            ", table flatbuffers.Table) *" + NativeName(enum_def) + " {\n";
-    code += "\tswitch t {\n";
+    code += "func (rcv " + enum_def.name +
+            ") UnPack(table flatbuffers.Table) *" + NativeName(enum_def) +
+            " {\n";
+    code += "\tswitch rcv {\n";
 
     for (auto it2 = enum_def.Vals().begin(); it2 != enum_def.Vals().end();
          ++it2) {
@@ -1021,14 +1022,13 @@ class GoGenerator : public BaseGenerator {
         code += "\tt." + field_name_camel + " = rcv." + field_name_camel +
                 "(nil).UnPack()\n";
       } else if (field.value.type.base_type == BASE_TYPE_UNION) {
-        const EnumDef &enum_def = *field.value.type.enum_def;
         std::string field_table = MakeCamel(field.name, false) + "Table";
         code += "\t" + field_table + " := flatbuffers.Table{}\n";
         code +=
             "\tif rcv." + MakeCamel(field.name) + "(&" + field_table + ") {\n";
-        code += "\t\tt." + field_name_camel + " = " + enum_def.name +
-                "UnPack(rcv." + MakeCamel(field.name + UnionTypeFieldSuffix()) +
-                "(), " + field_table + ")\n";
+        code += "\t\tt." + field_name_camel + " = rcv." +
+                MakeCamel(field.name + UnionTypeFieldSuffix()) + "().UnPack(" +
+                field_table + ")\n";
         code += "\t}\n";
       } else {
         FLATBUFFERS_ASSERT(0);

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -816,8 +816,8 @@ class GoGenerator : public BaseGenerator {
 
   void GenNativeUnionPack(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "func " + enum_def.name + "Pack(builder *flatbuffers.Builder, t *" +
-            NativeName(enum_def) + ") flatbuffers.UOffsetT {\n";
+    code += "func (t *" + NativeName(enum_def) +
+            ") Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {\n";
     code += "\tif t == nil {\n\t\treturn 0\n\t}\n";
 
     code += "\tswitch t.Type {\n";
@@ -826,9 +826,8 @@ class GoGenerator : public BaseGenerator {
       const EnumVal &ev = **it2;
       if (ev.IsZero()) continue;
       code += "\tcase " + enum_def.name + ev.name + ":\n";
-      code += "\t\treturn " +
-              WrapInNameSpaceAndTrack(*ev.union_type.struct_def) +
-              "Pack(builder, t.Value.(" + NativeType(ev.union_type) + "))\n";
+      code += "\t\treturn t.Value.(" + NativeType(ev.union_type) +
+              ").Pack(builder)\n";
     }
     code += "\t}\n";
     code += "\treturn 0\n";
@@ -862,9 +861,8 @@ class GoGenerator : public BaseGenerator {
   void GenNativeTablePack(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "func " + struct_def.name +
-            "Pack(builder *flatbuffers.Builder, t *" + NativeName(struct_def) +
-            ") flatbuffers.UOffsetT {\n";
+    code += "func (t *" + NativeName(struct_def) +
+            ") Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {\n";
     code += "\tif t == nil { return 0 }\n";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
@@ -903,9 +901,8 @@ class GoGenerator : public BaseGenerator {
           code += "\t\t" + offsets + " := make([]flatbuffers.UOffsetT, " +
                   length + ")\n";
           code += "\t\tfor j := 0; j < " + length + "; j++ {\n";
-          code += "\t\t\t" + offsets + "[j] = " +
-                  WrapInNameSpaceAndTrack(*field.value.type.struct_def) +
-                  "Pack(builder, t." + MakeCamel(field.name) + "[j])\n";
+          code += "\t\t\t" + offsets + "[j] = t." + MakeCamel(field.name) +
+                  "[j].Pack(builder)\n";
           code += "\t\t}\n";
         }
         code += "\t\t" + struct_def.name + "Start" + MakeCamel(field.name) +
@@ -919,9 +916,7 @@ class GoGenerator : public BaseGenerator {
                   ")\n";
         } else if (field.value.type.element == BASE_TYPE_STRUCT &&
                    field.value.type.struct_def->fixed) {
-          code += "\t\t\t" +
-                  WrapInNameSpaceAndTrack(*field.value.type.struct_def) +
-                  "Pack(builder, t." + MakeCamel(field.name) + "[j])\n";
+          code += "\t\t\tt." + MakeCamel(field.name) + "[j].Pack(builder)\n";
         } else {
           code += "\t\t\tbuilder.PrependUOffsetT(" + offsets + "[j])\n";
         }
@@ -930,13 +925,11 @@ class GoGenerator : public BaseGenerator {
         code += "\t}\n";
       } else if (field.value.type.base_type == BASE_TYPE_STRUCT) {
         if (field.value.type.struct_def->fixed) continue;
-        code += "\t" + offset +
-                " := " + WrapInNameSpaceAndTrack(*field.value.type.struct_def) +
-                "Pack(builder, t." + MakeCamel(field.name) + ")\n";
+        code += "\t" + offset + " := t." + MakeCamel(field.name) +
+                ".Pack(builder)\n";
       } else if (field.value.type.base_type == BASE_TYPE_UNION) {
-        code += "\t" + offset +
-                " := " + WrapInNameSpaceAndTrack(*field.value.type.enum_def) +
-                "Pack(builder, t." + MakeCamel(field.name) + ")\n";
+        code += "\t" + offset + " := t." + MakeCamel(field.name) +
+                ".Pack(builder)\n";
         code += "\t\n";
       } else {
         FLATBUFFERS_ASSERT(0);
@@ -958,9 +951,8 @@ class GoGenerator : public BaseGenerator {
       } else {
         if (field.value.type.base_type == BASE_TYPE_STRUCT &&
             field.value.type.struct_def->fixed) {
-          code += "\t" + offset + " := " +
-                  WrapInNameSpaceAndTrack(*field.value.type.struct_def) +
-                  "Pack(builder, t." + MakeCamel(field.name) + ")\n";
+          code += "\t" + offset + " := t." + MakeCamel(field.name) +
+                  ".Pack(builder)\n";
         } else if (field.value.type.enum_def != nullptr &&
                    field.value.type.enum_def->is_union) {
           code += "\tif t." + MakeCamel(field.name) + " != nil {\n";
@@ -1056,9 +1048,8 @@ class GoGenerator : public BaseGenerator {
   void GenNativeStructPack(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "func " + struct_def.name +
-            "Pack(builder *flatbuffers.Builder, t *" + NativeName(struct_def) +
-            ") flatbuffers.UOffsetT {\n";
+    code += "func (t *" + NativeName(struct_def) +
+            ") Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {\n";
     code += "\tif t == nil { return 0 }\n";
     code += "\treturn Create" + struct_def.name + "(builder";
     StructPackArgs(struct_def, "", code_ptr);

--- a/tests/MyGame/Example/Ability.go
+++ b/tests/MyGame/Example/Ability.go
@@ -11,7 +11,7 @@ type AbilityT struct {
 	Distance uint32
 }
 
-func AbilityPack(builder *flatbuffers.Builder, t *AbilityT) flatbuffers.UOffsetT {
+func (t *AbilityT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	return CreateAbility(builder, t.Id, t.Distance)
 }

--- a/tests/MyGame/Example/Any.go
+++ b/tests/MyGame/Example/Any.go
@@ -45,17 +45,17 @@ type AnyT struct {
 	Value interface{}
 }
 
-func AnyPack(builder *flatbuffers.Builder, t *AnyT) flatbuffers.UOffsetT {
+func (t *AnyT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
 	switch t.Type {
 	case AnyMonster:
-		return MonsterPack(builder, t.Value.(*MonsterT))
+		return t.Value.(*MonsterT).Pack(builder)
 	case AnyTestSimpleTableWithEnum:
-		return TestSimpleTableWithEnumPack(builder, t.Value.(*TestSimpleTableWithEnumT))
+		return t.Value.(*TestSimpleTableWithEnumT).Pack(builder)
 	case AnyMyGame_Example2_Monster:
-		return MyGame__Example2.MonsterPack(builder, t.Value.(*MyGame__Example2.MonsterT))
+		return t.Value.(*MyGame__Example2.MonsterT).Pack(builder)
 	}
 	return 0
 }

--- a/tests/MyGame/Example/Any.go
+++ b/tests/MyGame/Example/Any.go
@@ -60,8 +60,8 @@ func (t *AnyT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return 0
 }
 
-func AnyUnPack(t Any, table flatbuffers.Table) *AnyT {
-	switch t {
+func (rcv Any) UnPack(table flatbuffers.Table) *AnyT {
+	switch rcv {
 	case AnyMonster:
 		x := Monster{_tab: table}
 		return &AnyT{ Type: AnyMonster, Value: x.UnPack() }

--- a/tests/MyGame/Example/AnyAmbiguousAliases.go
+++ b/tests/MyGame/Example/AnyAmbiguousAliases.go
@@ -58,8 +58,8 @@ func (t *AnyAmbiguousAliasesT) Pack(builder *flatbuffers.Builder) flatbuffers.UO
 	return 0
 }
 
-func AnyAmbiguousAliasesUnPack(t AnyAmbiguousAliases, table flatbuffers.Table) *AnyAmbiguousAliasesT {
-	switch t {
+func (rcv AnyAmbiguousAliases) UnPack(table flatbuffers.Table) *AnyAmbiguousAliasesT {
+	switch rcv {
 	case AnyAmbiguousAliasesM1:
 		x := Monster{_tab: table}
 		return &AnyAmbiguousAliasesT{ Type: AnyAmbiguousAliasesM1, Value: x.UnPack() }

--- a/tests/MyGame/Example/AnyAmbiguousAliases.go
+++ b/tests/MyGame/Example/AnyAmbiguousAliases.go
@@ -43,17 +43,17 @@ type AnyAmbiguousAliasesT struct {
 	Value interface{}
 }
 
-func AnyAmbiguousAliasesPack(builder *flatbuffers.Builder, t *AnyAmbiguousAliasesT) flatbuffers.UOffsetT {
+func (t *AnyAmbiguousAliasesT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
 	switch t.Type {
 	case AnyAmbiguousAliasesM1:
-		return MonsterPack(builder, t.Value.(*MonsterT))
+		return t.Value.(*MonsterT).Pack(builder)
 	case AnyAmbiguousAliasesM2:
-		return MonsterPack(builder, t.Value.(*MonsterT))
+		return t.Value.(*MonsterT).Pack(builder)
 	case AnyAmbiguousAliasesM3:
-		return MonsterPack(builder, t.Value.(*MonsterT))
+		return t.Value.(*MonsterT).Pack(builder)
 	}
 	return 0
 }

--- a/tests/MyGame/Example/AnyUniqueAliases.go
+++ b/tests/MyGame/Example/AnyUniqueAliases.go
@@ -45,17 +45,17 @@ type AnyUniqueAliasesT struct {
 	Value interface{}
 }
 
-func AnyUniqueAliasesPack(builder *flatbuffers.Builder, t *AnyUniqueAliasesT) flatbuffers.UOffsetT {
+func (t *AnyUniqueAliasesT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil {
 		return 0
 	}
 	switch t.Type {
 	case AnyUniqueAliasesM:
-		return MonsterPack(builder, t.Value.(*MonsterT))
+		return t.Value.(*MonsterT).Pack(builder)
 	case AnyUniqueAliasesTS:
-		return TestSimpleTableWithEnumPack(builder, t.Value.(*TestSimpleTableWithEnumT))
+		return t.Value.(*TestSimpleTableWithEnumT).Pack(builder)
 	case AnyUniqueAliasesM2:
-		return MyGame__Example2.MonsterPack(builder, t.Value.(*MyGame__Example2.MonsterT))
+		return t.Value.(*MyGame__Example2.MonsterT).Pack(builder)
 	}
 	return 0
 }

--- a/tests/MyGame/Example/AnyUniqueAliases.go
+++ b/tests/MyGame/Example/AnyUniqueAliases.go
@@ -60,8 +60,8 @@ func (t *AnyUniqueAliasesT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffs
 	return 0
 }
 
-func AnyUniqueAliasesUnPack(t AnyUniqueAliases, table flatbuffers.Table) *AnyUniqueAliasesT {
-	switch t {
+func (rcv AnyUniqueAliases) UnPack(table flatbuffers.Table) *AnyUniqueAliasesT {
+	switch rcv {
 	case AnyUniqueAliasesM:
 		x := Monster{_tab: table}
 		return &AnyUniqueAliasesT{ Type: AnyUniqueAliasesM, Value: x.UnPack() }

--- a/tests/MyGame/Example/Monster.go
+++ b/tests/MyGame/Example/Monster.go
@@ -57,21 +57,21 @@ type MonsterT struct {
 	SignedEnum Race
 }
 
-func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT {
+func (t *MonsterT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	nameOffset := builder.CreateString(t.Name)
 	inventoryOffset := flatbuffers.UOffsetT(0)
 	if t.Inventory != nil {
 		inventoryOffset = builder.CreateByteString(t.Inventory)
 	}
-	testOffset := AnyPack(builder, t.Test)
+	testOffset := t.Test.Pack(builder)
 	
 	test4Offset := flatbuffers.UOffsetT(0)
 	if t.Test4 != nil {
 		test4Length := len(t.Test4)
 		MonsterStartTest4Vector(builder, test4Length)
 		for j := test4Length - 1; j >= 0; j-- {
-			TestPack(builder, t.Test4[j])
+			t.Test4[j].Pack(builder)
 		}
 		test4Offset = builder.EndVector(test4Length)
 	}
@@ -93,7 +93,7 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 		testarrayoftablesLength := len(t.Testarrayoftables)
 		testarrayoftablesOffsets := make([]flatbuffers.UOffsetT, testarrayoftablesLength)
 		for j := 0; j < testarrayoftablesLength; j++ {
-			testarrayoftablesOffsets[j] = MonsterPack(builder, t.Testarrayoftables[j])
+			testarrayoftablesOffsets[j] = t.Testarrayoftables[j].Pack(builder)
 		}
 		MonsterStartTestarrayoftablesVector(builder, testarrayoftablesLength)
 		for j := testarrayoftablesLength - 1; j >= 0; j-- {
@@ -101,12 +101,12 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 		}
 		testarrayoftablesOffset = builder.EndVector(testarrayoftablesLength)
 	}
-	enemyOffset := MonsterPack(builder, t.Enemy)
+	enemyOffset := t.Enemy.Pack(builder)
 	testnestedflatbufferOffset := flatbuffers.UOffsetT(0)
 	if t.Testnestedflatbuffer != nil {
 		testnestedflatbufferOffset = builder.CreateByteString(t.Testnestedflatbuffer)
 	}
-	testemptyOffset := StatPack(builder, t.Testempty)
+	testemptyOffset := t.Testempty.Pack(builder)
 	testarrayofboolsOffset := flatbuffers.UOffsetT(0)
 	if t.Testarrayofbools != nil {
 		testarrayofboolsLength := len(t.Testarrayofbools)
@@ -134,7 +134,7 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 		testarrayofsortedstructLength := len(t.Testarrayofsortedstruct)
 		MonsterStartTestarrayofsortedstructVector(builder, testarrayofsortedstructLength)
 		for j := testarrayofsortedstructLength - 1; j >= 0; j-- {
-			AbilityPack(builder, t.Testarrayofsortedstruct[j])
+			t.Testarrayofsortedstruct[j].Pack(builder)
 		}
 		testarrayofsortedstructOffset = builder.EndVector(testarrayofsortedstructLength)
 	}
@@ -147,7 +147,7 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 		test5Length := len(t.Test5)
 		MonsterStartTest5Vector(builder, test5Length)
 		for j := test5Length - 1; j >= 0; j-- {
-			TestPack(builder, t.Test5[j])
+			t.Test5[j].Pack(builder)
 		}
 		test5Offset = builder.EndVector(test5Length)
 	}
@@ -169,13 +169,13 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 		}
 		vectorOfDoublesOffset = builder.EndVector(vectorOfDoublesLength)
 	}
-	parentNamespaceTestOffset := MyGame.InParentNamespacePack(builder, t.ParentNamespaceTest)
+	parentNamespaceTestOffset := t.ParentNamespaceTest.Pack(builder)
 	vectorOfReferrablesOffset := flatbuffers.UOffsetT(0)
 	if t.VectorOfReferrables != nil {
 		vectorOfReferrablesLength := len(t.VectorOfReferrables)
 		vectorOfReferrablesOffsets := make([]flatbuffers.UOffsetT, vectorOfReferrablesLength)
 		for j := 0; j < vectorOfReferrablesLength; j++ {
-			vectorOfReferrablesOffsets[j] = ReferrablePack(builder, t.VectorOfReferrables[j])
+			vectorOfReferrablesOffsets[j] = t.VectorOfReferrables[j].Pack(builder)
 		}
 		MonsterStartVectorOfReferrablesVector(builder, vectorOfReferrablesLength)
 		for j := vectorOfReferrablesLength - 1; j >= 0; j-- {
@@ -197,7 +197,7 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 		vectorOfStrongReferrablesLength := len(t.VectorOfStrongReferrables)
 		vectorOfStrongReferrablesOffsets := make([]flatbuffers.UOffsetT, vectorOfStrongReferrablesLength)
 		for j := 0; j < vectorOfStrongReferrablesLength; j++ {
-			vectorOfStrongReferrablesOffsets[j] = ReferrablePack(builder, t.VectorOfStrongReferrables[j])
+			vectorOfStrongReferrablesOffsets[j] = t.VectorOfStrongReferrables[j].Pack(builder)
 		}
 		MonsterStartVectorOfStrongReferrablesVector(builder, vectorOfStrongReferrablesLength)
 		for j := vectorOfStrongReferrablesLength - 1; j >= 0; j-- {
@@ -223,9 +223,9 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 		}
 		vectorOfNonOwningReferencesOffset = builder.EndVector(vectorOfNonOwningReferencesLength)
 	}
-	anyUniqueOffset := AnyUniqueAliasesPack(builder, t.AnyUnique)
+	anyUniqueOffset := t.AnyUnique.Pack(builder)
 	
-	anyAmbiguousOffset := AnyAmbiguousAliasesPack(builder, t.AnyAmbiguous)
+	anyAmbiguousOffset := t.AnyAmbiguous.Pack(builder)
 	
 	vectorOfEnumsOffset := flatbuffers.UOffsetT(0)
 	if t.VectorOfEnums != nil {
@@ -237,7 +237,7 @@ func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT
 		vectorOfEnumsOffset = builder.EndVector(vectorOfEnumsLength)
 	}
 	MonsterStart(builder)
-	posOffset := Vec3Pack(builder, t.Pos)
+	posOffset := t.Pos.Pack(builder)
 	MonsterAddPos(builder, posOffset)
 	MonsterAddMana(builder, t.Mana)
 	MonsterAddHp(builder, t.Hp)

--- a/tests/MyGame/Example/Monster.go
+++ b/tests/MyGame/Example/Monster.go
@@ -304,7 +304,7 @@ func (rcv *Monster) UnPackTo(t *MonsterT) {
 	t.Color = rcv.Color()
 	testTable := flatbuffers.Table{}
 	if rcv.Test(&testTable) {
-		t.Test = AnyUnPack(rcv.TestType(), testTable)
+		t.Test = rcv.TestType().UnPack(testTable)
 	}
 	test4Length := rcv.Test4Length()
 	t.Test4 = make([]*TestT, test4Length)
@@ -410,11 +410,11 @@ func (rcv *Monster) UnPackTo(t *MonsterT) {
 	}
 	anyUniqueTable := flatbuffers.Table{}
 	if rcv.AnyUnique(&anyUniqueTable) {
-		t.AnyUnique = AnyUniqueAliasesUnPack(rcv.AnyUniqueType(), anyUniqueTable)
+		t.AnyUnique = rcv.AnyUniqueType().UnPack(anyUniqueTable)
 	}
 	anyAmbiguousTable := flatbuffers.Table{}
 	if rcv.AnyAmbiguous(&anyAmbiguousTable) {
-		t.AnyAmbiguous = AnyAmbiguousAliasesUnPack(rcv.AnyAmbiguousType(), anyAmbiguousTable)
+		t.AnyAmbiguous = rcv.AnyAmbiguousType().UnPack(anyAmbiguousTable)
 	}
 	vectorOfEnumsLength := rcv.VectorOfEnumsLength()
 	t.VectorOfEnums = make([]Color, vectorOfEnumsLength)

--- a/tests/MyGame/Example/Referrable.go
+++ b/tests/MyGame/Example/Referrable.go
@@ -10,7 +10,7 @@ type ReferrableT struct {
 	Id uint64
 }
 
-func ReferrablePack(builder *flatbuffers.Builder, t *ReferrableT) flatbuffers.UOffsetT {
+func (t *ReferrableT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	ReferrableStart(builder)
 	ReferrableAddId(builder, t.Id)

--- a/tests/MyGame/Example/Stat.go
+++ b/tests/MyGame/Example/Stat.go
@@ -12,7 +12,7 @@ type StatT struct {
 	Count uint16
 }
 
-func StatPack(builder *flatbuffers.Builder, t *StatT) flatbuffers.UOffsetT {
+func (t *StatT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	idOffset := builder.CreateString(t.Id)
 	StatStart(builder)

--- a/tests/MyGame/Example/Test.go
+++ b/tests/MyGame/Example/Test.go
@@ -11,7 +11,7 @@ type TestT struct {
 	B int8
 }
 
-func TestPack(builder *flatbuffers.Builder, t *TestT) flatbuffers.UOffsetT {
+func (t *TestT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	return CreateTest(builder, t.A, t.B)
 }

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.go
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.go
@@ -10,7 +10,7 @@ type TestSimpleTableWithEnumT struct {
 	Color Color
 }
 
-func TestSimpleTableWithEnumPack(builder *flatbuffers.Builder, t *TestSimpleTableWithEnumT) flatbuffers.UOffsetT {
+func (t *TestSimpleTableWithEnumT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	TestSimpleTableWithEnumStart(builder)
 	TestSimpleTableWithEnumAddColor(builder, t.Color)

--- a/tests/MyGame/Example/TypeAliases.go
+++ b/tests/MyGame/Example/TypeAliases.go
@@ -21,7 +21,7 @@ type TypeAliasesT struct {
 	Vf64 []float64
 }
 
-func TypeAliasesPack(builder *flatbuffers.Builder, t *TypeAliasesT) flatbuffers.UOffsetT {
+func (t *TypeAliasesT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	v8Offset := flatbuffers.UOffsetT(0)
 	if t.V8 != nil {

--- a/tests/MyGame/Example/Vec3.go
+++ b/tests/MyGame/Example/Vec3.go
@@ -15,7 +15,7 @@ type Vec3T struct {
 	Test3 *TestT
 }
 
-func Vec3Pack(builder *flatbuffers.Builder, t *Vec3T) flatbuffers.UOffsetT {
+func (t *Vec3T) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	return CreateVec3(builder, t.X, t.Y, t.Z, t.Test1, t.Test2, t.Test3.A, t.Test3.B)
 }

--- a/tests/MyGame/Example2/Monster.go
+++ b/tests/MyGame/Example2/Monster.go
@@ -9,7 +9,7 @@ import (
 type MonsterT struct {
 }
 
-func MonsterPack(builder *flatbuffers.Builder, t *MonsterT) flatbuffers.UOffsetT {
+func (t *MonsterT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	MonsterStart(builder)
 	return MonsterEnd(builder)

--- a/tests/MyGame/InParentNamespace.go
+++ b/tests/MyGame/InParentNamespace.go
@@ -9,7 +9,7 @@ import (
 type InParentNamespaceT struct {
 }
 
-func InParentNamespacePack(builder *flatbuffers.Builder, t *InParentNamespaceT) flatbuffers.UOffsetT {
+func (t *InParentNamespaceT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	InParentNamespaceStart(builder)
 	return InParentNamespaceEnd(builder)

--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -463,7 +463,7 @@ func CheckObjectAPI(buf []byte, offset flatbuffers.UOffsetT, fail func(string, .
 	}
 
 	builder := flatbuffers.NewBuilder(0)
-	builder.Finish(example.MonsterPack(builder, monster))
+	builder.Finish(monster.Pack(builder))
 	monster2 := example.GetRootAsMonster(builder.FinishedBytes(), 0).UnPack()
 	if !reflect.DeepEqual(monster, monster2) {
 		fail(FailString("Pack/Unpack()", monster, monster2))

--- a/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.go
+++ b/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.go
@@ -11,7 +11,7 @@ type StructInNestedNST struct {
 	B int32
 }
 
-func StructInNestedNSPack(builder *flatbuffers.Builder, t *StructInNestedNST) flatbuffers.UOffsetT {
+func (t *StructInNestedNST) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	return CreateStructInNestedNS(builder, t.A, t.B)
 }

--- a/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.go
+++ b/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.go
@@ -10,7 +10,7 @@ type TableInNestedNST struct {
 	Foo int32
 }
 
-func TableInNestedNSPack(builder *flatbuffers.Builder, t *TableInNestedNST) flatbuffers.UOffsetT {
+func (t *TableInNestedNST) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
 	TableInNestedNSStart(builder)
 	TableInNestedNSAddFoo(builder, t.Foo)

--- a/tests/namespace_test/NamespaceA/SecondTableInA.go
+++ b/tests/namespace_test/NamespaceA/SecondTableInA.go
@@ -12,9 +12,9 @@ type SecondTableInAT struct {
 	ReferToC *NamespaceC.TableInCT
 }
 
-func SecondTableInAPack(builder *flatbuffers.Builder, t *SecondTableInAT) flatbuffers.UOffsetT {
+func (t *SecondTableInAT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
-	referToCOffset := NamespaceC.TableInCPack(builder, t.ReferToC)
+	referToCOffset := t.ReferToC.Pack(builder)
 	SecondTableInAStart(builder)
 	SecondTableInAAddReferToC(builder, referToCOffset)
 	return SecondTableInAEnd(builder)

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.go
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.go
@@ -14,13 +14,13 @@ type TableInFirstNST struct {
 	FooStruct *NamespaceA__NamespaceB.StructInNestedNST
 }
 
-func TableInFirstNSPack(builder *flatbuffers.Builder, t *TableInFirstNST) flatbuffers.UOffsetT {
+func (t *TableInFirstNST) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
-	fooTableOffset := NamespaceA__NamespaceB.TableInNestedNSPack(builder, t.FooTable)
+	fooTableOffset := t.FooTable.Pack(builder)
 	TableInFirstNSStart(builder)
 	TableInFirstNSAddFooTable(builder, fooTableOffset)
 	TableInFirstNSAddFooEnum(builder, t.FooEnum)
-	fooStructOffset := NamespaceA__NamespaceB.StructInNestedNSPack(builder, t.FooStruct)
+	fooStructOffset := t.FooStruct.Pack(builder)
 	TableInFirstNSAddFooStruct(builder, fooStructOffset)
 	return TableInFirstNSEnd(builder)
 }

--- a/tests/namespace_test/NamespaceC/TableInC.go
+++ b/tests/namespace_test/NamespaceC/TableInC.go
@@ -13,10 +13,10 @@ type TableInCT struct {
 	ReferToA2 *NamespaceA.SecondTableInAT
 }
 
-func TableInCPack(builder *flatbuffers.Builder, t *TableInCT) flatbuffers.UOffsetT {
+func (t *TableInCT) Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	if t == nil { return 0 }
-	referToA1Offset := NamespaceA.TableInFirstNSPack(builder, t.ReferToA1)
-	referToA2Offset := NamespaceA.SecondTableInAPack(builder, t.ReferToA2)
+	referToA1Offset := t.ReferToA1.Pack(builder)
+	referToA2Offset := t.ReferToA2.Pack(builder)
 	TableInCStart(builder)
 	TableInCAddReferToA1(builder, referToA1Offset)
 	TableInCAddReferToA2(builder, referToA2Offset)


### PR DESCRIPTION
Most details of the need for this PR were already discussed in Issue https://github.com/google/flatbuffers/issues/5668.

I have also (additionally) converted the generated union types' UnPack func into a method.

e.g.
Generated func:
```go
func AnyUnPack(t Any, table flatbuffers.Table) *AnyT
```

Becomes method,
```go
func (rcv Any) UnPack(table flatbuffers.Table) *AnyT
``` 