### PR TITLE
Rust Flexbuffers streaming conversions

### DIFF
--- a/rust/flexbuffers/src/builder/de.rs
+++ b/rust/flexbuffers/src/builder/de.rs
@@ -1,0 +1,210 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate serde;
+use crate::{Blob, Builder, MapBuilder, Pushable, VectorBuilder};
+use serde::de::{Deserialize, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
+use std::fmt;
+
+impl<'de> Deserialize<'de> for Builder {
+    fn deserialize<D>(deserializer: D) -> Result<Builder, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut builder = Builder::default();
+        {
+            let visitor = BuilderDeserializer {
+                builder: &mut builder,
+            };
+            deserializer.deserialize_any(visitor)?;
+        }
+        Ok(builder)
+    }
+}
+
+struct BuilderDeserializer<'a> {
+    builder: &'a mut Builder,
+}
+
+struct VectorBuilderDeserializer<'a, 'b: 'a> {
+    vectorbuilder: &'a mut VectorBuilder<'b>,
+}
+
+struct MapBuilderDeserializer<'de, 'a, 'b: 'a> {
+    key: &'de str,
+    mapbuilder: &'a mut MapBuilder<'b>,
+}
+
+impl<'a> BuilderDeserializer<'a> {
+    fn push_value<E, P: Pushable>(self, value: P) -> Result<(), E> {
+        self.builder.build_singleton(value);
+        Ok(())
+    }
+
+    fn start_vector(self) -> VectorBuilder<'a> {
+        self.builder.start_vector()
+    }
+
+    fn start_map(self) -> MapBuilder<'a> {
+        self.builder.start_map()
+    }
+}
+
+impl<'a, 'b: 'a> VectorBuilderDeserializer<'a, 'b> {
+    fn push_value<E, P: Pushable>(self, value: P) -> Result<(), E> {
+        self.vectorbuilder.push(value);
+        Ok(())
+    }
+
+    fn start_vector(self) -> VectorBuilder<'a> {
+        self.vectorbuilder.start_vector()
+    }
+
+    fn start_map(self) -> MapBuilder<'a> {
+        self.vectorbuilder.start_map()
+    }
+}
+
+impl<'de, 'a, 'b: 'a> MapBuilderDeserializer<'de, 'a, 'b> {
+    fn push_value<E, P: Pushable>(self, value: P) -> Result<(), E> {
+        self.mapbuilder.push(self.key, value);
+        Ok(())
+    }
+
+    fn start_vector(self) -> VectorBuilder<'a> {
+        self.mapbuilder.start_vector(self.key)
+    }
+
+    fn start_map(self) -> MapBuilder<'a> {
+        self.mapbuilder.start_map(self.key)
+    }
+}
+
+macro_rules! visit_builder {
+    ( $( $visit:ident($ty:ty) )* ) => {
+        $(fn $visit<E>(self, value: $ty) -> Result<(), E> {
+            self.push_value(value)
+        })*
+    }
+}
+
+// Unable to implement external trait for generic bound by local trait.
+macro_rules! visitor_impl {
+    () => {
+        type Value = ();
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("any valid Flexbuffer value")
+        }
+
+        visit_builder!(
+            visit_bool(bool)
+            visit_str(&str)
+            visit_i8(i8) visit_i16(i16) visit_i32(i32) visit_i64(i64)
+            visit_u8(u8) visit_u16(u16) visit_u32(u32) visit_u64(u64)
+            visit_f32(f32) visit_f64(f64)
+        );
+
+        fn visit_bytes<E>(self, value: &[u8]) -> Result<(), E> {
+            self.push_value(Blob(value))
+        }
+
+        fn visit_none<E>(self) -> Result<(), E> {
+            self.push_value(())
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<(), D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            Deserialize::deserialize(deserializer)
+        }
+
+        fn visit_unit<E>(self) -> Result<(), E> {
+            self.push_value(())
+        }
+
+        fn visit_seq<V>(self, mut visitor: V) -> Result<(), V::Error>
+        where
+            V: SeqAccess<'de>,
+        {
+            let mut vectorbuilder = self.start_vector();
+            while let Some(()) = visitor.next_element_seed(VectorBuilderDeserializer {
+                vectorbuilder: &mut vectorbuilder,
+            })? {}
+            vectorbuilder.end_vector();
+            Ok(())
+        }
+
+        fn visit_map<V>(self, mut visitor: V) -> Result<(), V::Error>
+        where
+            V: MapAccess<'de>,
+        {
+            let mut mapbuilder = self.start_map();
+            while let Some(key) = visitor.next_key::<&str>()? {
+                visitor.next_value_seed(MapBuilderDeserializer {
+                    key,
+                    mapbuilder: &mut mapbuilder,
+                })?
+            }
+            mapbuilder.end_map();
+            Ok(())
+        }
+    };
+}
+
+impl<'de, 'a> DeserializeSeed<'de> for BuilderDeserializer<'a> {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        impl<'de, 'a> Visitor<'de> for BuilderDeserializer<'a> {
+            visitor_impl!();
+        }
+
+        deserializer.deserialize_any(self)
+    }
+}
+
+impl<'de, 'a, 'b> DeserializeSeed<'de> for VectorBuilderDeserializer<'a, 'b> {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        impl<'de, 'a, 'b> Visitor<'de> for VectorBuilderDeserializer<'a, 'b> {
+            visitor_impl!();
+        }
+
+        deserializer.deserialize_any(self)
+    }
+}
+
+impl<'de, 'a, 'b: 'a> DeserializeSeed<'de> for MapBuilderDeserializer<'de, 'a, 'b> {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        impl<'de, 'a, 'b> Visitor<'de> for MapBuilderDeserializer<'de, 'a, 'b> {
+            visitor_impl!();
+        }
+
+        deserializer.deserialize_any(self)
+    }
+}

