### PR TITLE
Update Rust Flexbuffers metadata before publishing

### DIFF
--- a/rust/flexbuffers/Cargo.toml
+++ b/rust/flexbuffers/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
 name = "flexbuffers"
 version = "0.1.0"
-authors = ["Casper Neo <cneo@google.com>"]
+authors = ["Casper Neo <cneo@google.com>", "FlatBuffers Maintainers"]
 edition = "2018"
 license = "Apache-2.0"
+description = "Official FlexBuffers Rust runtime library."
+homepage = "https://google.github.io/flatbuffers/flexbuffers"
+repository = "https://github.com/google/flatbuffers"
+keywords = ["flatbuffers", "flexbuffers", "serialization", "zero-copy"]
+categories = ["encoding", "data-structures", "memory-management"]
 
 [dependencies]
 serde = "1.0.103"


### PR DESCRIPTION
After this PR is merged, I will publish the package on crates.io