### PR TITLE
Fix interpretation of 'nan(number)' by the idl_parser

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1795,8 +1795,7 @@ class FlatBufferBuilder {
       return a.KeyCompareLessThan(&b);
     }
 
-   private:
-    StructKeyComparator &operator=(const StructKeyComparator &);
+    FLATBUFFERS_DELETE_FUNC(StructKeyComparator &operator=(const StructKeyComparator &))
   };
   /// @endcond
 

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -891,6 +891,7 @@ class Parser : public ParserState {
   FLATBUFFERS_CHECKED_ERROR TokenError();
   FLATBUFFERS_CHECKED_ERROR ParseSingleValue(const std::string *name, Value &e,
                                              bool check_now);
+  FLATBUFFERS_CHECKED_ERROR ParseFunction(const std::string *name, Value &e);
   FLATBUFFERS_CHECKED_ERROR ParseEnumFromString(const Type &type,
                                                 std::string *result);
   StructDef *LookupCreateStruct(const std::string &name,

--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -1,96 +1,134 @@
 cmake_minimum_required(VERSION 3.9)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 project(FlatBuffersFuzzerTests)
 
-set(CMAKE_CXX_FLAGS
-  "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -pedantic -Werror -Wextra -Wno-unused-parameter -fsigned-char")
-
-set(CMAKE_CXX_FLAGS
-  "${CMAKE_CXX_FLAGS} -g -fsigned-char -fno-omit-frame-pointer")
-
-# Typical slowdown introduced by MemorySanitizer (memory) is 3x.
-# '-fsanitize=address' not allowed with '-fsanitize=memory'
-if(YES)
-  set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -fsanitize=fuzzer,address,undefined")
-else()
-  # MemorySanitizer will not work out-of-the-box, and will instead report false positives coming from uninstrumented code.
-  # Need to re-build both C++ standard library:
-  # https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
-  set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -fsanitize=fuzzer,memory,undefined -fsanitize-memory-track-origins=2")
-endif()
-
-set(CMAKE_CXX_FLAGS
-  "${CMAKE_CXX_FLAGS} -fsanitize-coverage=edge,trace-cmp")
-
-# Use clang linker
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
-
-# Use  Clang libc++ instead of GNU
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-
-# enable link-time optimisation
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
-
-# https://llvm.org/docs/Passes.html
-# save IR to see call graph
-# make one bitcode file:> llvm-link *.bc -o out.bc
-# print call-graph:> opt out.bc -analyze -print-callgraph &> callgraph.txt
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -save-temps -flto")
-
-set(FLATBUFFERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
-
-set(FlatBuffers_Library_SRCS
-  ${FLATBUFFERS_DIR}/include/flatbuffers/base.h
-  ${FLATBUFFERS_DIR}/include/flatbuffers/flatbuffers.h
-  ${FLATBUFFERS_DIR}/include/flatbuffers/hash.h
-  ${FLATBUFFERS_DIR}/include/flatbuffers/idl.h
-  ${FLATBUFFERS_DIR}/include/flatbuffers/util.h
-  ${FLATBUFFERS_DIR}/include/flatbuffers/reflection.h
-  ${FLATBUFFERS_DIR}/include/flatbuffers/reflection_generated.h
-  ${FLATBUFFERS_DIR}/include/flatbuffers/stl_emulation.h
-  ${FLATBUFFERS_DIR}/include/flatbuffers/flexbuffers.h
-  ${FLATBUFFERS_DIR}/include/flatbuffers/registry.h
-  ${FLATBUFFERS_DIR}/include/flatbuffers/minireflect.h
-  ${FLATBUFFERS_DIR}/src/idl_parser.cpp
-  ${FLATBUFFERS_DIR}/src/idl_gen_text.cpp
-  ${FLATBUFFERS_DIR}/src/reflection.cpp
-  ${FLATBUFFERS_DIR}/src/util.cpp
-  ${FLATBUFFERS_DIR}/tests/test_assert.cpp
-)
-
-include_directories(${FLATBUFFERS_DIR}/include)
-include_directories(${FLATBUFFERS_DIR}/tests)
-add_library(flatbuffers STATIC ${FlatBuffers_Library_SRCS})
-
-# FLATBUFFERS_ASSERT should assert in Release as well.
-# Redefine FLATBUFFERS_ASSERT macro definition.
-# Declare as PUBLIC to cover asserts in all included header files.
-target_compile_definitions(flatbuffers PUBLIC
-   FLATBUFFERS_ASSERT=fuzzer_assert_impl)
-target_compile_definitions(flatbuffers PUBLIC
-   FLATBUFFERS_ASSERT_INCLUDE="${CMAKE_CURRENT_SOURCE_DIR}/fuzzer_assert.h")
+option(BUILD_DEBUGGER "Compile a debugger with main() and without libFuzzer"
+       OFF)
 
 if(NOT DEFINED FLATBUFFERS_MAX_PARSING_DEPTH)
   # Force checking of RecursionError in the test
   set(FLATBUFFERS_MAX_PARSING_DEPTH 8)
 endif()
-message(STATUS "FLATBUFFERS_MAX_PARSING_DEPTH: ${FLATBUFFERS_MAX_PARSING_DEPTH}")
-target_compile_definitions(flatbuffers PRIVATE FLATBUFFERS_MAX_PARSING_DEPTH=8)
+message(
+  STATUS "FLATBUFFERS_MAX_PARSING_DEPTH: ${FLATBUFFERS_MAX_PARSING_DEPTH}")
+
+# Usage '-fsanitize=address' doesn't allowed with '-fsanitize=memory'.
+# MemorySanitizer will not work out-of-the-box, and will instead report false
+# positives coming from uninstrumented code. Need to re-build both C++ standard
+# library: https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
+option(USE_MSAN "Use MSAN instead of ASASN" OFF)
+
+# Use Clang linker.
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+
+# add_link_options(-stdlib=libc++)
+
+add_compile_options(
+  # -stdlib=libc++ # Use Clang libc++ instead of GNU.
+  -std=c++14
+  -Wall
+  -pedantic
+  -Werror
+  -Wextra
+  -Wno-unused-parameter
+  -fsigned-char
+  -fno-omit-frame-pointer
+  -g # Generate source-level debug information
+  # -flto # enable link-time optimisation
+)
+
+# https://llvm.org/docs/Passes.html save IR to see call graph make one bitcode
+# file:> llvm-link *.bc -o out.bc print call-graph:> opt out.bc -analyze -print-
+# callgraph &> callgraph.txt set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -save-temps
+# -flto")
+
+# A special target with fuzzer+sanitizer flags.
+add_library(fuzzer_config INTERFACE)
+
+target_compile_options(
+  fuzzer_config
+  INTERFACE -fsanitize-coverage=edge,trace-cmp
+            $<$<BOOL:NOT
+            ${USE_MSAN}>:
+            -fsanitize=fuzzer,undefined,address
+            >
+            $<$<BOOL:${USE_MSAN}>:
+            -fsanitize=fuzzer,undefined,memory
+            -fsanitize-memory-track-origins=2
+            >)
+target_link_libraries(
+  fuzzer_config
+  INTERFACE $<$<BOOL:NOT
+            ${USE_MSAN}>:
+            -fsanitize=fuzzer,undefined,address
+            >
+            $<$<BOOL:${USE_MSAN}>:
+            -fsanitize=fuzzer,undefined,memory
+            >)
+
+set(FLATBUFFERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
+
+set(FlatBuffers_Library_SRCS
+    ${FLATBUFFERS_DIR}/include/flatbuffers/base.h
+    ${FLATBUFFERS_DIR}/include/flatbuffers/flatbuffers.h
+    ${FLATBUFFERS_DIR}/include/flatbuffers/hash.h
+    ${FLATBUFFERS_DIR}/include/flatbuffers/idl.h
+    ${FLATBUFFERS_DIR}/include/flatbuffers/util.h
+    ${FLATBUFFERS_DIR}/include/flatbuffers/reflection.h
+    ${FLATBUFFERS_DIR}/include/flatbuffers/reflection_generated.h
+    ${FLATBUFFERS_DIR}/include/flatbuffers/stl_emulation.h
+    ${FLATBUFFERS_DIR}/include/flatbuffers/flexbuffers.h
+    ${FLATBUFFERS_DIR}/include/flatbuffers/registry.h
+    ${FLATBUFFERS_DIR}/include/flatbuffers/minireflect.h
+    ${FLATBUFFERS_DIR}/src/idl_parser.cpp
+    ${FLATBUFFERS_DIR}/src/idl_gen_text.cpp
+    ${FLATBUFFERS_DIR}/src/reflection.cpp
+    ${FLATBUFFERS_DIR}/src/util.cpp
+    ${FLATBUFFERS_DIR}/tests/test_assert.cpp)
+
+include_directories(${FLATBUFFERS_DIR}/include)
+include_directories(${FLATBUFFERS_DIR}/tests)
+
+add_library(flatbuffers_fuzzed STATIC ${FlatBuffers_Library_SRCS})
+# Use PUBLIC to force 'fuzzer_config' for all dependent targets
+target_link_libraries(flatbuffers_fuzzed PUBLIC fuzzer_config)
+
+# FLATBUFFERS_ASSERT should assert in Release as well. Redefine
+# FLATBUFFERS_ASSERT macro definition. Declare as PUBLIC to cover asserts in all
+# included header files.
+target_compile_definitions(
+  flatbuffers_fuzzed
+  PUBLIC
+    FLATBUFFERS_ASSERT=fuzzer_assert_impl
+    FLATBUFFERS_ASSERT_INCLUDE="${CMAKE_CURRENT_SOURCE_DIR}/fuzzer_assert.h"
+  PRIVATE FLATBUFFERS_MAX_PARSING_DEPTH=${FLATBUFFERS_MAX_PARSING_DEPTH})
 
 # Setup fuzzer tests.
 
 add_executable(scalar_fuzzer flatbuffers_scalar_fuzzer.cc)
-target_link_libraries(scalar_fuzzer PRIVATE flatbuffers)
+target_link_libraries(scalar_fuzzer PRIVATE flatbuffers_fuzzed)
 
 add_executable(parser_fuzzer flatbuffers_parser_fuzzer.cc)
-target_link_libraries(parser_fuzzer PRIVATE flatbuffers)
+target_link_libraries(parser_fuzzer PRIVATE flatbuffers_fuzzed)
 
 add_executable(verifier_fuzzer flatbuffers_verifier_fuzzer.cc)
-target_link_libraries(verifier_fuzzer PRIVATE flatbuffers)
+target_link_libraries(verifier_fuzzer PRIVATE flatbuffers_fuzzed)
+
+# Build debugger for weird cases found with fuzzer.
+if(BUILD_DEBUGGER)
+  add_library(flatbuffers_nonfuzz STATIC ${FlatBuffers_Library_SRCS})
+  target_compile_definitions(
+    flatbuffers_nonfuzz
+    PUBLIC
+      FLATBUFFERS_ASSERT=fuzzer_assert_impl
+      FLATBUFFERS_ASSERT_INCLUDE="${CMAKE_CURRENT_SOURCE_DIR}/fuzzer_assert.h"
+    PRIVATE FLATBUFFERS_MAX_PARSING_DEPTH=${FLATBUFFERS_MAX_PARSING_DEPTH})
+
+  add_executable(scalar_debug flatbuffers_scalar_fuzzer.cc scalar_debug.cpp)
+  target_link_libraries(scalar_debug PRIVATE flatbuffers_nonfuzz)
+
+endif(BUILD_DEBUGGER)

--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -19,12 +19,21 @@ if(YES)
   set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -fsanitize=fuzzer,address,undefined")
 else()
+  # MemorySanitizer will not work out-of-the-box, and will instead report false positives coming from uninstrumented code.
+  # Need to re-build both C++ standard library:
+  # https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
   set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -fsanitize=fuzzer,memory,undefined -fsanitize-memory-track-origins=2")
 endif()
 
 set(CMAKE_CXX_FLAGS
   "${CMAKE_CXX_FLAGS} -fsanitize-coverage=edge,trace-cmp")
+
+# Use clang linker
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+
+# Use  Clang libc++ instead of GNU
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 
 # enable link-time optimisation
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
@@ -34,8 +43,6 @@ set(CMAKE_CXX_FLAGS
 # make one bitcode file:> llvm-link *.bc -o out.bc
 # print call-graph:> opt out.bc -analyze -print-callgraph &> callgraph.txt
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -save-temps -flto")
-
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
 
 set(FLATBUFFERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
 

--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -6,15 +6,13 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 project(FlatBuffersFuzzerTests)
 
-option(BUILD_DEBUGGER "Compile a debugger with main() and without libFuzzer"
-       OFF)
+option(BUILD_DEBUGGER "Compile a debugger with main() and without libFuzzer" OFF)
 
 if(NOT DEFINED FLATBUFFERS_MAX_PARSING_DEPTH)
   # Force checking of RecursionError in the test
   set(FLATBUFFERS_MAX_PARSING_DEPTH 8)
 endif()
-message(
-  STATUS "FLATBUFFERS_MAX_PARSING_DEPTH: ${FLATBUFFERS_MAX_PARSING_DEPTH}")
+message(STATUS "FLATBUFFERS_MAX_PARSING_DEPTH: ${FLATBUFFERS_MAX_PARSING_DEPTH}")
 
 # Usage '-fsanitize=address' doesn't allowed with '-fsanitize=memory'.
 # MemorySanitizer will not work out-of-the-box, and will instead report false
@@ -51,24 +49,27 @@ add_library(fuzzer_config INTERFACE)
 
 target_compile_options(
   fuzzer_config
-  INTERFACE -fsanitize-coverage=edge,trace-cmp
-            $<$<BOOL:NOT
-            ${USE_MSAN}>:
-            -fsanitize=fuzzer,undefined,address
-            >
-            $<$<BOOL:${USE_MSAN}>:
-            -fsanitize=fuzzer,undefined,memory
-            -fsanitize-memory-track-origins=2
-            >)
+  INTERFACE
+    -fsanitize-coverage=edge,trace-cmp
+    $<$<BOOL:NOT ${USE_MSAN}>:
+      -fsanitize=fuzzer,undefined,address
+    >
+    $<$<BOOL:${USE_MSAN}>:
+      -fsanitize=fuzzer,undefined,memory
+      -fsanitize-memory-track-origins=2
+    >
+)
+
 target_link_libraries(
   fuzzer_config
-  INTERFACE $<$<BOOL:NOT
-            ${USE_MSAN}>:
-            -fsanitize=fuzzer,undefined,address
-            >
-            $<$<BOOL:${USE_MSAN}>:
-            -fsanitize=fuzzer,undefined,memory
-            >)
+  INTERFACE
+    $<$<BOOL:NOT ${USE_MSAN}>:
+      -fsanitize=fuzzer,undefined,address
+    >
+    $<$<BOOL:${USE_MSAN}>:
+      -fsanitize=fuzzer,undefined,memory
+    >
+)
 
 set(FLATBUFFERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../")
 
@@ -88,7 +89,8 @@ set(FlatBuffers_Library_SRCS
     ${FLATBUFFERS_DIR}/src/idl_gen_text.cpp
     ${FLATBUFFERS_DIR}/src/reflection.cpp
     ${FLATBUFFERS_DIR}/src/util.cpp
-    ${FLATBUFFERS_DIR}/tests/test_assert.cpp)
+    ${FLATBUFFERS_DIR}/tests/test_assert.cpp
+)
 
 include_directories(${FLATBUFFERS_DIR}/include)
 include_directories(${FLATBUFFERS_DIR}/tests)
@@ -105,7 +107,9 @@ target_compile_definitions(
   PUBLIC
     FLATBUFFERS_ASSERT=fuzzer_assert_impl
     FLATBUFFERS_ASSERT_INCLUDE="${CMAKE_CURRENT_SOURCE_DIR}/fuzzer_assert.h"
-  PRIVATE FLATBUFFERS_MAX_PARSING_DEPTH=${FLATBUFFERS_MAX_PARSING_DEPTH})
+  PRIVATE
+    FLATBUFFERS_MAX_PARSING_DEPTH=${FLATBUFFERS_MAX_PARSING_DEPTH}
+)
 
 # Setup fuzzer tests.
 
@@ -126,9 +130,9 @@ if(BUILD_DEBUGGER)
     PUBLIC
       FLATBUFFERS_ASSERT=fuzzer_assert_impl
       FLATBUFFERS_ASSERT_INCLUDE="${CMAKE_CURRENT_SOURCE_DIR}/fuzzer_assert.h"
-    PRIVATE FLATBUFFERS_MAX_PARSING_DEPTH=${FLATBUFFERS_MAX_PARSING_DEPTH})
-
+    PRIVATE
+      FLATBUFFERS_MAX_PARSING_DEPTH=${FLATBUFFERS_MAX_PARSING_DEPTH}
+  )
   add_executable(scalar_debug flatbuffers_scalar_fuzzer.cc scalar_debug.cpp)
   target_link_libraries(scalar_debug PRIVATE flatbuffers_nonfuzz)
-
 endif(BUILD_DEBUGGER)

--- a/tests/fuzzer/flatbuffers_parser_fuzzer.cc
+++ b/tests/fuzzer/flatbuffers_parser_fuzzer.cc
@@ -26,7 +26,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (size < 3) return 0;
   const uint8_t flags = data[0];
   // normalize to ascii alphabet
-  const int extra_rep_number = data[1] >= '0' ? (data[1] - '0') : 0;
+  const int extra_rep_number =
+      std::max(5, (data[1] < '0' ? (data[1] - '0') : 0));
   data += 2;
   size -= 2;  // bypass
 

--- a/tests/fuzzer/scalar_debug.cpp
+++ b/tests/fuzzer/scalar_debug.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include "flatbuffers/util.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    std::cerr << "Usage: scalar_debug <path to fuzzer crash file>\n";
+    return 0;
+  }
+  std::string crash_file_name(argv[1]);
+  std::string crash_file_data;
+  auto done =
+      flatbuffers::LoadFile(crash_file_name.c_str(), true, &crash_file_data);
+  if (!done) {
+    std::cerr << "Can not load file: '" << crash_file_name << "'";
+    return -1;
+  }
+  if (crash_file_data.size() < 3) {
+    std::cerr << "Invalid file data: '" << crash_file_data << "'";
+    return -2;
+  }
+  auto rc = LLVMFuzzerTestOneInput(
+      reinterpret_cast<const uint8_t *>(crash_file_data.data()),
+      crash_file_data.size());
+  std::cout << "LLVMFuzzerTestOneInput finished with code " << rc;
+  return rc;
+}

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -2019,6 +2019,9 @@ void InvalidFloatTest() {
   TestError("table T { F:float; } root_type T; { F:0x0 }", invalid_msg);
   TestError("table T { F:float; } root_type T; { F:-0x. }", invalid_msg);
   TestError("table T { F:float; } root_type T; { F:0x. }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:0Xe }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:\"0Xe\" }", invalid_msg);
+  TestError("table T { F:float; } root_type T; { F:\"nan(1)\" }", invalid_msg);
   // eE not exponent in hex-float!
   TestError("table T { F:float; } root_type T; { F:0x0.0e+ }", invalid_msg);
   TestError("table T { F:float; } root_type T; { F:0x0.0e- }", invalid_msg);


### PR DESCRIPTION
There is an ambiguity in the interpretation of an expression `nan(number)`.
This expression is interpreted as a function call  `{  "x" : nan() }` if it is used without string quotes.
But if it is surrounded by quotes `"nan()"` it will be interpreted as a numeric literal `{  "x" : "nan()" }` instead of the function call.
According to the grammar, Flattbuffers accepts numbers embedded to string literal.
In turn, [strtod()](https://en.cppreference.com/w/cpp/string/byte/strtof) function accepts "nan()":
>* NAN or NAN(char_sequence) ignoring case of the NAN part. char_sequence can only contain digits, Latin letters, and underscores. The result is a quiet NaN floating-point value.

This PR disables expression `number-in-sting` which looks like a function call.
- Additional checks added to `Parser::ParseSingleValue()`.

Minor changes:
- Extracted method `Parser::ParseFunction()`.
- The `Parser::TryTypedValue()` was moved closer to `ParseSingleValue()` for readability.
- Added `FLATBUFFERS_DELETE_FUNC` for the `StructKeyComparator` to make Clang-10 happy. It dislikes declaration of methods without implementation.

The second part of changes connected with fuzzers:
* Added optional target `scalar_debug` for in-place debugging of crash-files from the scalar fuzzer.
* Added workaround for `$schema` expression in json which has blocked the scalar fuzzer.
