### PR TITLE
[C++] Add an option to not generate constructors for classes of Object-based API

### DIFF
--- a/docs/source/Compiler.md
+++ b/docs/source/Compiler.md
@@ -143,6 +143,9 @@ Additional options:
 
 -   `--object-suffix` : Customise class suffix for C++ object-based API.
 
+-   `--object-no-constructor` : Do not generator constructor when generating classes
+    for Object-based API.
+
 -   `--no-js-exports` : Removes Node.js style export lines (useful for JS)
 
 -   `--goog-js-export` :  Uses goog.exportsSymbol and goog.exportsProperty

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -535,6 +535,7 @@ struct IDLOptions {
   bool gen_generated;
   std::string object_prefix;
   std::string object_suffix;
+  bool object_no_constructor;
   bool union_value_namespacing;
   bool allow_non_utf8;
   bool natural_utf8;
@@ -627,6 +628,7 @@ struct IDLOptions {
         java_checkerframework(false),
         gen_generated(false),
         object_suffix("T"),
+        object_no_constructor(false),
         union_value_namespacing(true),
         allow_non_utf8(false),
         natural_utf8(false),

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -127,6 +127,8 @@ std::string FlatCompiler::GetUsageString(const char *program_name) const {
     "  --object-prefix        Customise class prefix for C++ object-based API.\n"
     "  --object-suffix        Customise class suffix for C++ object-based API.\n"
     "                         Default value is \"T\".\n"
+    "  --object-no-construct  Do not generate constructor when generating classes\n"
+    "                         for Object-based API.\n"
     "  --no-js-exports        Removes Node.js style export lines in JS.\n"
     "  --goog-js-export       Uses goog.exports* for closure compiler exporting in JS.\n"
     "  --es6-js-export        Uses ECMAScript 6 export style lines in JS.\n"
@@ -292,6 +294,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
       } else if (arg == "--object-suffix") {
         if (++argi >= argc) Error("missing suffix following: " + arg, true);
         opts.object_suffix = argv[argi];
+      } else if (arg == "--object-no-constructor") {
+        opts.object_no_constructor = true;
       } else if (arg == "--gen-all") {
         opts.generate_all = true;
         opts.include_dependence_headers = false;

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -1782,7 +1782,9 @@ class CppGenerator : public BaseGenerator {
       GenMember(**it);
     }
     GenOperatorNewDelete(struct_def);
-    GenDefaultConstructor(struct_def);
+    if (!opts_.object_no_constructor) {
+      GenDefaultConstructor(struct_def);
+    }
     code_ += "};";
     if (opts_.gen_compare) GenCompareOperator(struct_def);
     code_ += "";


### PR DESCRIPTION
The following option is added to flatc:

```
  --object-no-construct  Do not generate constructor when generating classes
                         for Object-based API.
```

When `--object-no-construct` is on, the constructors (which is to initialize scale fields) for classes of Object-based API will not be generated.

Thus C++ designated initialization can be used to initialize instances of those classes.

