### PR TITLE
[C++17] Expose file_identifier in traits

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2282,12 +2282,15 @@ class CppGenerator : public BaseGenerator {
     // Definition for type traits for this table type. This allows querying var-
     // ious compile-time traits of the table.
     if (opts_.g_cpp_std >= cpp::CPP_STD_17) {
+      auto file_identifier = parser_.file_identifier_.length()
+                                 ? ('"' + parser_.file_identifier_ + '"')
+                                 : "nullptr";
       code_ += "struct {{STRUCT_NAME}}::Traits {";
       code_ += "  using type = {{STRUCT_NAME}};";
       code_ += "  static auto constexpr Create = Create{{STRUCT_NAME}};";
-      if (parser_.file_identifier_.length())
-        code_ += "  static auto constexpr FileIdentifier = \"" +
-                 parser_.file_identifier_ + "\";";
+      code_ +=
+          "  static const char* constexpr FileIdentifier = " + file_identifier +
+          ';';
       code_ += "};";
       code_ += "";
     }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2285,6 +2285,9 @@ class CppGenerator : public BaseGenerator {
       code_ += "struct {{STRUCT_NAME}}::Traits {";
       code_ += "  using type = {{STRUCT_NAME}};";
       code_ += "  static auto constexpr Create = Create{{STRUCT_NAME}};";
+      if (parser_.file_identifier_.length())
+        code_ += "  static auto constexpr FileIdentifier = \"" +
+                 parser_.file_identifier_ + "\";";
       code_ += "};";
       code_ += "";
     }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2287,9 +2287,9 @@ class CppGenerator : public BaseGenerator {
                                  : "nullptr";
       code_ += "struct {{STRUCT_NAME}}::Traits {";
       code_ += "  using type = {{STRUCT_NAME}};";
-      code_ += "  static auto constexpr Create = Create{{STRUCT_NAME}};";
+      code_ += "  static constexpr auto Create = Create{{STRUCT_NAME}};";
       code_ +=
-          "  static const char* constexpr FileIdentifier = " + file_identifier +
+          "  static constexpr const char *file_identifier = " + file_identifier +
           ';';
       code_ += "};";
       code_ += "";

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -658,7 +658,7 @@ inline flatbuffers::Offset<InParentNamespace> CreateInParentNamespace(
 struct InParentNamespace::Traits {
   using type = InParentNamespace;
   static auto constexpr Create = CreateInParentNamespace;
-  static auto constexpr FileIdentifier = "MONS";
+  static const char* constexpr FileIdentifier = "MONS";
 };
 
 flatbuffers::Offset<InParentNamespace> CreateInParentNamespace(flatbuffers::FlatBufferBuilder &_fbb, const InParentNamespaceT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -711,7 +711,7 @@ inline flatbuffers::Offset<Monster> CreateMonster(
 struct Monster::Traits {
   using type = Monster;
   static auto constexpr Create = CreateMonster;
-  static auto constexpr FileIdentifier = "MONS";
+  static const char* constexpr FileIdentifier = "MONS";
 };
 
 flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -783,7 +783,7 @@ inline flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnu
 struct TestSimpleTableWithEnum::Traits {
   using type = TestSimpleTableWithEnum;
   static auto constexpr Create = CreateTestSimpleTableWithEnum;
-  static auto constexpr FileIdentifier = "MONS";
+  static const char* constexpr FileIdentifier = "MONS";
 };
 
 flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnum(flatbuffers::FlatBufferBuilder &_fbb, const TestSimpleTableWithEnumT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -881,7 +881,7 @@ inline flatbuffers::Offset<Stat> CreateStat(
 struct Stat::Traits {
   using type = Stat;
   static auto constexpr Create = CreateStat;
-  static auto constexpr FileIdentifier = "MONS";
+  static const char* constexpr FileIdentifier = "MONS";
 };
 
 inline flatbuffers::Offset<Stat> CreateStatDirect(
@@ -968,7 +968,7 @@ inline flatbuffers::Offset<Referrable> CreateReferrable(
 struct Referrable::Traits {
   using type = Referrable;
   static auto constexpr Create = CreateReferrable;
-  static auto constexpr FileIdentifier = "MONS";
+  static const char* constexpr FileIdentifier = "MONS";
 };
 
 flatbuffers::Offset<Referrable> CreateReferrable(flatbuffers::FlatBufferBuilder &_fbb, const ReferrableT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -1799,7 +1799,7 @@ inline flatbuffers::Offset<Monster> CreateMonster(
 struct Monster::Traits {
   using type = Monster;
   static auto constexpr Create = CreateMonster;
-  static auto constexpr FileIdentifier = "MONS";
+  static const char* constexpr FileIdentifier = "MONS";
 };
 
 inline flatbuffers::Offset<Monster> CreateMonsterDirect(
@@ -2153,7 +2153,7 @@ inline flatbuffers::Offset<TypeAliases> CreateTypeAliases(
 struct TypeAliases::Traits {
   using type = TypeAliases;
   static auto constexpr Create = CreateTypeAliases;
-  static auto constexpr FileIdentifier = "MONS";
+  static const char* constexpr FileIdentifier = "MONS";
 };
 
 inline flatbuffers::Offset<TypeAliases> CreateTypeAliasesDirect(

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -658,6 +658,7 @@ inline flatbuffers::Offset<InParentNamespace> CreateInParentNamespace(
 struct InParentNamespace::Traits {
   using type = InParentNamespace;
   static auto constexpr Create = CreateInParentNamespace;
+  static auto constexpr FileIdentifier = "MONS";
 };
 
 flatbuffers::Offset<InParentNamespace> CreateInParentNamespace(flatbuffers::FlatBufferBuilder &_fbb, const InParentNamespaceT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -710,6 +711,7 @@ inline flatbuffers::Offset<Monster> CreateMonster(
 struct Monster::Traits {
   using type = Monster;
   static auto constexpr Create = CreateMonster;
+  static auto constexpr FileIdentifier = "MONS";
 };
 
 flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -781,6 +783,7 @@ inline flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnu
 struct TestSimpleTableWithEnum::Traits {
   using type = TestSimpleTableWithEnum;
   static auto constexpr Create = CreateTestSimpleTableWithEnum;
+  static auto constexpr FileIdentifier = "MONS";
 };
 
 flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnum(flatbuffers::FlatBufferBuilder &_fbb, const TestSimpleTableWithEnumT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -878,6 +881,7 @@ inline flatbuffers::Offset<Stat> CreateStat(
 struct Stat::Traits {
   using type = Stat;
   static auto constexpr Create = CreateStat;
+  static auto constexpr FileIdentifier = "MONS";
 };
 
 inline flatbuffers::Offset<Stat> CreateStatDirect(
@@ -964,6 +968,7 @@ inline flatbuffers::Offset<Referrable> CreateReferrable(
 struct Referrable::Traits {
   using type = Referrable;
   static auto constexpr Create = CreateReferrable;
+  static auto constexpr FileIdentifier = "MONS";
 };
 
 flatbuffers::Offset<Referrable> CreateReferrable(flatbuffers::FlatBufferBuilder &_fbb, const ReferrableT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -1794,6 +1799,7 @@ inline flatbuffers::Offset<Monster> CreateMonster(
 struct Monster::Traits {
   using type = Monster;
   static auto constexpr Create = CreateMonster;
+  static auto constexpr FileIdentifier = "MONS";
 };
 
 inline flatbuffers::Offset<Monster> CreateMonsterDirect(
@@ -2147,6 +2153,7 @@ inline flatbuffers::Offset<TypeAliases> CreateTypeAliases(
 struct TypeAliases::Traits {
   using type = TypeAliases;
   static auto constexpr Create = CreateTypeAliases;
+  static auto constexpr FileIdentifier = "MONS";
 };
 
 inline flatbuffers::Offset<TypeAliases> CreateTypeAliasesDirect(

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -657,8 +657,8 @@ inline flatbuffers::Offset<InParentNamespace> CreateInParentNamespace(
 
 struct InParentNamespace::Traits {
   using type = InParentNamespace;
-  static auto constexpr Create = CreateInParentNamespace;
-  static const char* constexpr FileIdentifier = "MONS";
+  static constexpr auto Create = CreateInParentNamespace;
+  static constexpr const char *file_identifier = "MONS";
 };
 
 flatbuffers::Offset<InParentNamespace> CreateInParentNamespace(flatbuffers::FlatBufferBuilder &_fbb, const InParentNamespaceT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -710,8 +710,8 @@ inline flatbuffers::Offset<Monster> CreateMonster(
 
 struct Monster::Traits {
   using type = Monster;
-  static auto constexpr Create = CreateMonster;
-  static const char* constexpr FileIdentifier = "MONS";
+  static constexpr auto Create = CreateMonster;
+  static constexpr const char *file_identifier = "MONS";
 };
 
 flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb, const MonsterT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -782,8 +782,8 @@ inline flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnu
 
 struct TestSimpleTableWithEnum::Traits {
   using type = TestSimpleTableWithEnum;
-  static auto constexpr Create = CreateTestSimpleTableWithEnum;
-  static const char* constexpr FileIdentifier = "MONS";
+  static constexpr auto Create = CreateTestSimpleTableWithEnum;
+  static constexpr const char *file_identifier = "MONS";
 };
 
 flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnum(flatbuffers::FlatBufferBuilder &_fbb, const TestSimpleTableWithEnumT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -880,8 +880,8 @@ inline flatbuffers::Offset<Stat> CreateStat(
 
 struct Stat::Traits {
   using type = Stat;
-  static auto constexpr Create = CreateStat;
-  static const char* constexpr FileIdentifier = "MONS";
+  static constexpr auto Create = CreateStat;
+  static constexpr const char *file_identifier = "MONS";
 };
 
 inline flatbuffers::Offset<Stat> CreateStatDirect(
@@ -967,8 +967,8 @@ inline flatbuffers::Offset<Referrable> CreateReferrable(
 
 struct Referrable::Traits {
   using type = Referrable;
-  static auto constexpr Create = CreateReferrable;
-  static const char* constexpr FileIdentifier = "MONS";
+  static constexpr auto Create = CreateReferrable;
+  static constexpr const char *file_identifier = "MONS";
 };
 
 flatbuffers::Offset<Referrable> CreateReferrable(flatbuffers::FlatBufferBuilder &_fbb, const ReferrableT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -1798,8 +1798,8 @@ inline flatbuffers::Offset<Monster> CreateMonster(
 
 struct Monster::Traits {
   using type = Monster;
-  static auto constexpr Create = CreateMonster;
-  static const char* constexpr FileIdentifier = "MONS";
+  static constexpr auto Create = CreateMonster;
+  static constexpr const char *file_identifier = "MONS";
 };
 
 inline flatbuffers::Offset<Monster> CreateMonsterDirect(
@@ -2152,8 +2152,8 @@ inline flatbuffers::Offset<TypeAliases> CreateTypeAliases(
 
 struct TypeAliases::Traits {
   using type = TypeAliases;
-  static auto constexpr Create = CreateTypeAliases;
-  static const char* constexpr FileIdentifier = "MONS";
+  static constexpr auto Create = CreateTypeAliases;
+  static constexpr const char *file_identifier = "MONS";
 };
 
 inline flatbuffers::Offset<TypeAliases> CreateTypeAliasesDirect(

--- a/tests/cpp17/test_cpp17.cpp
+++ b/tests/cpp17/test_cpp17.cpp
@@ -59,8 +59,13 @@ void CreateTableByTypeTest() {
   TEST_EQ(stat->count(), 7);
 }
 
+void AccessFileIdentifierInTraits() {
+  TEST_EQ_STR(cpp17::MyGame::Example::Monster::Traits::FileIdentifier, "MONS");
+}
+
 int FlatBufferCpp17Tests() {
   CreateTableByTypeTest();
+  AccessFileIdentifierInTraits();
   return 0;
 }
 

--- a/tests/cpp17/test_cpp17.cpp
+++ b/tests/cpp17/test_cpp17.cpp
@@ -60,7 +60,7 @@ void CreateTableByTypeTest() {
 }
 
 void AccessFileIdentifierInTraits() {
-  TEST_EQ_STR(cpp17::MyGame::Example::Monster::Traits::FileIdentifier, "MONS");
+  TEST_EQ_STR(cpp17::MyGame::Example::Monster::Traits::file_identifier, "MONS");
 }
 
 int FlatBufferCpp17Tests() {


### PR DESCRIPTION
This PR adds a new field `FileIdentifier` to the C++17 `Traits` struct. Previously it was impossible to access the the `file_identifier` in schema file in a generic fashion, because only the function `MonsterIdentifier()` exposed it.