### PR TITLE
Added flatbuffers_generate_headers and flatbuffers_generate_binary_files cmake functions.

### DIFF
--- a/CMake/BuildFlatBuffers.cmake
+++ b/CMake/BuildFlatBuffers.cmake
@@ -95,7 +95,7 @@ function(build_flatbuffers flatbuffers_schemas
       set(generated_include ${generated_includes_dir}/${filename}_generated.h)
       add_custom_command(
         OUTPUT ${generated_include}
-        COMMAND ${FLATC} ${FLATC_SCHEMA_ARGS}
+        COMMAND ${FLATC} ${FLATC_ARGS}
         -o ${generated_includes_dir}
         ${include_params}
         -c ${schema}
@@ -149,4 +149,250 @@ function(build_flatbuffers flatbuffers_schemas
       PROPERTY COPY_TEXT_SCHEMAS_DIR
       ${copy_text_schemas_dir})
   endif()
+endfunction()
+
+# Creates a target that can be linked against that generates flatbuffer headers.
+#
+# This function takes a target name and a list of schemas. You can also specify
+# other flagc flags using the FLAGS option to change the behavior of the flatc
+# tool.
+#
+# Arguments:
+#   TARGET: The name of the target to generate.
+#   SCHEMAS: The list of schema files to generate code for.
+#   BINARY_SCHEMAS_DIR: The directory in which to generate binary schemas.
+#       Binary schemas will only be generated if a path is provided.
+#   INCLUDE: Search for includes in the specified paths. (Use this instead of
+#       "-I <path>" and the FLAGS option so that CMake is aware of the
+#       directories that need to be searched).
+#   FLAGS: A list of any additional flags that you would like to pass to flatc.
+#
+# Example:
+#
+#     flatbuffers_generate_headers(
+#         TARGET my_generated_headers_target
+#         SCHEMAS ${MY_SCHEMA_FILES}
+#         BINARY_SCHEMAS_DIR "${MY_BINARY_SCHEMA_DIRECTORY}"
+#         FLAGS
+#           --include-prefix "${MY_INCLUDE_PREFIX}"
+#           --gen-object-api)
+#
+#     target_link_libraries(MyExecutableTarget
+#         PRIVATE my_generated_headers_target
+#     )
+function(flatbuffers_generate_headers)
+  # Parse function arguments.
+  set(options)
+  set(one_value_args
+    "TARGET"
+    "BINARY_SCHEMAS_DIR")
+  set(multi_value_args
+    "SCHEMAS"
+    "INCLUDE"
+    "FLAGS")
+  cmake_parse_arguments(
+    PARSE_ARGV 0
+    FLATBUFFERS_GENERATE_HEADERS
+    "${options}"
+    "${one_value_args}"
+    "${multi_value_args}")
+
+  # Test if including from FindFlatBuffers
+  if(FLATBUFFERS_FLATC_EXECUTABLE)
+    set(FLATC_TARGET "")
+    set(FLATC ${FLATBUFFERS_FLATC_EXECUTABLE})
+  else()
+    set(FLATC_TARGET flatc)
+    set(FLATC flatc)
+  endif()
+
+  set(working_dir "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  # Generate the include files parameters.
+  set(include_params "")
+  foreach (include_dir ${FLATBUFFERS_GENERATE_HEADERS_INCLUDE})
+    set(include_params -I ${include_dir} ${include_params})
+  endforeach()
+
+  # Create a directory to place the generated code.
+  set(generated_target_dir "${CMAKE_CURRENT_BINARY_DIR}/${FLATBUFFERS_GENERATE_HEADERS_TARGET}")
+  set(generated_include_dir "${generated_target_dir}")
+  if (NOT ${FLATBUFFERS_GENERATE_HEADERS_INCLUDE_PREFIX} STREQUAL "")
+    set(generated_include_dir "${generated_include_dir}/${FLATBUFFERS_GENERATE_HEADERS_INCLUDE_PREFIX}")
+  endif()
+
+  # Create rules to generate the code for each schema.
+  foreach(schema ${FLATBUFFERS_GENERATE_HEADERS_SCHEMAS})
+    get_filename_component(filename ${schema} NAME_WE)
+    set(generated_include "${generated_include_dir}/${filename}_generated.h")
+    add_custom_command(
+      OUTPUT ${generated_include}
+      COMMAND ${FLATC} ${FLATC_ARGS}
+      -o ${generated_include_dir}
+      ${include_params}
+      -c ${schema}
+      ${FLATBUFFERS_GENERATE_HEADERS_FLAGS}
+      DEPENDS ${FLATC_TARGET} ${schema}
+      WORKING_DIRECTORY "${working_dir}")
+    list(APPEND all_generated_header_files ${generated_include})
+
+    # Geneate the binary flatbuffers schemas if instructed to.
+    if (NOT ${FLATBUFFERS_GENERATE_HEADERS_BINARY_SCHEMAS_DIR} STREQUAL "")
+      set(binary_schema
+          "${FLATBUFFERS_GENERATE_HEADERS_BINARY_SCHEMAS_DIR}/${filename}.bfbs")
+      add_custom_command(
+        OUTPUT ${binary_schema}
+        COMMAND ${FLATC} -b --schema
+        -o ${FLATBUFFERS_GENERATE_HEADERS_BINARY_SCHEMAS_DIR}
+        ${include_params}
+        ${schema}
+        DEPENDS ${FLATC_TARGET} ${schema}
+        WORKING_DIRECTORY "${working_dir}")
+      list(APPEND all_generated_binary_files ${binary_schema})
+    endif()
+  endforeach()
+
+  # Set up interface library
+  add_library(${FLATBUFFERS_GENERATE_HEADERS_TARGET} INTERFACE)
+  target_sources(
+    ${FLATBUFFERS_GENERATE_HEADERS_TARGET}
+    INTERFACE
+      ${all_generated_header_files}
+      ${all_generated_binary_files}
+      ${FLATBUFFERS_GENERATE_HEADERS_SCHEMAS})
+  add_dependencies(
+    ${FLATBUFFERS_GENERATE_HEADERS_TARGET}
+    ${FLATC}
+    ${FLATBUFFERS_GENERATE_HEADERS_SCHEMAS})
+  target_include_directories(
+    ${FLATBUFFERS_GENERATE_HEADERS_TARGET}
+    INTERFACE ${generated_target_dir})
+
+  # Organize file layout for IDEs.
+  source_group(
+    TREE "${generated_target_dir}"
+    PREFIX "Flatbuffers/Generated/Headers Files"
+    FILES ${all_generated_header_files})
+  source_group(
+    TREE ${working_dir}
+    PREFIX "Flatbuffers/Schemas"
+    FILES ${FLATBUFFERS_GENERATE_HEADERS_SCHEMAS})
+  if (NOT ${FLATBUFFERS_GENERATE_HEADERS_BINARY_SCHEMAS_DIR} STREQUAL "")
+    source_group(
+      TREE "${FLATBUFFERS_GENERATE_HEADERS_BINARY_SCHEMAS_DIR}"
+      PREFIX "Flatbuffers/Generated/Binary Schemas"
+      FILES ${all_generated_binary_files})
+  endif()
+endfunction()
+
+# Creates a target that can be linked against that generates flatbuffer binaries
+# from json files.
+#
+# This function takes a target name and a list of schemas and Json files. You
+# can also specify other flagc flags and options to change the behavior of the
+# flatc compiler. Flags are named the same as they would be in the flatc tool
+# except ALL_CAPS. For example, --strict-json would be passed in as STRICT_JSON.
+#
+# Adding this target to your executable ensurses that the flatbuffer binaries
+# are compiled before your executable is run.
+#
+# Arguments:
+#   TARGET: The name of the target to generate.
+#   JSON_FILES: The list of json files to compile to flatbuffers binaries.
+#   SCHEMA: The flatbuffers schema of the Json files to be compiled.
+#   INCLUDE: Search for includes in the specified paths. (Use this instead of
+#       "-I <path>" and the FLAGS option so that CMake is aware of the
+#       directories that need to be searched).
+#   OUTPUT_DIR: The directly where the generated flatbuffers binaries should be
+#       placed.
+#   FLAGS: A list of any additional flags that you would like to pass to flatc.
+#
+# Example:
+#
+#     flatbuffers_generate_binary_files(
+#         TARGET my_binary_data
+#         SCHEMA "${MY_SCHEMA_DIR}/my_example_schema.fbs"
+#         JSON_FILES ${MY_JSON_FILES}
+#         OUTPUT_DIR "${MY_BINARY_DATA_DIRECTORY}"
+#         FLAGS --strict-json)
+#
+#     target_link_libraries(MyExecutableTarget
+#         PRIVATE my_binary_data
+#     )
+function(flatbuffers_generate_binary_files)
+  # Parse function arguments.
+  set(options)
+  set(one_value_args
+    "TARGET"
+    "SCHEMA"
+    "OUTPUT_DIR")
+  set(multi_value_args
+    "JSON_FILES"
+    "INCLUDE"
+    "FLAGS")
+  cmake_parse_arguments(
+    PARSE_ARGV 0
+    FLATBUFFERS_GENERATE_BINARY_FILES
+    "${options}"
+    "${one_value_args}"
+    "${multi_value_args}")
+
+  # Test if including from FindFlatBuffers
+  if(FLATBUFFERS_FLATC_EXECUTABLE)
+    set(FLATC_TARGET "")
+    set(FLATC ${FLATBUFFERS_FLATC_EXECUTABLE})
+  else()
+    set(FLATC_TARGET flatc)
+    set(FLATC flatc)
+  endif()
+
+  set(working_dir "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  # Generate the include files parameters.
+  set(include_params "")
+  foreach (include_dir ${FLATBUFFERS_GENERATE_BINARY_FILES_INCLUDE})
+    set(include_params -I ${include_dir} ${include_params})
+  endforeach()
+
+  # Create rules to generate the flatbuffers binary for each json file.
+  foreach(json_file ${FLATBUFFERS_GENERATE_BINARY_FILES_JSON_FILES})
+    get_filename_component(filename ${json_file} NAME_WE)
+    set(generated_binary_file "${FLATBUFFERS_GENERATE_BINARY_FILES_OUTPUT_DIR}/${filename}.bin")
+    add_custom_command(
+      OUTPUT ${generated_binary_file}
+      COMMAND ${FLATC} ${FLATC_ARGS}
+      -o ${FLATBUFFERS_GENERATE_BINARY_FILES_OUTPUT_DIR}
+      ${include_params}
+      -b ${FLATBUFFERS_GENERATE_BINARY_FILES_SCHEMA} ${json_file}
+      ${FLATBUFFERS_GENERATE_BINARY_FILES_FLAGS}
+      DEPENDS ${FLATC_TARGET} ${json_file}
+      WORKING_DIRECTORY "${working_dir}")
+      list(APPEND all_generated_binary_files ${generated_binary_file})
+  endforeach()
+
+  # Set up interface library
+  add_library(${FLATBUFFERS_GENERATE_BINARY_FILES_TARGET} INTERFACE)
+  target_sources(
+    ${FLATBUFFERS_GENERATE_BINARY_FILES_TARGET}
+    INTERFACE
+      ${all_generated_binary_files}
+      ${FLATBUFFERS_GENERATE_BINARY_FILES_JSON_FILES}
+      ${FLATBUFFERS_GENERATE_BINARY_FILES_SCHEMA})
+  add_dependencies(
+    ${FLATBUFFERS_GENERATE_BINARY_FILES_TARGET}
+    ${FLATC})
+
+  # Organize file layout for IDEs.
+  source_group(
+    TREE ${working_dir}
+    PREFIX "Flatbuffers/JSON Files"
+    FILES ${FLATBUFFERS_GENERATE_BINARY_FILES_JSON_FILES})
+  source_group(
+    TREE ${working_dir}
+    PREFIX "Flatbuffers/Schemas"
+    FILES ${FLATBUFFERS_GENERATE_BINARY_FILES_SCHEMA})
+  source_group(
+    TREE ${FLATBUFFERS_GENERATE_BINARY_FILES_OUTPUT_DIR}
+    PREFIX "Flatbuffers/Generated/Binary Files"
+    FILES ${all_generated_binary_files})
 endfunction()


### PR DESCRIPTION
flatbuffers_generate_headers is a function that can be used to generate Flatbuffers headers and binary headers. It uses named argument flags to wrap all the flags relevant to C++ header generation that flatc uses. It generates an interface library that can be added as a dependency of other targets.

flatbuffers_generate_binary_files is a function that can be used to generate Flatbuffers binaries. It uses named argument flags to wrap all the flags relevant to C++ binary generation from JSON file that flatc uses. It generates an interface library that can be added as a dependency of other targets.

---

I'm by no means a CMake expert, but I found the existing cmake utility that Flatbuffers shipped with to be cumbersome so I wrote ones that I found to be far more useful. If anyone has any suggestions on how to improve them further please let me know. 
