### PR TITLE
Fix Clang-trunk warnings about special members deprecated in C++20.

### DIFF
--- a/include/flatbuffers/reflection.h
+++ b/include/flatbuffers/reflection.h
@@ -362,7 +362,6 @@ template<typename T, typename U> class pointer_inside_vector {
         reinterpret_cast<uint8_t *>(flatbuffers::vector_data(vec_)) + offset_);
   }
   T *operator->() const { return operator*(); }
-  void operator=(const pointer_inside_vector &piv);
 
  private:
   size_t offset_;

--- a/include/flatbuffers/reflection_generated.h
+++ b/include/flatbuffers/reflection_generated.h
@@ -161,7 +161,6 @@ struct TypeBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TypeBuilder &operator=(const TypeBuilder &);
   flatbuffers::Offset<Type> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Type>(end);
@@ -225,7 +224,6 @@ struct KeyValueBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  KeyValueBuilder &operator=(const KeyValueBuilder &);
   flatbuffers::Offset<KeyValue> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<KeyValue>(end);
@@ -325,7 +323,6 @@ struct EnumValBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  EnumValBuilder &operator=(const EnumValBuilder &);
   flatbuffers::Offset<EnumVal> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<EnumVal>(end);
@@ -448,7 +445,6 @@ struct EnumBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  EnumBuilder &operator=(const EnumBuilder &);
   flatbuffers::Offset<Enum> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Enum>(end);
@@ -617,7 +613,6 @@ struct FieldBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  FieldBuilder &operator=(const FieldBuilder &);
   flatbuffers::Offset<Field> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Field>(end);
@@ -773,7 +768,6 @@ struct ObjectBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  ObjectBuilder &operator=(const ObjectBuilder &);
   flatbuffers::Offset<Object> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Object>(end);
@@ -898,7 +892,6 @@ struct RPCCallBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  RPCCallBuilder &operator=(const RPCCallBuilder &);
   flatbuffers::Offset<RPCCall> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<RPCCall>(end);
@@ -1007,7 +1000,6 @@ struct ServiceBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  ServiceBuilder &operator=(const ServiceBuilder &);
   flatbuffers::Offset<Service> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Service>(end);
@@ -1123,7 +1115,6 @@ struct SchemaBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  SchemaBuilder &operator=(const SchemaBuilder &);
   flatbuffers::Offset<Schema> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Schema>(end);

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -402,7 +402,6 @@ struct MonsterBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  MonsterBuilder &operator=(const MonsterBuilder &);
   flatbuffers::Offset<Monster> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Monster>(end);
@@ -536,7 +535,6 @@ struct WeaponBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  WeaponBuilder &operator=(const WeaponBuilder &);
   flatbuffers::Offset<Weapon> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Weapon>(end);

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2228,11 +2228,6 @@ class CppGenerator : public BaseGenerator {
     code_ += "    start_ = fbb_.StartTable();";
     code_ += "  }";
 
-    // Assignment operator;
-    code_ +=
-        "  {{STRUCT_NAME}}Builder &operator="
-        "(const {{STRUCT_NAME}}Builder &);";
-
     // Finish() function.
     code_ += "  flatbuffers::Offset<{{STRUCT_NAME}}> Finish() {";
     code_ += "    const auto end = fbb_.EndTable(start_);";

--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -296,8 +296,6 @@ class ResizeContext {
     }
   }
 
-  void operator=(const ResizeContext &rc);
-
  private:
   const reflection::Schema &schema_;
   uint8_t *startptr_;

--- a/tests/arrays_test_generated.h
+++ b/tests/arrays_test_generated.h
@@ -264,7 +264,6 @@ struct ArrayTableBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  ArrayTableBuilder &operator=(const ArrayTableBuilder &);
   flatbuffers::Offset<ArrayTable> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<ArrayTable>(end);

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -642,7 +642,6 @@ struct InParentNamespaceBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  InParentNamespaceBuilder &operator=(const InParentNamespaceBuilder &);
   flatbuffers::Offset<InParentNamespace> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<InParentNamespace>(end);
@@ -695,7 +694,6 @@ struct MonsterBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  MonsterBuilder &operator=(const MonsterBuilder &);
   flatbuffers::Offset<Monster> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Monster>(end);
@@ -765,7 +763,6 @@ struct TestSimpleTableWithEnumBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TestSimpleTableWithEnumBuilder &operator=(const TestSimpleTableWithEnumBuilder &);
   flatbuffers::Offset<TestSimpleTableWithEnum> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TestSimpleTableWithEnum>(end);
@@ -859,7 +856,6 @@ struct StatBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  StatBuilder &operator=(const StatBuilder &);
   flatbuffers::Offset<Stat> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Stat>(end);
@@ -950,7 +946,6 @@ struct ReferrableBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  ReferrableBuilder &operator=(const ReferrableBuilder &);
   flatbuffers::Offset<Referrable> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Referrable>(end);
@@ -1686,7 +1681,6 @@ struct MonsterBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  MonsterBuilder &operator=(const MonsterBuilder &);
   flatbuffers::Offset<Monster> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Monster>(end);
@@ -2113,7 +2107,6 @@ struct TypeAliasesBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TypeAliasesBuilder &operator=(const TypeAliasesBuilder &);
   flatbuffers::Offset<TypeAliases> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TypeAliases>(end);

--- a/tests/evolution_test/evolution_v1_generated.h
+++ b/tests/evolution_test/evolution_v1_generated.h
@@ -152,7 +152,6 @@ struct TableABuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TableABuilder &operator=(const TableABuilder &);
   flatbuffers::Offset<TableA> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TableA>(end);
