### PR TITLE
[Swift] Initialize memory when clear ByteBuffer

### DIFF
--- a/swift/FlatBuffers.podspec
+++ b/swift/FlatBuffers.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FlatBuffers'
-  s.version          = '0.5.2'
+  s.version          = '0.5.3'
   s.summary          = 'FlatBuffers: Memory Efficient Serialization Library'
 
   s.description      = "FlatBuffers is a cross platform serialization library architected for

--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -24,7 +24,7 @@ public struct ByteBuffer {
             memory.copyMemory(from: ptr, byteCount: count)
         }
         
-        func initalize(for size: Int) {
+        func initialize(for size: Int) {
             memset(memory, 0, size)
         }
         
@@ -92,7 +92,7 @@ public struct ByteBuffer {
     init(initialSize size: Int) {
         let size = size.convertToPowerofTwo
         _storage = Storage(count: size, alignment: alignment)
-        _storage.initalize(for: size)
+        _storage.initialize(for: size)
     }
 
 #if swift(>=5.0)
@@ -244,6 +244,7 @@ public struct ByteBuffer {
         alignment = 1
         _storage.memory.deallocate()
         _storage.memory = UnsafeMutableRawPointer.allocate(byteCount: _storage.capacity, alignment: alignment)
+        _storage.initialize(for: _storage.capacity)
     }
     
     /// Resizes the buffer size


### PR DESCRIPTION
It seems (based on my limited understanding) that FlatBuffers requires
the writable area to be 0 initialized. However, we missed it when clear
the buffer to reinitialize it.

This PR fixed that by calling initialize (also fixed the typo)
explicitly.
