### PR TITLE
[C#] add ObjectAPI Serialization Utility

### DIFF
--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -1997,7 +1997,7 @@ class CSharpGenerator : public BaseGenerator {
               "(new ByteBuffer(fbBuffer)).UnPack();\n";
       code += "  }\n";
       code += "  public byte[] SerializeToFlatBuffers() {\n";
-      code += "    var fbb = new FlatBufferBuilder(1);\n";
+      code += "    var fbb = new FlatBufferBuilder(0x10000);\n";
       code +=
           "    fbb.Finish(" + struct_def.name + ".Pack(fbb, this).Value);\n";
       code += "    return fbb.DataBuffer.ToSizedArray();\n";

--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -1990,6 +1990,19 @@ class CSharpGenerator : public BaseGenerator {
           "Newtonsoft.Json.Formatting.Indented);\n";
       code += "  }\n";
     }
+    if (parser_.root_struct_def_ == &struct_def) {
+      code += "  public static " + class_name +
+              " DeserializeFromFlatBuffers(byte[] fbBuffer) {\n";
+      code += "    return " + struct_def.name + ".GetRootAs" + struct_def.name +
+              "(new ByteBuffer(fbBuffer)).UnPack();\n";
+      code += "  }\n";
+      code += "  public byte[] SerializeToFlatBuffers() {\n";
+      code += "    var fbb = new FlatBufferBuilder(1);\n";
+      code +=
+          "    fbb.Finish(" + struct_def.name + ".Pack(fbb, this).Value);\n";
+      code += "    return fbb.DataBuffer.ToSizedArray();\n";
+      code += "  }\n";
+    }
     code += "}\n\n";
   }
 

--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -1992,11 +1992,11 @@ class CSharpGenerator : public BaseGenerator {
     }
     if (parser_.root_struct_def_ == &struct_def) {
       code += "  public static " + class_name +
-              " DeserializeFromFlatBuffers(byte[] fbBuffer) {\n";
+              " DeserializeFromBinary(byte[] fbBuffer) {\n";
       code += "    return " + struct_def.name + ".GetRootAs" + struct_def.name +
               "(new ByteBuffer(fbBuffer)).UnPack();\n";
       code += "  }\n";
-      code += "  public byte[] SerializeToFlatBuffers() {\n";
+      code += "  public byte[] SerializeToBinary() {\n";
       code += "    var fbb = new FlatBufferBuilder(0x10000);\n";
       code +=
           "    fbb.Finish(" + struct_def.name + ".Pack(fbb, this).Value);\n";

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -674,8 +674,8 @@ namespace FlatBuffers.Test
             var d = MonsterT.DeserializeFromJson(jsonText);
             AreEqual(a, d);
 
-            var fbBuffer = b.SerializeToFlatBuffers();
-            var e = MonsterT.DeserializeFromFlatBuffers(fbBuffer);
+            var fbBuffer = b.SerializeToBinary();
+            var e = MonsterT.DeserializeFromBinary(fbBuffer);
             AreEqual(a, e);
         }
 
@@ -777,8 +777,8 @@ namespace FlatBuffers.Test
             var d = ArrayTableT.DeserializeFromJson(jsonText);
             AreEqual(a, d);
 
-            var fbBuffer = b.SerializeToFlatBuffers();
-            var e = ArrayTableT.DeserializeFromFlatBuffers(fbBuffer);
+            var fbBuffer = b.SerializeToBinary();
+            var e = ArrayTableT.DeserializeFromBinary(fbBuffer);
             AreEqual(a, e);
         }
 
@@ -824,8 +824,8 @@ namespace FlatBuffers.Test
             var d = MovieT.DeserializeFromJson(jsonText);
             AreEqual(a, d);
 
-            var fbBuffer = b.SerializeToFlatBuffers();
-            var e = MovieT.DeserializeFromFlatBuffers(fbBuffer);
+            var fbBuffer = b.SerializeToBinary();
+            var e = MovieT.DeserializeFromBinary(fbBuffer);
             AreEqual(a, e);
         }
     }

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -673,6 +673,10 @@ namespace FlatBuffers.Test
             var jsonText = b.SerializeToJson();
             var d = MonsterT.DeserializeFromJson(jsonText);
             AreEqual(a, d);
+
+            var fbBuffer = b.SerializeToFlatBuffers();
+            var e = MonsterT.DeserializeFromFlatBuffers(fbBuffer);
+            AreEqual(a, e);
         }
 
         private void AreEqual(ArrayTable a, ArrayTableT b)
@@ -772,6 +776,10 @@ namespace FlatBuffers.Test
             var jsonText = b.SerializeToJson();
             var d = ArrayTableT.DeserializeFromJson(jsonText);
             AreEqual(a, d);
