### PR TITLE
[Scripts] Updated doxyfile - added missing files

### DIFF
--- a/docs/source/doxyfile
+++ b/docs/source/doxyfile
@@ -753,7 +753,9 @@ INPUT = "FlatBuffers.md" \
         "CUsage.md" \
         "DartUsage.md" \
         "GoUsage.md" \
-        "JavaCsharpUsage.md" \
+        "JavaUsage.md" \
+        "CsharpUsage.md" \
+        "SwiftUsage.md" \
         "JavaScriptUsage.md" \
         "TypeScriptUsage.md" \
         "PHPUsage.md" \


### PR DESCRIPTION
- Added missing Java/C#/Swift files - that fixes references to them. 
- Removed non-existent "JavaCsharpUsage.md".

----

That fixes multiple errors during docs build via `doxygen`:

<details>
  <summary>Dump</summary>

	Generating docs for namespace FlatBuffers
	Generating docs for compound FlatBuffers::FlatBufferBuilder...
	Generating docs for compound Google::FlatBuffers::FlatbufferBuilder...
	Generating graph info page...
	Generating directory documentation...
	explicit link request to 'flatbuffers_guide_use_java' in layout file 'doxygen_layout.xml' could not be resolved
	explicit link request to 'flatbuffers_guide_use_c-sharp' in layout file 'doxygen_layout.xml' could not be resolved
	explicit link request to 'flatbuffers_guide_use_swift' in layout file 'doxygen_layout.xml' could not be resolved
	Generating index page...
	explicit link request to 'flatbuffers_guide_use_java' in layout file 'doxygen_layout.xml' could not be resolved
	explicit link request to 'flatbuffers_guide_use_c-sharp' in layout file 'doxygen_layout.xml' could not be resolved
	explicit link request to 'flatbuffers_guide_use_swift' in layout file 'doxygen_layout.xml' could not be resolved
	explicit link request to 'flatbuffers_guide_use_java' in layout file 'doxygen_layout.xml' could not be resolved
	explicit link request to 'flatbuffers_guide_use_c-sharp' in layout file 'doxygen_layout.xml' could not be resolved
	explicit link request to 'flatbuffers_guide_use_swift' in layout file 'doxygen_layout.xml' could not be resolved
	Generating module index...
	Generating annotated compound index...
	Generating alphabetical compound index...
	Generating hierarchical class index...
	Generating member index...
	finalizing index lists...
	writing tag file...
	lookup cache used 943/65536 hits=19693 misses=1024

</details>


Related to https://github.com/google/flatbuffers/issues/5809