### PR TITLE
Add static asserts to ensure that reflection API arrays are kept in sync

### DIFF
--- a/include/flatbuffers/reflection.h
+++ b/include/flatbuffers/reflection.h
@@ -46,7 +46,9 @@ inline bool IsLong(reflection::BaseType t) {
 // Size of a basic type, don't use with structs.
 inline size_t GetTypeSize(reflection::BaseType base_type) {
   // This needs to correspond to the BaseType enum.
-  static size_t sizes[] = { 0, 1, 1, 1, 1, 2, 2, 4, 4, 8, 8, 4, 8, 4, 4, 4, 4 };
+  static size_t sizes[] = { 0, 1, 1, 1, 1, 2, 2, 4, 4, 8, 8, 4, 8, 4, 4, 4, 4, 0 };
+  static_assert(sizeof(sizes) / sizeof(size_t) == reflection::CountBaseTypes,
+                "Size of sizes[] array does not match the count of BaseType enum values.");
   return sizes[base_type];
 }
 

--- a/include/flatbuffers/reflection.h
+++ b/include/flatbuffers/reflection.h
@@ -46,8 +46,29 @@ inline bool IsLong(reflection::BaseType t) {
 // Size of a basic type, don't use with structs.
 inline size_t GetTypeSize(reflection::BaseType base_type) {
   // This needs to correspond to the BaseType enum.
-  static size_t sizes[] = { 0, 1, 1, 1, 1, 2, 2, 4, 4, 8, 8, 4, 8, 4, 4, 4, 4, 0 };
-  static_assert(sizeof(sizes) / sizeof(size_t) == reflection::MaxBaseType,
+  static size_t sizes[] = {
+    0, // None
+    1, // UType
+    1, // Bool
+    1, // Byte
+    1, // UByte
+    2, // Short
+    2, // UShort
+    4, // Int
+    4, // UInt
+    8, // Long
+    8, // ULong
+    4, // Float
+    8, // Double
+    4, // String
+    4, // Vector
+    4, // Obj
+    4, // Union
+    0, // Array. Only used in structs. 0 was chosen to prevent out-of-bounds errors.
+
+    0  // MaxBaseType. This must be kept the last entry in this array.
+    };
+  static_assert(sizeof(sizes) / sizeof(size_t) == reflection::MaxBaseType + 1,
                 "Size of sizes[] array does not match the count of BaseType enum values.");
   return sizes[base_type];
 }

--- a/include/flatbuffers/reflection.h
+++ b/include/flatbuffers/reflection.h
@@ -47,7 +47,7 @@ inline bool IsLong(reflection::BaseType t) {
 inline size_t GetTypeSize(reflection::BaseType base_type) {
   // This needs to correspond to the BaseType enum.
   static size_t sizes[] = { 0, 1, 1, 1, 1, 2, 2, 4, 4, 8, 8, 4, 8, 4, 4, 4, 4, 0 };
-  static_assert(sizeof(sizes) / sizeof(size_t) == reflection::CountBaseTypes,
+  static_assert(sizeof(sizes) / sizeof(size_t) == reflection::MaxBaseType,
                 "Size of sizes[] array does not match the count of BaseType enum values.");
   return sizes[base_type];
 }

--- a/include/flatbuffers/reflection_generated.h
+++ b/include/flatbuffers/reflection_generated.h
@@ -54,10 +54,10 @@ enum BaseType {
   Obj = 15,
   Union = 16,
   Array = 17,
-  CountBaseTypes
+  MaxBaseType = 18
 };
 
-inline const BaseType (&EnumValuesBaseType())[18] {
+inline const BaseType (&EnumValuesBaseType())[19] {
   static const BaseType values[] = {
     None,
     UType,
@@ -76,13 +76,14 @@ inline const BaseType (&EnumValuesBaseType())[18] {
     Vector,
     Obj,
     Union,
-    Array
+    Array,
+    MaxBaseType
   };
   return values;
 }
 
 inline const char * const *EnumNamesBaseType() {
-  static const char * const names[19] = {
+  static const char * const names[20] = {
     "None",
     "UType",
     "Bool",
@@ -101,13 +102,14 @@ inline const char * const *EnumNamesBaseType() {
     "Obj",
     "Union",
     "Array",
+    "MaxBaseType",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameBaseType(BaseType e) {
-  if (flatbuffers::IsOutRange(e, None, Array)) return "";
+  if (flatbuffers::IsOutRange(e, None, MaxBaseType)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesBaseType()[index];
 }

--- a/include/flatbuffers/reflection_generated.h
+++ b/include/flatbuffers/reflection_generated.h
@@ -54,9 +54,6 @@ enum BaseType {
   Obj = 15,
   Union = 16,
   Array = 17,
-
-  // This line must be the last enum value.
-  // Add any new type above this line.
   CountBaseTypes
 };
 
@@ -81,8 +78,6 @@ inline const BaseType (&EnumValuesBaseType())[18] {
     Union,
     Array
   };
-  static_assert(sizeof(values) / sizeof(BaseType) == CountBaseTypes,
-                "Size of values[] array does not match the count of BaseType enum values.");
   return values;
 }
 
@@ -108,8 +103,6 @@ inline const char * const *EnumNamesBaseType() {
     "Array",
     nullptr
   };
-  static_assert(sizeof(names) / sizeof(char *) == CountBaseTypes + 1,
-                "Size of names[] array does not match the count of BaseType enum values.");
   return names;
 }
 

--- a/include/flatbuffers/reflection_generated.h
+++ b/include/flatbuffers/reflection_generated.h
@@ -53,7 +53,11 @@ enum BaseType {
   Vector = 14,
   Obj = 15,
   Union = 16,
-  Array = 17
+  Array = 17,
+
+  // This line must be the last enum value.
+  // Add any new type above this line.
+  CountBaseTypes
 };
 
 inline const BaseType (&EnumValuesBaseType())[18] {
@@ -77,6 +81,8 @@ inline const BaseType (&EnumValuesBaseType())[18] {
     Union,
     Array
   };
+  static_assert(sizeof(values) / sizeof(BaseType) == CountBaseTypes,
+                "Size of values[] array does not match the count of BaseType enum values.");
   return values;
 }
 
@@ -102,6 +108,8 @@ inline const char * const *EnumNamesBaseType() {
     "Array",
     nullptr
   };
+  static_assert(sizeof(names) / sizeof(char *) == CountBaseTypes + 1,
+                "Size of names[] array does not match the count of BaseType enum values.");
   return names;
 }
 

--- a/reflection/reflection.fbs
+++ b/reflection/reflection.fbs
@@ -24,12 +24,15 @@ enum BaseType : byte {
     Vector,
     Obj,     // Used for tables & structs.
     Union,
-    Array
+    Array,
+
+    // Add any new type above this value.
+    CountBaseTypes
 }
 
 table Type {
     base_type:BaseType;
-    element:BaseType = None;  // Only if base_type == Vector 
+    element:BaseType = None;  // Only if base_type == Vector
                               // or base_type == Array.
     index:int = -1;  // If base_type == Object, index into "objects" below.
                      // If base_type == Union, UnionType, or integral derived

--- a/reflection/reflection.fbs
+++ b/reflection/reflection.fbs
@@ -27,7 +27,7 @@ enum BaseType : byte {
     Array,
 
     // Add any new type above this value.
-    CountBaseTypes
+    MaxBaseType
 }
 
 table Type {


### PR DESCRIPTION
This change addresses issue 5933: https://github.com/google/flatbuffers/issues/5933.

The reflection API includes 3 arrays that need to be kept in sync with the BaseType enum values. This change adds static_asserts that detect discrepancies at compile time. It asso adds an entry missing in the sizes[] array.

Tests: Added asserts and verified that compilation fails due to sizes[] array missing a value. Added value to sizes[] array and verified that the code compiled successfully. Also ran flattests successfully.
I used typical cmake steps to build. I.e.: mkdir build; cd build; cmake ..; make