### PR TITLE
[Java][FlexBuffers] Make ReadBuf and ReadWriteBuf interfaces public.

### DIFF
--- a/java/com/google/flatbuffers/ReadBuf.java
+++ b/java/com/google/flatbuffers/ReadBuf.java
@@ -3,7 +3,7 @@ package com.google.flatbuffers;
 /**
  *  Represent a chunk of data, where FlexBuffers will read from.
  */
-interface ReadBuf {
+public interface ReadBuf {
 
   /**
    * Read boolean from data. Booleans as stored as single byte

--- a/java/com/google/flatbuffers/ReadWriteBuf.java
+++ b/java/com/google/flatbuffers/ReadWriteBuf.java
@@ -4,7 +4,7 @@ package com.google.flatbuffers;
  * Interface to represent a read-write buffer. This interface will be used to access and write
  * FlexBuffers message.
  */
-interface ReadWriteBuf extends ReadBuf {
+public interface ReadWriteBuf extends ReadBuf {
 
     /**
      * Clears (resets) the buffer so that it can be reused. Write position will be set to the


### PR DESCRIPTION
[FlexBuffer][Java] ReadWriteBuf and ReadBuf interface public

Those interfaces need to be public for use cases where the user pass a buffer to FlexBuffers class that is not a ByteBuffer.

This will fix #5944