### PR TITLE
[CMake] Align package name to FindFlatBuffers.cmake filename

### DIFF
--- a/CMake/FindFlatBuffers.cmake
+++ b/CMake/FindFlatBuffers.cmake
@@ -30,7 +30,7 @@ find_program(FLATBUFFERS_FLATC_EXECUTABLE NAMES flatc)
 find_path(FLATBUFFERS_INCLUDE_DIR NAMES flatbuffers/flatbuffers.h)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(flatbuffers
+find_package_handle_standard_args(FlatBuffers
   DEFAULT_MSG FLATBUFFERS_FLATC_EXECUTABLE FLATBUFFERS_INCLUDE_DIR)
 
 if(FLATBUFFERS_FOUND)


### PR DESCRIPTION
This change is for fix warning:
```
CMake Warning (dev) at /home/aoleksy/share/cmake-3.17/Modules/FindPackageHandleStandardArgs.cmake:272 (message):
  The package name passed to `find_package_handle_standard_args`
  (flatbuffers) does not match the name of the calling package (FlatBuffers).
  This can lead to problems in calling code that expects `find_package`
  result variables (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  FindFlatBuffers.cmake:33 (find_package_handle_standard_args)
  CMakeLists.txt:6 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```