@@ -194,7 +193,6 @@ struct TableBBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TableBBuilder &operator=(const TableBBuilder &);
   flatbuffers::Offset<TableB> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TableB>(end);
@@ -326,7 +324,6 @@ struct RootBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  RootBuilder &operator=(const RootBuilder &);
   flatbuffers::Offset<Root> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Root>(end);

--- a/tests/evolution_test/evolution_v2_generated.h
+++ b/tests/evolution_test/evolution_v2_generated.h
@@ -176,7 +176,6 @@ struct TableABuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TableABuilder &operator=(const TableABuilder &);
   flatbuffers::Offset<TableA> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TableA>(end);
@@ -233,7 +232,6 @@ struct TableBBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TableBBuilder &operator=(const TableBBuilder &);
   flatbuffers::Offset<TableB> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TableB>(end);
@@ -282,7 +280,6 @@ struct TableCBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TableCBuilder &operator=(const TableCBuilder &);
   flatbuffers::Offset<TableC> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TableC>(end);
@@ -443,7 +440,6 @@ struct RootBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  RootBuilder &operator=(const RootBuilder &);
   flatbuffers::Offset<Root> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Root>(end);

--- a/tests/monster_extra_generated.h
+++ b/tests/monster_extra_generated.h
@@ -197,7 +197,6 @@ struct MonsterExtraBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  MonsterExtraBuilder &operator=(const MonsterExtraBuilder &);
   flatbuffers::Offset<MonsterExtra> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<MonsterExtra>(end);

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -802,7 +802,6 @@ struct InParentNamespaceBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  InParentNamespaceBuilder &operator=(const InParentNamespaceBuilder &);
   flatbuffers::Offset<InParentNamespace> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<InParentNamespace>(end);
@@ -858,7 +857,6 @@ struct MonsterBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  MonsterBuilder &operator=(const MonsterBuilder &);
   flatbuffers::Offset<Monster> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Monster>(end);
@@ -932,7 +930,6 @@ struct TestSimpleTableWithEnumBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TestSimpleTableWithEnumBuilder &operator=(const TestSimpleTableWithEnumBuilder &);
   flatbuffers::Offset<TestSimpleTableWithEnum> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TestSimpleTableWithEnum>(end);
@@ -1032,7 +1029,6 @@ struct StatBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  StatBuilder &operator=(const StatBuilder &);
   flatbuffers::Offset<Stat> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Stat>(end);
@@ -1127,7 +1123,6 @@ struct ReferrableBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  ReferrableBuilder &operator=(const ReferrableBuilder &);
   flatbuffers::Offset<Referrable> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Referrable>(end);
@@ -1911,7 +1906,6 @@ struct MonsterBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  MonsterBuilder &operator=(const MonsterBuilder &);
   flatbuffers::Offset<Monster> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Monster>(end);
@@ -2353,7 +2347,6 @@ struct TypeAliasesBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TypeAliasesBuilder &operator=(const TypeAliasesBuilder &);
   flatbuffers::Offset<TypeAliases> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TypeAliases>(end);

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -153,7 +153,6 @@ struct TableInNestedNSBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TableInNestedNSBuilder &operator=(const TableInNestedNSBuilder &);
   flatbuffers::Offset<TableInNestedNS> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TableInNestedNS>(end);

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -138,7 +138,6 @@ struct TableInFirstNSBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TableInFirstNSBuilder &operator=(const TableInFirstNSBuilder &);
   flatbuffers::Offset<TableInFirstNS> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TableInFirstNS>(end);
@@ -232,7 +231,6 @@ struct TableInCBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  TableInCBuilder &operator=(const TableInCBuilder &);
   flatbuffers::Offset<TableInC> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<TableInC>(end);
@@ -310,7 +308,6 @@ struct SecondTableInABuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  SecondTableInABuilder &operator=(const SecondTableInABuilder &);
   flatbuffers::Offset<SecondTableInA> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<SecondTableInA>(end);

--- a/tests/native_type_test_generated.h
+++ b/tests/native_type_test_generated.h
@@ -103,7 +103,6 @@ struct ApplicationDataBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  ApplicationDataBuilder &operator=(const ApplicationDataBuilder &);
   flatbuffers::Offset<ApplicationData> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<ApplicationData>(end);

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -314,7 +314,6 @@ struct AttackerBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  AttackerBuilder &operator=(const AttackerBuilder &);
   flatbuffers::Offset<Attacker> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Attacker>(end);
@@ -439,7 +438,6 @@ struct MovieBuilder {
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  MovieBuilder &operator=(const MovieBuilder &);
   flatbuffers::Offset<Movie> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Movie>(end);


### PR DESCRIPTION
For example:

    include/flatbuffers/reflection.h:365:8: error: definition of implicit copy
          constructor for 'pointer_inside_vector<flatbuffers::Table, unsigned char>'
          is deprecated because it has a user-declared copy assignment operator
          [-Werror,-Wdeprecated-copy]
      void operator=(const pointer_inside_vector &piv);
           ^

It's unclear why the old code wanted to declare a public `operator=`
without defining it; that just seems like a misunderstanding of the C++03 idiom
for deleting a member function. And anyway, we don't *want* to delete the
assignment operator; these are polymorphic types that do not follow value
semantics and nobody should ever be trying to copy them. So the simplest fix
is just to go back to the Rule of Zero: remove the declaration of `operator=`
and let the compiler do what it wanted to do originally anyway.
"The best code is no code."

Fixes #5649.