### PR TITLE
[Rust] Parameterize FlatBufferBuilder's owned_buf

### DIFF
--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -69,8 +69,7 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
     ///
     /// The maximum valid value is `FLATBUFFERS_MAX_BUFFER_SIZE`.
     pub fn new_with_capacity(size: usize) -> Self {
-        // Safety: the vector is initialized with all-zero elements
-        unsafe { FlatBufferBuilder::new_with_zeroed_buffer(vec![0u8; size]) }
+        FlatBufferBuilder::new_with_buffer(vec![0u8; size])
     }
 }
 
@@ -82,36 +81,7 @@ where
     /// the given buffer as storage for the serialized bytes.
     ///
     /// The buffer may not be larger than `FLATBUFFERS_MAX_BUFFER_SIZE`.
-    pub fn new_with_buffer(mut buffer: Buf) -> FlatBufferBuilder<'fbb, Buf> {
-        let to_clear = buffer.len();
-        let ptr = buffer.as_mut_ptr();
-
-        // Safety:
-        // Alignment is checked by getting the pointer from an already valid
-        // slice; validity for writing to the range is checked by getting the
-        // length from the slice
-        unsafe {
-            write_bytes(ptr, 0, to_clear);
-        }
-
-        // Safety: the buffer was just zeroed
-        unsafe { Self::new_with_zeroed_buffer(buffer) }
-    }
-
-    /// Create a FlatBufferBuilder that is ready for writing, which will use
-    /// the given buffer as storage for the serialized bytes.
-    ///
-    /// The buffer may not be larger than `FLATBUFFERS_MAX_BUFFER_SIZE`.
-    ///
-    /// Unlike `new_with_buffer`, this function will not zero the buffer before
-    /// using it, instead assuming that it is already zeroed. This may lead to
-    /// unexpected results if the values are not actually zero, and thus this
-    /// function is marked `unsafe`.
-    ///
-    /// # Safety
-    ///
-    /// The given buffer must already be zeroed
-    pub unsafe fn new_with_zeroed_buffer(buffer: Buf) -> FlatBufferBuilder<'fbb, Buf> {
+    pub fn new_with_buffer(buffer: Buf) -> FlatBufferBuilder<'fbb, Buf> {
         let size = buffer.len();
 
         // we need to check the size here because the buffer was created

--- a/tests/include_test/include_test1_generated.rs
+++ b/tests/include_test/include_test1_generated.rs
@@ -34,9 +34,10 @@ impl<'a> TableA<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args TableAArgs<'args>) -> flatbuffers::WIPOffset<TableA<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        args: &'args TableAArgs<'args>) -> flatbuffers::WIPOffset<TableA<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = TableABuilder::new(_fbb);
       if let Some(x) = args.b { builder.add_b(x); }
       builder.finish()
@@ -61,17 +62,18 @@ impl<'a> Default for TableAArgs<'a> {
         }
     }
 }
-pub struct TableABuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableABuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableABuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> TableABuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
   pub fn add_b(&mut self, b: flatbuffers::WIPOffset<my_game::other_name_space::TableB<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<my_game::other_name_space::TableB>>(TableA::VT_B, b);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableABuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> TableABuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     TableABuilder {
       fbb_: _fbb,

--- a/tests/include_test/sub/include_test2_generated.rs
+++ b/tests/include_test/sub/include_test2_generated.rs
@@ -166,9 +166,10 @@ impl<'a> TableB<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args TableBArgs<'args>) -> flatbuffers::WIPOffset<TableB<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        args: &'args TableBArgs<'args>) -> flatbuffers::WIPOffset<TableB<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = TableBBuilder::new(_fbb);
       if let Some(x) = args.a { builder.add_a(x); }
       builder.finish()
@@ -193,17 +194,18 @@ impl<'a> Default for TableBArgs<'a> {
         }
     }
 }
-pub struct TableBBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableBBuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableBBuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> TableBBuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
   pub fn add_a(&mut self, a: flatbuffers::WIPOffset<super::super::TableA<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<super::super::TableA>>(TableB::VT_A, a);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableBBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> TableBBuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     TableBBuilder {
       fbb_: _fbb,

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -50,9 +50,10 @@ impl<'a> InParentNamespace<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        _args: &'args InParentNamespaceArgs) -> flatbuffers::WIPOffset<InParentNamespace<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        _args: &'args InParentNamespaceArgs) -> flatbuffers::WIPOffset<InParentNamespace<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = InParentNamespaceBuilder::new(_fbb);
       builder.finish()
     }
