### PR TITLE
[Swift] Required is now implemented for readers

### DIFF
--- a/swift/FlatBuffers.podspec
+++ b/swift/FlatBuffers.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FlatBuffers'
-  s.version          = '0.4.0'
+  s.version          = '0.5.1'
   s.summary          = 'FlatBuffers: Memory Efficient Serialization Library'
 
   s.description      = "FlatBuffers is a cross platform serialization library architected for

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
@@ -164,8 +164,11 @@ public struct Test: Readable {
         return TestT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout TestT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout TestT) -> Offset<UOffset> {
         return builder.create(struct: createTest(a: obj.a, b: obj.b), type: Test.self)
     }
 }
@@ -212,8 +215,11 @@ public struct Vec3: Readable {
         return Vec3T(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout Vec3T?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout Vec3T) -> Offset<UOffset> {
         return builder.create(struct: createVec3(x: obj.x, y: obj.y, z: obj.z, test1: obj.test1, test2: obj.test2, test3a: obj.test3.a, test3b: obj.test3.b), type: Vec3.self)
     }
 }
@@ -267,8 +273,11 @@ public struct Ability: Readable {
         return AbilityT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout AbilityT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout AbilityT) -> Offset<UOffset> {
         return builder.create(struct: createAbility(id: obj.id, distance: obj.distance), type: Ability.self)
     }
 }
@@ -343,8 +352,11 @@ public struct InParentNamespace: FlatBufferObject {
         return InParentNamespaceT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout InParentNamespaceT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout InParentNamespaceT) -> Offset<UOffset> {
         let __root = InParentNamespace.startInParentNamespace(&builder)
         return InParentNamespace.endInParentNamespace(&builder, start: __root)
     }
@@ -382,8 +394,11 @@ public struct Monster: FlatBufferObject {
         return MonsterT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MonsterT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MonsterT) -> Offset<UOffset> {
         let __root = Monster.startMonster(&builder)
         return Monster.endMonster(&builder, start: __root)
     }
