### PR TITLE
Fixed refactoring issue in reflection/generate_code.sh

### DIFF
--- a/reflection/generate_code.sh
+++ b/reflection/generate_code.sh
@@ -23,8 +23,9 @@ newFile="$tempDir/reflection_generated.h"
 
 if [ -f "$newFile" ]; then
   if ! cmp -s "$originalFile" "$newFile"; then
-    mv $newFile $original
+    mv $newFile $originalFile
+  else
+    rm $newFile
   fi
-  rm $newFile
   rmdir $tempDir
 fi


### PR DESCRIPTION
For #5776 I tested and then refactored the code, and missed a $original -> $originalFile conversion. This fixes that oversight.

Also, the `mv` command deletes the first file, so I don't need to delete it explicitly with `rm`, which causes the .tmp/ directory to not be deleted because the `rm $newFile` command fails.

Fix: #5776