### PR TITLE
[Swift] Improves reallocation function

### DIFF
--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -135,7 +135,6 @@ public struct FlatBufferBuilder {
         return _bb.size
     }
     
-    
     /// Endtable will let the builder know that the object that's written to it is completed
     ///
     /// This would be called after all the elements are serialized, it will add the vtable into the buffer.
@@ -156,8 +155,10 @@ public struct FlatBufferBuilder {
         _bb.write(value: VOffset(tableObjectSize), index: _bb.writerIndex + sizeofVoffset, direct: true)
         _bb.write(value: VOffset(_max), index: _bb.writerIndex, direct: true)
         
-        for index in stride(from: 0, to: _vtableStorage.writtenIndex, by: _vtableStorage.size) {
-            let loaded = _vtableStorage.load(at: index)
+        var itr = 0
+        while itr < _vtableStorage.writtenIndex {
+            let loaded = _vtableStorage.load(at: itr)
+            itr += _vtableStorage.size
             guard loaded.offset != 0 else { continue }
             let _index = (_bb.writerIndex + Int(loaded.position))
             _bb.write(value: VOffset(vTableOffset - loaded.offset), index: _index, direct: true)

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/XCTestManifests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/XCTestManifests.swift
@@ -36,6 +36,7 @@ extension FlatBuffersStructsTests {
         ("testCreatingVectorStructWithForcedDefaults", testCreatingVectorStructWithForcedDefaults),
         ("testReadingStruct", testReadingStruct),
         ("testReadingStructWithEnums", testReadingStructWithEnums),
+        ("testWritingAndMutatingBools", testWritingAndMutatingBools),
     ]
 }
 


### PR DESCRIPTION
This PR includes improvements to the reallocation function: 

1- Since we removed it from the ByteBuffer struct, into the `Storage` class
2- Using `memcpy()` instead of the swift implementation of it. 
3- Using `memset()` when reallocating the buffer, and only initializing `capacity - current index` instead of using the full capacity.
4- use while instead of stride in `endTable()` function
```
master: 
writing 500_000 objects in 123 ms
----------------------------------
improve reallocation function: 
writing 500_000 objects in 109 ms
----------------------------------
```

#5798