### PR TITLE
[snap] Fix versioning

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,8 +26,6 @@ parts:
       - -DCMAKE_BUILD_TYPE=Release
     build-packages:
       - g++
-      # used to set version number
-      - git
 
 apps:
   flatc:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,6 @@
 name: flatbuffers
 base: core18
-version: latest
-version-script: git describe --always | sed -e 's/-/+git/;y/-/./' | tail -c +2
+version: git
 summary: FlatBuffers compiler
 description: |
   FlatBuffers compiler


### PR DESCRIPTION
A recent (?) change to the way how a new version is tagged for flatbuffers broke snap build. This PR fixes that.