@@ -442,8 +457,11 @@ public struct TestSimpleTableWithEnum: FlatBufferObject {
         return TestSimpleTableWithEnumT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout TestSimpleTableWithEnumT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout TestSimpleTableWithEnumT) -> Offset<UOffset> {
         let __root = TestSimpleTableWithEnum.startTestSimpleTableWithEnum(&builder)
         TestSimpleTableWithEnum.add(color: obj.color, &builder)
         return TestSimpleTableWithEnum.endTestSimpleTableWithEnum(&builder, start: __root)
@@ -510,8 +528,11 @@ public struct Stat: FlatBufferObject {
         return StatT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout StatT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout StatT) -> Offset<UOffset> {
         let __id: Offset<String>
         if let s = obj.id {
             __id = builder.create(string: s)
@@ -604,8 +625,11 @@ public struct Referrable: FlatBufferObject {
         return ReferrableT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout ReferrableT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout ReferrableT) -> Offset<UOffset> {
         let __root = Referrable.startReferrable(&builder)
         Referrable.add(id: obj.id, &builder)
         return Referrable.endReferrable(&builder, start: __root)
@@ -696,8 +720,8 @@ public struct Monster: FlatBufferObject {
     @discardableResult public func mutate(mana: Int16) -> Bool {let o = _accessor.offset(VTOFFSET.mana.v);  return _accessor.mutate(mana, index: o) }
     public var hp: Int16 { let o = _accessor.offset(VTOFFSET.hp.v); return o == 0 ? 100 : _accessor.readBuffer(of: Int16.self, at: o) }
     @discardableResult public func mutate(hp: Int16) -> Bool {let o = _accessor.offset(VTOFFSET.hp.v);  return _accessor.mutate(hp, index: o) }
-    public var name: String? { let o = _accessor.offset(VTOFFSET.name.v); return o == 0 ? nil : _accessor.string(at: o) }
-    public var nameSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.name.v) }
+    public var name: String! { let o = _accessor.offset(VTOFFSET.name.v); return _accessor.string(at: o) }
+    public var nameSegmentArray: [UInt8]! { return _accessor.getVector(at: VTOFFSET.name.v) }
     public var inventoryCount: Int32 { let o = _accessor.offset(VTOFFSET.inventory.v); return o == 0 ? 0 : _accessor.vector(count: o) }
     public func inventory(at index: Int32) -> UInt8 { let o = _accessor.offset(VTOFFSET.inventory.v); return o == 0 ? 0 : _accessor.directRead(of: UInt8.self, offset: _accessor.vector(at: o) + index * 1) }
     public var inventory: [UInt8] { return _accessor.getVector(at: VTOFFSET.inventory.v) ?? [] }
@@ -981,15 +1005,12 @@ public struct Monster: FlatBufferObject {
         return MonsterT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MonsterT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
-        let __name: Offset<String>
-        if let s = obj.name {
-            __name = builder.create(string: s)
-        } else {
-            __name = Offset<String>()
-        }
-
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MonsterT) -> Offset<UOffset> {
+        let __name = builder.create(string: obj.name)
         let __inventory = builder.createVector(obj.inventory)
         let __test = obj.test?.pack(builder: &builder) ?? Offset()
         var __test4__: [UnsafeMutableRawPointer] = []
@@ -1108,7 +1129,7 @@ public class MonsterT: NativeTable {
     var pos: MyGame.Example.Vec3T?
     var mana: Int16
     var hp: Int16
-    var name: String?
+    var name: String
     var inventory: [UInt8]
     var color: MyGame.Example.Color
     var test: Any_Union?
@@ -1300,6 +1321,7 @@ public class MonsterT: NativeTable {
         pos = MyGame.Example.Vec3T()
         mana = 150
         hp = 100
+        name = ""
         inventory = []
         color = .blue
         test4 = []
@@ -1446,8 +1468,11 @@ public struct TypeAliases: FlatBufferObject {
         return TypeAliasesT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout TypeAliasesT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout TypeAliasesT) -> Offset<UOffset> {
         let __v8 = builder.createVector(obj.v8)
         let __vf64 = builder.createVector(obj.vf64)
         let __root = TypeAliases.startTypeAliases(&builder)

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
@@ -62,8 +62,11 @@ public struct Rapunzel: Readable {
         return RapunzelT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout RapunzelT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout RapunzelT) -> Offset<UOffset> {
         return builder.create(struct: createRapunzel(hairLength: obj.hairLength), type: Rapunzel.self)
     }
 }
@@ -99,8 +102,11 @@ public struct BookReader: Readable {
         return BookReaderT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout BookReaderT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout BookReaderT) -> Offset<UOffset> {
         return builder.create(struct: createBookReader(booksRead: obj.booksRead), type: BookReader.self)
     }
 }
@@ -167,8 +173,11 @@ public struct Attacker: FlatBufferObject {
         return AttackerT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout AttackerT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout AttackerT) -> Offset<UOffset> {
         let __root = Attacker.startAttacker(&builder)
         Attacker.add(swordAttackDamage: obj.swordAttackDamage, &builder)
         return Attacker.endAttacker(&builder, start: __root)
@@ -239,8 +248,11 @@ public struct Movie: FlatBufferObject {
         return MovieT(&self)
     }
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MovieT?) -> Offset<UOffset> {
-        guard let obj = obj else { return Offset<UOffset>() }
+        guard var obj = obj else { return Offset<UOffset>() }
+        return pack(&builder, obj: &obj)
+    }
 
+    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MovieT) -> Offset<UOffset> {
         let __mainCharacter = obj.mainCharacter?.pack(builder: &builder) ?? Offset()
         var __characters__: [Offset<UOffset>] = []
         for i in obj.characters {


### PR DESCRIPTION
The following PR Closes #5936 by implementing the following:

1- Required is now going to mark the field as none-optional for readers:
```swift
public var name: String! { let o = _accessor.offset(VTOFFSET.name.v); return _accessor.string(at: o) }
public var enemy: MyGame.Example.Monster! { let o = _accessor.offset(VTOFFSET.enemy.v); return MyGame.Example.Monster(_accessor.bb, o: _accessor.indirect(o + _accessor.postion)) }
```
this would fatal error the program if the value is not there. However, unions in swift would always remain optional.

2- suppresses the warning for the function:
```swift
    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MonsterT?) -> Offset<UOffset> {
        guard var obj = obj else { return Offset<UOffset>() }
        return pack(&builder, obj: &obj)
    }
```
by adding a none optional pack function. that would be called after validating the data.

3- bumps version to 0.5.1 on cocoa-pods.