### PR TITLE
[C++] Use strong enum type for vectors when scoped-enums is on.

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2638,7 +2638,8 @@ class CppGenerator : public BaseGenerator {
             break;
           }
           default: {
-            if (field.value.type.enum_def && !opts_.scoped_enums) {
+            if (field.value.type.enum_def &&
+                !VectorElementUserFacing(vector_type)) {
               // For enumerations, we need to get access to the array data for
               // the underlying storage type (eg. uint8_t).
               const auto basetype = GenTypeBasic(

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -629,7 +629,9 @@ class CppGenerator : public BaseGenerator {
     // Normally, in non-Object-API, we use the non-user-facing type when
     // emitting the Vector element type, however in the case of enums
     // we want to avoid that when using scoped-enums.
-    return opts_.scoped_enums && IsEnum(type);
+    return opts_.g_cpp_std >= cpp::CPP_STD_17 &&
+           opts_.scoped_enums &&
+           IsEnum(type);
   }
 
   void GenComment(const std::vector<std::string> &dc, const char *prefix = "") {

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -626,11 +626,8 @@ class CppGenerator : public BaseGenerator {
   }
 
   bool VectorElementUserFacing(const Type& type) const {
-    // Normally, in non-Object-API, we use the non-user-facing type when
-    // emitting the Vector element type, however in the case of enums
-    // we want to avoid that when using scoped-enums.
     return opts_.g_cpp_std >= cpp::CPP_STD_17 &&
-           opts_.scoped_enums &&
+           opts_.g_only_fixed_enums &&
            IsEnum(type);
   }
 

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -1411,11 +1411,11 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   void *mutable_any_ambiguous() {
     return GetPointer<void *>(VT_ANY_AMBIGUOUS);
   }
-  const flatbuffers::Vector<uint8_t> *vector_of_enums() const {
-    return GetPointer<const flatbuffers::Vector<uint8_t> *>(VT_VECTOR_OF_ENUMS);
+  const flatbuffers::Vector<MyGame::Example::Color> *vector_of_enums() const {
+    return GetPointer<const flatbuffers::Vector<MyGame::Example::Color> *>(VT_VECTOR_OF_ENUMS);
   }
-  flatbuffers::Vector<uint8_t> *mutable_vector_of_enums() {
-    return GetPointer<flatbuffers::Vector<uint8_t> *>(VT_VECTOR_OF_ENUMS);
+  flatbuffers::Vector<MyGame::Example::Color> *mutable_vector_of_enums() {
+    return GetPointer<flatbuffers::Vector<MyGame::Example::Color> *>(VT_VECTOR_OF_ENUMS);
   }
   MyGame::Example::Race signed_enum() const {
     return static_cast<MyGame::Example::Race>(GetField<int8_t>(VT_SIGNED_ENUM, -1));
@@ -1676,7 +1676,7 @@ struct MonsterBuilder {
   void add_any_ambiguous(flatbuffers::Offset<void> any_ambiguous) {
     fbb_.AddOffset(Monster::VT_ANY_AMBIGUOUS, any_ambiguous);
   }
-  void add_vector_of_enums(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> vector_of_enums) {
+  void add_vector_of_enums(flatbuffers::Offset<flatbuffers::Vector<MyGame::Example::Color>> vector_of_enums) {
     fbb_.AddOffset(Monster::VT_VECTOR_OF_ENUMS, vector_of_enums);
   }
   void add_signed_enum(MyGame::Example::Race signed_enum) {
@@ -1743,7 +1743,7 @@ inline flatbuffers::Offset<Monster> CreateMonster(
     flatbuffers::Offset<void> any_unique = 0,
     MyGame::Example::AnyAmbiguousAliases any_ambiguous_type = MyGame::Example::AnyAmbiguousAliases::NONE,
     flatbuffers::Offset<void> any_ambiguous = 0,
-    flatbuffers::Offset<flatbuffers::Vector<uint8_t>> vector_of_enums = 0,
+    flatbuffers::Offset<flatbuffers::Vector<MyGame::Example::Color>> vector_of_enums = 0,
     MyGame::Example::Race signed_enum = MyGame::Example::Race::None) {
   MonsterBuilder builder_(_fbb);
   builder_.add_non_owning_reference(non_owning_reference);
@@ -1850,7 +1850,7 @@ inline flatbuffers::Offset<Monster> CreateMonsterDirect(
     flatbuffers::Offset<void> any_unique = 0,
     MyGame::Example::AnyAmbiguousAliases any_ambiguous_type = MyGame::Example::AnyAmbiguousAliases::NONE,
     flatbuffers::Offset<void> any_ambiguous = 0,
-    const std::vector<uint8_t> *vector_of_enums = nullptr,
+    const std::vector<MyGame::Example::Color> *vector_of_enums = nullptr,
     MyGame::Example::Race signed_enum = MyGame::Example::Race::None) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
   auto inventory__ = inventory ? _fbb.CreateVector<uint8_t>(*inventory) : 0;
@@ -1870,7 +1870,7 @@ inline flatbuffers::Offset<Monster> CreateMonsterDirect(
   auto vector_of_strong_referrables__ = vector_of_strong_referrables ? _fbb.CreateVectorOfSortedTables<MyGame::Example::Referrable>(vector_of_strong_referrables) : 0;
   auto vector_of_co_owning_references__ = vector_of_co_owning_references ? _fbb.CreateVector<uint64_t>(*vector_of_co_owning_references) : 0;
   auto vector_of_non_owning_references__ = vector_of_non_owning_references ? _fbb.CreateVector<uint64_t>(*vector_of_non_owning_references) : 0;
-  auto vector_of_enums__ = vector_of_enums ? _fbb.CreateVector<uint8_t>(*vector_of_enums) : 0;
+  auto vector_of_enums__ = vector_of_enums ? _fbb.CreateVector<MyGame::Example::Color>(*vector_of_enums) : 0;
   return MyGame::Example::CreateMonster(
       _fbb,
       pos,
@@ -2448,7 +2448,7 @@ inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder
   auto _any_unique = _o->any_unique.Pack(_fbb);
   auto _any_ambiguous_type = _o->any_ambiguous.type;
   auto _any_ambiguous = _o->any_ambiguous.Pack(_fbb);
-  auto _vector_of_enums = _o->vector_of_enums.size() ? _fbb.CreateVectorScalarCast<uint8_t>(flatbuffers::data(_o->vector_of_enums), _o->vector_of_enums.size()) : 0;
+  auto _vector_of_enums = _o->vector_of_enums.size() ? _fbb.CreateVector(_o->vector_of_enums) : 0;
   auto _signed_enum = _o->signed_enum;
   return MyGame::Example::CreateMonster(
       _fbb,


### PR DESCRIPTION
These changes only apply when scoped-enums is on, and thus only
the C++17 tests show diffs.

This may break users who use 1) use scoped-enums and 2) use
vectors of enums.  However, it seems that this change should
have been made originally when scoped-enums were added.

Fixes #5285