### PR TITLE
[Swift] Add parsing from unowned UnsafeMutableRawPointer for ByteBuffer

### DIFF
--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -35,7 +35,7 @@ public struct ByteBuffer {
             memory.copyMemory(from: ptr, byteCount: count)
         }
         
-        func initialize(for size: Int) {
+        func initalize(for size: Int) {
             precondition(!unowned)
             memset(memory, 0, size)
         }
@@ -104,7 +104,7 @@ public struct ByteBuffer {
     init(initialSize size: Int) {
         let size = size.convertToPowerofTwo
         _storage = Storage(count: size, alignment: alignment)
-        _storage.initialize(for: size)
+        _storage.initalize(for: size)
     }
   
     /// Constructor that creates a Flatbuffer from unsafe memory region without copying
@@ -264,7 +264,6 @@ public struct ByteBuffer {
         alignment = 1
         _storage.memory.deallocate()
         _storage.memory = UnsafeMutableRawPointer.allocate(byteCount: _storage.capacity, alignment: alignment)
-        _storage.initialize(for: _storage.capacity)
     }
     
     /// Resizes the buffer size

--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -1,15 +1,25 @@
 import Foundation
 
+@usableFromInline protocol Storage {
+    /// pointer to the start of the buffer object in memory
+    var memory: UnsafeMutableRawPointer { get set }
+    /// Capacity of UInt8 the buffer can hold
+    var capacity: Int { get set }
+    func copy(from ptr: UnsafeRawPointer, count: Int)
+    func initialize(for size: Int)
+    func reallocate(_ size: Int, writerSize: Int, alignment: Int)
+}
+
 public struct ByteBuffer {
     
     /// Storage is a container that would hold the memory pointer to solve the issue of
     /// deallocating the memory that was held by (memory: UnsafeMutableRawPointer)
-    @usableFromInline final class Storage {
+    @usableFromInline final class InternalStorage: Storage {
         
         /// pointer to the start of the buffer object in memory
-        var memory: UnsafeMutableRawPointer
+        @usableFromInline var memory: UnsafeMutableRawPointer
         /// Capacity of UInt8 the buffer can hold
-        var capacity: Int
+        @usableFromInline var capacity: Int
         
         init(count: Int, alignment: Int) {
             memory = UnsafeMutableRawPointer.allocate(byteCount: count, alignment: alignment)
@@ -20,17 +30,17 @@ public struct ByteBuffer {
             memory.deallocate()
         }
         
-        func copy(from ptr: UnsafeRawPointer, count: Int) {
+        @usableFromInline func copy(from ptr: UnsafeRawPointer, count: Int) {
             memory.copyMemory(from: ptr, byteCount: count)
         }
         
-        func initalize(for size: Int) {
+        @usableFromInline func initialize(for size: Int) {
             memset(memory, 0, size)
         }
         
         /// Reallocates the buffer incase the object to be written doesnt fit in the current buffer
         /// - Parameter size: Size of the current object
-        @usableFromInline internal func reallocate(_ size: Int, writerSize: Int, alignment: Int) {
+        @usableFromInline func reallocate(_ size: Int, writerSize: Int, alignment: Int) {
             let currentWritingIndex = capacity &- writerSize
             while capacity <= writerSize &+ size {
                 capacity = capacity << 1
@@ -44,6 +54,30 @@ public struct ByteBuffer {
             memcpy(newData.advanced(by: capacity &- writerSize), memory.advanced(by: currentWritingIndex), writerSize)
             memory.deallocate()
             memory = newData
+        }
+    }
+
+    @usableFromInline final class ExternalStorage: Storage {
+
+        /// pointer to the start of the buffer object in memory
+        @usableFromInline var memory: UnsafeMutableRawPointer
+        /// Capacity of UInt8 the buffer can hold
+        @usableFromInline var capacity: Int
+
+        init(memory: UnsafeMutableRawPointer, capacity: Int) {
+            self.memory = memory
+            self.capacity = capacity
+        }
+
+        @usableFromInline func copy(from ptr: UnsafeRawPointer, count: Int) {
+            fatalError() // Cannot copy to.
+        }
+        
+        @usableFromInline func initialize(for size: Int) {
+            // No initialization
+        }
+        @usableFromInline func reallocate(_ size: Int, writerSize: Int, alignment: Int) {
+            fatalError()
         }
     }
     
@@ -69,7 +103,7 @@ public struct ByteBuffer {
     /// - Parameter bytes: Array of UInt8
     public init(bytes: [UInt8]) {
         var b = bytes
-        _storage = Storage(count: bytes.count, alignment: alignment)
+        _storage = InternalStorage(count: bytes.count, alignment: alignment)
         _writerSize = _storage.capacity
         b.withUnsafeMutableBytes { bufferPointer in
             self._storage.copy(from: bufferPointer.baseAddress!, count: bytes.count)
@@ -80,19 +114,27 @@ public struct ByteBuffer {
     /// - Parameter data: Swift data Object
     public init(data: Data) {
         var b = data
-        _storage = Storage(count: data.count, alignment: alignment)
+        _storage = InternalStorage(count: data.count, alignment: alignment)
         _writerSize = _storage.capacity
         b.withUnsafeMutableBytes { bufferPointer in
             self._storage.copy(from: bufferPointer.baseAddress!, count: data.count)
         }
     }
 
+    /// Constructor that creates a Flatbuffer from unsafe memory region without copying
+    /// - Parameter assumingMemoryBound: The unsafe memory region
+    /// - Parameter capacity: The size of the given memory region
+    public init(assumingMemoryBound: UnsafeMutableRawPointer, capacity: Int) {
+      _storage = ExternalStorage(memory: assumingMemoryBound, capacity: capacity)
+      _writerSize = capacity
+    }
+
     /// Constructor that creates a Flatbuffer instance with a size
     /// - Parameter size: Length of the buffer
     init(initialSize size: Int) {
         let size = size.convertToPowerofTwo
-        _storage = Storage(count: size, alignment: alignment)
-        _storage.initalize(for: size)
+        _storage = InternalStorage(count: size, alignment: alignment)
+        _storage.initialize(for: size)
     }
 
 #if swift(>=5.0)
@@ -104,7 +146,7 @@ public struct ByteBuffer {
         contiguousBytes: Bytes,
         count: Int
     ) {
-        _storage = Storage(count: count, alignment: alignment)
+        _storage = InternalStorage(count: count, alignment: alignment)
         _writerSize = _storage.capacity
         contiguousBytes.withUnsafeBytes { buf in
             _storage.copy(from: buf.baseAddress!, count: buf.count)
@@ -117,7 +159,7 @@ public struct ByteBuffer {
     ///   - memory: Current memory of the buffer
     ///   - count: count of bytes
     internal init(memory: UnsafeMutableRawPointer, count: Int) {
-        _storage = Storage(count: count, alignment: alignment)
+        _storage = InternalStorage(count: count, alignment: alignment)
         _storage.copy(from: memory, count: count)
         _writerSize = _storage.capacity
     }
@@ -128,7 +170,7 @@ public struct ByteBuffer {
     ///   - count: count of bytes
     ///   - removeBytes: Removes a number of bytes from the current size
     internal init(memory: UnsafeMutableRawPointer, count: Int, removing removeBytes: Int) {
-        _storage = Storage(count: count, alignment: alignment)
+        _storage = InternalStorage(count: count, alignment: alignment)
         _storage.copy(from: memory, count: count)
         _writerSize = removeBytes
     }

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
@@ -15,7 +15,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
         readMonster(fb: _data)
     }
     
-    func testReadFromOtherLangagues() {
+    func testReadFromOtherLanguages() {
         let path = FileManager.default.currentDirectoryPath
         let url = URL(fileURLWithPath: path, isDirectory: true).appendingPathComponent("monsterdata_test").appendingPathExtension("mon")
         guard let data = try? Data(contentsOf: url) else { return }
@@ -43,6 +43,18 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
         
         let newBuf = FlatBuffersUtils.removeSizePrefix(bb: bytes.buffer)
         readMonster(fb: newBuf)
+    }
+
+    func testReadMonsterFromUnsafePointerWithoutCopying() {
+        var array: [UInt8] = [48, 0, 0, 0, 77, 79, 78, 83, 0, 0, 0, 0, 36, 0, 72, 0, 40, 0, 0, 0, 38, 0, 32, 0, 0, 0, 28, 0, 0, 0, 27, 0, 20, 0, 16, 0, 12, 0, 4, 0, 0, 0, 0, 0, 0, 0, 11, 0, 36, 0, 0, 0, 164, 0, 0, 0, 0, 0, 0, 1, 60, 0, 0, 0, 68, 0, 0, 0, 76, 0, 0, 0, 0, 0, 0, 1, 88, 0, 0, 0, 120, 0, 0, 0, 0, 0, 80, 0, 0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 64, 2, 0, 5, 0, 6, 0, 0, 0, 2, 0, 0, 0, 64, 0, 0, 0, 48, 0, 0, 0, 2, 0, 0, 0, 30, 0, 40, 0, 10, 0, 20, 0, 152, 255, 255, 255, 4, 0, 0, 0, 4, 0, 0, 0, 70, 114, 101, 100, 0, 0, 0, 0, 5, 0, 0, 0, 0, 1, 2, 3, 4, 0, 0, 0, 5, 0, 0, 0, 116, 101, 115, 116, 50, 0, 0, 0, 5, 0, 0, 0, 116, 101, 115, 116, 49, 0, 0, 0, 9, 0, 0, 0, 77, 121, 77, 111, 110, 115, 116, 101, 114, 0, 0, 0, 3, 0, 0, 0, 20, 0, 0, 0, 36, 0, 0, 0, 4, 0, 0, 0, 240, 255, 255, 255, 32, 0, 0, 0, 248, 255, 255, 255, 36, 0, 0, 0, 12, 0, 8, 0, 0, 0, 0, 0, 0, 0, 4, 0, 12, 0, 0, 0, 28, 0, 0, 0, 5, 0, 0, 0, 87, 105, 108, 109, 97, 0, 0, 0, 6, 0, 0, 0, 66, 97, 114, 110, 101, 121, 0, 0, 5, 0, 0, 0, 70, 114, 111, 100, 111, 0, 0, 0]
+        let unpacked = array.withUnsafeMutableBytes { (memory) -> MyGame.Example.MonsterT in
+            let bytes = ByteBuffer(assumingMemoryBound: memory.baseAddress!, capacity: memory.count)
+            var monster = Monster.getRootAsMonster(bb: bytes)
+            readFlatbufferMonster(monster: &monster)
+            let unpacked = monster.unpack()
+            return unpacked
+        }
+        readObjectApi(monster: unpacked)
     }
     
     func readMonster(fb: ByteBuffer) {

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/XCTestManifests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/XCTestManifests.swift
@@ -21,7 +21,8 @@ extension FlatBuffersMonsterWriterTests {
         ("testCreateMonsterPrefixed", testCreateMonsterPrefixed),
         ("testCreateMonsterResizedBuffer", testCreateMonsterResizedBuffer),
         ("testData", testData),
-        ("testReadFromOtherLangagues", testReadFromOtherLangagues),
+        ("testReadFromOtherLanguages", testReadFromOtherLanguages),
+        ("testReadMonsterFromUnsafePointerWithoutCopying", testReadMonsterFromUnsafePointerWithoutCopying),
     ]
 }
 


### PR DESCRIPTION
This PR proposed one more API for ByteBuffer such that no copy is
required to parse FlatBuffers content. This API has limited use, but for
cases that you need to read part of the flatbuffers' data to decide
whether you want to parse / copy the full buffer out, it is useful.

I can add unit tests etc. if maintainers find this PR reasonable to
merge.