### PR TITLE
[C++, UB] Fix error in SimpleQSort

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1280,7 +1280,7 @@ void SimpleQsort(T *begin, T *end, size_t width, F comparator, S swapper) {
       r -= width;
       swapper(l, r);
     } else {
-      l++;
+      l += width;
     }
   }
   l -= width;


### PR DESCRIPTION
This PR fixes an error in `SimpleQSort` routine.
This issue connected with #5945, #5928.