### PR TITLE
[Java] Grow ArrayReadWriteBuf enough to match requested capacity.

### DIFF
--- a/java/com/google/flatbuffers/ArrayReadWriteBuf.java
+++ b/java/com/google/flatbuffers/ArrayReadWriteBuf.java
@@ -240,6 +240,13 @@ public class ArrayReadWriteBuf implements ReadWriteBuf {
     // implemented in the same growing fashion as ArrayList
     int oldCapacity = buffer.length;
     int newCapacity = oldCapacity + (oldCapacity >> 1);
+    if (newCapacity - capacity <= 0) {
+      if (capacity < 0) {
+        // capacity has overflown
+        throw new OutOfMemoryError();
+      }
+      newCapacity = capacity;
+    }
     buffer = Arrays.copyOf(buffer, newCapacity);
     return true;
   }

--- a/java/com/google/flatbuffers/ArrayReadWriteBuf.java
+++ b/java/com/google/flatbuffers/ArrayReadWriteBuf.java
@@ -234,17 +234,16 @@ public class ArrayReadWriteBuf implements ReadWriteBuf {
 
   @Override
   public boolean requestCapacity(int capacity) {
-    if (buffer.length > capacity) {
+    if (capacity < 0) {
+      throw new IllegalArgumentException("Capacity may not be negative (likely a previous int overflow)");
+    }
+    if (buffer.length >= capacity) {
       return true;
     }
     // implemented in the same growing fashion as ArrayList
     int oldCapacity = buffer.length;
     int newCapacity = oldCapacity + (oldCapacity >> 1);
-    if (newCapacity - capacity <= 0) {
-      if (capacity < 0) {
-        // capacity has overflown
-        throw new OutOfMemoryError();
-      }
+    if (newCapacity < capacity) {  // Note: this also catches newCapacity int overflow
       newCapacity = capacity;
     }
     buffer = Arrays.copyOf(buffer, newCapacity);

--- a/tests/JavaTest.java
+++ b/tests/JavaTest.java
@@ -1027,14 +1027,9 @@ class JavaTest {
         TestEq("This is a small string", FlexBuffers.getRoot(b).asString());
 
         FlexBuffersBuilder failBuilder = new FlexBuffersBuilder(ByteBuffer.allocate(1));
-        try {
-            failBuilder.putString("This is a small string");
-            // This should never be reached, it should throw an exception
-            // since ByteBuffers do not grow
-            assert(false);
-        } catch (java.lang.ArrayIndexOutOfBoundsException exception) {
-            // It should throw exception
-        }
+        // Should never throw an exception
+        // since internally ArrayReadWriteBuf is used which does grow
+        failBuilder.putString("This is a small string");
     }
     
     public static void testFlexBuffersUtf8Map() {

--- a/tests/JavaTest.java
+++ b/tests/JavaTest.java
@@ -1021,19 +1021,18 @@ class JavaTest {
     }
 
     public static void testBuilderGrowth() {
-        FlexBuffersBuilder builder = new FlexBuffersBuilder(1);
-        // FlexBuffersBuilder internally uses ArrayReadWriteBuf, which grows beyond the initial capacity of 1
-        builder.putString("This is a small string");
+        FlexBuffersBuilder builder = new FlexBuffersBuilder();
+        String someString = "This is a small string";
+        builder.putString(someString);
         ByteBuffer b = builder.finish();
-        TestEq("This is a small string", FlexBuffers.getRoot(b).asString());
-
+        TestEq(someString, FlexBuffers.getRoot(b).asString());
 
         FlexBuffersBuilder failBuilder = new FlexBuffersBuilder(ByteBuffer.allocate(1));
         try {
-            failBuilder.putString("This is a small string");
+            failBuilder.putString(someString);
             // This should never be reached, it should throw an exception
             // since ByteBuffers do not grow
-            // TODO enable this: TestFail("should have thrown");
+            assert(false);
         } catch (java.lang.ArrayIndexOutOfBoundsException exception) {
             // It should throw exception
         }
@@ -1227,10 +1226,4 @@ class JavaTest {
         }
     }
 
-    static void TestFail(String message) {
-        System.out.println("FlatBuffers test FAILED: \'" + message + "\'");
-        new Throwable().printStackTrace();
-        assert false;
-        System.exit(1);
-    }
 }

--- a/tests/JavaTest.java
+++ b/tests/JavaTest.java
@@ -1021,14 +1021,22 @@ class JavaTest {
     }
 
     public static void testBuilderGrowth() {
-        FlexBuffersBuilder builder = new FlexBuffersBuilder();
+        FlexBuffersBuilder builder = new FlexBuffersBuilder(1);
+        // FlexBuffersBuilder internally uses ArrayReadWriteBuf, which grows beyond the initial capacity of 1
         builder.putString("This is a small string");
         ByteBuffer b = builder.finish();
         TestEq("This is a small string", FlexBuffers.getRoot(b).asString());
 
-        FlexBuffersBuilder smallCapacityBuilder = new FlexBuffersBuilder(ByteBuffer.allocate(1));
-        // FlexBuffersBuilder internally uses ArrayReadWriteBuf, which grows beyond the initial capacity of 1
-        smallCapacityBuilder.putString("This is a small string");
+
+        FlexBuffersBuilder failBuilder = new FlexBuffersBuilder(ByteBuffer.allocate(1));
+        try {
+            failBuilder.putString("This is a small string");
+            // This should never be reached, it should throw an exception
+            // since ByteBuffers do not grow
+            // TODO enable this: TestFail("should have thrown");
+        } catch (java.lang.ArrayIndexOutOfBoundsException exception) {
+            // It should throw exception
+        }
     }
     
     public static void testFlexBuffersUtf8Map() {
@@ -1217,5 +1225,12 @@ class JavaTest {
             assert false;
             System.exit(1);
         }
+    }
+
+    static void TestFail(String message) {
+        System.out.println("FlatBuffers test FAILED: \'" + message + "\'");
+        new Throwable().printStackTrace();
+        assert false;
+        System.exit(1);
     }
 }

--- a/tests/JavaTest.java
+++ b/tests/JavaTest.java
@@ -1026,10 +1026,9 @@ class JavaTest {
         ByteBuffer b = builder.finish();
         TestEq("This is a small string", FlexBuffers.getRoot(b).asString());
 
-        FlexBuffersBuilder failBuilder = new FlexBuffersBuilder(ByteBuffer.allocate(1));
-        // Should never throw an exception
-        // since internally ArrayReadWriteBuf is used which does grow
-        failBuilder.putString("This is a small string");
+        FlexBuffersBuilder smallCapacityBuilder = new FlexBuffersBuilder(ByteBuffer.allocate(1));
+        // FlexBuffersBuilder internally uses ArrayReadWriteBuf, which grows beyond the initial capacity of 1
+        smallCapacityBuilder.putString("This is a small string");
     }
     
     public static void testFlexBuffersUtf8Map() {


### PR DESCRIPTION
Suggested fix for #5908.

Current tests did not catch #5908 as it expected `FlexBuffersBuilder` to throw with `ArrayIndexOutOfBoundsException` due to `ByteBuffer` not being able to grow. However, since `ArrayReadWriteBuf` was introduced growing is supported. But it still threw the expected exception, yet with a different cause (grown array too small vs. `ByteBuffer` backed buffer can not grow).