### PR TITLE
[typescript] Size-prefixed root accessors not taking into account size prefix

### DIFF
--- a/src/idl_gen_js_ts.cpp
+++ b/src/idl_gen_js_ts.cpp
@@ -600,6 +600,10 @@ class JsTsGenerator : public BaseGenerator {
     }
   }
 
+  std::string GenerateNewExpression(const std::string &object_name) {
+    return "new " + object_name + (lang_.language == IDLOptions::kTs ? "()" : "");
+  }
+
   void GenerateRootAccessor(StructDef &struct_def, std::string *code_ptr,
                             std::string &code, std::string &object_name,
                             bool size_prefixed) {
@@ -622,7 +626,7 @@ class JsTsGenerator : public BaseGenerator {
       if (size_prefixed) {
         code += "  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);\n";
       }
-      code += "  return (obj || new " + object_name;
+      code += "  return (obj || " + GenerateNewExpression(object_name);
       code += ").__init(bb.readInt32(bb.position()) + bb.position(), bb);\n";
       code += "};\n\n";
     }
@@ -861,12 +865,12 @@ class JsTsGenerator : public BaseGenerator {
             }
 
             if (struct_def.fixed) {
-              code += "  return (obj || new " + type;
+              code += "  return (obj || " + GenerateNewExpression(type);
               code += ").__init(this.bb_pos";
               code +=
                   MaybeAdd(field.value.offset) + ", " + GenBBAccess() + ");\n";
             } else {
-              code += offset_prefix + "(obj || new " + type + ").__init(";
+              code += offset_prefix + "(obj || " + GenerateNewExpression(type) + ").__init(";
               code += field.value.type.struct_def->fixed
                           ? "this.bb_pos + offset"
                           : GenBBAccess() + ".__indirect(this.bb_pos + offset)";
@@ -948,7 +952,7 @@ class JsTsGenerator : public BaseGenerator {
             }
 
             if (vectortype.base_type == BASE_TYPE_STRUCT) {
-              code += offset_prefix + "(obj || new " + vectortypename;
+              code += offset_prefix + "(obj || " + GenerateNewExpression(vectortypename);
               code += ").__init(";
               code += vectortype.struct_def->fixed
                           ? index

--- a/src/idl_gen_js_ts.cpp
+++ b/src/idl_gen_js_ts.cpp
@@ -619,6 +619,9 @@ class JsTsGenerator : public BaseGenerator {
                 "Root" + Verbose(struct_def, "As");
         code += " = function(bb, obj) {\n";
       }
+      if (size_prefixed) {
+        code += "  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);\n";
+      }
       code += "  return (obj || new " + object_name;
       code += ").__init(bb.readInt32(bb.position()) + bb.position(), bb);\n";
       code += "};\n\n";

--- a/tests/monster_test_generated.js
+++ b/tests/monster_test_generated.js
@@ -185,6 +185,7 @@ MyGame.InParentNamespace.getRootAsInParentNamespace = function(bb, obj) {
  * @returns {MyGame.InParentNamespace}
  */
 MyGame.InParentNamespace.getSizePrefixedRootAsInParentNamespace = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new MyGame.InParentNamespace).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
@@ -254,6 +255,7 @@ MyGame.Example2.Monster.getRootAsMonster = function(bb, obj) {
  * @returns {MyGame.Example2.Monster}
  */
 MyGame.Example2.Monster.getSizePrefixedRootAsMonster = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new MyGame.Example2.Monster).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
@@ -407,6 +409,7 @@ MyGame.Example.TestSimpleTableWithEnum.getRootAsTestSimpleTableWithEnum = functi
  * @returns {MyGame.Example.TestSimpleTableWithEnum}
  */
 MyGame.Example.TestSimpleTableWithEnum.getSizePrefixedRootAsTestSimpleTableWithEnum = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new MyGame.Example.TestSimpleTableWithEnum).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
@@ -764,6 +767,7 @@ MyGame.Example.Stat.getRootAsStat = function(bb, obj) {
  * @returns {MyGame.Example.Stat}
  */
 MyGame.Example.Stat.getSizePrefixedRootAsStat = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new MyGame.Example.Stat).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
@@ -918,6 +922,7 @@ MyGame.Example.Referrable.getRootAsReferrable = function(bb, obj) {
  * @returns {MyGame.Example.Referrable}
  */
 MyGame.Example.Referrable.getSizePrefixedRootAsReferrable = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new MyGame.Example.Referrable).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
@@ -1022,6 +1027,7 @@ MyGame.Example.Monster.getRootAsMonster = function(bb, obj) {
  * @returns {MyGame.Example.Monster}
  */
 MyGame.Example.Monster.getSizePrefixedRootAsMonster = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new MyGame.Example.Monster).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
@@ -2833,6 +2839,7 @@ MyGame.Example.TypeAliases.getRootAsTypeAliases = function(bb, obj) {
  * @returns {MyGame.Example.TypeAliases}
  */
 MyGame.Example.TypeAliases.getSizePrefixedRootAsTypeAliases = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new MyGame.Example.TypeAliases).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 

--- a/tests/monster_test_generated.ts
+++ b/tests/monster_test_generated.ts
@@ -90,7 +90,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):InParentNamespace {
  * @returns InParentNamespace
  */
 static getRootAsInParentNamespace(bb:flatbuffers.ByteBuffer, obj?:InParentNamespace):InParentNamespace {
-  return (obj || new InParentNamespace).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new InParentNamespace()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -99,7 +99,8 @@ static getRootAsInParentNamespace(bb:flatbuffers.ByteBuffer, obj?:InParentNamesp
  * @returns InParentNamespace
  */
 static getSizePrefixedRootAsInParentNamespace(bb:flatbuffers.ByteBuffer, obj?:InParentNamespace):InParentNamespace {
-  return (obj || new InParentNamespace).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new InParentNamespace()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -149,7 +150,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):Monster {
  * @returns Monster
  */
 static getRootAsMonster(bb:flatbuffers.ByteBuffer, obj?:Monster):Monster {
-  return (obj || new Monster).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new Monster()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -158,7 +159,8 @@ static getRootAsMonster(bb:flatbuffers.ByteBuffer, obj?:Monster):Monster {
  * @returns Monster
  */
 static getSizePrefixedRootAsMonster(bb:flatbuffers.ByteBuffer, obj?:Monster):Monster {
-  return (obj || new Monster).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new Monster()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -287,7 +289,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):TestSimpleTableWithEnum {
  * @returns TestSimpleTableWithEnum
  */
 static getRootAsTestSimpleTableWithEnum(bb:flatbuffers.ByteBuffer, obj?:TestSimpleTableWithEnum):TestSimpleTableWithEnum {
-  return (obj || new TestSimpleTableWithEnum).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new TestSimpleTableWithEnum()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -296,7 +298,8 @@ static getRootAsTestSimpleTableWithEnum(bb:flatbuffers.ByteBuffer, obj?:TestSimp
  * @returns TestSimpleTableWithEnum
  */
 static getSizePrefixedRootAsTestSimpleTableWithEnum(bb:flatbuffers.ByteBuffer, obj?:TestSimpleTableWithEnum):TestSimpleTableWithEnum {
-  return (obj || new TestSimpleTableWithEnum).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new TestSimpleTableWithEnum()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -487,7 +490,7 @@ mutate_test2(value:MyGame.Example.Color):boolean {
  * @returns MyGame.Example.Test|null
  */
 test3(obj?:MyGame.Example.Test):MyGame.Example.Test|null {
-  return (obj || new MyGame.Example.Test).__init(this.bb_pos + 26, this.bb!);
+  return (obj || new MyGame.Example.Test()).__init(this.bb_pos + 26, this.bb!);
 };
 
 /**
@@ -623,7 +626,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):Stat {
  * @returns Stat
  */
 static getRootAsStat(bb:flatbuffers.ByteBuffer, obj?:Stat):Stat {
-  return (obj || new Stat).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new Stat()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -632,7 +635,8 @@ static getRootAsStat(bb:flatbuffers.ByteBuffer, obj?:Stat):Stat {
  * @returns Stat
  */
 static getSizePrefixedRootAsStat(bb:flatbuffers.ByteBuffer, obj?:Stat):Stat {
-  return (obj || new Stat).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new Stat()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -766,7 +770,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):Referrable {
  * @returns Referrable
  */
 static getRootAsReferrable(bb:flatbuffers.ByteBuffer, obj?:Referrable):Referrable {
-  return (obj || new Referrable).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new Referrable()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -775,7 +779,8 @@ static getRootAsReferrable(bb:flatbuffers.ByteBuffer, obj?:Referrable):Referrabl
  * @returns Referrable
  */
 static getSizePrefixedRootAsReferrable(bb:flatbuffers.ByteBuffer, obj?:Referrable):Referrable {
-  return (obj || new Referrable).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new Referrable()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -859,7 +864,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):Monster {
  * @returns Monster
  */
 static getRootAsMonster(bb:flatbuffers.ByteBuffer, obj?:Monster):Monster {
-  return (obj || new Monster).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new Monster()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -868,7 +873,8 @@ static getRootAsMonster(bb:flatbuffers.ByteBuffer, obj?:Monster):Monster {
  * @returns Monster
  */
 static getSizePrefixedRootAsMonster(bb:flatbuffers.ByteBuffer, obj?:Monster):Monster {
-  return (obj || new Monster).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new Monster()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -885,7 +891,7 @@ static bufferHasIdentifier(bb:flatbuffers.ByteBuffer):boolean {
  */
 pos(obj?:MyGame.Example.Vec3):MyGame.Example.Vec3|null {
   var offset = this.bb!.__offset(this.bb_pos, 4);
-  return offset ? (obj || new MyGame.Example.Vec3).__init(this.bb_pos + offset, this.bb!) : null;
+  return offset ? (obj || new MyGame.Example.Vec3()).__init(this.bb_pos + offset, this.bb!) : null;
 };
 
 /**
@@ -1017,7 +1023,7 @@ test<T extends flatbuffers.Table>(obj:T):T|null {
  */
 test4(index: number, obj?:MyGame.Example.Test):MyGame.Example.Test|null {
   var offset = this.bb!.__offset(this.bb_pos, 22);
-  return offset ? (obj || new MyGame.Example.Test).__init(this.bb!.__vector(this.bb_pos + offset) + index * 4, this.bb!) : null;
+  return offset ? (obj || new MyGame.Example.Test()).__init(this.bb!.__vector(this.bb_pos + offset) + index * 4, this.bb!) : null;
 };
 
 /**
@@ -1058,7 +1064,7 @@ testarrayofstringLength():number {
  */
 testarrayoftables(index: number, obj?:MyGame.Example.Monster):MyGame.Example.Monster|null {
   var offset = this.bb!.__offset(this.bb_pos, 26);
-  return offset ? (obj || new MyGame.Example.Monster).__init(this.bb!.__indirect(this.bb!.__vector(this.bb_pos + offset) + index * 4), this.bb!) : null;
+  return offset ? (obj || new MyGame.Example.Monster()).__init(this.bb!.__indirect(this.bb!.__vector(this.bb_pos + offset) + index * 4), this.bb!) : null;
 };
 
 /**
@@ -1075,7 +1081,7 @@ testarrayoftablesLength():number {
  */
 enemy(obj?:MyGame.Example.Monster):MyGame.Example.Monster|null {
   var offset = this.bb!.__offset(this.bb_pos, 28);
-  return offset ? (obj || new MyGame.Example.Monster).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
+  return offset ? (obj || new MyGame.Example.Monster()).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
 };
 
 /**
@@ -1109,7 +1115,7 @@ testnestedflatbufferArray():Uint8Array|null {
  */
 testempty(obj?:MyGame.Example.Stat):MyGame.Example.Stat|null {
   var offset = this.bb!.__offset(this.bb_pos, 32);
-  return offset ? (obj || new MyGame.Example.Stat).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
+  return offset ? (obj || new MyGame.Example.Stat()).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
 };
 
 /**
@@ -1440,7 +1446,7 @@ testarrayofstring2Length():number {
  */
 testarrayofsortedstruct(index: number, obj?:MyGame.Example.Ability):MyGame.Example.Ability|null {
   var offset = this.bb!.__offset(this.bb_pos, 62);
-  return offset ? (obj || new MyGame.Example.Ability).__init(this.bb!.__vector(this.bb_pos + offset) + index * 8, this.bb!) : null;
+  return offset ? (obj || new MyGame.Example.Ability()).__init(this.bb!.__vector(this.bb_pos + offset) + index * 8, this.bb!) : null;
 };
 
 /**
@@ -1483,7 +1489,7 @@ flexArray():Uint8Array|null {
  */
 test5(index: number, obj?:MyGame.Example.Test):MyGame.Example.Test|null {
   var offset = this.bb!.__offset(this.bb_pos, 66);
-  return offset ? (obj || new MyGame.Example.Test).__init(this.bb!.__vector(this.bb_pos + offset) + index * 4, this.bb!) : null;
+  return offset ? (obj || new MyGame.Example.Test()).__init(this.bb!.__vector(this.bb_pos + offset) + index * 4, this.bb!) : null;
 };
 
 /**
@@ -1542,7 +1548,7 @@ vectorOfDoublesArray():Float64Array|null {
  */
 parentNamespaceTest(obj?:MyGame.InParentNamespace):MyGame.InParentNamespace|null {
   var offset = this.bb!.__offset(this.bb_pos, 72);
-  return offset ? (obj || new MyGame.InParentNamespace).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
+  return offset ? (obj || new MyGame.InParentNamespace()).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
 };
 
 /**
@@ -1552,7 +1558,7 @@ parentNamespaceTest(obj?:MyGame.InParentNamespace):MyGame.InParentNamespace|null
  */
 vectorOfReferrables(index: number, obj?:MyGame.Example.Referrable):MyGame.Example.Referrable|null {
   var offset = this.bb!.__offset(this.bb_pos, 74);
-  return offset ? (obj || new MyGame.Example.Referrable).__init(this.bb!.__indirect(this.bb!.__vector(this.bb_pos + offset) + index * 4), this.bb!) : null;
+  return offset ? (obj || new MyGame.Example.Referrable()).__init(this.bb!.__indirect(this.bb!.__vector(this.bb_pos + offset) + index * 4), this.bb!) : null;
 };
 
 /**
@@ -1610,7 +1616,7 @@ vectorOfWeakReferencesLength():number {
  */
 vectorOfStrongReferrables(index: number, obj?:MyGame.Example.Referrable):MyGame.Example.Referrable|null {
   var offset = this.bb!.__offset(this.bb_pos, 80);
-  return offset ? (obj || new MyGame.Example.Referrable).__init(this.bb!.__indirect(this.bb!.__vector(this.bb_pos + offset) + index * 4), this.bb!) : null;
+  return offset ? (obj || new MyGame.Example.Referrable()).__init(this.bb!.__indirect(this.bb!.__vector(this.bb_pos + offset) + index * 4), this.bb!) : null;
 };
 
 /**
@@ -2618,7 +2624,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):TypeAliases {
  * @returns TypeAliases
  */
 static getRootAsTypeAliases(bb:flatbuffers.ByteBuffer, obj?:TypeAliases):TypeAliases {
-  return (obj || new TypeAliases).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new TypeAliases()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -2627,7 +2633,8 @@ static getRootAsTypeAliases(bb:flatbuffers.ByteBuffer, obj?:TypeAliases):TypeAli
  * @returns TypeAliases
  */
 static getSizePrefixedRootAsTypeAliases(bb:flatbuffers.ByteBuffer, obj?:TypeAliases):TypeAliases {
-  return (obj || new TypeAliases).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new TypeAliases()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**

--- a/tests/namespace_test/namespace_test1_generated.js
+++ b/tests/namespace_test/namespace_test1_generated.js
@@ -71,6 +71,7 @@ NamespaceA.NamespaceB.TableInNestedNS.getRootAsTableInNestedNS = function(bb, ob
  * @returns {NamespaceA.NamespaceB.TableInNestedNS}
  */
 NamespaceA.NamespaceB.TableInNestedNS.getSizePrefixedRootAsTableInNestedNS = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new NamespaceA.NamespaceB.TableInNestedNS).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 

--- a/tests/namespace_test/namespace_test1_generated.ts
+++ b/tests/namespace_test/namespace_test1_generated.ts
@@ -35,7 +35,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):TableInNestedNS {
  * @returns TableInNestedNS
  */
 static getRootAsTableInNestedNS(bb:flatbuffers.ByteBuffer, obj?:TableInNestedNS):TableInNestedNS {
-  return (obj || new TableInNestedNS).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new TableInNestedNS()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -44,7 +44,8 @@ static getRootAsTableInNestedNS(bb:flatbuffers.ByteBuffer, obj?:TableInNestedNS)
  * @returns TableInNestedNS
  */
 static getSizePrefixedRootAsTableInNestedNS(bb:flatbuffers.ByteBuffer, obj?:TableInNestedNS):TableInNestedNS {
-  return (obj || new TableInNestedNS).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new TableInNestedNS()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**

--- a/tests/namespace_test/namespace_test2_generated.js
+++ b/tests/namespace_test/namespace_test2_generated.js
@@ -59,6 +59,7 @@ NamespaceA.TableInFirstNS.getRootAsTableInFirstNS = function(bb, obj) {
  * @returns {NamespaceA.TableInFirstNS}
  */
 NamespaceA.TableInFirstNS.getSizePrefixedRootAsTableInFirstNS = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new NamespaceA.TableInFirstNS).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
@@ -199,6 +200,7 @@ NamespaceC.TableInC.getRootAsTableInC = function(bb, obj) {
  * @returns {NamespaceC.TableInC}
  */
 NamespaceC.TableInC.getSizePrefixedRootAsTableInC = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new NamespaceC.TableInC).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
@@ -306,6 +308,7 @@ NamespaceA.SecondTableInA.getRootAsSecondTableInA = function(bb, obj) {
  * @returns {NamespaceA.SecondTableInA}
  */
 NamespaceA.SecondTableInA.getSizePrefixedRootAsSecondTableInA = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new NamespaceA.SecondTableInA).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 

--- a/tests/namespace_test/namespace_test2_generated.ts
+++ b/tests/namespace_test/namespace_test2_generated.ts
@@ -26,7 +26,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):TableInFirstNS {
  * @returns TableInFirstNS
  */
 static getRootAsTableInFirstNS(bb:flatbuffers.ByteBuffer, obj?:TableInFirstNS):TableInFirstNS {
-  return (obj || new TableInFirstNS).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new TableInFirstNS()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -35,7 +35,8 @@ static getRootAsTableInFirstNS(bb:flatbuffers.ByteBuffer, obj?:TableInFirstNS):T
  * @returns TableInFirstNS
  */
 static getSizePrefixedRootAsTableInFirstNS(bb:flatbuffers.ByteBuffer, obj?:TableInFirstNS):TableInFirstNS {
-  return (obj || new TableInFirstNS).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new TableInFirstNS()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -44,7 +45,7 @@ static getSizePrefixedRootAsTableInFirstNS(bb:flatbuffers.ByteBuffer, obj?:Table
  */
 fooTable(obj?:NS8755221360535654258.NamespaceA.NamespaceB.TableInNestedNS):NS8755221360535654258.NamespaceA.NamespaceB.TableInNestedNS|null {
   var offset = this.bb!.__offset(this.bb_pos, 4);
-  return offset ? (obj || new NS8755221360535654258.NamespaceA.NamespaceB.TableInNestedNS).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
+  return offset ? (obj || new NS8755221360535654258.NamespaceA.NamespaceB.TableInNestedNS()).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
 };
 
 /**
@@ -76,7 +77,7 @@ mutate_foo_enum(value:NS8755221360535654258.NamespaceA.NamespaceB.EnumInNestedNS
  */
 fooStruct(obj?:NS8755221360535654258.NamespaceA.NamespaceB.StructInNestedNS):NS8755221360535654258.NamespaceA.NamespaceB.StructInNestedNS|null {
   var offset = this.bb!.__offset(this.bb_pos, 8);
-  return offset ? (obj || new NS8755221360535654258.NamespaceA.NamespaceB.StructInNestedNS).__init(this.bb_pos + offset, this.bb!) : null;
+  return offset ? (obj || new NS8755221360535654258.NamespaceA.NamespaceB.StructInNestedNS()).__init(this.bb_pos + offset, this.bb!) : null;
 };
 
 /**
@@ -153,7 +154,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):TableInC {
  * @returns TableInC
  */
 static getRootAsTableInC(bb:flatbuffers.ByteBuffer, obj?:TableInC):TableInC {
-  return (obj || new TableInC).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new TableInC()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -162,7 +163,8 @@ static getRootAsTableInC(bb:flatbuffers.ByteBuffer, obj?:TableInC):TableInC {
  * @returns TableInC
  */
 static getSizePrefixedRootAsTableInC(bb:flatbuffers.ByteBuffer, obj?:TableInC):TableInC {
-  return (obj || new TableInC).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new TableInC()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -171,7 +173,7 @@ static getSizePrefixedRootAsTableInC(bb:flatbuffers.ByteBuffer, obj?:TableInC):T
  */
 referToA1(obj?:NamespaceA.TableInFirstNS):NamespaceA.TableInFirstNS|null {
   var offset = this.bb!.__offset(this.bb_pos, 4);
-  return offset ? (obj || new NamespaceA.TableInFirstNS).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
+  return offset ? (obj || new NamespaceA.TableInFirstNS()).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
 };
 
 /**
@@ -180,7 +182,7 @@ referToA1(obj?:NamespaceA.TableInFirstNS):NamespaceA.TableInFirstNS|null {
  */
 referToA2(obj?:NamespaceA.SecondTableInA):NamespaceA.SecondTableInA|null {
   var offset = this.bb!.__offset(this.bb_pos, 6);
-  return offset ? (obj || new NamespaceA.SecondTableInA).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
+  return offset ? (obj || new NamespaceA.SecondTableInA()).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
 };
 
 /**
@@ -248,7 +250,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):SecondTableInA {
  * @returns SecondTableInA
  */
 static getRootAsSecondTableInA(bb:flatbuffers.ByteBuffer, obj?:SecondTableInA):SecondTableInA {
-  return (obj || new SecondTableInA).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new SecondTableInA()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -257,7 +259,8 @@ static getRootAsSecondTableInA(bb:flatbuffers.ByteBuffer, obj?:SecondTableInA):S
  * @returns SecondTableInA
  */
 static getSizePrefixedRootAsSecondTableInA(bb:flatbuffers.ByteBuffer, obj?:SecondTableInA):SecondTableInA {
-  return (obj || new SecondTableInA).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new SecondTableInA()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -266,7 +269,7 @@ static getSizePrefixedRootAsSecondTableInA(bb:flatbuffers.ByteBuffer, obj?:Secon
  */
 referToC(obj?:NamespaceC.TableInC):NamespaceC.TableInC|null {
   var offset = this.bb!.__offset(this.bb_pos, 4);
-  return offset ? (obj || new NamespaceC.TableInC).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
+  return offset ? (obj || new NamespaceC.TableInC()).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
 };
 
 /**

--- a/tests/union_vector/union_vector_generated.js
+++ b/tests/union_vector/union_vector_generated.js
@@ -67,6 +67,7 @@ Attacker.getRootAsAttacker = function(bb, obj) {
  * @returns {Attacker}
  */
 Attacker.getSizePrefixedRootAsAttacker = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new Attacker).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
@@ -287,6 +288,7 @@ Movie.getRootAsMovie = function(bb, obj) {
  * @returns {Movie}
  */
 Movie.getSizePrefixedRootAsMovie = function(bb, obj) {
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
   return (obj || new Movie).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 

--- a/tests/union_vector/union_vector_generated.ts
+++ b/tests/union_vector/union_vector_generated.ts
@@ -37,7 +37,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):Attacker {
  * @returns Attacker
  */
 static getRootAsAttacker(bb:flatbuffers.ByteBuffer, obj?:Attacker):Attacker {
-  return (obj || new Attacker).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new Attacker()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -46,7 +46,8 @@ static getRootAsAttacker(bb:flatbuffers.ByteBuffer, obj?:Attacker):Attacker {
  * @returns Attacker
  */
 static getSizePrefixedRootAsAttacker(bb:flatbuffers.ByteBuffer, obj?:Attacker):Attacker {
-  return (obj || new Attacker).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new Attacker()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -230,7 +231,7 @@ __init(i:number, bb:flatbuffers.ByteBuffer):Movie {
  * @returns Movie
  */
 static getRootAsMovie(bb:flatbuffers.ByteBuffer, obj?:Movie):Movie {
-  return (obj || new Movie).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  return (obj || new Movie()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**
@@ -239,7 +240,8 @@ static getRootAsMovie(bb:flatbuffers.ByteBuffer, obj?:Movie):Movie {
  * @returns Movie
  */
 static getSizePrefixedRootAsMovie(bb:flatbuffers.ByteBuffer, obj?:Movie):Movie {
-  return (obj || new Movie).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+  bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+  return (obj || new Movie()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 };
 
 /**


### PR DESCRIPTION
It seems the size-prefixed root accessors aren't taking into account the size prefix.

I'm not sure if this is the right fix, but 

Also, this change adds parentheses after new object expressions for Typescript generated code. (ie, `new MyGame.Example.Monster()` instead of `new MyGame.Example.Monster`).