### PR TITLE
[Rust] idl_gen_rust.cpp: (Option/required-aware codegen for unions)

### DIFF
--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1350,9 +1350,14 @@ class RustGenerator : public BaseGenerator {
         code_ +=
             "    if self.{{FIELD_TYPE_FIELD_NAME}}_type() == "
             "{{U_ELEMENT_ENUM_TYPE}} {";
-        code_ +=
-            "      self.{{FIELD_NAME}}().map(|u| "
-            "{{U_ELEMENT_TABLE_TYPE}}::init_from_table(u))";
+        if (!field.required) {
+          code_ +=
+              "      self.{{FIELD_NAME}}().map(|u| "
+              "{{U_ELEMENT_TABLE_TYPE}}::init_from_table(u))";
+        } else {
+          code_ += "      let u = self.{{FIELD_NAME}}();";
+          code_ += "      Some({{U_ELEMENT_TABLE_TYPE}}::init_from_table(u))";
+        }
         code_ += "    } else {";
         code_ += "      None";
         code_ += "    }";

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1350,13 +1350,13 @@ class RustGenerator : public BaseGenerator {
         code_ +=
             "    if self.{{FIELD_TYPE_FIELD_NAME}}_type() == "
             "{{U_ELEMENT_ENUM_TYPE}} {";
-        if (!field.required) {
-          code_ +=
-              "      self.{{FIELD_NAME}}().map(|u| "
-              "{{U_ELEMENT_TABLE_TYPE}}::init_from_table(u))";
-        } else {
+        if (field.required) {
           code_ += "      let u = self.{{FIELD_NAME}}();";
           code_ += "      Some({{U_ELEMENT_TABLE_TYPE}}::init_from_table(u))";
+        } else {
+          code_ +=
+            "      self.{{FIELD_NAME}}().map(|u| "
+            "{{U_ELEMENT_TABLE_TYPE}}::init_from_table(u))";
         }
         code_ += "    } else {";
         code_ += "      None";

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1350,6 +1350,9 @@ class RustGenerator : public BaseGenerator {
         code_ +=
             "    if self.{{FIELD_TYPE_FIELD_NAME}}_type() == "
             "{{U_ELEMENT_ENUM_TYPE}} {";
+
+        // The following logic is not tested in the integration test,
+        // as of April 10, 2020
         if (field.required) {
           code_ += "      let u = self.{{FIELD_NAME}}();";
           code_ += "      Some({{U_ELEMENT_TABLE_TYPE}}::init_from_table(u))";


### PR DESCRIPTION
Fix google/flatbuffers#5849 

The generated code was assuming that an Option is always returned by the
union-getter methods: however, this is only true if the field is not
marked as `(required)`.

See the above issue (linked) for a description of the issue.

Thank you for submitting a PR!