@@ -68,13 +69,14 @@ impl<'a> Default for InParentNamespaceArgs {
         }
     }
 }
-pub struct InParentNamespaceBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct InParentNamespaceBuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> InParentNamespaceBuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> InParentNamespaceBuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> InParentNamespaceBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> InParentNamespaceBuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     InParentNamespaceBuilder {
       fbb_: _fbb,
@@ -128,9 +130,10 @@ impl<'a> Monster<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        _args: &'args MonsterArgs) -> flatbuffers::WIPOffset<Monster<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        _args: &'args MonsterArgs) -> flatbuffers::WIPOffset<Monster<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = MonsterBuilder::new(_fbb);
       builder.finish()
     }
@@ -146,13 +149,14 @@ impl<'a> Default for MonsterArgs {
         }
     }
 }
-pub struct MonsterBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct MonsterBuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> MonsterBuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> MonsterBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> MonsterBuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     MonsterBuilder {
       fbb_: _fbb,
@@ -780,9 +784,10 @@ impl<'a> TestSimpleTableWithEnum<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args TestSimpleTableWithEnumArgs) -> flatbuffers::WIPOffset<TestSimpleTableWithEnum<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        args: &'args TestSimpleTableWithEnumArgs) -> flatbuffers::WIPOffset<TestSimpleTableWithEnum<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = TestSimpleTableWithEnumBuilder::new(_fbb);
       builder.add_color(args.color);
       builder.finish()
@@ -807,17 +812,18 @@ impl<'a> Default for TestSimpleTableWithEnumArgs {
         }
     }
 }
-pub struct TestSimpleTableWithEnumBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TestSimpleTableWithEnumBuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TestSimpleTableWithEnumBuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> TestSimpleTableWithEnumBuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
   pub fn add_color(&mut self, color: Color) {
     self.fbb_.push_slot::<Color>(TestSimpleTableWithEnum::VT_COLOR, color, Color::Green);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TestSimpleTableWithEnumBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> TestSimpleTableWithEnumBuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     TestSimpleTableWithEnumBuilder {
       fbb_: _fbb,
@@ -860,9 +866,10 @@ impl<'a> Stat<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args StatArgs<'args>) -> flatbuffers::WIPOffset<Stat<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        args: &'args StatArgs<'args>) -> flatbuffers::WIPOffset<Stat<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = StatBuilder::new(_fbb);
       builder.add_val(args.val);
       if let Some(x) = args.id { builder.add_id(x); }
@@ -903,11 +910,12 @@ impl<'a> Default for StatArgs<'a> {
         }
     }
 }
-pub struct StatBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct StatBuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> StatBuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> StatBuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
   pub fn add_id(&mut self, id: flatbuffers::WIPOffset<&'b  str>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Stat::VT_ID, id);
@@ -921,7 +929,7 @@ impl<'a: 'b, 'b> StatBuilder<'a, 'b> {
     self.fbb_.push_slot::<u16>(Stat::VT_COUNT, count, 0);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> StatBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> StatBuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     StatBuilder {
       fbb_: _fbb,
@@ -964,9 +972,10 @@ impl<'a> Referrable<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args ReferrableArgs) -> flatbuffers::WIPOffset<Referrable<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        args: &'args ReferrableArgs) -> flatbuffers::WIPOffset<Referrable<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = ReferrableBuilder::new(_fbb);
       builder.add_id(args.id);
       builder.finish()
@@ -1001,17 +1010,18 @@ impl<'a> Default for ReferrableArgs {
         }
     }
 }
-pub struct ReferrableBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct ReferrableBuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> ReferrableBuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> ReferrableBuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
   pub fn add_id(&mut self, id: u64) {
     self.fbb_.push_slot::<u64>(Referrable::VT_ID, id, 0);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ReferrableBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> ReferrableBuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     ReferrableBuilder {
       fbb_: _fbb,
@@ -1055,9 +1065,10 @@ impl<'a> Monster<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args MonsterArgs<'args>) -> flatbuffers::WIPOffset<Monster<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        args: &'args MonsterArgs<'args>) -> flatbuffers::WIPOffset<Monster<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = MonsterBuilder::new(_fbb);
       builder.add_non_owning_reference(args.non_owning_reference);
       builder.add_co_owning_reference(args.co_owning_reference);
@@ -1569,11 +1580,12 @@ impl<'a> Default for MonsterArgs<'a> {
         }
     }
 }
