### PR TITLE
rust: pub export the VectorIter type

### DIFF
--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -46,7 +46,7 @@ pub use follow::{Follow, FollowStart};
 pub use primitives::*;
 pub use push::Push;
 pub use table::{buffer_has_identifier, get_root, get_size_prefixed_root, Table};
-pub use vector::{follow_cast_ref, SafeSliceAccess, Vector};
+pub use vector::{follow_cast_ref, SafeSliceAccess, Vector, VectorIter};
 pub use vtable::field_index_to_field_offset;
 
 // TODO(rw): Unify `create_vector` and `create_vector_direct` by using

--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -154,6 +154,7 @@ impl<'a, T: Follow<'a> + 'a> Follow<'a> for Vector<'a, T> {
     }
 }
 
+/// An iterator over a `Vector`.
 #[derive(Debug)]
 pub struct VectorIter<'a, T: 'a> {
     buf: &'a [u8],


### PR DESCRIPTION
Fix the missing import.