### PR TITLE
[Swift] Improves swift performance

### DIFF
--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -271,7 +271,7 @@ class SwiftGenerator : public BaseGenerator {
       if (parser_.file_identifier_.length()) {
         code_.SetValue("FILENAME", parser_.file_identifier_);
         code_ +=
-            "\tpublic static func finish(_ fbb: FlatBufferBuilder, end: "
+            "\tpublic static func finish(_ fbb: inout FlatBufferBuilder, end: "
             "Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, "
             "fileId: "
             "\"{{FILENAME}}\", addPrefix: prefix) }";
@@ -316,7 +316,7 @@ class SwiftGenerator : public BaseGenerator {
 
     code_.SetValue("NUMBEROFFIELDS", NumToString(struct_def.fields.vec.size()));
     code_ +=
-        "\tpublic static func start{{STRUCTNAME}}(_ fbb: FlatBufferBuilder) -> "
+        "\tpublic static func start{{STRUCTNAME}}(_ fbb: inout FlatBufferBuilder) -> "
         "UOffset { fbb.startTable(with: {{NUMBEROFFIELDS}}) }";
 
     for (auto it = struct_def.fields.vec.begin();
@@ -332,7 +332,7 @@ class SwiftGenerator : public BaseGenerator {
           static_cast<int>(it - struct_def.fields.vec.begin()));
     }
     code_ +=
-        "\tpublic static func end{{STRUCTNAME}}(_ fbb: FlatBufferBuilder, "
+        "\tpublic static func end{{STRUCTNAME}}(_ fbb: inout FlatBufferBuilder, "
         "start: "
         "UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: "
         "fbb.endTable(at: start))\\";
@@ -346,16 +346,16 @@ class SwiftGenerator : public BaseGenerator {
     code_ += "; return end }";
 
     code_ +=
-        "\tpublic static func create{{STRUCTNAME}}(_ fbb: FlatBufferBuilder\\";
+        "\tpublic static func create{{STRUCTNAME}}(_ fbb: inout FlatBufferBuilder\\";
     if (should_generate_create)
       code_ += ",\n" +
                create_func_header.substr(0, create_func_header.size() - 2) +
                "\\";
     code_ += ") -> Offset<UOffset> {";
-    code_ += "\t\tlet __start = {{STRUCTNAME}}.start{{STRUCTNAME}}(fbb)";
+    code_ += "\t\tlet __start = {{STRUCTNAME}}.start{{STRUCTNAME}}(&fbb)";
     if (should_generate_create)
       code_ += create_func_body.substr(0, create_func_body.size() - 1);
-    code_ += "\t\treturn {{STRUCTNAME}}.end{{STRUCTNAME}}(fbb, start: __start)";
+    code_ += "\t\treturn {{STRUCTNAME}}.end{{STRUCTNAME}}(&fbb, start: __start)";
     code_ += "\t}";
 
     std::string spacing = "\t\t";
@@ -367,7 +367,7 @@ class SwiftGenerator : public BaseGenerator {
       code_ +=
           "\tpublic static func "
           "sortVectorOf{{VALUENAME}}(offsets:[Offset<UOffset>], "
-          "_ fbb: FlatBufferBuilder) -> Offset<UOffset> {";
+          "_ fbb: inout FlatBufferBuilder) -> Offset<UOffset> {";
       code_ += spacing + "var off = offsets";
       code_ +=
           spacing +
@@ -382,7 +382,7 @@ class SwiftGenerator : public BaseGenerator {
 
   void GenTableWriterFields(const FieldDef &field, std::string *create_body,
                             std::string *create_header, const int position) {
-    std::string builder_string = ", _ fbb: FlatBufferBuilder) { fbb.add(";
+    std::string builder_string = ", _ fbb: inout FlatBufferBuilder) { fbb.add(";
     auto &create_func_body = *create_body;
     auto &create_func_header = *create_header;
     auto name = Name(field);
@@ -399,7 +399,7 @@ class SwiftGenerator : public BaseGenerator {
     std::string body = "add" + check_if_vector + name + ": ";
     code_ += "\tpublic static func " + body + "\\";
 
-    create_func_body += "\t\t{{STRUCTNAME}}." + body + name + ", fbb)\n";
+    create_func_body += "\t\t{{STRUCTNAME}}." + body + name + ", &fbb)\n";
 
     if (IsScalar(field.value.type.base_type) &&
         !IsBool(field.value.type.base_type)) {

--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -1,55 +1,80 @@
 import Foundation
 
-public final class ByteBuffer {
+public struct ByteBuffer {
     
-    /// pointer to the start of the buffer object in memory
-    private var _memory: UnsafeMutableRawPointer
+    /// Storage is a container that would hold the memory pointer to solve the issue of
+    /// deallocating the memory that was held by (memory: UnsafeMutableRawPointer)
+    @usableFromInline final class Storage {
+        
+        /// pointer to the start of the buffer object in memory
+        var memory: UnsafeMutableRawPointer
+        /// Capacity of UInt8 the buffer can hold
+        var capacity: Int
+        
+        init(count: Int, alignment: Int) {
+            memory = UnsafeMutableRawPointer.allocate(byteCount: count, alignment: alignment)
+            capacity = count
+        }
+        
+        deinit {
+            memory.deallocate()
+        }
+        
+        func copy(from ptr: UnsafeRawPointer, count: Int) {
+            memory.copyMemory(from: ptr, byteCount: count)
+        }
+        
+        func initalize(for size: Int) {
+            memory.initializeMemory(as: UInt8.self, repeating: 0, count: size)
+        }
+    }
+    
+    @usableFromInline var _storage: Storage
+    
     /// The size of the elements written to the buffer + their paddings
     private var _writerSize: Int = 0
-    /// Capacity of UInt8 the buffer can hold
-    private var _capacity: Int
-    
     /// Aliginment of the current  memory being written to the buffer
     internal var alignment = 1
     /// Current Index which is being used to write to the buffer, it is written from the end to the start of the buffer
-    internal var writerIndex: Int { return _capacity - _writerSize }
-    
+    internal var writerIndex: Int { return _storage.capacity - _writerSize }
+
     /// Reader is the position of the current Writer Index (capacity - size)
     public var reader: Int { return writerIndex }
     /// Current size of the buffer
     public var size: UOffset { return UOffset(_writerSize) }
     /// Public Pointer to the buffer object in memory. This should NOT be modified for any reason
-    public var memory: UnsafeMutableRawPointer { return _memory }
+    public var memory: UnsafeMutableRawPointer { return _storage.memory }
     /// Current capacity for the buffer
-    public var capacity: Int { return _capacity }
-    
+    public var capacity: Int { return _storage.capacity }
+
     /// Constructor that creates a Flatbuffer object from a UInt8
     /// - Parameter bytes: Array of UInt8
     public init(bytes: [UInt8]) {
-        let ptr = UnsafePointer(bytes)
-        _memory = UnsafeMutableRawPointer.allocate(byteCount: bytes.count, alignment: alignment)
-        _memory.copyMemory(from: ptr, byteCount: bytes.count)
-        _capacity = bytes.count
-        _writerSize = _capacity
+        var b = bytes
+        _storage = Storage(count: bytes.count, alignment: alignment)
+        _writerSize = _storage.capacity
+        b.withUnsafeMutableBytes { bufferPointer in
+            self._storage.copy(from: bufferPointer.baseAddress!, count: bytes.count)
+        }
     }
-    
+
     /// Constructor that creates a Flatbuffer from the Swift Data type object
     /// - Parameter data: Swift data Object
     public init(data: Data) {
-        let pointer = UnsafeMutablePointer<UInt8>.allocate(capacity: data.count)
-        data.copyBytes(to: pointer, count: data.count)
-        _memory = UnsafeMutableRawPointer(pointer)
-        _capacity = data.count
-        _writerSize = _capacity
+        var b = data
+        _storage = Storage(count: data.count, alignment: alignment)
+        _writerSize = _storage.capacity
+        b.withUnsafeMutableBytes { bufferPointer in
+            self._storage.copy(from: bufferPointer.baseAddress!, count: data.count)
+        }
     }
-    
+
     /// Constructor that creates a Flatbuffer instance with a size
     /// - Parameter size: Length of the buffer
     init(initialSize size: Int) {
         let size = size.convertToPowerofTwo
-        _memory = UnsafeMutableRawPointer.allocate(byteCount: size, alignment: alignment)
-        _memory.initializeMemory(as: UInt8.self, repeating: 0, count: size)
-        _capacity = size
+        _storage = Storage(count: size, alignment: alignment)
+        _storage.initalize(for: size)
     }
 
 #if swift(>=5.0)
@@ -61,83 +86,78 @@ public final class ByteBuffer {
         contiguousBytes: Bytes,
         count: Int
     ) {
-        _memory = UnsafeMutableRawPointer.allocate(byteCount: count, alignment: alignment)
-        _capacity = count
-        _writerSize = _capacity
+        _storage = Storage(count: count, alignment: alignment)
+        _writerSize = _storage.capacity
         contiguousBytes.withUnsafeBytes { buf in
-            _memory.copyMemory(from: buf.baseAddress!, byteCount: buf.count)
+            _storage.copy(from: buf.baseAddress!, count: buf.count)
         }
     }
 #endif
-    
+
     /// Creates a copy of the buffer that's being built by calling sizedBuffer
     /// - Parameters:
     ///   - memory: Current memory of the buffer
     ///   - count: count of bytes
     internal init(memory: UnsafeMutableRawPointer, count: Int) {
-        _memory = UnsafeMutableRawPointer.allocate(byteCount: count, alignment: alignment)
-        _memory.copyMemory(from: memory, byteCount: count)
-        _capacity = count
-        _writerSize = _capacity
+        _storage = Storage(count: count, alignment: alignment)
+        _storage.copy(from: memory, count: count)
+        _writerSize = _storage.capacity
     }
-    
+
     /// Creates a copy of the existing flatbuffer, by copying it to a different memory.
     /// - Parameters:
     ///   - memory: Current memory of the buffer
     ///   - count: count of bytes
     ///   - removeBytes: Removes a number of bytes from the current size
     internal init(memory: UnsafeMutableRawPointer, count: Int, removing removeBytes: Int) {
-        _memory = UnsafeMutableRawPointer.allocate(byteCount: count, alignment: alignment)
-        _memory.copyMemory(from: memory, byteCount: count)
-        _capacity = count
+        _storage = Storage(count: count, alignment: alignment)
+        _storage.copy(from: memory, count: count)
         _writerSize = removeBytes
     }
-    
-    deinit { _memory.deallocate() }
-    
+
     /// Fills the buffer with padding by adding to the writersize
     /// - Parameter padding: Amount of padding between two to be serialized objects
-    func fill(padding: UInt32) {
+    @usableFromInline mutating func fill(padding: UInt32) {
         ensureSpace(size: padding)
         _writerSize += (MemoryLayout<UInt8>.size * Int(padding))
     }
-    
+
     ///Adds an array of type Scalar to the buffer memory
     /// - Parameter elements: An array of Scalars
-    func push<T: Scalar>(elements: [T]) {
+    @usableFromInline mutating func push<T: Scalar>(elements: [T]) {
         let size = elements.count * MemoryLayout<T>.size
         ensureSpace(size: UInt32(size))
         elements.lazy.reversed().forEach { (s) in
             push(value: s, len: MemoryLayout.size(ofValue: s))
         }
     }
-    
+
     /// A custom type of structs that are padded according to the flatbuffer padding,
     /// - Parameters:
     ///   - value: Pointer to the object in memory
     ///   - size: Size of Value being written to the buffer
-    func push(struct value: UnsafeMutableRawPointer, size: Int) {
+    @usableFromInline mutating func push(struct value: UnsafeMutableRawPointer, size: Int) {
         ensureSpace(size: UInt32(size))
-        memcpy(_memory.advanced(by: writerIndex - size), value, size)
+        memcpy(_storage.memory.advanced(by: writerIndex - size), value, size)
         defer { value.deallocate() }
         _writerSize += size
     }
-    
+
     /// Adds an object of type Scalar into the buffer
     /// - Parameters:
     ///   - value: Object  that will be written to the buffer
     ///   - len: Offset to subtract from the WriterIndex
-    func push<T: Scalar>(value: T, len: Int) {
+    @usableFromInline mutating func push<T: Scalar>(value: T, len: Int) {
         ensureSpace(size: UInt32(len))
         var v = value.convertedEndian
-        memcpy(_memory.advanced(by: writerIndex - len), &v, len)
+        memcpy(_storage.memory.advanced(by: writerIndex - len), &v, len)
         _writerSize += len
     }
-    
+
     /// Adds a string to the buffer using swift.utf8 object
     /// - Parameter str: String that will be added to the buffer
     /// - Parameter len: length of the string
-    func push(string str: String, len: Int) {
+    @usableFromInline mutating func push(string str: String, len: Int) {
         ensureSpace(size: UInt32(len))
         if str.utf8.withContiguousStorageIfAvailable({ self.push(bytes: $0, len: len) }) != nil {
         } else {
@@ -147,18 +167,19 @@ public final class ByteBuffer {
             }
         }
     }
-    
+
     /// Writes a string to Bytebuffer using UTF8View
     /// - Parameters:
     ///   - bytes: Pointer to the view
     ///   - len: Size of string
-    private func push(bytes: UnsafeBufferPointer<String.UTF8View.Element>, len: Int) -> Bool {
-        _memory.advanced(by: writerIndex - len).copyMemory(from:
-            UnsafeRawPointer(bytes.baseAddress!), byteCount: len)
+    @usableFromInline mutating internal func push(bytes: UnsafeBufferPointer<String.UTF8View.Element>, len: Int) -> Bool {
+        memcpy(_storage.memory.advanced(by: writerIndex - len), UnsafeRawPointer(bytes.baseAddress!), len)
+//        _memory.advanced(by: writerIndex - len).copyMemory(from:
+//            UnsafeRawPointer(bytes.baseAddress!), byteCount: len)
         _writerSize += len
         return true
     }
-    
+
     /// Write stores an object into the buffer directly or indirectly.
     ///
     /// Direct: ignores the capacity of buffer which would mean we are referring to the direct point in memory
@@ -170,78 +191,78 @@ public final class ByteBuffer {
     func write<T>(value: T, index: Int, direct: Bool = false) {
         var index = index
         if !direct {
-            index = _capacity - index
+            index = _storage.capacity - index
         }
-        _memory.storeBytes(of: value, toByteOffset: index, as: T.self)
+        _storage.memory.storeBytes(of: value, toByteOffset: index, as: T.self)
     }
-    
+
     /// Makes sure that buffer has enouch space for each of the objects that will be written into it
     /// - Parameter size: size of object
     @discardableResult
-    func ensureSpace(size: UInt32) -> UInt32 {
-        if Int(size) + _writerSize > _capacity { reallocate(size) }
+    @usableFromInline mutating func ensureSpace(size: UInt32) -> UInt32 {
+        if Int(size) + _writerSize > _storage.capacity { reallocate(size) }
         assert(size < FlatBufferMaxSize, "Buffer can't grow beyond 2 Gigabytes")
         return size
     }
-    
+
     /// Reallocates the buffer incase the object to be written doesnt fit in the current buffer
     /// - Parameter size: Size of the current object
-    fileprivate func reallocate(_ size: UInt32) {
+    @usableFromInline mutating internal func reallocate(_ size: UInt32) {
         let currentWritingIndex = writerIndex
-        while _capacity <= _writerSize + Int(size) {
-            _capacity = _capacity << 1
+        while _storage.capacity <= _writerSize + Int(size) {
+            _storage.capacity = _storage.capacity << 1
         }
-        
+
         /// solution take from Apple-NIO
-        _capacity = _capacity.convertToPowerofTwo
-        
-        let newData = UnsafeMutableRawPointer.allocate(byteCount: _capacity, alignment: alignment)
-        newData.initializeMemory(as: UInt8.self, repeating: 0, count: _capacity)
+        _storage.capacity = _storage.capacity.convertToPowerofTwo
+
+        let newData = UnsafeMutableRawPointer.allocate(byteCount: _storage.capacity, alignment: alignment)
+        newData.initializeMemory(as: UInt8.self, repeating: 0, count: _storage.capacity)
         newData
             .advanced(by: writerIndex)
-            .copyMemory(from: _memory.advanced(by: currentWritingIndex), byteCount: _writerSize)
-        _memory.deallocate()
-        _memory = newData
+            .copyMemory(from: _storage.memory.advanced(by: currentWritingIndex), byteCount: _writerSize)
+        _storage.memory.deallocate()
+        _storage.memory = newData
     }
-    
+
     /// Clears the current size of the buffer
-    public func clearSize() {
+    mutating public func clearSize() {
         _writerSize = 0
     }
-    
+
     /// Clears the current instance of the buffer, replacing it with new memory
-    public func clear() {
+    mutating public func clear() {
         _writerSize = 0
         alignment = 1
-        _memory.deallocate()
-        _memory = UnsafeMutableRawPointer.allocate(byteCount: _capacity, alignment: alignment)
+        _storage.memory.deallocate()
+        _storage.memory = UnsafeMutableRawPointer.allocate(byteCount: _storage.capacity, alignment: alignment)
     }
     
     /// Resizes the buffer size
     /// - Parameter size: new size for the buffer
-    internal func resize(_ size: Int) {
+    @usableFromInline mutating internal func resize(_ size: Int) {
         _writerSize = size
     }
-    
+
     /// Reads an object from the buffer
     /// - Parameters:
     ///   - def: Type of the object
     ///   - position: the index of the object in the buffer
     public func read<T>(def: T.Type, position: Int) -> T {
-        return _memory.advanced(by: position).load(as: T.self)
+        return _storage.memory.advanced(by: position).load(as: T.self)
     }
-    
+
     /// Reads a slice from the memory assuming a type of T
     /// - Parameters:
     ///   - index: index of the object to be read from the buffer
     ///   - count: count of bytes in memory
     public func readSlice<T>(index: Int32,
                              count: Int32) -> [T] {
-        let start = _memory.advanced(by: Int(index)).assumingMemoryBound(to: T.self)
+        let start = _storage.memory.advanced(by: Int(index)).assumingMemoryBound(to: T.self)
         let array = UnsafeBufferPointer(start: start, count: Int(count))
         return Array(array)
     }
-    
+
     /// Reads a string from the buffer and encodes it to a swift string
     /// - Parameters:
     ///   - index: index of the string in the buffer
@@ -250,23 +271,23 @@ public final class ByteBuffer {
     public func readString(at index: Int32,
                            count: Int32,
                            type: String.Encoding = .utf8) -> String? {
-        let start = _memory.advanced(by: Int(index)).assumingMemoryBound(to: UInt8.self)
+        let start = _storage.memory.advanced(by: Int(index)).assumingMemoryBound(to: UInt8.self)
         let bufprt = UnsafeBufferPointer(start: start, count: Int(count))
         return String(bytes: Array(bufprt), encoding: type)
     }
-    
+
     /// Creates a new Flatbuffer object that's duplicated from the current one
     /// - Parameter removeBytes: the amount of bytes to remove from the current Size
     public func duplicate(removing removeBytes: Int = 0) -> ByteBuffer {
-        return ByteBuffer(memory: _memory, count: _capacity, removing: _writerSize - removeBytes)
+        return ByteBuffer(memory: _storage.memory, count: _storage.capacity, removing: _writerSize - removeBytes)
     }
 }
 
 extension ByteBuffer: CustomDebugStringConvertible {
-    
+
     public var debugDescription: String {
         """
-        buffer located at: \(_memory), with capacity of \(_capacity)
+        buffer located at: \(_storage.memory), with capacity of \(_storage.capacity)
         { writerSize: \(_writerSize), readerSize: \(reader), writerIndex: \(writerIndex) }
         """
     }

--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public final class FlatBufferBuilder {
+public struct FlatBufferBuilder {
     
     /// Vtables used in the buffer are stored in here, so they would be written later in EndTable
     private var _vtable: [UInt32] = []
@@ -72,7 +72,7 @@ public final class FlatBufferBuilder {
     }
     
     /// Clears the buffer and the builder from it's data
-    public func clear() {
+    mutating public func clear() {
         _minAlignment = 0
         isNested = false
         _bb.clear()
@@ -80,7 +80,7 @@ public final class FlatBufferBuilder {
     }
     
     /// Removes all the offsets from the VTable
-    public func clearOffsets() {
+    mutating public func clearOffsets() {
         _vtable = []
     }
     
@@ -90,7 +90,7 @@ public final class FlatBufferBuilder {
     /// - Parameters:
     ///   - table: offset for the table
     ///   - fields: Array of all the important fields to be serialized
-    public func require(table: Offset<UOffset>, fields: [Int32]) {
+    mutating public func require(table: Offset<UOffset>, fields: [Int32]) {
         for field in fields {
             let start = _bb.capacity - Int(table.o)
             let startTable = start - Int(_bb.read(def: Int32.self, position: start))
@@ -104,7 +104,7 @@ public final class FlatBufferBuilder {
     ///   - offset: Offset of the table
     ///   - fileId: Takes the fileId
     ///   - prefix: if false it wont add the size of the buffer
-    public func finish<T>(offset: Offset<T>, fileId: String, addPrefix prefix: Bool = false) {
+    mutating public func finish<T>(offset: Offset<T>, fileId: String, addPrefix prefix: Bool = false) {
         let size = MemoryLayout<UOffset>.size
         preAlign(len: size + (prefix ? size : 0) + FileIdLength, alignment: _minAlignment)
         assert(fileId.count == FileIdLength, "Flatbuffers requires file id to be 4")
@@ -116,7 +116,7 @@ public final class FlatBufferBuilder {
     /// - Parameters:
     ///   - offset: Offset of the table
     ///   - prefix: if false it wont add the size of the buffer
-    public func finish<T>(offset: Offset<T>, addPrefix prefix: Bool = false) {
+    mutating public func finish<T>(offset: Offset<T>, addPrefix prefix: Bool = false) {
         notNested()
         let size = MemoryLayout<UOffset>.size
         preAlign(len: size + (prefix ? size : 0), alignment: _minAlignment)
@@ -130,7 +130,7 @@ public final class FlatBufferBuilder {
     ///
     /// The function will fatalerror if called while there is another object being serialized
     /// - Parameter numOfFields: Number of elements to be written to the buffer
-    public func startTable(with numOfFields: Int) -> UOffset {
+    mutating public func startTable(with numOfFields: Int) -> UOffset {
         notNested()
         isNested = true
         _vtable = [UInt32](repeating: 0, count: numOfFields)
@@ -145,7 +145,7 @@ public final class FlatBufferBuilder {
     ///  2GB,
     /// - Parameter startOffset:Start point of the object written
     /// - returns: The root of the table
-    public func endTable(at startOffset: UOffset)  -> UOffset {
+    mutating public func endTable(at startOffset: UOffset)  -> UOffset {
         assert(isNested, "Calling endtable without calling starttable")
         let sizeofVoffset = MemoryLayout<VOffset>.size
         let vTableOffset = push(element: SOffset(0))
@@ -203,13 +203,13 @@ public final class FlatBufferBuilder {
     // MARK: - Builds Buffer
     
     /// asserts to see if the object is not nested
-    fileprivate func notNested()  {
+    @usableFromInline mutating internal func notNested()  {
         assert(!isNested, "Object serialization must not be nested")
     }
     
     /// Changes the minimuim alignment of the buffer
     /// - Parameter size: size of the current alignment
-    fileprivate func minAlignment(size: Int) {
+    @usableFromInline mutating internal func minAlignment(size: Int) {
         if size > _minAlignment {
             _minAlignment = size
         }
@@ -219,7 +219,7 @@ public final class FlatBufferBuilder {
     /// - Parameters:
     ///   - bufSize: Current size of the buffer + the offset of the object to be written
     ///   - elementSize: Element size
-    fileprivate func padding(bufSize: UInt32, elementSize: UInt32) -> UInt32 {
+    @usableFromInline mutating internal func padding(bufSize: UInt32, elementSize: UInt32) -> UInt32 {
         ((~bufSize) &+ 1) & (elementSize - 1)
     }
     
@@ -227,7 +227,7 @@ public final class FlatBufferBuilder {
     /// - Parameters:
     ///   - len:Length of the object
     ///   - alignment: Alignment type
-    fileprivate func preAlign(len: Int, alignment: Int) {
+    @usableFromInline mutating internal func preAlign(len: Int, alignment: Int) {
         minAlignment(size: alignment)
         _bb.fill(padding: padding(bufSize: _bb.size + UOffset(len), elementSize: UOffset(alignment)))
     }
@@ -236,13 +236,13 @@ public final class FlatBufferBuilder {
     /// - Parameters:
     ///   - len: Length of the object
     ///   - type: Type of the object to be written
-    fileprivate func preAlign<T: Scalar>(len: Int, type: T.Type) {
+    @usableFromInline mutating internal func preAlign<T: Scalar>(len: Int, type: T.Type) {
         preAlign(len: len, alignment: MemoryLayout<T>.size)
     }
     
     /// Refers to an object that's written in the buffer
     /// - Parameter off: the objects index value
-    fileprivate func refer(to off: UOffset) -> UOffset {
+    @usableFromInline mutating internal func refer(to off: UOffset) -> UOffset {
         let size = MemoryLayout<UOffset>.size
         preAlign(len: size, alignment: size)
         return _bb.size - off + UInt32(size)
@@ -252,14 +252,14 @@ public final class FlatBufferBuilder {
     /// - Parameters:
     ///   - offset: The offset of the element witten
     ///   - position: The position of the element
-    fileprivate func track(offset: UOffset, at position: VOffset) {
+    @usableFromInline mutating internal func track(offset: UOffset, at position: VOffset) {
         _vtable[Int(position)] = offset
     }
 
     // MARK: - Vectors
     
     /// Starts a vector of length and Element size
-    public func startVector(_ len: Int, elementSize: Int) {
+    mutating public func startVector(_ len: Int, elementSize: Int) {
         notNested()
         isNested = true
         preAlign(len: len * elementSize, type: UOffset.self)
@@ -270,7 +270,7 @@ public final class FlatBufferBuilder {
     ///
     /// The current function will fatalError if startVector is called before serializing the vector
     /// - Parameter len: Length of the buffer
-    public func endVector(len: Int) -> UOffset {
+    mutating public func endVector(len: Int) -> UOffset {
         assert(isNested, "Calling endVector without calling startVector")
         isNested = false
         return push(element: Int32(len))
@@ -279,7 +279,7 @@ public final class FlatBufferBuilder {
     /// Creates a vector of type Scalar in the buffer
     /// - Parameter elements: elements to be written into the buffer
     /// - returns: Offset of the vector
-    public func createVector<T: Scalar>(_ elements: [T]) -> Offset<UOffset> {
+    mutating public func createVector<T: Scalar>(_ elements: [T]) -> Offset<UOffset> {
         return createVector(elements, size: elements.count)
     }
     
@@ -287,7 +287,7 @@ public final class FlatBufferBuilder {
     /// - Parameter elements: Elements to be written into the buffer
     /// - Parameter size: Count of elements
     /// - returns: Offset of the vector
-    public func createVector<T: Scalar>(_ elements: [T], size: Int) -> Offset<UOffset> {
+    mutating public func createVector<T: Scalar>(_ elements: [T], size: Int) -> Offset<UOffset> {
         let size = size
         startVector(size, elementSize: MemoryLayout<T>.size)
         _bb.push(elements: elements)
@@ -297,7 +297,7 @@ public final class FlatBufferBuilder {
     /// Creates a vector of type Enums in the buffer
     /// - Parameter elements: elements to be written into the buffer
     /// - returns: Offset of the vector
-    public func createVector<T: Enum>(_ elements: [T]) -> Offset<UOffset> {
+    mutating public func createVector<T: Enum>(_ elements: [T]) -> Offset<UOffset> {
         return createVector(elements, size: elements.count)
     }
     
@@ -305,7 +305,7 @@ public final class FlatBufferBuilder {
     /// - Parameter elements: Elements to be written into the buffer
     /// - Parameter size: Count of elements
     /// - returns: Offset of the vector
-    public func createVector<T: Enum>(_ elements: [T], size: Int) -> Offset<UOffset> {
+    mutating public func createVector<T: Enum>(_ elements: [T], size: Int) -> Offset<UOffset> {
         let size = size
         startVector(size, elementSize: T.byteSize)
         for e in elements.lazy.reversed() {
@@ -317,7 +317,7 @@ public final class FlatBufferBuilder {
     /// Creates a vector of type Offsets  in the buffer
     /// - Parameter offsets:Array of offsets of type T
     /// - returns: Offset of the vector
-    public func createVector<T>(ofOffsets offsets: [Offset<T>]) -> Offset<UOffset> {
+    mutating public func createVector<T>(ofOffsets offsets: [Offset<T>]) -> Offset<UOffset> {
         createVector(ofOffsets: offsets, len: offsets.count)
     }
     
@@ -325,7 +325,7 @@ public final class FlatBufferBuilder {
     /// - Parameter elements: Array of offsets of type T
     /// - Parameter size: Count of elements
     /// - returns: Offset of the vector
-    public func createVector<T>(ofOffsets offsets: [Offset<T>], len: Int) -> Offset<UOffset> {
+    mutating public func createVector<T>(ofOffsets offsets: [Offset<T>], len: Int) -> Offset<UOffset> {
         startVector(len, elementSize: MemoryLayout<Offset<T>>.size)
         for o in offsets.lazy.reversed() {
             push(element: o)
@@ -336,7 +336,7 @@ public final class FlatBufferBuilder {
     /// Creates a vector of Strings
     /// - Parameter str: a vector of strings that will be written into the buffer
     /// - returns: Offset of the vector
-    public func createVector(ofStrings str: [String]) -> Offset<UOffset> {
+    mutating public func createVector(ofStrings str: [String]) -> Offset<UOffset> {
         var offsets: [Offset<String>] = []
         for s in str {
             offsets.append(create(string: s))
@@ -351,7 +351,7 @@ public final class FlatBufferBuilder {
     ///   - structs: An array of UnsafeMutableRawPointer
     ///   - type: Type of the struct being written
     /// - returns: Offset of the vector
-    public func createVector<T: Readable>(structs: [UnsafeMutableRawPointer],
+    mutating public func createVector<T: Readable>(structs: [UnsafeMutableRawPointer],
                                           type: T.Type) -> Offset<UOffset> {
         startVector(structs.count * T.size, elementSize: T.alignment)
         for i in structs.lazy.reversed() {
@@ -368,7 +368,7 @@ public final class FlatBufferBuilder {
     ///   - type: Type of the element to be serialized
     /// - returns: Offset of the Object
     @discardableResult
-    public func create<T: Readable>(struct s: UnsafeMutableRawPointer,
+    mutating public func create<T: Readable>(struct s: UnsafeMutableRawPointer,
                                     type: T.Type) -> Offset<UOffset> {
         let size = T.size
         preAlign(len: size, alignment: T.alignment)
@@ -380,7 +380,7 @@ public final class FlatBufferBuilder {
     ///
     /// The function fatalErrors if we pass an offset that is out of range
     /// - Parameter o: offset
-    public func add(structOffset o: UOffset) {
+    mutating public func add(structOffset o: UOffset) {
         guard Int(o) < _vtable.count else { fatalError("Out of the table range") }
         _vtable[Int(o)] = _bb.size
     }
@@ -390,7 +390,7 @@ public final class FlatBufferBuilder {
     /// Insets a string into the buffer using UTF8
     /// - Parameter str: String to be serialized
     /// - returns: The strings offset in the buffer
-    public func create(string str: String) -> Offset<String> {
+    mutating public func create(string str: String) -> Offset<String> {
         let len = str.count
         notNested()
         preAlign(len: len + 1, type: UOffset.self)
@@ -405,7 +405,7 @@ public final class FlatBufferBuilder {
     /// The function checks the stringOffsetmap if it's seen a similar string before
     /// - Parameter str: String to be serialized
     /// - returns: The strings offset in the buffer
-    public func createShared(string str: String) -> Offset<String> {
+    mutating public func createShared(string str: String) -> Offset<String> {
         if let offset = stringOffsetMap[str] {
             return offset
         }
@@ -420,7 +420,7 @@ public final class FlatBufferBuilder {
     /// - Parameters:
     ///   - offset: Offset of another object to be written
     ///   - position: The  predefined position of the object
-    public func add<T>(offset: Offset<T>, at position: VOffset) {
+    mutating public func add<T>(offset: Offset<T>, at position: VOffset) {
         if offset.isEmpty {
             track(offset: 0, at: position)
             return
@@ -432,7 +432,7 @@ public final class FlatBufferBuilder {
     /// - Parameter o: Offset
     /// - returns: Position of the offset
     @discardableResult
-    public func push<T>(element o: Offset<T>) -> UOffset {
+    mutating public func push<T>(element o: Offset<T>) -> UOffset {
         push(element: refer(to: o.o))
     }
     
@@ -444,7 +444,7 @@ public final class FlatBufferBuilder {
     ///   - element: Element to insert
     ///   - def: Default value for that element
     ///   - position: The predefined position of the element
-    public func add<T: Scalar>(element: T, def: T, at position: VOffset) {
+    mutating public func add<T: Scalar>(element: T, def: T, at position: VOffset) {
         if (element == def && !serializeDefaults) {
             track(offset: 0, at: position)
             return
@@ -458,7 +458,7 @@ public final class FlatBufferBuilder {
     ///   - condition: Condition to insert
     ///   - def: Default condition
     ///   - position: The predefined position of the element
-    public func add(condition: Bool, def: Bool, at position: VOffset) {
+    mutating public func add(condition: Bool, def: Bool, at position: VOffset) {
         if (condition == def && !serializeDefaults) {
             track(offset: 0, at: position)
             return
@@ -471,12 +471,13 @@ public final class FlatBufferBuilder {
     /// - Parameter element: Element to insert
     /// - returns: Postion of the Element
     @discardableResult
-    public func push<T: Scalar>(element: T) -> UOffset {
+    mutating public func push<T: Scalar>(element: T) -> UOffset {
         preAlign(len: MemoryLayout<T>.size,
                  alignment: MemoryLayout<T>.size)
         _bb.push(value: element, len: MemoryLayout<T>.size)
         return _bb.size
     }
+    
 }
 
 extension FlatBufferBuilder: CustomDebugStringConvertible {

--- a/tests/FlatBuffers.Benchmarks.swift/Sources/FlatBuffers.Benchmarks.swift/main.swift
+++ b/tests/FlatBuffers.Benchmarks.swift/Sources/FlatBuffers.Benchmarks.swift/main.swift
@@ -34,21 +34,21 @@ func createDocument(Benchmarks: [Benchmark]) -> String {
 }
 
 @inlinable func create10Strings() {
-    let fb = FlatBufferBuilder(initialSize: 1<<20)
+    var fb = FlatBufferBuilder(initialSize: 1<<20)
     for _ in 0..<10_000 {
         _ = fb.create(string: "foobarbaz")
     }
 }
 
 @inlinable func create100Strings(str: String) {
-    let fb = FlatBufferBuilder(initialSize: 1<<20)
+    var fb = FlatBufferBuilder(initialSize: 1<<20)
     for _ in 0..<10_000 {
         _ = fb.create(string: str)
     }
 }
 
 @inlinable func benchmarkFiveHundredAdds() {
-    let fb = FlatBufferBuilder(initialSize: 1024 * 1024 * 32)
+    var fb = FlatBufferBuilder(initialSize: 1024 * 1024 * 32)
     for _ in 0..<500_000 {
         let off = fb.create(string: "T")
         let s = fb.startTable(with: 4)

--- a/tests/FlatBuffers.GRPC.Swift/Sources/Model/greeter_generated.swift
+++ b/tests/FlatBuffers.GRPC.Swift/Sources/Model/greeter_generated.swift
@@ -15,14 +15,14 @@ public struct HelloReply: FlatBufferObject {
 
 	public var message: String? { let o = _accessor.offset(4); return o == 0 ? nil : _accessor.string(at: o) }
 	public var messageSegmentArray: [UInt8]? { return _accessor.getVector(at: 4) }
-	public static func startHelloReply(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
-	public static func add(message: Offset<String>, _ fbb: FlatBufferBuilder) { fbb.add(offset: message, at: 0)  }
-	public static func endHelloReply(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-	public static func createHelloReply(_ fbb: FlatBufferBuilder,
+	public static func startHelloReply(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
+	public static func add(message: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: message, at: 0)  }
+	public static func endHelloReply(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+	public static func createHelloReply(_ fbb: inout FlatBufferBuilder,
 		offsetOfMessage message: Offset<String> = Offset()) -> Offset<UOffset> {
-		let __start = HelloReply.startHelloReply(fbb)
-		HelloReply.add(message: message, fbb)
-		return HelloReply.endHelloReply(fbb, start: __start)
+		let __start = HelloReply.startHelloReply(&fbb)
+		HelloReply.add(message: message, &fbb)
+		return HelloReply.endHelloReply(&fbb, start: __start)
 	}
 }
 
@@ -39,14 +39,14 @@ public struct HelloRequest: FlatBufferObject {
 
 	public var name: String? { let o = _accessor.offset(4); return o == 0 ? nil : _accessor.string(at: o) }
 	public var nameSegmentArray: [UInt8]? { return _accessor.getVector(at: 4) }
-	public static func startHelloRequest(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
-	public static func add(name: Offset<String>, _ fbb: FlatBufferBuilder) { fbb.add(offset: name, at: 0)  }
-	public static func endHelloRequest(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-	public static func createHelloRequest(_ fbb: FlatBufferBuilder,
+	public static func startHelloRequest(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
+	public static func add(name: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: name, at: 0)  }
+	public static func endHelloRequest(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+	public static func createHelloRequest(_ fbb: inout FlatBufferBuilder,
 		offsetOfName name: Offset<String> = Offset()) -> Offset<UOffset> {
-		let __start = HelloRequest.startHelloRequest(fbb)
-		HelloRequest.add(name: name, fbb)
-		return HelloRequest.endHelloRequest(fbb, start: __start)
+		let __start = HelloRequest.startHelloRequest(&fbb)
+		HelloRequest.add(name: name, &fbb)
+		return HelloRequest.endHelloRequest(&fbb, start: __start)
 	}
 }
 
@@ -64,17 +64,17 @@ public struct ManyHellosRequest: FlatBufferObject {
 	public var name: String? { let o = _accessor.offset(4); return o == 0 ? nil : _accessor.string(at: o) }
 	public var nameSegmentArray: [UInt8]? { return _accessor.getVector(at: 4) }
 	public var numGreetings: Int32 { let o = _accessor.offset(6); return o == 0 ? 0 : _accessor.readBuffer(of: Int32.self, at: o) }
-	public static func startManyHellosRequest(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 2) }
-	public static func add(name: Offset<String>, _ fbb: FlatBufferBuilder) { fbb.add(offset: name, at: 0)  }
-	public static func add(numGreetings: Int32, _ fbb: FlatBufferBuilder) { fbb.add(element: numGreetings, def: 0, at: 1) }
-	public static func endManyHellosRequest(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-	public static func createManyHellosRequest(_ fbb: FlatBufferBuilder,
+	public static func startManyHellosRequest(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 2) }
+	public static func add(name: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: name, at: 0)  }
+	public static func add(numGreetings: Int32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: numGreetings, def: 0, at: 1) }
+	public static func endManyHellosRequest(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+	public static func createManyHellosRequest(_ fbb: inout FlatBufferBuilder,
 		offsetOfName name: Offset<String> = Offset(),
 		numGreetings: Int32 = 0) -> Offset<UOffset> {
-		let __start = ManyHellosRequest.startManyHellosRequest(fbb)
-		ManyHellosRequest.add(name: name, fbb)
-		ManyHellosRequest.add(numGreetings: numGreetings, fbb)
-		return ManyHellosRequest.endManyHellosRequest(fbb, start: __start)
+		let __start = ManyHellosRequest.startManyHellosRequest(&fbb)
+		ManyHellosRequest.add(name: name, &fbb)
+		ManyHellosRequest.add(numGreetings: numGreetings, &fbb)
+		return ManyHellosRequest.endManyHellosRequest(&fbb, start: __start)
 	}
 }
 

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
@@ -45,20 +45,20 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     }
 
     func createMonster(withPrefix prefix: Bool) -> FlatBufferBuilder {
-        let fbb = FlatBufferBuilder(initialSize: 1)
+        var fbb = FlatBufferBuilder(initialSize: 1)
         let names = [fbb.create(string: "Frodo"), fbb.create(string: "Barney"), fbb.create(string: "Wilma")]
         var offsets: [Offset<UOffset>] = []
-        let start1 = Monster1.startMonster(fbb)
-        Monster1.add(name: names[0], fbb)
-        offsets.append(Monster1.endMonster(fbb, start: start1))
-        let start2 = Monster1.startMonster(fbb)
-        Monster1.add(name: names[1], fbb)
-        offsets.append(Monster1.endMonster(fbb, start: start2))
-        let start3 = Monster1.startMonster(fbb)
-        Monster1.add(name: names[2], fbb)
-        offsets.append(Monster1.endMonster(fbb, start: start3))
+        let start1 = Monster1.startMonster(&fbb)
+        Monster1.add(name: names[0], &fbb)
+        offsets.append(Monster1.endMonster(&fbb, start: start1))
+        let start2 = Monster1.startMonster(&fbb)
+        Monster1.add(name: names[1], &fbb)
+        offsets.append(Monster1.endMonster(&fbb, start: start2))
+        let start3 = Monster1.startMonster(&fbb)
+        Monster1.add(name: names[2], &fbb)
+        offsets.append(Monster1.endMonster(&fbb, start: start3))
 
-        let sortedArray = Monster1.sortVectorOfMonster(offsets: offsets, fbb)
+        let sortedArray = Monster1.sortVectorOfMonster(offsets: offsets, &fbb)
 
         let str = fbb.create(string: "MyMonster")
         let test1 = fbb.create(string: "test1")
@@ -67,29 +67,29 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
         let inv = fbb.createVector(_inv)
 
         let fred = fbb.create(string: "Fred")
-        let mon1Start = Monster1.startMonster(fbb)
-        Monster1.add(name: fred, fbb)
-        let mon2 = Monster1.endMonster(fbb, start: mon1Start)
+        let mon1Start = Monster1.startMonster(&fbb)
+        Monster1.add(name: fred, &fbb)
+        let mon2 = Monster1.endMonster(&fbb, start: mon1Start)
         let test4 = fbb.createVector(structs: [MyGame.Example.createTest(a: 30, b: 40),
                                                MyGame.Example.createTest(a: 10, b: 20)],
                                      type: Test1.self)
 
         let stringTestVector = fbb.createVector(ofOffsets: [test1, test2])
 
-        let mStart = Monster1.startMonster(fbb)
+        let mStart = Monster1.startMonster(&fbb)
         let posOffset = fbb.create(struct: MyGame.Example.createVec3(x: 1, y: 2, z: 3, test1: 3, test2: .green, test3a: 5, test3b: 6), type: Vec3.self)
-        Monster1.add(pos: posOffset, fbb)
-        Monster1.add(hp: 80, fbb)
-        Monster1.add(name: str, fbb)
-        Monster1.addVectorOf(inventory: inv, fbb)
-        Monster1.add(testType: .monster, fbb)
-        Monster1.add(test: mon2, fbb)
-        Monster1.addVectorOf(test4: test4, fbb)
-        Monster1.addVectorOf(testarrayofstring: stringTestVector, fbb)
-        Monster1.add(testbool: true, fbb)
-        Monster1.addVectorOf(testarrayoftables: sortedArray, fbb)
-        let end = Monster1.endMonster(fbb, start: mStart)
-        Monster1.finish(fbb, end: end, prefix: prefix)
+        Monster1.add(pos: posOffset, &fbb)
+        Monster1.add(hp: 80, &fbb)
+        Monster1.add(name: str, &fbb)
+        Monster1.addVectorOf(inventory: inv, &fbb)
+        Monster1.add(testType: .monster, &fbb)
+        Monster1.add(test: mon2, &fbb)
+        Monster1.addVectorOf(test4: test4, &fbb)
+        Monster1.addVectorOf(testarrayofstring: stringTestVector, &fbb)
+        Monster1.add(testbool: true, &fbb)
+        Monster1.addVectorOf(testarrayoftables: sortedArray, &fbb)
+        let end = Monster1.endMonster(&fbb, start: mStart)
+        Monster1.finish(&fbb, end: end, prefix: prefix)
         return fbb
     }
 

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersStructsTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersStructsTests.swift
@@ -5,18 +5,18 @@ final class FlatBuffersStructsTests: XCTestCase {
     
     func testCreatingStruct() {
         let v = createVecWrite(x: 1.0, y: 2.0, z: 3.0)
-        let b = FlatBufferBuilder(initialSize: 20)
+        var b = FlatBufferBuilder(initialSize: 20)
         let o = b.create(struct: v, type: Vec.self)
-        let end = VPointerVec.createVPointer(b: b, o: o)
+        let end = VPointerVec.createVPointer(b: &b, o: o)
         b.finish(offset: end)
         XCTAssertEqual(b.sizedByteArray, [12, 0, 0, 0, 0, 0, 6, 0, 4, 0, 4, 0, 6, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64])
     }
     
     func testReadingStruct() {
         let v = createVecWrite(x: 1.0, y: 2.0, z: 3.0)
-        let b = FlatBufferBuilder(initialSize: 20)
+        var b = FlatBufferBuilder(initialSize: 20)
         let o = b.create(struct: v, type: Vec.self)
-        let end = VPointerVec.createVPointer(b: b, o: o)
+        let end = VPointerVec.createVPointer(b: &b, o: o)
         b.finish(offset: end)
         let buffer = b.sizedByteArray
         XCTAssertEqual(buffer, [12, 0, 0, 0, 0, 0, 6, 0, 4, 0, 4, 0, 6, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64])
@@ -25,34 +25,34 @@ final class FlatBuffersStructsTests: XCTestCase {
     }
     
     func testCreatingVectorStruct() {
-        let b = FlatBufferBuilder(initialSize: 20)
+        var b = FlatBufferBuilder(initialSize: 20)
         let path = b.createVector(structs: [createVecWrite(x: 1, y: 2, z: 3), createVecWrite(x: 4.0, y: 5.0, z: 6)], type: Vec.self)
-        let end = VPointerVectorVec.createVPointer(b: b, v: path)
+        let end = VPointerVectorVec.createVPointer(b: &b, v: path)
         b.finish(offset: end)
         XCTAssertEqual(b.sizedByteArray, [12, 0, 0, 0, 8, 0, 8, 0, 0, 0, 4, 0, 8, 0, 0, 0, 4, 0, 0, 0, 2, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 128, 64, 0, 0, 160, 64, 0, 0, 192, 64])
     }
     
     func testCreatingVectorStructWithForcedDefaults() {
-        let b = FlatBufferBuilder(initialSize: 20, serializeDefaults: true)
+        var b = FlatBufferBuilder(initialSize: 20, serializeDefaults: true)
         let path = b.createVector(structs: [createVecWrite(x: 1, y: 2, z: 3), createVecWrite(x: 4.0, y: 5.0, z: 6)], type: Vec.self)
-        let end = VPointerVectorVec.createVPointer(b: b, v: path)
+        let end = VPointerVectorVec.createVPointer(b: &b, v: path)
         b.finish(offset: end)
         XCTAssertEqual(b.sizedByteArray, [12, 0, 0, 0, 8, 0, 12, 0, 4, 0, 8, 0, 8, 0, 0, 0, 1, 0, 0, 0, 4, 0, 0, 0, 2, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 128, 64, 0, 0, 160, 64, 0, 0, 192, 64])
     }
     
     func testCreatingEnums() {
-        let b = FlatBufferBuilder(initialSize: 20)
+        var b = FlatBufferBuilder(initialSize: 20)
         let path = b.createVector(structs: [createVecWrite(x: 1, y: 2, z: 3), createVecWrite(x: 4, y: 5, z: 6)], type: Vec.self)
-        let end = VPointerVectorVec.createVPointer(b: b, color: .blue, v: path)
+        let end = VPointerVectorVec.createVPointer(b: &b, color: .blue, v: path)
         b.finish(offset: end)
         XCTAssertEqual(b.sizedByteArray, [12, 0, 0, 0, 8, 0, 12, 0, 4, 0, 8, 0, 8, 0, 0, 0, 2, 0, 0, 0, 4, 0, 0, 0, 2, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 128, 64, 0, 0, 160, 64, 0, 0, 192, 64])
     }
     
     func testReadingStructWithEnums() {
-        let b = FlatBufferBuilder(initialSize: 20)
+        var b = FlatBufferBuilder(initialSize: 20)
         let vec = createVec2(x: 1, y: 2, z: 3, color: .red)
         let o = b.create(struct: vec, type: Vec2.self)
-        let end = VPointerVec2.createVPointer(b: b, o: o, type: .vec)
+        let end = VPointerVec2.createVPointer(b: &b, o: o, type: .vec)
         b.finish(offset: end)
         let buffer = b.sizedByteArray
         XCTAssertEqual(buffer, [16, 0, 0, 0, 0, 0, 10, 0, 12, 0, 12, 0, 11, 0, 4, 0, 10, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1, 0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 0, 0])
@@ -101,13 +101,13 @@ struct VPointerVec {
         return VPointerVec(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: 0))))
     }
     
-    static func startVPointer(b: FlatBufferBuilder) -> UOffset { b.startTable(with: 1) }
-    static func finish(b: FlatBufferBuilder, s: UOffset) -> Offset<UOffset> { return Offset(offset: b.endTable(at: s)) }
+    static func startVPointer(b: inout FlatBufferBuilder) -> UOffset { b.startTable(with: 1) }
+    static func finish(b: inout FlatBufferBuilder, s: UOffset) -> Offset<UOffset> { return Offset(offset: b.endTable(at: s)) }
     
-    static func createVPointer(b: FlatBufferBuilder, o: Offset<UOffset>) -> Offset<UOffset> {
-        let s = VPointerVec.startVPointer(b: b)
+    static func createVPointer(b: inout FlatBufferBuilder, o: Offset<UOffset>) -> Offset<UOffset> {
+        let s = VPointerVec.startVPointer(b: &b)
         b.add(structOffset: 0)
-        return VPointerVec.finish(b: b, s: s)
+        return VPointerVec.finish(b: &b, s: s)
     }
 }
 
@@ -117,19 +117,19 @@ private let VPointerVectorVecOffsets: (color: VOffset, vector: VOffset) = (0, 1)
 
 struct VPointerVectorVec {
     
-    static func startVPointer(b: FlatBufferBuilder) -> UOffset { b.startTable(with: 2) }
+    static func startVPointer(b: inout FlatBufferBuilder) -> UOffset { b.startTable(with: 2) }
     
-    static func addVector(b: FlatBufferBuilder, v: Offset<UOffset>) { b.add(offset: v, at: VPointerVectorVecOffsets.vector) }
+    static func addVector(b: inout FlatBufferBuilder, v: Offset<UOffset>) { b.add(offset: v, at: VPointerVectorVecOffsets.vector) }
     
-    static func addColor(b: FlatBufferBuilder, color: Color) { b.add(element: color.rawValue, def: 1, at: VPointerVectorVecOffsets.color) }
+    static func addColor(b: inout FlatBufferBuilder, color: Color) { b.add(element: color.rawValue, def: 1, at: VPointerVectorVecOffsets.color) }
     
-    static func finish(b: FlatBufferBuilder, s: UOffset) -> Offset<UOffset> { return Offset(offset: b.endTable(at: s)) }
+    static func finish(b: inout FlatBufferBuilder, s: UOffset) -> Offset<UOffset> { return Offset(offset: b.endTable(at: s)) }
     
-    static func createVPointer(b: FlatBufferBuilder, color: Color = .green, v: Offset<UOffset>) -> Offset<UOffset> {
-        let s = VPointerVectorVec.startVPointer(b: b)
-        VPointerVectorVec.addVector(b: b, v: v)
-        VPointerVectorVec.addColor(b: b, color: color)
-        return VPointerVectorVec.finish(b: b, s: s)
+    static func createVPointer(b: inout FlatBufferBuilder, color: Color = .green, v: Offset<UOffset>) -> Offset<UOffset> {
+        let s = VPointerVectorVec.startVPointer(b: &b)
+        VPointerVectorVec.addVector(b: &b, v: v)
+        VPointerVectorVec.addColor(b: &b, color: color)
+        return VPointerVectorVec.finish(b: &b, s: s)
     }
 }
 
@@ -174,14 +174,14 @@ struct VPointerVec2 {
         return VPointerVec2(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: 0))))
     }
     
-    static func startVPointer(b: FlatBufferBuilder) -> UOffset { b.startTable(with: 3) }
-    static func finish(b: FlatBufferBuilder, s: UOffset) -> Offset<UOffset> { return Offset(offset: b.endTable(at: s)) }
+    static func startVPointer(b: inout FlatBufferBuilder) -> UOffset { b.startTable(with: 3) }
+    static func finish(b: inout FlatBufferBuilder, s: UOffset) -> Offset<UOffset> { return Offset(offset: b.endTable(at: s)) }
     
-    static func createVPointer(b: FlatBufferBuilder, o: Offset<UOffset>, type: Test) -> Offset<UOffset> {
-        let s = VPointerVec2.startVPointer(b: b)
+    static func createVPointer(b: inout FlatBufferBuilder, o: Offset<UOffset>, type: Test) -> Offset<UOffset> {
+        let s = VPointerVec2.startVPointer(b: &b)
         b.add(structOffset: 0)
         b.add(element: type.rawValue, def: Test.none.rawValue, at: 1)
         b.add(offset: o, at: 2)
-        return VPointerVec2.finish(b: b, s: s)
+        return VPointerVec2.finish(b: &b, s: s)
     }
 }

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersTests.swift
@@ -16,7 +16,7 @@ final class FlatBuffersTests: XCTestCase {
     
     func testCreateString() {
         let helloWorld = "Hello, world!"
-        let b = FlatBufferBuilder(initialSize: 16)
+        var b = FlatBufferBuilder(initialSize: 16)
         XCTAssertEqual(b.create(string: country).o, 12)
         XCTAssertEqual(b.create(string: helloWorld).o, 32)
         b.clear()
@@ -27,7 +27,7 @@ final class FlatBuffersTests: XCTestCase {
     }
     
     func testStartTable() {
-        let b = FlatBufferBuilder(initialSize: 16)
+        var b = FlatBufferBuilder(initialSize: 16)
         XCTAssertNoThrow(b.startTable(with: 0))
         b.clear()
         XCTAssertEqual(b.create(string: country).o, 12)

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersUnionTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersUnionTests.swift
@@ -59,11 +59,11 @@ final class FlatBuffersUnionTests: XCTestCase {
     func testEnumVector() {
         let vectorOfEnums: [ColorsNameSpace.RGB] = [.blue, .green]
         
-        let builder = FlatBufferBuilder(initialSize: 1)
+        var builder = FlatBufferBuilder(initialSize: 1)
         let off = builder.createVector(vectorOfEnums)
-        let start = ColorsNameSpace.Monster.startMonster(builder)
-        ColorsNameSpace.Monster.add(colors: off, builder)
-        let end = ColorsNameSpace.Monster.endMonster(builder, start: start)
+        let start = ColorsNameSpace.Monster.startMonster(&builder)
+        ColorsNameSpace.Monster.add(colors: off, &builder)
+        let end = ColorsNameSpace.Monster.endMonster(&builder, start: start)
         builder.finish(offset: end)
         XCTAssertEqual(builder.sizedByteArray, [12, 0, 0, 0, 0, 0, 6, 0, 8, 0, 4, 0, 6, 0, 0, 0, 4, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0])
         let monster = ColorsNameSpace.Monster.getRootAsMonster(bb: builder.buffer)
@@ -73,12 +73,12 @@ final class FlatBuffersUnionTests: XCTestCase {
     }
     
     func testUnionVector() {
-        let fb = FlatBufferBuilder()
+        var fb = FlatBufferBuilder()
         
         let swordDmg: Int32 = 8
-        let attackStart = Attacker.startAttacker(fb)
-        Attacker.add(swordAttackDamage: swordDmg, fb)
-        let attack = Attacker.endAttacker(fb, start: attackStart)
+        let attackStart = Attacker.startAttacker(&fb)
+        Attacker.add(swordAttackDamage: swordDmg, &fb)
+        let attack = Attacker.endAttacker(&fb, start: attackStart)
         
         let characterType: [Character] = [.belle, .mulan, .bookfan]
         let characters = [
@@ -88,8 +88,8 @@ final class FlatBuffersUnionTests: XCTestCase {
         ]
         let types = fb.createVector(characterType)
         let characterVector = fb.createVector(ofOffsets: characters)
-        let end = Movie.createMovie(fb, vectorOfCharactersType: types, vectorOfCharacters: characterVector)
-        Movie.finish(fb, end: end)
+        let end = Movie.createMovie(&fb, vectorOfCharactersType: types, vectorOfCharacters: characterVector)
+        Movie.finish(&fb, end: end)
         
         let movie = Movie.getRootAsMovie(bb: fb.buffer)
         XCTAssertEqual(movie.charactersTypeCount, Int32(characterType.count))
@@ -125,9 +125,9 @@ struct Monster: FlatBufferObject {
 
     public var colorsCount: Int32 { let o = _accessor.offset(4); return o == 0 ? 0 : _accessor.vector(count: o) }
     public func colors(at index: Int32) -> ColorsNameSpace.RGB? { let o = _accessor.offset(4); return o == 0 ? ColorsNameSpace.RGB(rawValue: 0)! : ColorsNameSpace.RGB(rawValue: _accessor.directRead(of: Int32.self, offset: _accessor.vector(at: o) + index * 4)) }
-    static func startMonster(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
-    static func add(colors: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: colors, at: 0)  }
-    static func endMonster(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+    static func startMonster(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
+    static func add(colors: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: colors, at: 0)  }
+    static func endMonster(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
 }
 }
 

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersVectorsTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersVectorsTests.swift
@@ -19,7 +19,7 @@ final class FlatBuffersVectors: XCTestCase {
     
     func testCreateIntArray() {
         let numbers: [Int32] = [1, 2, 3, 4, 5]
-        let b = FlatBufferBuilder(initialSize: 20)
+        var b = FlatBufferBuilder(initialSize: 20)
         let o = b.createVector(numbers, size: numbers.count)
         b.finish(offset: o)
         XCTAssertEqual(b.sizedByteArray, [4, 0, 0, 0, 5, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0])
@@ -27,7 +27,7 @@ final class FlatBuffersVectors: XCTestCase {
     
     func testCreateEmptyIntArray() {
         let numbers: [Int32] = []
-        let b = FlatBufferBuilder(initialSize: 20)
+        var b = FlatBufferBuilder(initialSize: 20)
         let o = b.createVector(numbers, size: numbers.count)
         b.finish(offset: o)
         XCTAssertEqual(b.sizedByteArray, [4, 0, 0, 0, 0, 0, 0, 0])
@@ -35,7 +35,7 @@ final class FlatBuffersVectors: XCTestCase {
 
     func testCreateVectorOfStrings() {
         let strs = ["Denmark", "Norway"]
-        let b = FlatBufferBuilder(initialSize: 20)
+        var b = FlatBufferBuilder(initialSize: 20)
         let o = b.createVector(ofStrings: strs)
         b.finish(offset: o)
         XCTAssertEqual(b.sizedByteArray, [4, 0, 0, 0, 2, 0, 0, 0, 20, 0, 0, 0, 4, 0, 0, 0, 6, 0, 0, 0, 78, 111, 114, 119, 97, 121, 0, 0, 7, 0, 0, 0, 68, 101, 110, 109, 97, 114, 107, 0])
@@ -43,7 +43,7 @@ final class FlatBuffersVectors: XCTestCase {
     func testCreateSharedStringVector() {
         let norway = "Norway"
         let denmark = "Denmark"
-        let b = FlatBufferBuilder(initialSize: 20)
+        var b = FlatBufferBuilder(initialSize: 20)
         let noStr = b.createShared(string: norway)
         let deStr = b.createShared(string: denmark)
         let _noStr = b.createShared(string: norway)
@@ -56,9 +56,9 @@ final class FlatBuffersVectors: XCTestCase {
     
     func testReadInt32Array() {
         let data: [Int32] = [1, 2, 3, 4, 5]
-        let b = FlatBufferBuilder(initialSize: 20)
-        let v = Numbers.createNumbersVector(b: b, array: data)
-        let end = Numbers.createNumbers(b: b, o: v)
+        var b = FlatBufferBuilder(initialSize: 20)
+        let v = Numbers.createNumbersVector(b: &b, array: data)
+        let end = Numbers.createNumbers(b: &b, o: v)
         b.finish(offset: end)
         let number = Numbers.getRootAsNumbers(ByteBuffer(bytes: b.sizedByteArray))
         XCTAssertEqual(number.vArrayInt32, [1, 2, 3, 4, 5])
@@ -66,9 +66,9 @@ final class FlatBuffersVectors: XCTestCase {
     
     func testReadDoubleArray() {
         let data: [Double] = [1, 2, 3, 4, 5]
-        let b = FlatBufferBuilder(initialSize: 20)
-        let v = Numbers.createNumbersVector(b: b, array: data)
-        let end = Numbers.createNumbers(b: b, o: v)
+        var b = FlatBufferBuilder(initialSize: 20)
+        let v = Numbers.createNumbersVector(b: &b, array: data)
+        let end = Numbers.createNumbers(b: &b, o: v)
         b.finish(offset: end)
         let number = Numbers.getRootAsNumbers(ByteBuffer(bytes: b.sizedByteArray))
         XCTAssertEqual(number.vArrayDouble, [1, 2, 3, 4, 5])
@@ -92,23 +92,23 @@ struct Numbers {
     var vArrayDouble: [Double]? { return __t.getVector(at: 4) }
     var vArrayFloat: [Float32]? { return __t.getVector(at: 4) }
     
-    static func createNumbersVector(b: FlatBufferBuilder, array: [Int]) -> Offset<UOffset> {
+    static func createNumbersVector(b: inout FlatBufferBuilder, array: [Int]) -> Offset<UOffset> {
         return b.createVector(array, size: array.count)
     }
     
-    static func createNumbersVector(b: FlatBufferBuilder, array: [Int32]) -> Offset<UOffset> {
+    static func createNumbersVector(b: inout FlatBufferBuilder, array: [Int32]) -> Offset<UOffset> {
         return b.createVector(array, size: array.count)
     }
     
-    static func createNumbersVector(b: FlatBufferBuilder, array: [Double]) -> Offset<UOffset> {
+    static func createNumbersVector(b: inout FlatBufferBuilder, array: [Double]) -> Offset<UOffset> {
         return b.createVector(array, size: array.count)
     }
     
-    static func createNumbersVector(b: FlatBufferBuilder, array: [Float32]) -> Offset<UOffset> {
+    static func createNumbersVector(b: inout FlatBufferBuilder, array: [Float32]) -> Offset<UOffset> {
         return b.createVector(array, size: array.count)
     }
     
-    static func createNumbers(b: FlatBufferBuilder, o: Offset<UOffset>) -> Offset<UOffset> {
+    static func createNumbers(b: inout FlatBufferBuilder, o: Offset<UOffset>) -> Offset<UOffset> {
         let start = b.startTable(with: 1)
         b.add(offset: o, at: 0)
         return Offset(offset: b.endTable(at: start))

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
@@ -172,17 +172,17 @@ public struct InParentNamespace: FlatBufferObject {
 	public var __buffer: ByteBuffer! { return _accessor.bb }
 
 	private var _accessor: Table
-	public static func finish(_ fbb: FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+	public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
 	public static func getRootAsInParentNamespace(bb: ByteBuffer) -> InParentNamespace { return InParentNamespace(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
 	private init(_ t: Table) { _accessor = t }
 	public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-	public static func startInParentNamespace(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 0) }
-	public static func endInParentNamespace(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-	public static func createInParentNamespace(_ fbb: FlatBufferBuilder) -> Offset<UOffset> {
-		let __start = InParentNamespace.startInParentNamespace(fbb)
-		return InParentNamespace.endInParentNamespace(fbb, start: __start)
+	public static func startInParentNamespace(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 0) }
+	public static func endInParentNamespace(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+	public static func createInParentNamespace(_ fbb: inout FlatBufferBuilder) -> Offset<UOffset> {
+		let __start = InParentNamespace.startInParentNamespace(&fbb)
+		return InParentNamespace.endInParentNamespace(&fbb, start: __start)
 	}
 }
 
@@ -194,17 +194,17 @@ public struct Monster: FlatBufferObject {
 	public var __buffer: ByteBuffer! { return _accessor.bb }
 
 	private var _accessor: Table
-	public static func finish(_ fbb: FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+	public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
 	public static func getRootAsMonster(bb: ByteBuffer) -> Monster { return Monster(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
 	private init(_ t: Table) { _accessor = t }
 	public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-	public static func startMonster(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 0) }
-	public static func endMonster(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-	public static func createMonster(_ fbb: FlatBufferBuilder) -> Offset<UOffset> {
-		let __start = Monster.startMonster(fbb)
-		return Monster.endMonster(fbb, start: __start)
+	public static func startMonster(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 0) }
+	public static func endMonster(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+	public static func createMonster(_ fbb: inout FlatBufferBuilder) -> Offset<UOffset> {
+		let __start = Monster.startMonster(&fbb)
+		return Monster.endMonster(&fbb, start: __start)
 	}
 }
 
@@ -222,7 +222,7 @@ public struct TestSimpleTableWithEnum: FlatBufferObject {
 	public var __buffer: ByteBuffer! { return _accessor.bb }
 
 	private var _accessor: Table
-	public static func finish(_ fbb: FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+	public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
 	public static func getRootAsTestSimpleTableWithEnum(bb: ByteBuffer) -> TestSimpleTableWithEnum { return TestSimpleTableWithEnum(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
 	private init(_ t: Table) { _accessor = t }
@@ -230,14 +230,14 @@ public struct TestSimpleTableWithEnum: FlatBufferObject {
 
 	public var color: MyGame.Example.Color { let o = _accessor.offset(4); return o == 0 ? .green : MyGame.Example.Color(rawValue: _accessor.readBuffer(of: UInt8.self, at: o)) ?? .green }
 	public func mutate(color: MyGame.Example.Color) -> Bool {let o = _accessor.offset(4);  return _accessor.mutate(color.rawValue, index: o) }
-	public static func startTestSimpleTableWithEnum(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
-	public static func add(color: MyGame.Example.Color, _ fbb: FlatBufferBuilder) { fbb.add(element: color.rawValue, def: 2, at: 0) }
-	public static func endTestSimpleTableWithEnum(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-	public static func createTestSimpleTableWithEnum(_ fbb: FlatBufferBuilder,
+	public static func startTestSimpleTableWithEnum(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
+	public static func add(color: MyGame.Example.Color, _ fbb: inout FlatBufferBuilder) { fbb.add(element: color.rawValue, def: 2, at: 0) }
+	public static func endTestSimpleTableWithEnum(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+	public static func createTestSimpleTableWithEnum(_ fbb: inout FlatBufferBuilder,
 		color: MyGame.Example.Color = .green) -> Offset<UOffset> {
-		let __start = TestSimpleTableWithEnum.startTestSimpleTableWithEnum(fbb)
-		TestSimpleTableWithEnum.add(color: color, fbb)
-		return TestSimpleTableWithEnum.endTestSimpleTableWithEnum(fbb, start: __start)
+		let __start = TestSimpleTableWithEnum.startTestSimpleTableWithEnum(&fbb)
+		TestSimpleTableWithEnum.add(color: color, &fbb)
+		return TestSimpleTableWithEnum.endTestSimpleTableWithEnum(&fbb, start: __start)
 	}
 }
 
@@ -247,7 +247,7 @@ public struct Stat: FlatBufferObject {
 	public var __buffer: ByteBuffer! { return _accessor.bb }
 
 	private var _accessor: Table
-	public static func finish(_ fbb: FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+	public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
 	public static func getRootAsStat(bb: ByteBuffer) -> Stat { return Stat(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
 	private init(_ t: Table) { _accessor = t }
@@ -259,20 +259,20 @@ public struct Stat: FlatBufferObject {
 	public func mutate(val: Int64) -> Bool {let o = _accessor.offset(6);  return _accessor.mutate(val, index: o) }
 	public var count: UInt16 { let o = _accessor.offset(8); return o == 0 ? 0 : _accessor.readBuffer(of: UInt16.self, at: o) }
 	public func mutate(count: UInt16) -> Bool {let o = _accessor.offset(8);  return _accessor.mutate(count, index: o) }
-	public static func startStat(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 3) }
-	public static func add(id: Offset<String>, _ fbb: FlatBufferBuilder) { fbb.add(offset: id, at: 0)  }
-	public static func add(val: Int64, _ fbb: FlatBufferBuilder) { fbb.add(element: val, def: 0, at: 1) }
-	public static func add(count: UInt16, _ fbb: FlatBufferBuilder) { fbb.add(element: count, def: 0, at: 2) }
-	public static func endStat(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-	public static func createStat(_ fbb: FlatBufferBuilder,
+	public static func startStat(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 3) }
+	public static func add(id: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: id, at: 0)  }
+	public static func add(val: Int64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: val, def: 0, at: 1) }
+	public static func add(count: UInt16, _ fbb: inout FlatBufferBuilder) { fbb.add(element: count, def: 0, at: 2) }
+	public static func endStat(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+	public static func createStat(_ fbb: inout FlatBufferBuilder,
 		offsetOfId id: Offset<String> = Offset(),
 		val: Int64 = 0,
 		count: UInt16 = 0) -> Offset<UOffset> {
-		let __start = Stat.startStat(fbb)
-		Stat.add(id: id, fbb)
-		Stat.add(val: val, fbb)
-		Stat.add(count: count, fbb)
-		return Stat.endStat(fbb, start: __start)
+		let __start = Stat.startStat(&fbb)
+		Stat.add(id: id, &fbb)
+		Stat.add(val: val, &fbb)
+		Stat.add(count: count, &fbb)
+		return Stat.endStat(&fbb, start: __start)
 	}
 }
 
@@ -282,7 +282,7 @@ public struct Referrable: FlatBufferObject {
 	public var __buffer: ByteBuffer! { return _accessor.bb }
 
 	private var _accessor: Table
-	public static func finish(_ fbb: FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+	public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
 	public static func getRootAsReferrable(bb: ByteBuffer) -> Referrable { return Referrable(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
 	private init(_ t: Table) { _accessor = t }
@@ -290,16 +290,16 @@ public struct Referrable: FlatBufferObject {
 
 	public var id: UInt64 { let o = _accessor.offset(4); return o == 0 ? 0 : _accessor.readBuffer(of: UInt64.self, at: o) }
 	public func mutate(id: UInt64) -> Bool {let o = _accessor.offset(4);  return _accessor.mutate(id, index: o) }
-	public static func startReferrable(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
-	public static func add(id: UInt64, _ fbb: FlatBufferBuilder) { fbb.add(element: id, def: 0, at: 0) }
-	public static func endReferrable(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-	public static func createReferrable(_ fbb: FlatBufferBuilder,
+	public static func startReferrable(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
+	public static func add(id: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: id, def: 0, at: 0) }
+	public static func endReferrable(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+	public static func createReferrable(_ fbb: inout FlatBufferBuilder,
 		id: UInt64 = 0) -> Offset<UOffset> {
-		let __start = Referrable.startReferrable(fbb)
-		Referrable.add(id: id, fbb)
-		return Referrable.endReferrable(fbb, start: __start)
+		let __start = Referrable.startReferrable(&fbb)
+		Referrable.add(id: id, &fbb)
+		return Referrable.endReferrable(&fbb, start: __start)
 	}
-	public static func sortVectorOfReferrable(offsets:[Offset<UOffset>], _ fbb: FlatBufferBuilder) -> Offset<UOffset> {
+	public static func sortVectorOfReferrable(offsets:[Offset<UOffset>], _ fbb: inout FlatBufferBuilder) -> Offset<UOffset> {
 		var off = offsets
 		off.sort { Table.compare(Table.offset(Int32($1.o), vOffset: 4, fbb: fbb.buffer), Table.offset(Int32($0.o), vOffset: 4, fbb: fbb.buffer), fbb: fbb.buffer) < 0 } 
 		return fbb.createVector(ofOffsets: off)
@@ -332,7 +332,7 @@ public struct Monster: FlatBufferObject {
 	public var __buffer: ByteBuffer! { return _accessor.bb }
 
 	private var _accessor: Table
-	public static func finish(_ fbb: FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+	public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
 	public static func getRootAsMonster(bb: ByteBuffer) -> Monster { return Monster(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
 	private init(_ t: Table) { _accessor = t }
@@ -447,57 +447,57 @@ public struct Monster: FlatBufferObject {
 	public func vectorOfEnums(at index: Int32) -> MyGame.Example.Color? { let o = _accessor.offset(98); return o == 0 ? MyGame.Example.Color.red : MyGame.Example.Color(rawValue: _accessor.directRead(of: UInt8.self, offset: _accessor.vector(at: o) + index * 1)) }
 	public var signedEnum: MyGame.Example.Race { let o = _accessor.offset(100); return o == 0 ? .none : MyGame.Example.Race(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .none }
 	public func mutate(signedEnum: MyGame.Example.Race) -> Bool {let o = _accessor.offset(100);  return _accessor.mutate(signedEnum.rawValue, index: o) }
-	public static func startMonster(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 49) }
-	public static func add(pos: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(structOffset: 0) }
-	public static func add(mana: Int16, _ fbb: FlatBufferBuilder) { fbb.add(element: mana, def: 150, at: 1) }
-	public static func add(hp: Int16, _ fbb: FlatBufferBuilder) { fbb.add(element: hp, def: 100, at: 2) }
-	public static func add(name: Offset<String>, _ fbb: FlatBufferBuilder) { fbb.add(offset: name, at: 3)  }
-	public static func addVectorOf(inventory: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: inventory, at: 5)  }
-	public static func add(color: MyGame.Example.Color, _ fbb: FlatBufferBuilder) { fbb.add(element: color.rawValue, def: 8, at: 6) }
-	public static func add(testType: MyGame.Example.Any_, _ fbb: FlatBufferBuilder) { fbb.add(element: testType.rawValue, def: 0, at: 7) }
-	public static func add(test: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: test, at: 8)  }
-	public static func addVectorOf(test4: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: test4, at: 9)  }
-	public static func addVectorOf(testarrayofstring: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: testarrayofstring, at: 10)  }
-	public static func addVectorOf(testarrayoftables: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: testarrayoftables, at: 11)  }
-	public static func add(enemy: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: enemy, at: 12)  }
-	public static func addVectorOf(testnestedflatbuffer: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: testnestedflatbuffer, at: 13)  }
-	public static func add(testempty: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: testempty, at: 14)  }
-	public static func add(testbool: Bool, _ fbb: FlatBufferBuilder) { fbb.add(condition: testbool, def: false, at: 15) }
-	public static func add(testhashs32Fnv1: Int32, _ fbb: FlatBufferBuilder) { fbb.add(element: testhashs32Fnv1, def: 0, at: 16) }
-	public static func add(testhashu32Fnv1: UInt32, _ fbb: FlatBufferBuilder) { fbb.add(element: testhashu32Fnv1, def: 0, at: 17) }
-	public static func add(testhashs64Fnv1: Int64, _ fbb: FlatBufferBuilder) { fbb.add(element: testhashs64Fnv1, def: 0, at: 18) }
-	public static func add(testhashu64Fnv1: UInt64, _ fbb: FlatBufferBuilder) { fbb.add(element: testhashu64Fnv1, def: 0, at: 19) }
-	public static func add(testhashs32Fnv1a: Int32, _ fbb: FlatBufferBuilder) { fbb.add(element: testhashs32Fnv1a, def: 0, at: 20) }
-	public static func add(testhashu32Fnv1a: UInt32, _ fbb: FlatBufferBuilder) { fbb.add(element: testhashu32Fnv1a, def: 0, at: 21) }
-	public static func add(testhashs64Fnv1a: Int64, _ fbb: FlatBufferBuilder) { fbb.add(element: testhashs64Fnv1a, def: 0, at: 22) }
-	public static func add(testhashu64Fnv1a: UInt64, _ fbb: FlatBufferBuilder) { fbb.add(element: testhashu64Fnv1a, def: 0, at: 23) }
-	public static func addVectorOf(testarrayofbools: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: testarrayofbools, at: 24)  }
-	public static func add(testf: Float32, _ fbb: FlatBufferBuilder) { fbb.add(element: testf, def: 3.14159, at: 25) }
-	public static func add(testf2: Float32, _ fbb: FlatBufferBuilder) { fbb.add(element: testf2, def: 3.0, at: 26) }
-	public static func add(testf3: Float32, _ fbb: FlatBufferBuilder) { fbb.add(element: testf3, def: 0.0, at: 27) }
-	public static func addVectorOf(testarrayofstring2: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: testarrayofstring2, at: 28)  }
-	public static func addVectorOf(testarrayofsortedstruct: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: testarrayofsortedstruct, at: 29)  }
-	public static func addVectorOf(flex: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: flex, at: 30)  }
-	public static func addVectorOf(test5: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: test5, at: 31)  }
-	public static func addVectorOf(vectorOfLongs: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: vectorOfLongs, at: 32)  }
-	public static func addVectorOf(vectorOfDoubles: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: vectorOfDoubles, at: 33)  }
-	public static func add(parentNamespaceTest: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: parentNamespaceTest, at: 34)  }
-	public static func addVectorOf(vectorOfReferrables: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: vectorOfReferrables, at: 35)  }
-	public static func add(singleWeakReference: UInt64, _ fbb: FlatBufferBuilder) { fbb.add(element: singleWeakReference, def: 0, at: 36) }
-	public static func addVectorOf(vectorOfWeakReferences: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: vectorOfWeakReferences, at: 37)  }
-	public static func addVectorOf(vectorOfStrongReferrables: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: vectorOfStrongReferrables, at: 38)  }
-	public static func add(coOwningReference: UInt64, _ fbb: FlatBufferBuilder) { fbb.add(element: coOwningReference, def: 0, at: 39) }
-	public static func addVectorOf(vectorOfCoOwningReferences: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: vectorOfCoOwningReferences, at: 40)  }
-	public static func add(nonOwningReference: UInt64, _ fbb: FlatBufferBuilder) { fbb.add(element: nonOwningReference, def: 0, at: 41) }
-	public static func addVectorOf(vectorOfNonOwningReferences: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: vectorOfNonOwningReferences, at: 42)  }
-	public static func add(anyUniqueType: MyGame.Example.AnyUniqueAliases, _ fbb: FlatBufferBuilder) { fbb.add(element: anyUniqueType.rawValue, def: 0, at: 43) }
-	public static func add(anyUnique: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: anyUnique, at: 44)  }
-	public static func add(anyAmbiguousType: MyGame.Example.AnyAmbiguousAliases, _ fbb: FlatBufferBuilder) { fbb.add(element: anyAmbiguousType.rawValue, def: 0, at: 45) }
-	public static func add(anyAmbiguous: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: anyAmbiguous, at: 46)  }
-	public static func addVectorOf(vectorOfEnums: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: vectorOfEnums, at: 47)  }
-	public static func add(signedEnum: MyGame.Example.Race, _ fbb: FlatBufferBuilder) { fbb.add(element: signedEnum.rawValue, def: -1, at: 48) }
-	public static func endMonster(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); fbb.require(table: end, fields: [10]); return end }
-	public static func createMonster(_ fbb: FlatBufferBuilder,
+	public static func startMonster(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 49) }
+	public static func add(pos: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(structOffset: 0) }
+	public static func add(mana: Int16, _ fbb: inout FlatBufferBuilder) { fbb.add(element: mana, def: 150, at: 1) }
+	public static func add(hp: Int16, _ fbb: inout FlatBufferBuilder) { fbb.add(element: hp, def: 100, at: 2) }
+	public static func add(name: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: name, at: 3)  }
+	public static func addVectorOf(inventory: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: inventory, at: 5)  }
+	public static func add(color: MyGame.Example.Color, _ fbb: inout FlatBufferBuilder) { fbb.add(element: color.rawValue, def: 8, at: 6) }
+	public static func add(testType: MyGame.Example.Any_, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testType.rawValue, def: 0, at: 7) }
+	public static func add(test: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: test, at: 8)  }
+	public static func addVectorOf(test4: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: test4, at: 9)  }
+	public static func addVectorOf(testarrayofstring: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofstring, at: 10)  }
+	public static func addVectorOf(testarrayoftables: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayoftables, at: 11)  }
+	public static func add(enemy: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: enemy, at: 12)  }
+	public static func addVectorOf(testnestedflatbuffer: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testnestedflatbuffer, at: 13)  }
+	public static func add(testempty: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testempty, at: 14)  }
+	public static func add(testbool: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(condition: testbool, def: false, at: 15) }
+	public static func add(testhashs32Fnv1: Int32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashs32Fnv1, def: 0, at: 16) }
+	public static func add(testhashu32Fnv1: UInt32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashu32Fnv1, def: 0, at: 17) }
+	public static func add(testhashs64Fnv1: Int64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashs64Fnv1, def: 0, at: 18) }
+	public static func add(testhashu64Fnv1: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashu64Fnv1, def: 0, at: 19) }
+	public static func add(testhashs32Fnv1a: Int32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashs32Fnv1a, def: 0, at: 20) }
+	public static func add(testhashu32Fnv1a: UInt32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashu32Fnv1a, def: 0, at: 21) }
+	public static func add(testhashs64Fnv1a: Int64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashs64Fnv1a, def: 0, at: 22) }
+	public static func add(testhashu64Fnv1a: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashu64Fnv1a, def: 0, at: 23) }
+	public static func addVectorOf(testarrayofbools: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofbools, at: 24)  }
+	public static func add(testf: Float32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testf, def: 3.14159, at: 25) }
+	public static func add(testf2: Float32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testf2, def: 3.0, at: 26) }
+	public static func add(testf3: Float32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testf3, def: 0.0, at: 27) }
+	public static func addVectorOf(testarrayofstring2: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofstring2, at: 28)  }
+	public static func addVectorOf(testarrayofsortedstruct: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofsortedstruct, at: 29)  }
+	public static func addVectorOf(flex: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: flex, at: 30)  }
+	public static func addVectorOf(test5: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: test5, at: 31)  }
+	public static func addVectorOf(vectorOfLongs: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfLongs, at: 32)  }
+	public static func addVectorOf(vectorOfDoubles: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfDoubles, at: 33)  }
+	public static func add(parentNamespaceTest: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: parentNamespaceTest, at: 34)  }
+	public static func addVectorOf(vectorOfReferrables: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfReferrables, at: 35)  }
+	public static func add(singleWeakReference: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: singleWeakReference, def: 0, at: 36) }
+	public static func addVectorOf(vectorOfWeakReferences: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfWeakReferences, at: 37)  }
+	public static func addVectorOf(vectorOfStrongReferrables: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfStrongReferrables, at: 38)  }
+	public static func add(coOwningReference: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: coOwningReference, def: 0, at: 39) }
+	public static func addVectorOf(vectorOfCoOwningReferences: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfCoOwningReferences, at: 40)  }
+	public static func add(nonOwningReference: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: nonOwningReference, def: 0, at: 41) }
+	public static func addVectorOf(vectorOfNonOwningReferences: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfNonOwningReferences, at: 42)  }
+	public static func add(anyUniqueType: MyGame.Example.AnyUniqueAliases, _ fbb: inout FlatBufferBuilder) { fbb.add(element: anyUniqueType.rawValue, def: 0, at: 43) }
+	public static func add(anyUnique: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: anyUnique, at: 44)  }
+	public static func add(anyAmbiguousType: MyGame.Example.AnyAmbiguousAliases, _ fbb: inout FlatBufferBuilder) { fbb.add(element: anyAmbiguousType.rawValue, def: 0, at: 45) }
+	public static func add(anyAmbiguous: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: anyAmbiguous, at: 46)  }
+	public static func addVectorOf(vectorOfEnums: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfEnums, at: 47)  }
+	public static func add(signedEnum: MyGame.Example.Race, _ fbb: inout FlatBufferBuilder) { fbb.add(element: signedEnum.rawValue, def: -1, at: 48) }
+	public static func endMonster(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); fbb.require(table: end, fields: [10]); return end }
+	public static func createMonster(_ fbb: inout FlatBufferBuilder,
 		offsetOfPos pos: Offset<UOffset> = Offset(),
 		mana: Int16 = 150,
 		hp: Int16 = 100,
@@ -546,58 +546,58 @@ public struct Monster: FlatBufferObject {
 		offsetOfAnyAmbiguous anyAmbiguous: Offset<UOffset> = Offset(),
 		vectorOfVectorOfEnums vectorOfEnums: Offset<UOffset> = Offset(),
 		signedEnum: MyGame.Example.Race = .none) -> Offset<UOffset> {
-		let __start = Monster.startMonster(fbb)
-		Monster.add(pos: pos, fbb)
-		Monster.add(mana: mana, fbb)
-		Monster.add(hp: hp, fbb)
-		Monster.add(name: name, fbb)
-		Monster.addVectorOf(inventory: inventory, fbb)
-		Monster.add(color: color, fbb)
-		Monster.add(testType: testType, fbb)
-		Monster.add(test: test, fbb)
-		Monster.addVectorOf(test4: test4, fbb)
-		Monster.addVectorOf(testarrayofstring: testarrayofstring, fbb)
-		Monster.addVectorOf(testarrayoftables: testarrayoftables, fbb)
-		Monster.add(enemy: enemy, fbb)
-		Monster.addVectorOf(testnestedflatbuffer: testnestedflatbuffer, fbb)
-		Monster.add(testempty: testempty, fbb)
-		Monster.add(testbool: testbool, fbb)
-		Monster.add(testhashs32Fnv1: testhashs32Fnv1, fbb)
-		Monster.add(testhashu32Fnv1: testhashu32Fnv1, fbb)
-		Monster.add(testhashs64Fnv1: testhashs64Fnv1, fbb)
-		Monster.add(testhashu64Fnv1: testhashu64Fnv1, fbb)
-		Monster.add(testhashs32Fnv1a: testhashs32Fnv1a, fbb)
-		Monster.add(testhashu32Fnv1a: testhashu32Fnv1a, fbb)
-		Monster.add(testhashs64Fnv1a: testhashs64Fnv1a, fbb)
-		Monster.add(testhashu64Fnv1a: testhashu64Fnv1a, fbb)
-		Monster.addVectorOf(testarrayofbools: testarrayofbools, fbb)
-		Monster.add(testf: testf, fbb)
-		Monster.add(testf2: testf2, fbb)
-		Monster.add(testf3: testf3, fbb)
-		Monster.addVectorOf(testarrayofstring2: testarrayofstring2, fbb)
-		Monster.addVectorOf(testarrayofsortedstruct: testarrayofsortedstruct, fbb)
-		Monster.addVectorOf(flex: flex, fbb)
-		Monster.addVectorOf(test5: test5, fbb)
-		Monster.addVectorOf(vectorOfLongs: vectorOfLongs, fbb)
-		Monster.addVectorOf(vectorOfDoubles: vectorOfDoubles, fbb)
-		Monster.add(parentNamespaceTest: parentNamespaceTest, fbb)
-		Monster.addVectorOf(vectorOfReferrables: vectorOfReferrables, fbb)
-		Monster.add(singleWeakReference: singleWeakReference, fbb)
-		Monster.addVectorOf(vectorOfWeakReferences: vectorOfWeakReferences, fbb)
-		Monster.addVectorOf(vectorOfStrongReferrables: vectorOfStrongReferrables, fbb)
-		Monster.add(coOwningReference: coOwningReference, fbb)
-		Monster.addVectorOf(vectorOfCoOwningReferences: vectorOfCoOwningReferences, fbb)
-		Monster.add(nonOwningReference: nonOwningReference, fbb)
-		Monster.addVectorOf(vectorOfNonOwningReferences: vectorOfNonOwningReferences, fbb)
-		Monster.add(anyUniqueType: anyUniqueType, fbb)
-		Monster.add(anyUnique: anyUnique, fbb)
-		Monster.add(anyAmbiguousType: anyAmbiguousType, fbb)
-		Monster.add(anyAmbiguous: anyAmbiguous, fbb)
-		Monster.addVectorOf(vectorOfEnums: vectorOfEnums, fbb)
-		Monster.add(signedEnum: signedEnum, fbb)
-		return Monster.endMonster(fbb, start: __start)
+		let __start = Monster.startMonster(&fbb)
+		Monster.add(pos: pos, &fbb)
+		Monster.add(mana: mana, &fbb)
+		Monster.add(hp: hp, &fbb)
+		Monster.add(name: name, &fbb)
+		Monster.addVectorOf(inventory: inventory, &fbb)
+		Monster.add(color: color, &fbb)
+		Monster.add(testType: testType, &fbb)
+		Monster.add(test: test, &fbb)
+		Monster.addVectorOf(test4: test4, &fbb)
+		Monster.addVectorOf(testarrayofstring: testarrayofstring, &fbb)
+		Monster.addVectorOf(testarrayoftables: testarrayoftables, &fbb)
+		Monster.add(enemy: enemy, &fbb)
+		Monster.addVectorOf(testnestedflatbuffer: testnestedflatbuffer, &fbb)
+		Monster.add(testempty: testempty, &fbb)
+		Monster.add(testbool: testbool, &fbb)
+		Monster.add(testhashs32Fnv1: testhashs32Fnv1, &fbb)
+		Monster.add(testhashu32Fnv1: testhashu32Fnv1, &fbb)
+		Monster.add(testhashs64Fnv1: testhashs64Fnv1, &fbb)
+		Monster.add(testhashu64Fnv1: testhashu64Fnv1, &fbb)
+		Monster.add(testhashs32Fnv1a: testhashs32Fnv1a, &fbb)
+		Monster.add(testhashu32Fnv1a: testhashu32Fnv1a, &fbb)
+		Monster.add(testhashs64Fnv1a: testhashs64Fnv1a, &fbb)
+		Monster.add(testhashu64Fnv1a: testhashu64Fnv1a, &fbb)
+		Monster.addVectorOf(testarrayofbools: testarrayofbools, &fbb)
+		Monster.add(testf: testf, &fbb)
+		Monster.add(testf2: testf2, &fbb)
+		Monster.add(testf3: testf3, &fbb)
+		Monster.addVectorOf(testarrayofstring2: testarrayofstring2, &fbb)
+		Monster.addVectorOf(testarrayofsortedstruct: testarrayofsortedstruct, &fbb)
+		Monster.addVectorOf(flex: flex, &fbb)
+		Monster.addVectorOf(test5: test5, &fbb)
+		Monster.addVectorOf(vectorOfLongs: vectorOfLongs, &fbb)
+		Monster.addVectorOf(vectorOfDoubles: vectorOfDoubles, &fbb)
+		Monster.add(parentNamespaceTest: parentNamespaceTest, &fbb)
+		Monster.addVectorOf(vectorOfReferrables: vectorOfReferrables, &fbb)
+		Monster.add(singleWeakReference: singleWeakReference, &fbb)
+		Monster.addVectorOf(vectorOfWeakReferences: vectorOfWeakReferences, &fbb)
+		Monster.addVectorOf(vectorOfStrongReferrables: vectorOfStrongReferrables, &fbb)
+		Monster.add(coOwningReference: coOwningReference, &fbb)
+		Monster.addVectorOf(vectorOfCoOwningReferences: vectorOfCoOwningReferences, &fbb)
+		Monster.add(nonOwningReference: nonOwningReference, &fbb)
+		Monster.addVectorOf(vectorOfNonOwningReferences: vectorOfNonOwningReferences, &fbb)
+		Monster.add(anyUniqueType: anyUniqueType, &fbb)
+		Monster.add(anyUnique: anyUnique, &fbb)
+		Monster.add(anyAmbiguousType: anyAmbiguousType, &fbb)
+		Monster.add(anyAmbiguous: anyAmbiguous, &fbb)
+		Monster.addVectorOf(vectorOfEnums: vectorOfEnums, &fbb)
+		Monster.add(signedEnum: signedEnum, &fbb)
+		return Monster.endMonster(&fbb, start: __start)
 	}
-	public static func sortVectorOfMonster(offsets:[Offset<UOffset>], _ fbb: FlatBufferBuilder) -> Offset<UOffset> {
+	public static func sortVectorOfMonster(offsets:[Offset<UOffset>], _ fbb: inout FlatBufferBuilder) -> Offset<UOffset> {
 		var off = offsets
 		off.sort { Table.compare(Table.offset(Int32($1.o), vOffset: 10, fbb: fbb.buffer), Table.offset(Int32($0.o), vOffset: 10, fbb: fbb.buffer), fbb: fbb.buffer) < 0 } 
 		return fbb.createVector(ofOffsets: off)
@@ -630,7 +630,7 @@ public struct TypeAliases: FlatBufferObject {
 	public var __buffer: ByteBuffer! { return _accessor.bb }
 
 	private var _accessor: Table
-	public static func finish(_ fbb: FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+	public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
 	public static func getRootAsTypeAliases(bb: ByteBuffer) -> TypeAliases { return TypeAliases(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
 	private init(_ t: Table) { _accessor = t }
@@ -664,21 +664,21 @@ public struct TypeAliases: FlatBufferObject {
 	public func vf64(at index: Int32) -> Double { let o = _accessor.offset(26); return o == 0 ? 0 : _accessor.directRead(of: Double.self, offset: _accessor.vector(at: o) + index * 8) }
 	public var vf64: [Double] { return _accessor.getVector(at: 26) ?? [] }
 	public func mutate(vf64: Double, at index: Int32) -> Bool { let o = _accessor.offset(26); return _accessor.directMutate(vf64, index: _accessor.vector(at: o) + index * 8) }
-	public static func startTypeAliases(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 12) }
-	public static func add(i8: Int8, _ fbb: FlatBufferBuilder) { fbb.add(element: i8, def: 0, at: 0) }
-	public static func add(u8: UInt8, _ fbb: FlatBufferBuilder) { fbb.add(element: u8, def: 0, at: 1) }
-	public static func add(i16: Int16, _ fbb: FlatBufferBuilder) { fbb.add(element: i16, def: 0, at: 2) }
-	public static func add(u16: UInt16, _ fbb: FlatBufferBuilder) { fbb.add(element: u16, def: 0, at: 3) }
-	public static func add(i32: Int32, _ fbb: FlatBufferBuilder) { fbb.add(element: i32, def: 0, at: 4) }
-	public static func add(u32: UInt32, _ fbb: FlatBufferBuilder) { fbb.add(element: u32, def: 0, at: 5) }
-	public static func add(i64: Int64, _ fbb: FlatBufferBuilder) { fbb.add(element: i64, def: 0, at: 6) }
-	public static func add(u64: UInt64, _ fbb: FlatBufferBuilder) { fbb.add(element: u64, def: 0, at: 7) }
-	public static func add(f32: Float32, _ fbb: FlatBufferBuilder) { fbb.add(element: f32, def: 0.0, at: 8) }
-	public static func add(f64: Double, _ fbb: FlatBufferBuilder) { fbb.add(element: f64, def: 0.0, at: 9) }
-	public static func addVectorOf(v8: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: v8, at: 10)  }
-	public static func addVectorOf(vf64: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: vf64, at: 11)  }
-	public static func endTypeAliases(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-	public static func createTypeAliases(_ fbb: FlatBufferBuilder,
+	public static func startTypeAliases(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 12) }
+	public static func add(i8: Int8, _ fbb: inout FlatBufferBuilder) { fbb.add(element: i8, def: 0, at: 0) }
+	public static func add(u8: UInt8, _ fbb: inout FlatBufferBuilder) { fbb.add(element: u8, def: 0, at: 1) }
+	public static func add(i16: Int16, _ fbb: inout FlatBufferBuilder) { fbb.add(element: i16, def: 0, at: 2) }
+	public static func add(u16: UInt16, _ fbb: inout FlatBufferBuilder) { fbb.add(element: u16, def: 0, at: 3) }
+	public static func add(i32: Int32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: i32, def: 0, at: 4) }
+	public static func add(u32: UInt32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: u32, def: 0, at: 5) }
+	public static func add(i64: Int64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: i64, def: 0, at: 6) }
+	public static func add(u64: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: u64, def: 0, at: 7) }
+	public static func add(f32: Float32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: f32, def: 0.0, at: 8) }
+	public static func add(f64: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: f64, def: 0.0, at: 9) }
+	public static func addVectorOf(v8: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: v8, at: 10)  }
+	public static func addVectorOf(vf64: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vf64, at: 11)  }
+	public static func endTypeAliases(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+	public static func createTypeAliases(_ fbb: inout FlatBufferBuilder,
 		i8: Int8 = 0,
 		u8: UInt8 = 0,
 		i16: Int16 = 0,
@@ -691,20 +691,20 @@ public struct TypeAliases: FlatBufferObject {
 		f64: Double = 0.0,
 		vectorOfV8 v8: Offset<UOffset> = Offset(),
 		vectorOfVf64 vf64: Offset<UOffset> = Offset()) -> Offset<UOffset> {
-		let __start = TypeAliases.startTypeAliases(fbb)
-		TypeAliases.add(i8: i8, fbb)
-		TypeAliases.add(u8: u8, fbb)
-		TypeAliases.add(i16: i16, fbb)
-		TypeAliases.add(u16: u16, fbb)
-		TypeAliases.add(i32: i32, fbb)
-		TypeAliases.add(u32: u32, fbb)
-		TypeAliases.add(i64: i64, fbb)
-		TypeAliases.add(u64: u64, fbb)
-		TypeAliases.add(f32: f32, fbb)
-		TypeAliases.add(f64: f64, fbb)
-		TypeAliases.addVectorOf(v8: v8, fbb)
-		TypeAliases.addVectorOf(vf64: vf64, fbb)
-		return TypeAliases.endTypeAliases(fbb, start: __start)
+		let __start = TypeAliases.startTypeAliases(&fbb)
+		TypeAliases.add(i8: i8, &fbb)
+		TypeAliases.add(u8: u8, &fbb)
+		TypeAliases.add(i16: i16, &fbb)
+		TypeAliases.add(u16: u16, &fbb)
+		TypeAliases.add(i32: i32, &fbb)
+		TypeAliases.add(u32: u32, &fbb)
+		TypeAliases.add(i64: i64, &fbb)
+		TypeAliases.add(u64: u64, &fbb)
+		TypeAliases.add(f32: f32, &fbb)
+		TypeAliases.add(f64: f64, &fbb)
+		TypeAliases.addVectorOf(v8: v8, &fbb)
+		TypeAliases.addVectorOf(vf64: vf64, &fbb)
+		return TypeAliases.endTypeAliases(&fbb, start: __start)
 	}
 }
 

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
@@ -67,7 +67,7 @@ public struct Attacker: FlatBufferObject {
 	public var __buffer: ByteBuffer! { return _accessor.bb }
 
 	private var _accessor: Table
-	public static func finish(_ fbb: FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MOVI", addPrefix: prefix) }
+	public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MOVI", addPrefix: prefix) }
 	public static func getRootAsAttacker(bb: ByteBuffer) -> Attacker { return Attacker(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
 	private init(_ t: Table) { _accessor = t }
@@ -75,14 +75,14 @@ public struct Attacker: FlatBufferObject {
 
 	public var swordAttackDamage: Int32 { let o = _accessor.offset(4); return o == 0 ? 0 : _accessor.readBuffer(of: Int32.self, at: o) }
 	public func mutate(swordAttackDamage: Int32) -> Bool {let o = _accessor.offset(4);  return _accessor.mutate(swordAttackDamage, index: o) }
-	public static func startAttacker(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
-	public static func add(swordAttackDamage: Int32, _ fbb: FlatBufferBuilder) { fbb.add(element: swordAttackDamage, def: 0, at: 0) }
-	public static func endAttacker(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-	public static func createAttacker(_ fbb: FlatBufferBuilder,
+	public static func startAttacker(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
+	public static func add(swordAttackDamage: Int32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: swordAttackDamage, def: 0, at: 0) }
+	public static func endAttacker(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+	public static func createAttacker(_ fbb: inout FlatBufferBuilder,
 		swordAttackDamage: Int32 = 0) -> Offset<UOffset> {
-		let __start = Attacker.startAttacker(fbb)
-		Attacker.add(swordAttackDamage: swordAttackDamage, fbb)
-		return Attacker.endAttacker(fbb, start: __start)
+		let __start = Attacker.startAttacker(&fbb)
+		Attacker.add(swordAttackDamage: swordAttackDamage, &fbb)
+		return Attacker.endAttacker(&fbb, start: __start)
 	}
 }
 
@@ -92,7 +92,7 @@ public struct Movie: FlatBufferObject {
 	public var __buffer: ByteBuffer! { return _accessor.bb }
 
 	private var _accessor: Table
-	public static func finish(_ fbb: FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MOVI", addPrefix: prefix) }
+	public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MOVI", addPrefix: prefix) }
 	public static func getRootAsMovie(bb: ByteBuffer) -> Movie { return Movie(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
 	private init(_ t: Table) { _accessor = t }
@@ -104,23 +104,23 @@ public struct Movie: FlatBufferObject {
 	public func charactersType(at index: Int32) -> Character? { let o = _accessor.offset(8); return o == 0 ? Character.none : Character(rawValue: _accessor.directRead(of: UInt8.self, offset: _accessor.vector(at: o) + index * 1)) }
 	public var charactersCount: Int32 { let o = _accessor.offset(10); return o == 0 ? 0 : _accessor.vector(count: o) }
 	public func characters<T: FlatBufferObject>(at index: Int32, type: T.Type) -> T? { let o = _accessor.offset(10); return o == 0 ? nil : _accessor.directUnion(_accessor.vector(at: o) + index * 4) }
-	public static func startMovie(_ fbb: FlatBufferBuilder) -> UOffset { fbb.startTable(with: 4) }
-	public static func add(mainCharacterType: Character, _ fbb: FlatBufferBuilder) { fbb.add(element: mainCharacterType.rawValue, def: 0, at: 0) }
-	public static func add(mainCharacter: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: mainCharacter, at: 1)  }
-	public static func addVectorOf(charactersType: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: charactersType, at: 2)  }
-	public static func addVectorOf(characters: Offset<UOffset>, _ fbb: FlatBufferBuilder) { fbb.add(offset: characters, at: 3)  }
-	public static func endMovie(_ fbb: FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-	public static func createMovie(_ fbb: FlatBufferBuilder,
+	public static func startMovie(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 4) }
+	public static func add(mainCharacterType: Character, _ fbb: inout FlatBufferBuilder) { fbb.add(element: mainCharacterType.rawValue, def: 0, at: 0) }
+	public static func add(mainCharacter: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: mainCharacter, at: 1)  }
+	public static func addVectorOf(charactersType: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: charactersType, at: 2)  }
+	public static func addVectorOf(characters: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: characters, at: 3)  }
+	public static func endMovie(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+	public static func createMovie(_ fbb: inout FlatBufferBuilder,
 		mainCharacterType: Character = .none,
 		offsetOfMainCharacter mainCharacter: Offset<UOffset> = Offset(),
 		vectorOfCharactersType charactersType: Offset<UOffset> = Offset(),
 		vectorOfCharacters characters: Offset<UOffset> = Offset()) -> Offset<UOffset> {
-		let __start = Movie.startMovie(fbb)
-		Movie.add(mainCharacterType: mainCharacterType, fbb)
-		Movie.add(mainCharacter: mainCharacter, fbb)
-		Movie.addVectorOf(charactersType: charactersType, fbb)
-		Movie.addVectorOf(characters: characters, fbb)
-		return Movie.endMovie(fbb, start: __start)
+		let __start = Movie.startMovie(&fbb)
+		Movie.add(mainCharacterType: mainCharacterType, &fbb)
+		Movie.add(mainCharacter: mainCharacter, &fbb)
+		Movie.addVectorOf(charactersType: charactersType, &fbb)
+		Movie.addVectorOf(characters: characters, &fbb)
+		return Movie.endMovie(&fbb, start: __start)
 	}
 }
 


### PR DESCRIPTION
The following PR Fixes some of the issues that are in the swift implementation regarding it's speed, the following benchmark shows how the changes that where implemented actually speed up the library. the following screenshot shows the improvement in terms of speed to the swift library where when we switched the library to use structs instead of classes the implementation became faster than it was directly. and since the swift library is still at it's young age a change like this, would be really amazing to speed it up! 

Changes to the library:

 - builder and buffer are now structs
 - functions for the Tables would be taking inout instead of being normal parameters. (Calling by reference)

<img width="698" alt="Screen Shot 2020-03-30 at 2 09 36 AM" src="https://user-images.githubusercontent.com/26250654/77863490-92c89300-722b-11ea-8fa5-fdb220a4296e.png">

(Average of 20 runs per benchmark)
The 500,000 benchmark is similar to the C# one:
```swift
let off = fb.create(string: "T")        
let s = fb.startTable(with: 4)
fb.add(element: 3.2, def: 0, at: 0)
fb.add(element: 4.2, def: 0, at: 1)
fb.add(element: 5.2, def: 0, at: 2)
fb.add(offset: off, at: 3)
_ = fb.endTable(at: s)
```

I am working on many other improvements to the library but It would take some time.