-pub struct MonsterBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct MonsterBuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> MonsterBuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
   pub fn add_pos(&mut self, pos: &'b  Vec3) {
     self.fbb_.push_slot_always::<&Vec3>(Monster::VT_POS, pos);
@@ -1767,7 +1779,7 @@ impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
     self.fbb_.push_slot::<Race>(Monster::VT_SIGNED_ENUM, signed_enum, Race::None);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> MonsterBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> MonsterBuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     MonsterBuilder {
       fbb_: _fbb,
@@ -1811,9 +1823,10 @@ impl<'a> TypeAliases<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args TypeAliasesArgs<'args>) -> flatbuffers::WIPOffset<TypeAliases<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        args: &'args TypeAliasesArgs<'args>) -> flatbuffers::WIPOffset<TypeAliases<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = TypeAliasesBuilder::new(_fbb);
       builder.add_f64_(args.f64_);
       builder.add_u64_(args.u64_);
@@ -1926,11 +1939,12 @@ impl<'a> Default for TypeAliasesArgs<'a> {
         }
     }
 }
-pub struct TypeAliasesBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TypeAliasesBuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TypeAliasesBuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> TypeAliasesBuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
   pub fn add_i8_(&mut self, i8_: i8) {
     self.fbb_.push_slot::<i8>(TypeAliases::VT_I8_, i8_, 0);
@@ -1980,7 +1994,7 @@ impl<'a: 'b, 'b> TypeAliasesBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TypeAliases::VT_VF64, vf64);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TypeAliasesBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> TypeAliasesBuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     TypeAliasesBuilder {
       fbb_: _fbb,
@@ -2019,14 +2033,16 @@ pub fn monster_size_prefixed_buffer_has_identifier(buf: &[u8]) -> bool {
 pub const MONSTER_EXTENSION: &'static str = "mon";
 
 #[inline]
-pub fn finish_monster_buffer<'a, 'b>(
-    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    root: flatbuffers::WIPOffset<Monster<'a>>) {
+pub fn finish_monster_buffer<'a, 'b, Buf>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
+    root: flatbuffers::WIPOffset<Monster<'a>>)
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   fbb.finish(root, Some(MONSTER_IDENTIFIER));
 }
 
 #[inline]
-pub fn finish_size_prefixed_monster_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<Monster<'a>>) {
+pub fn finish_size_prefixed_monster_buffer<'a, 'b, Buf>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<Monster<'a>>)
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   fbb.finish_size_prefixed(root, Some(MONSTER_IDENTIFIER));
 }
 }  // pub mod Example

--- a/tests/namespace_test/namespace_test1_generated.rs
+++ b/tests/namespace_test/namespace_test1_generated.rs
@@ -174,9 +174,10 @@ impl<'a> TableInNestedNS<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args TableInNestedNSArgs) -> flatbuffers::WIPOffset<TableInNestedNS<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        args: &'args TableInNestedNSArgs) -> flatbuffers::WIPOffset<TableInNestedNS<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = TableInNestedNSBuilder::new(_fbb);
       builder.add_foo(args.foo);
       builder.finish()
@@ -201,17 +202,18 @@ impl<'a> Default for TableInNestedNSArgs {
         }
     }
 }
-pub struct TableInNestedNSBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableInNestedNSBuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableInNestedNSBuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> TableInNestedNSBuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
   pub fn add_foo(&mut self, foo: i32) {
     self.fbb_.push_slot::<i32>(TableInNestedNS::VT_FOO, foo, 0);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableInNestedNSBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> TableInNestedNSBuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     TableInNestedNSBuilder {
       fbb_: _fbb,

--- a/tests/namespace_test/namespace_test2_generated.rs
+++ b/tests/namespace_test/namespace_test2_generated.rs
@@ -44,9 +44,10 @@ impl<'a> TableInFirstNS<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args TableInFirstNSArgs<'args>) -> flatbuffers::WIPOffset<TableInFirstNS<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        args: &'args TableInFirstNSArgs<'args>) -> flatbuffers::WIPOffset<TableInFirstNS<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = TableInFirstNSBuilder::new(_fbb);
       if let Some(x) = args.foo_struct { builder.add_foo_struct(x); }
       if let Some(x) = args.foo_table { builder.add_foo_table(x); }
@@ -87,11 +88,12 @@ impl<'a> Default for TableInFirstNSArgs<'a> {
         }
     }
 }
