### PR TITLE
Removed requirement that enums be declared in ascending order.

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1605,7 +1605,7 @@ void ErrorTest() {
   TestError("enum X:byte { Y } enum X {", "enum already");
   TestError("enum X:float {}", "underlying");
   TestError("enum X:byte { Y, Y }", "value already");
-  TestError("enum X:byte { Y=2, Z=1 }", "ascending");
+  TestError("enum X:byte { Y=2, Z=2 }", "unique");
   TestError("table X { Y:int; } table X {", "datatype already");
   TestError("struct X (force_align: 7) { Y:int; }", "force_align");
   TestError("struct X {}", "size 0");
@@ -1757,9 +1757,7 @@ void EnumOutOfRangeTest() {
   TestError("enum X:ubyte { Y = -1 }", "enum value does not fit");
   TestError("enum X:ubyte { Y = 256 }", "enum value does not fit");
   TestError("enum X:ubyte { Y = 255, Z }", "enum value does not fit");
-  // Unions begin with an implicit "NONE = 0".
-  TestError("table Y{} union X { Y = -1 }",
-            "enum values must be specified in ascending order");
+  TestError("table Y{} union X { Y = -1 }", "enum value does not fit");
   TestError("table Y{} union X { Y = 256 }", "enum value does not fit");
   TestError("table Y{} union X { Y = 255, Z:Y }", "enum value does not fit");
   TestError("enum X:int { Y = -2147483649 }", "enum value does not fit");
@@ -1802,6 +1800,8 @@ void EnumValueTest() {
           18446744073709551615ULL);
   // Assign non-enum value to enum field. Is it right?
   TEST_EQ(TestValue<int>("{ Y:7 }", "E", "enum E:int { V = 0 }"), 7);
+  // Check that non-ascending values are valid.
+  TEST_EQ(TestValue<int>("{ Y:5 }", "E=V", "enum E:int { Z=10, V=5 }"), 5);
 }
 
 void IntegerOutOfRangeTest() {


### PR DESCRIPTION
This change allows enums to be listed out of order, based on the discussion in #5762. 

My motivating example was that I wanted an enum that looked something like this:

```
enum Direction : uint8 {
    None = 0,
    Center = 0,

    Left = 1,
    Top = 2,
    Up = 2,
    Right = 4,
    Bottom = 8,
    Down = 8,

    TopLeft = 3,
    TopRight = 6,
    BottomLeft = 9,
    BottomRight = 12,
    
    AnyDirection = 15, // Left | Right | Top | Bottom
}
```

As a side effect of not needing to obey sorting order, we can now also map multiple enum identifiers to the same value. I added a test for this by adding new enum values to monster_test.fbs that represent the same value, and updating the tests appropriately. 

I'm a little bit worried that not every language will handle this change correctly. I did a spot check and it looks mostly right, but I'm not an expert in all languages, so it's possible some of them are broken? I'll be happy to fix up other language generators if necessary.