--- a/rust/flexbuffers/src/builder/mod.rs
+++ b/rust/flexbuffers/src/builder/mod.rs
@@ -17,6 +17,7 @@ mod value;
 use crate::FlexBufferType;
 use std::cmp::max;
 use value::{find_vector_type, store_value, Value};
+mod de;
 mod map;
 mod push;
 mod ser;

--- a/rust/flexbuffers/src/reader/mod.rs
+++ b/rust/flexbuffers/src/reader/mod.rs
@@ -22,6 +22,7 @@ use std::str::FromStr;
 mod de;
 mod iter;
 mod map;
+mod ser;
 mod vector;
 pub use de::DeserializationError;
 pub use iter::ReaderIterator;

--- a/rust/flexbuffers/src/reader/ser.rs
+++ b/rust/flexbuffers/src/reader/ser.rs
@@ -1,0 +1,67 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate serde;
+use crate::Reader;
+use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
+
+impl<'de> Serialize for Reader<'de> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use crate::BitWidth::*;
+        use crate::FlexBufferType::*;
+        match self.flexbuffer_type() {
+            Null => serializer.serialize_unit(),
+            Bool => serializer.serialize_bool(self.as_bool()),
+            Int | IndirectInt => match self.bitwidth() {
+                W8 => serializer.serialize_i8(self.as_i8()),
+                W16 => serializer.serialize_i16(self.as_i16()),
+                W32 => serializer.serialize_i32(self.as_i32()),
+                W64 => serializer.serialize_i64(self.as_i64()),
+            },
+            UInt | IndirectUInt => match self.bitwidth() {
+                W8 => serializer.serialize_u8(self.as_u8()),
+                W16 => serializer.serialize_u16(self.as_u16()),
+                W32 => serializer.serialize_u32(self.as_u32()),
+                W64 => serializer.serialize_u64(self.as_u64()),
+            },
+            Float | IndirectFloat => match self.bitwidth() {
+                W32 => serializer.serialize_f32(self.as_f32()),
+                W64 => serializer.serialize_f64(self.as_f64()),
+                bw => unreachable!("TODO serialize {:?}.", bw),
+            },
+            String | Key => serializer.serialize_str(self.as_str()),
+            Blob => serializer.serialize_bytes(self.as_blob().0),
+            Map => {
+                let mapreader = self.as_map();
+                let mut map = serializer.serialize_map(Some(mapreader.len()))?;
+                for (k, v) in mapreader.iter_keys().zip(mapreader.iter_values()) {
+                    map.serialize_entry(k, &v)?;
+                }
+                map.end()
+            }
+            ty if ty.is_vector() => {
+                let vecreader = self.as_vector();
+                let mut seq = serializer.serialize_seq(Some(vecreader.len()))?;
+                for e in vecreader.iter() {
+                    seq.serialize_element(&e)?;
+                }
+                seq.end()
+            }
+            ty => unreachable!("TODO serialize {:?}.", ty),
+        }
+    }
+}


### PR DESCRIPTION
This builds on #5669 to provide direct conversion between Flexbuffers and other Serde formats. With serde_json this looks like:

```rust
extern crate flexbuffers;
extern crate serde_json;
use std::io;

fn main() -> io::Result<()> {
    let bufin = b"{\"a\":1}";
    let builder: flexbuffers::Builder = serde_json::from_slice(&bufin[..])?;
    let buffer = builder.view();
    let reader = flexbuffers::Reader::get_root(buffer).unwrap();
    serde_json::to_writer(io::BufWriter::new(io::stdout()), &reader)?;
    Ok(())
}
```

I still need to write some tests, but wanted to submit this for feedback on the general approach.