### PR TITLE
Do not remove the last digit from float values [C++]

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -3280,10 +3280,6 @@ bool FieldDef::Deserialize(Parser &parser, const reflection::Field *field) {
     value.constant = NumToString(field->default_integer());
   } else if (IsFloat(value.type.base_type)) {
     value.constant = FloatToString(field->default_real(), 16);
-    size_t last_zero = value.constant.find_last_not_of('0');
-    if (last_zero != std::string::npos && last_zero != 0) {
-      value.constant.erase(last_zero, std::string::npos);
-    }
   }
   deprecated = field->deprecated();
   required = field->required();


### PR DESCRIPTION
Trailing zeros are already removed inside the function FloatToString,
that is called immediately before the lines deleted by this commit.
