### PR TITLE
Removes the inner loop to compare values in endtable

### DIFF
--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -118,7 +118,7 @@ public final class ByteBuffer {
     ///   - size: Size of Value being written to the buffer
     func push(struct value: UnsafeMutableRawPointer, size: Int) {
         ensureSpace(size: UInt32(size))
-        _memory.advanced(by: writerIndex - size).copyMemory(from: value, byteCount: size)
+        memcpy(_memory.advanced(by: writerIndex - size), value, size)
         defer { value.deallocate() }
         _writerSize += size
     }


### PR DESCRIPTION
The following PR 
- Removes the old way of comparing tables in the endtable function and replaces it with the cpp way of handling them. 
- Uses memcpy instead of the swift implementation for the CopyMemory function

-- this PR improves the internal swift implementation and won't affect anything in terms of the release of 1.12 @aardappel 