### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/source/Building.md
+++ b/docs/source/Building.md
@@ -29,6 +29,19 @@ Building should also produce two sample executables, `flatsamplebinary` and
 *Note that you MUST be in the root of the FlatBuffers distribution when you
 run 'flattests' or `flatsampletext`, or it will fail to load its files.*
 
+### Building with VCPKG
+
+You can download and install flatbuffers using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install flatbuffers
+
+The flatbuffers port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Building for Android
 
 There is a `flatbuffers/android` directory that contains all you need to build

--- a/docs/source/Building.md
+++ b/docs/source/Building.md
@@ -29,7 +29,7 @@ Building should also produce two sample executables, `flatsamplebinary` and
 *Note that you MUST be in the root of the FlatBuffers distribution when you
 run 'flattests' or `flatsampletext`, or it will fail to load its files.*
 
-### Building with VCPKG
+## Building with VCPKG
 
 You can download and install flatbuffers using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
 


### PR DESCRIPTION
Flatbuffers is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build flatbuffers, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for flatbuffers and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.