### PR TITLE
[ts] Fix empty source/dest namespaces when reexporting.

### DIFF
--- a/src/idl_gen_js_ts.cpp
+++ b/src/idl_gen_js_ts.cpp
@@ -144,11 +144,18 @@ class JsTsGenerator : public BaseGenerator {
           imported_files.emplace(file.first);
         }
 
-        code += "export namespace " + file.second.target_namespace + " { \n";
+        if (!file.second.target_namespace.empty()) {
+          code += "export namespace " + file.second.target_namespace + " { \n";
+        }
         code += "export import " + file.second.symbol + " = ";
-        code += GenFileNamespacePrefix(file.first) + "." +
-                file.second.source_namespace + "." + file.second.symbol +
-                "; }\n";
+        code += GenFileNamespacePrefix(file.first) + ".";
+        if (!file.second.source_namespace.empty()) {
+          code += file.second.source_namespace + ".";
+        }
+        code += file.second.symbol + ";\n";
+        if (!file.second.target_namespace.empty()) {
+          code += "}\n";
+        }
       }
     }
   }


### PR DESCRIPTION
When either source or destination or both namespaces were empty, flatc
was generating incorrect TS code.

For example:

```
export namespace  {
export import ObjectId = NS10770172024577249292..ObjectId;}
```

In this case the target namespace is empty, and so is the namespace
between the NSxxx placeholder and the target type.