-pub struct TableInFirstNSBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableInFirstNSBuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableInFirstNSBuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> TableInFirstNSBuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
   pub fn add_foo_table(&mut self, foo_table: flatbuffers::WIPOffset<namespace_b::TableInNestedNS<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<namespace_b::TableInNestedNS>>(TableInFirstNS::VT_FOO_TABLE, foo_table);
@@ -105,7 +107,7 @@ impl<'a: 'b, 'b> TableInFirstNSBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<&namespace_b::StructInNestedNS>(TableInFirstNS::VT_FOO_STRUCT, foo_struct);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableInFirstNSBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> TableInFirstNSBuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     TableInFirstNSBuilder {
       fbb_: _fbb,
@@ -144,9 +146,10 @@ impl<'a> SecondTableInA<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args SecondTableInAArgs<'args>) -> flatbuffers::WIPOffset<SecondTableInA<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        args: &'args SecondTableInAArgs<'args>) -> flatbuffers::WIPOffset<SecondTableInA<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = SecondTableInABuilder::new(_fbb);
       if let Some(x) = args.refer_to_c { builder.add_refer_to_c(x); }
       builder.finish()
@@ -171,17 +174,18 @@ impl<'a> Default for SecondTableInAArgs<'a> {
         }
     }
 }
-pub struct SecondTableInABuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct SecondTableInABuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> SecondTableInABuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> SecondTableInABuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
   pub fn add_refer_to_c(&mut self, refer_to_c: flatbuffers::WIPOffset<super::namespace_c::TableInC<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<super::namespace_c::TableInC>>(SecondTableInA::VT_REFER_TO_C, refer_to_c);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> SecondTableInABuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> SecondTableInABuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     SecondTableInABuilder {
       fbb_: _fbb,
@@ -232,9 +236,10 @@ impl<'a> TableInC<'a> {
         }
     }
     #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args TableInCArgs<'args>) -> flatbuffers::WIPOffset<TableInC<'bldr>> {
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, Buf>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, Buf>,
+        args: &'args TableInCArgs<'args>) -> flatbuffers::WIPOffset<TableInC<'bldr>>
+    where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
       let mut builder = TableInCBuilder::new(_fbb);
       if let Some(x) = args.refer_to_a2 { builder.add_refer_to_a2(x); }
       if let Some(x) = args.refer_to_a1 { builder.add_refer_to_a1(x); }
@@ -267,11 +272,12 @@ impl<'a> Default for TableInCArgs<'a> {
         }
     }
 }
-pub struct TableInCBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableInCBuilder<'a: 'b, 'b, Buf> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableInCBuilder<'a, 'b> {
+impl<'a: 'b, 'b, Buf> TableInCBuilder<'a, 'b, Buf>
+where Buf: std::ops::DerefMut<Target=[u8]> + Extend<u8> {
   #[inline]
   pub fn add_refer_to_a1(&mut self, refer_to_a1: flatbuffers::WIPOffset<super::namespace_a::TableInFirstNS<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<super::namespace_a::TableInFirstNS>>(TableInC::VT_REFER_TO_A1, refer_to_a1);
@@ -281,7 +287,7 @@ impl<'a: 'b, 'b> TableInCBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<super::namespace_a::SecondTableInA>>(TableInC::VT_REFER_TO_A2, refer_to_a2);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableInCBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, Buf>) -> TableInCBuilder<'a, 'b, Buf> {
     let start = _fbb.start_table();
     TableInCBuilder {
       fbb_: _fbb,


### PR DESCRIPTION
This changes FlatBufferBuilder to use a generic type to store its
collected bytes, instead of a `Vec<u8>`. This allows building into
buffers provided by the caller, which could be some custom buffer type,
or an already allocated buffer.

Very little buffer code actually relied on the Vec API, so the generic buffer
type is simply bound by the standard traits `DerefMut<Target=[u8]>` and
`Extend<u8>` for read/write access to the underlying bytes and size
growth respectively. The previous implementation used `resize(new_len, 0u8)`
to grow the vec, and the new code uses `extend(repeat(0u8).take(diff))`.
While this could be a cause for concern in performance, inspecting the
generated assembly shows that the two implementations result in almost
the same output at opt-level 2 and greater. The existing benchmarks also
show no difference.

The generic parameter on FlatBufferBuilder is set to use `Vec<u8>` as
its default type. This means that existing code should continue to work
without any changes; that includes both use of library code and
accessing generated code from before this change. Recompiling the schema
files should only be necessary if a user chooses to parameterize the
type.

Although this is a useful step towards a fully no-alloc builder
implementation, it is not sufficient; there are still other uses of
vectors in the builder aside from the serialized bytes, and this change
does not aim to address those.