### PR TITLE
only add native_include_files if object based api is enabled

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -200,10 +200,12 @@ class CppGenerator : public BaseGenerator {
 
   void GenIncludeDependencies() {
     int num_includes = 0;
-    for (auto it = parser_.native_included_files_.begin();
-         it != parser_.native_included_files_.end(); ++it) {
-      code_ += "#include \"" + *it + "\"";
-      num_includes++;
+    if (opts_.generate_object_based_api) {
+      for (auto it = parser_.native_included_files_.begin();
+           it != parser_.native_included_files_.end(); ++it) {
+        code_ += "#include \"" + *it + "\"";
+        num_includes++;
+      }
     }
     for (auto it = parser_.included_files_.begin();
          it != parser_.included_files_.end(); ++it) {


### PR DESCRIPTION
The native include files tag is intended to be used together with the object based api. A client which does not use the object based api should have no need to know about the additional include files needed for the object based api. The generated flatbuffers code without object api feature enabled should compile without the additional header files.

Thanks
Thomas