### PR TITLE
[Doc] Added missing letters to compiler options

### DIFF
--- a/docs/source/Compiler.md
+++ b/docs/source/Compiler.md
@@ -200,11 +200,11 @@ Additional options:
 
 -   `--keep-prefix` : Keep original prefix of schema include statement.
 
--   `--no-fb-impor` : Don't include flatbuffers import statement for TypeScript.
+-   `--no-fb-import` : Don't include flatbuffers import statement for TypeScript.
 
--   `--no-ts-reexpor` : Don't re-export imported dependencies for TypeScript.
+-   `--no-ts-reexport` : Don't re-export imported dependencies for TypeScript.
 
--   `--short-name` : Use short function names for JS and TypeScript.
+-   `--short-names` : Use short function names for JS and TypeScript.
 
 -   `--reflect-types` : Add minimal type reflection to code generation.
 


### PR DESCRIPTION
These are correct in the help section of compiler, but missing some letters here.
