### PR TITLE
Permit equal enumerators

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1968,12 +1968,12 @@ struct EnumValBuilder {
     if (enum_def.IsUInt64()) {
       uint64_t u64;
       fit = StringToNumber(value.c_str(), &u64);
-      ascending = u64 > temp->GetAsUInt64();
+      ascending = u64 >= temp->GetAsUInt64();
       temp->value = static_cast<int64_t>(u64);  // well-defined since C++20.
     } else {
       int64_t i64;
       fit = StringToNumber(value.c_str(), &i64);
-      ascending = i64 > temp->GetAsInt64();
+      ascending = i64 >= temp->GetAsInt64();
       temp->value = i64;
     }
     if (!fit) return parser.Error("enum value does not fit, \"" + value + "\"");


### PR DESCRIPTION
Languages like C++ allow enums to be declared with equal values, which
allows for declaring enum types like:

```
enum foo {
    CATEGORY_A_BEGIN = 128,
    CATEGORY_A_FIRST = 128,
    ...
    CATEGORY_A_LAST = 256,
    CATEGORY_A_END = 256,
    ...
}
```

and usage like:

```
if (foo_value >= CATEGORY_A_BEGIN && foo_value <= CATEGORY_A_END) {
    // do things relevant to category A values
}
```
This change allows for the expression of similar patterns in flatbuffers enumerations.