+
+            var fbBuffer = b.SerializeToFlatBuffers();
+            var e = ArrayTableT.DeserializeFromFlatBuffers(fbBuffer);
+            AreEqual(a, e);
         }
 
         private void AreEqual(Movie a, MovieT b)
@@ -815,6 +823,10 @@ namespace FlatBuffers.Test
             var jsonText = b.SerializeToJson();
             var d = MovieT.DeserializeFromJson(jsonText);
             AreEqual(a, d);
+
+            var fbBuffer = b.SerializeToFlatBuffers();
+            var e = MovieT.DeserializeFromFlatBuffers(fbBuffer);
+            AreEqual(a, e);
         }
     }
 }

--- a/tests/MyGame/Example/ArrayTable.cs
+++ b/tests/MyGame/Example/ArrayTable.cs
@@ -65,7 +65,7 @@ public class ArrayTableT
     return ArrayTable.GetRootAsArrayTable(new ByteBuffer(fbBuffer)).UnPack();
   }
   public byte[] SerializeToFlatBuffers() {
-    var fbb = new FlatBufferBuilder(1);
+    var fbb = new FlatBufferBuilder(0x10000);
     fbb.Finish(ArrayTable.Pack(fbb, this).Value);
     return fbb.DataBuffer.ToSizedArray();
   }

--- a/tests/MyGame/Example/ArrayTable.cs
+++ b/tests/MyGame/Example/ArrayTable.cs
@@ -61,10 +61,10 @@ public class ArrayTableT
   public string SerializeToJson() {
     return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
   }
