### PR TITLE
[C#] Add file identifier to ObjectAPI Serialization Utility.

### DIFF
--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -1823,7 +1823,9 @@ class CSharpGenerator : public BaseGenerator {
             code += "[idx" + NumToString(j++) + "]";
           }
           code += ";";
-          for (size_t i = 0; i < array_only_lengths.size(); ++i) { code += "}"; }
+          for (size_t i = 0; i < array_only_lengths.size(); ++i) {
+            code += "}";
+          }
         } else {
           code += "_o";
           for (size_t i = 0; i < array_lengths.size(); ++i) {
@@ -2035,8 +2037,8 @@ class CSharpGenerator : public BaseGenerator {
       code += "  }\n";
       code += "  public byte[] SerializeToBinary() {\n";
       code += "    var fbb = new FlatBufferBuilder(0x10000);\n";
-      code +=
-          "    fbb.Finish(" + struct_def.name + ".Pack(fbb, this).Value);\n";
+      code += "    " + struct_def.name + ".Finish" + struct_def.name +
+              "Buffer(fbb, " + struct_def.name + ".Pack(fbb, this));\n";
       code += "    return fbb.DataBuffer.ToSizedArray();\n";
       code += "  }\n";
     }

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -676,6 +676,7 @@ namespace FlatBuffers.Test
             AreEqual(a, d);
 
             var fbBuffer = b.SerializeToBinary();
+            Assert.IsTrue(Monster.MonsterBufferHasIdentifier(new ByteBuffer(fbBuffer)));
             var e = MonsterT.DeserializeFromBinary(fbBuffer);
             AreEqual(a, e);
         }
@@ -779,6 +780,7 @@ namespace FlatBuffers.Test
             AreEqual(a, d);
 
             var fbBuffer = b.SerializeToBinary();
+            Assert.IsTrue(ArrayTable.ArrayTableBufferHasIdentifier(new ByteBuffer(fbBuffer)));
             var e = ArrayTableT.DeserializeFromBinary(fbBuffer);
             AreEqual(a, e);
         }
@@ -826,6 +828,7 @@ namespace FlatBuffers.Test
             AreEqual(a, d);
 
             var fbBuffer = b.SerializeToBinary();
+            Assert.IsTrue(Movie.MovieBufferHasIdentifier(new ByteBuffer(fbBuffer)));
             var e = MovieT.DeserializeFromBinary(fbBuffer);
             AreEqual(a, e);
         }

--- a/tests/MyGame/Example/ArrayTable.cs
+++ b/tests/MyGame/Example/ArrayTable.cs
@@ -66,7 +66,7 @@ public class ArrayTableT
   }
   public byte[] SerializeToBinary() {
     var fbb = new FlatBufferBuilder(0x10000);
-    fbb.Finish(ArrayTable.Pack(fbb, this).Value);
+    ArrayTable.FinishArrayTableBuffer(fbb, ArrayTable.Pack(fbb, this));
     return fbb.DataBuffer.ToSizedArray();
   }
 }

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -891,7 +891,7 @@ public class MonsterT
   }
   public byte[] SerializeToBinary() {
     var fbb = new FlatBufferBuilder(0x10000);
-    fbb.Finish(Monster.Pack(fbb, this).Value);
+    Monster.FinishMonsterBuffer(fbb, Monster.Pack(fbb, this));
     return fbb.DataBuffer.ToSizedArray();
   }
 }

--- a/tests/MyGame/MonsterExtra.cs
+++ b/tests/MyGame/MonsterExtra.cs
@@ -196,7 +196,7 @@ public class MonsterExtraT
   }
   public byte[] SerializeToBinary() {
     var fbb = new FlatBufferBuilder(0x10000);
-    fbb.Finish(MonsterExtra.Pack(fbb, this).Value);
+    MonsterExtra.FinishMonsterExtraBuffer(fbb, MonsterExtra.Pack(fbb, this));
     return fbb.DataBuffer.ToSizedArray();
   }
 }

--- a/tests/union_vector/Movie.cs
+++ b/tests/union_vector/Movie.cs
@@ -196,7 +196,7 @@ public class MovieT
   }
   public byte[] SerializeToBinary() {
     var fbb = new FlatBufferBuilder(0x10000);
-    fbb.Finish(Movie.Pack(fbb, this).Value);
+    Movie.FinishMovieBuffer(fbb, Movie.Pack(fbb, this));
     return fbb.DataBuffer.ToSizedArray();
   }
 }


### PR DESCRIPTION
This pull request will fix #5785.

Add a `file_identifier` that I forgot to include 😓 

* use `T.FinishTBuffer()` for each class instead of `FlatBuffersBuilder.Finish()`.
* and add a test to ensure that the file_identifier exists.