-  public static ArrayTableT DeserializeFromFlatBuffers(byte[] fbBuffer) {
+  public static ArrayTableT DeserializeFromBinary(byte[] fbBuffer) {
     return ArrayTable.GetRootAsArrayTable(new ByteBuffer(fbBuffer)).UnPack();
   }
-  public byte[] SerializeToFlatBuffers() {
+  public byte[] SerializeToBinary() {
     var fbb = new FlatBufferBuilder(0x10000);
     fbb.Finish(ArrayTable.Pack(fbb, this).Value);
     return fbb.DataBuffer.ToSizedArray();

--- a/tests/MyGame/Example/ArrayTable.cs
+++ b/tests/MyGame/Example/ArrayTable.cs
@@ -61,6 +61,14 @@ public class ArrayTableT
   public string SerializeToJson() {
     return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
   }
+  public static ArrayTableT DeserializeFromFlatBuffers(byte[] fbBuffer) {
+    return ArrayTable.GetRootAsArrayTable(new ByteBuffer(fbBuffer)).UnPack();
+  }
+  public byte[] SerializeToFlatBuffers() {
+    var fbb = new FlatBufferBuilder(1);
+    fbb.Finish(ArrayTable.Pack(fbb, this).Value);
+    return fbb.DataBuffer.ToSizedArray();
+  }
 }
 
 

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -789,7 +789,7 @@ public class MonsterT
     return Monster.GetRootAsMonster(new ByteBuffer(fbBuffer)).UnPack();
   }
   public byte[] SerializeToFlatBuffers() {
-    var fbb = new FlatBufferBuilder(1);
+    var fbb = new FlatBufferBuilder(0x10000);
     fbb.Finish(Monster.Pack(fbb, this).Value);
     return fbb.DataBuffer.ToSizedArray();
   }

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -785,10 +785,10 @@ public class MonsterT
   public string SerializeToJson() {
     return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
   }
-  public static MonsterT DeserializeFromFlatBuffers(byte[] fbBuffer) {
+  public static MonsterT DeserializeFromBinary(byte[] fbBuffer) {
     return Monster.GetRootAsMonster(new ByteBuffer(fbBuffer)).UnPack();
   }
-  public byte[] SerializeToFlatBuffers() {
+  public byte[] SerializeToBinary() {
     var fbb = new FlatBufferBuilder(0x10000);
     fbb.Finish(Monster.Pack(fbb, this).Value);
     return fbb.DataBuffer.ToSizedArray();

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -785,6 +785,14 @@ public class MonsterT
   public string SerializeToJson() {
     return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
   }
+  public static MonsterT DeserializeFromFlatBuffers(byte[] fbBuffer) {
+    return Monster.GetRootAsMonster(new ByteBuffer(fbBuffer)).UnPack();
+  }
+  public byte[] SerializeToFlatBuffers() {
+    var fbb = new FlatBufferBuilder(1);
+    fbb.Finish(Monster.Pack(fbb, this).Value);
+    return fbb.DataBuffer.ToSizedArray();
+  }
 }
 
 

--- a/tests/MyGame/MonsterExtra.cs
+++ b/tests/MyGame/MonsterExtra.cs
@@ -195,7 +195,7 @@ public class MonsterExtraT
     return MonsterExtra.GetRootAsMonsterExtra(new ByteBuffer(fbBuffer)).UnPack();
   }
   public byte[] SerializeToFlatBuffers() {
-    var fbb = new FlatBufferBuilder(1);
+    var fbb = new FlatBufferBuilder(0x10000);
     fbb.Finish(MonsterExtra.Pack(fbb, this).Value);
     return fbb.DataBuffer.ToSizedArray();
   }

--- a/tests/MyGame/MonsterExtra.cs
+++ b/tests/MyGame/MonsterExtra.cs
@@ -191,10 +191,10 @@ public class MonsterExtraT
   public string SerializeToJson() {
     return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
   }
-  public static MonsterExtraT DeserializeFromFlatBuffers(byte[] fbBuffer) {
+  public static MonsterExtraT DeserializeFromBinary(byte[] fbBuffer) {
     return MonsterExtra.GetRootAsMonsterExtra(new ByteBuffer(fbBuffer)).UnPack();
   }
-  public byte[] SerializeToFlatBuffers() {
+  public byte[] SerializeToBinary() {
     var fbb = new FlatBufferBuilder(0x10000);
     fbb.Finish(MonsterExtra.Pack(fbb, this).Value);
     return fbb.DataBuffer.ToSizedArray();

--- a/tests/MyGame/MonsterExtra.cs
+++ b/tests/MyGame/MonsterExtra.cs
@@ -191,6 +191,14 @@ public class MonsterExtraT
   public string SerializeToJson() {
     return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
   }
+  public static MonsterExtraT DeserializeFromFlatBuffers(byte[] fbBuffer) {
+    return MonsterExtra.GetRootAsMonsterExtra(new ByteBuffer(fbBuffer)).UnPack();
+  }
+  public byte[] SerializeToFlatBuffers() {
+    var fbb = new FlatBufferBuilder(1);
+    fbb.Finish(MonsterExtra.Pack(fbb, this).Value);
+    return fbb.DataBuffer.ToSizedArray();
+  }
 }
 
 

--- a/tests/union_vector/Movie.cs
+++ b/tests/union_vector/Movie.cs
@@ -191,5 +191,13 @@ public class MovieT
   public string SerializeToJson() {
     return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
   }
+  public static MovieT DeserializeFromFlatBuffers(byte[] fbBuffer) {
+    return Movie.GetRootAsMovie(new ByteBuffer(fbBuffer)).UnPack();
+  }
+  public byte[] SerializeToFlatBuffers() {
+    var fbb = new FlatBufferBuilder(1);
+    fbb.Finish(Movie.Pack(fbb, this).Value);
+    return fbb.DataBuffer.ToSizedArray();
+  }
 }
 

--- a/tests/union_vector/Movie.cs
+++ b/tests/union_vector/Movie.cs
@@ -191,10 +191,10 @@ public class MovieT
   public string SerializeToJson() {
     return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
   }
-  public static MovieT DeserializeFromFlatBuffers(byte[] fbBuffer) {
+  public static MovieT DeserializeFromBinary(byte[] fbBuffer) {
     return Movie.GetRootAsMovie(new ByteBuffer(fbBuffer)).UnPack();
   }
-  public byte[] SerializeToFlatBuffers() {
+  public byte[] SerializeToBinary() {
     var fbb = new FlatBufferBuilder(0x10000);
     fbb.Finish(Movie.Pack(fbb, this).Value);
     return fbb.DataBuffer.ToSizedArray();

--- a/tests/union_vector/Movie.cs
+++ b/tests/union_vector/Movie.cs
@@ -195,7 +195,7 @@ public class MovieT
     return Movie.GetRootAsMovie(new ByteBuffer(fbBuffer)).UnPack();
   }
   public byte[] SerializeToFlatBuffers() {
-    var fbb = new FlatBufferBuilder(1);
+    var fbb = new FlatBufferBuilder(0x10000);
     fbb.Finish(Movie.Pack(fbb, this).Value);
     return fbb.DataBuffer.ToSizedArray();
   }


### PR DESCRIPTION
This PR adds Object-Based API Serialization Utility.

SerializeTo byte[] DeserializeFrom byte[] directly without `FlatBuffersBuilder` and `Pack, Unpack` methods.

### usage

```cs
MonsterT monster = new MonsterT();
byte[] fbBuffer = monster.SerializeToFlatBuffers();
var monster2 = MonsterT.DeserializeFromFlatBuffers(fbBuffer);
```
