### PR TITLE
[C++] Support C++ object copies

### DIFF
--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -239,6 +239,10 @@ struct MonsterT : public flatbuffers::NativeTable {
   std::vector<flatbuffers::unique_ptr<MyGame::Sample::WeaponT>> weapons{};
   MyGame::Sample::EquipmentUnion equipped{};
   std::vector<MyGame::Sample::Vec3> path{};
+  MonsterT() = default;
+  MonsterT(const MonsterT &o);
+  MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+  MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 
 struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -554,6 +558,32 @@ inline bool operator!=(const MonsterT &lhs, const MonsterT &rhs) {
     return !(lhs == rhs);
 }
 
+
+inline MonsterT::MonsterT(const MonsterT &o)
+      : pos((o.pos) ? new MyGame::Sample::Vec3(*o.pos) : nullptr),
+        mana(o.mana),
+        hp(o.hp),
+        name(o.name),
+        inventory(o.inventory),
+        color(o.color),
+        equipped(o.equipped),
+        path(o.path) {
+  weapons.reserve(o.weapons.size());
+  for (const auto &v : o.weapons) { weapons.emplace_back((v) ? new MyGame::Sample::WeaponT(*v) : nullptr); }
+}
+
+inline MonsterT &MonsterT::operator=(MonsterT o) FLATBUFFERS_NOEXCEPT {
+  std::swap(pos, o.pos);
+  std::swap(mana, o.mana);
+  std::swap(hp, o.hp);
+  std::swap(name, o.name);
+  std::swap(inventory, o.inventory);
+  std::swap(color, o.color);
+  std::swap(weapons, o.weapons);
+  std::swap(equipped, o.equipped);
+  std::swap(path, o.path);
+  return *this;
+}
 
 inline MonsterT *Monster::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::unique_ptr<MonsterT>(new MonsterT());

--- a/tests/arrays_test_generated.h
+++ b/tests/arrays_test_generated.h
@@ -265,6 +265,10 @@ inline bool operator!=(const ArrayStruct &lhs, const ArrayStruct &rhs) {
 struct ArrayTableT : public flatbuffers::NativeTable {
   typedef ArrayTable TableType;
   flatbuffers::unique_ptr<MyGame::Example::ArrayStruct> a{};
+  ArrayTableT() = default;
+  ArrayTableT(const ArrayTableT &o);
+  ArrayTableT(ArrayTableT&&) FLATBUFFERS_NOEXCEPT = default;
+  ArrayTableT &operator=(ArrayTableT o) FLATBUFFERS_NOEXCEPT;
 };
 
 struct ArrayTable FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -330,6 +334,15 @@ inline bool operator!=(const ArrayTableT &lhs, const ArrayTableT &rhs) {
     return !(lhs == rhs);
 }
 
+
+inline ArrayTableT::ArrayTableT(const ArrayTableT &o)
+      : a((o.a) ? new MyGame::Example::ArrayStruct(*o.a) : nullptr) {
+}
+
+inline ArrayTableT &ArrayTableT::operator=(ArrayTableT o) FLATBUFFERS_NOEXCEPT {
+  std::swap(a, o.a);
+  return *this;
+}
 
 inline ArrayTableT *ArrayTable::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::unique_ptr<ArrayTableT>(new ArrayTableT());

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -1238,6 +1238,10 @@ struct MonsterT : public flatbuffers::NativeTable {
   MyGame::Example::Race signed_enum = MyGame::Example::Race::None;
   std::vector<uint8_t> testrequirednestedflatbuffer{};
   std::vector<std::unique_ptr<MyGame::Example::StatT>> scalar_key_sorted_tables{};
+  MonsterT() = default;
+  MonsterT(const MonsterT &o);
+  MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+  MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 
 /// an example documentation comment: "monster object"
@@ -2698,6 +2702,112 @@ inline flatbuffers::Offset<Referrable> CreateReferrable(flatbuffers::FlatBufferB
       _id);
 }
 
+inline MonsterT::MonsterT(const MonsterT &o)
+      : pos((o.pos) ? new MyGame::Example::Vec3(*o.pos) : nullptr),
+        mana(o.mana),
+        hp(o.hp),
+        name(o.name),
+        inventory(o.inventory),
+        color(o.color),
+        test(o.test),
+        test4(o.test4),
+        testarrayofstring(o.testarrayofstring),
+        enemy((o.enemy) ? new MyGame::Example::MonsterT(*o.enemy) : nullptr),
+        testnestedflatbuffer(o.testnestedflatbuffer),
+        testempty((o.testempty) ? new MyGame::Example::StatT(*o.testempty) : nullptr),
+        testbool(o.testbool),
+        testhashs32_fnv1(o.testhashs32_fnv1),
+        testhashu32_fnv1(o.testhashu32_fnv1),
+        testhashs64_fnv1(o.testhashs64_fnv1),
+        testhashu64_fnv1(o.testhashu64_fnv1),
+        testhashs32_fnv1a(o.testhashs32_fnv1a),
+        testhashu32_fnv1a(o.testhashu32_fnv1a),
+        testhashs64_fnv1a(o.testhashs64_fnv1a),
+        testhashu64_fnv1a(o.testhashu64_fnv1a),
+        testarrayofbools(o.testarrayofbools),
+        testf(o.testf),
+        testf2(o.testf2),
+        testf3(o.testf3),
+        testarrayofstring2(o.testarrayofstring2),
+        testarrayofsortedstruct(o.testarrayofsortedstruct),
+        flex(o.flex),
+        test5(o.test5),
+        vector_of_longs(o.vector_of_longs),
+        vector_of_doubles(o.vector_of_doubles),
+        parent_namespace_test((o.parent_namespace_test) ? new MyGame::InParentNamespaceT(*o.parent_namespace_test) : nullptr),
+        single_weak_reference(o.single_weak_reference),
+        vector_of_weak_references(o.vector_of_weak_references),
+        co_owning_reference(o.co_owning_reference),
+        non_owning_reference(o.non_owning_reference),
+        vector_of_non_owning_references(o.vector_of_non_owning_references),
+        any_unique(o.any_unique),
+        any_ambiguous(o.any_ambiguous),
+        vector_of_enums(o.vector_of_enums),
+        signed_enum(o.signed_enum),
+        testrequirednestedflatbuffer(o.testrequirednestedflatbuffer) {
+  testarrayoftables.reserve(o.testarrayoftables.size());
+  for (const auto &v : o.testarrayoftables) { testarrayoftables.emplace_back((v) ? new MyGame::Example::MonsterT(*v) : nullptr); }
+  vector_of_referrables.reserve(o.vector_of_referrables.size());
+  for (const auto &v : o.vector_of_referrables) { vector_of_referrables.emplace_back((v) ? new MyGame::Example::ReferrableT(*v) : nullptr); }
+  vector_of_strong_referrables.reserve(o.vector_of_strong_referrables.size());
+  for (const auto &v : o.vector_of_strong_referrables) { vector_of_strong_referrables.emplace_back((v) ? new MyGame::Example::ReferrableT(*v) : nullptr); }
+  vector_of_co_owning_references.reserve(o.vector_of_co_owning_references.size());
+  for (const auto &v : o.vector_of_co_owning_references) { vector_of_co_owning_references.emplace_back((v) ? new ReferrableT(*v) : nullptr); }
+  scalar_key_sorted_tables.reserve(o.scalar_key_sorted_tables.size());
+  for (const auto &v : o.scalar_key_sorted_tables) { scalar_key_sorted_tables.emplace_back((v) ? new MyGame::Example::StatT(*v) : nullptr); }
+}
+
+inline MonsterT &MonsterT::operator=(MonsterT o) FLATBUFFERS_NOEXCEPT {
+  std::swap(pos, o.pos);
+  std::swap(mana, o.mana);
+  std::swap(hp, o.hp);
+  std::swap(name, o.name);
+  std::swap(inventory, o.inventory);
+  std::swap(color, o.color);
+  std::swap(test, o.test);
+  std::swap(test4, o.test4);
+  std::swap(testarrayofstring, o.testarrayofstring);
+  std::swap(testarrayoftables, o.testarrayoftables);
+  std::swap(enemy, o.enemy);
+  std::swap(testnestedflatbuffer, o.testnestedflatbuffer);
+  std::swap(testempty, o.testempty);
+  std::swap(testbool, o.testbool);
+  std::swap(testhashs32_fnv1, o.testhashs32_fnv1);
+  std::swap(testhashu32_fnv1, o.testhashu32_fnv1);
+  std::swap(testhashs64_fnv1, o.testhashs64_fnv1);
+  std::swap(testhashu64_fnv1, o.testhashu64_fnv1);
+  std::swap(testhashs32_fnv1a, o.testhashs32_fnv1a);
+  std::swap(testhashu32_fnv1a, o.testhashu32_fnv1a);
+  std::swap(testhashs64_fnv1a, o.testhashs64_fnv1a);
+  std::swap(testhashu64_fnv1a, o.testhashu64_fnv1a);
+  std::swap(testarrayofbools, o.testarrayofbools);
+  std::swap(testf, o.testf);
+  std::swap(testf2, o.testf2);
+  std::swap(testf3, o.testf3);
+  std::swap(testarrayofstring2, o.testarrayofstring2);
+  std::swap(testarrayofsortedstruct, o.testarrayofsortedstruct);
+  std::swap(flex, o.flex);
+  std::swap(test5, o.test5);
+  std::swap(vector_of_longs, o.vector_of_longs);
+  std::swap(vector_of_doubles, o.vector_of_doubles);
+  std::swap(parent_namespace_test, o.parent_namespace_test);
+  std::swap(vector_of_referrables, o.vector_of_referrables);
+  std::swap(single_weak_reference, o.single_weak_reference);
+  std::swap(vector_of_weak_references, o.vector_of_weak_references);
+  std::swap(vector_of_strong_referrables, o.vector_of_strong_referrables);
+  std::swap(co_owning_reference, o.co_owning_reference);
+  std::swap(vector_of_co_owning_references, o.vector_of_co_owning_references);
+  std::swap(non_owning_reference, o.non_owning_reference);
+  std::swap(vector_of_non_owning_references, o.vector_of_non_owning_references);
+  std::swap(any_unique, o.any_unique);
+  std::swap(any_ambiguous, o.any_ambiguous);
+  std::swap(vector_of_enums, o.vector_of_enums);
+  std::swap(signed_enum, o.signed_enum);
+  std::swap(testrequirednestedflatbuffer, o.testrequirednestedflatbuffer);
+  std::swap(scalar_key_sorted_tables, o.scalar_key_sorted_tables);
+  return *this;
+}
+
 inline MonsterT *Monster::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::make_unique<MonsterT>();
   UnPackTo(_o.get(), _resolver);
@@ -3011,7 +3121,7 @@ inline flatbuffers::Offset<void> AnyUnion::Pack(flatbuffers::FlatBufferBuilder &
 inline AnyUnion::AnyUnion(const AnyUnion &u) : type(u.type), value(nullptr) {
   switch (type) {
     case Any::Monster: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case Any::TestSimpleTableWithEnum: {
@@ -3124,7 +3234,7 @@ inline flatbuffers::Offset<void> AnyUniqueAliasesUnion::Pack(flatbuffers::FlatBu
 inline AnyUniqueAliasesUnion::AnyUniqueAliasesUnion(const AnyUniqueAliasesUnion &u) : type(u.type), value(nullptr) {
   switch (type) {
     case AnyUniqueAliases::M: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case AnyUniqueAliases::TS: {
@@ -3237,15 +3347,15 @@ inline flatbuffers::Offset<void> AnyAmbiguousAliasesUnion::Pack(flatbuffers::Fla
 inline AnyAmbiguousAliasesUnion::AnyAmbiguousAliasesUnion(const AnyAmbiguousAliasesUnion &u) : type(u.type), value(nullptr) {
   switch (type) {
     case AnyAmbiguousAliases::M1: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case AnyAmbiguousAliases::M2: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case AnyAmbiguousAliases::M3: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     default:

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -1233,6 +1233,10 @@ struct MonsterT : public flatbuffers::NativeTable {
   MyGame::Example::Race signed_enum = MyGame::Example::Race_None;
   std::vector<uint8_t> testrequirednestedflatbuffer{};
   std::vector<flatbuffers::unique_ptr<MyGame::Example::StatT>> scalar_key_sorted_tables{};
+  MonsterT() = default;
+  MonsterT(const MonsterT &o);
+  MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+  MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 
 /// an example documentation comment: "monster object"
@@ -2647,6 +2651,112 @@ inline bool operator!=(const MonsterT &lhs, const MonsterT &rhs) {
 }
 
 
+inline MonsterT::MonsterT(const MonsterT &o)
+      : pos((o.pos) ? new MyGame::Example::Vec3(*o.pos) : nullptr),
+        mana(o.mana),
+        hp(o.hp),
+        name(o.name),
+        inventory(o.inventory),
+        color(o.color),
+        test(o.test),
+        test4(o.test4),
+        testarrayofstring(o.testarrayofstring),
+        enemy((o.enemy) ? new MyGame::Example::MonsterT(*o.enemy) : nullptr),
+        testnestedflatbuffer(o.testnestedflatbuffer),
+        testempty((o.testempty) ? new MyGame::Example::StatT(*o.testempty) : nullptr),
+        testbool(o.testbool),
+        testhashs32_fnv1(o.testhashs32_fnv1),
+        testhashu32_fnv1(o.testhashu32_fnv1),
+        testhashs64_fnv1(o.testhashs64_fnv1),
+        testhashu64_fnv1(o.testhashu64_fnv1),
+        testhashs32_fnv1a(o.testhashs32_fnv1a),
+        testhashu32_fnv1a(o.testhashu32_fnv1a),
+        testhashs64_fnv1a(o.testhashs64_fnv1a),
+        testhashu64_fnv1a(o.testhashu64_fnv1a),
+        testarrayofbools(o.testarrayofbools),
+        testf(o.testf),
+        testf2(o.testf2),
+        testf3(o.testf3),
+        testarrayofstring2(o.testarrayofstring2),
+        testarrayofsortedstruct(o.testarrayofsortedstruct),
+        flex(o.flex),
+        test5(o.test5),
+        vector_of_longs(o.vector_of_longs),
+        vector_of_doubles(o.vector_of_doubles),
+        parent_namespace_test((o.parent_namespace_test) ? new MyGame::InParentNamespaceT(*o.parent_namespace_test) : nullptr),
+        single_weak_reference(o.single_weak_reference),
+        vector_of_weak_references(o.vector_of_weak_references),
+        co_owning_reference(o.co_owning_reference),
+        non_owning_reference(o.non_owning_reference),
+        vector_of_non_owning_references(o.vector_of_non_owning_references),
+        any_unique(o.any_unique),
+        any_ambiguous(o.any_ambiguous),
+        vector_of_enums(o.vector_of_enums),
+        signed_enum(o.signed_enum),
+        testrequirednestedflatbuffer(o.testrequirednestedflatbuffer) {
+  testarrayoftables.reserve(o.testarrayoftables.size());
+  for (const auto &v : o.testarrayoftables) { testarrayoftables.emplace_back((v) ? new MyGame::Example::MonsterT(*v) : nullptr); }
+  vector_of_referrables.reserve(o.vector_of_referrables.size());
+  for (const auto &v : o.vector_of_referrables) { vector_of_referrables.emplace_back((v) ? new MyGame::Example::ReferrableT(*v) : nullptr); }
+  vector_of_strong_referrables.reserve(o.vector_of_strong_referrables.size());
+  for (const auto &v : o.vector_of_strong_referrables) { vector_of_strong_referrables.emplace_back((v) ? new MyGame::Example::ReferrableT(*v) : nullptr); }
+  vector_of_co_owning_references.reserve(o.vector_of_co_owning_references.size());
+  for (const auto &v : o.vector_of_co_owning_references) { vector_of_co_owning_references.emplace_back((v) ? new ReferrableT(*v) : nullptr); }
+  scalar_key_sorted_tables.reserve(o.scalar_key_sorted_tables.size());
+  for (const auto &v : o.scalar_key_sorted_tables) { scalar_key_sorted_tables.emplace_back((v) ? new MyGame::Example::StatT(*v) : nullptr); }
+}
+
+inline MonsterT &MonsterT::operator=(MonsterT o) FLATBUFFERS_NOEXCEPT {
+  std::swap(pos, o.pos);
+  std::swap(mana, o.mana);
+  std::swap(hp, o.hp);
+  std::swap(name, o.name);
+  std::swap(inventory, o.inventory);
+  std::swap(color, o.color);
+  std::swap(test, o.test);
+  std::swap(test4, o.test4);
+  std::swap(testarrayofstring, o.testarrayofstring);
+  std::swap(testarrayoftables, o.testarrayoftables);
+  std::swap(enemy, o.enemy);
+  std::swap(testnestedflatbuffer, o.testnestedflatbuffer);
+  std::swap(testempty, o.testempty);
+  std::swap(testbool, o.testbool);
+  std::swap(testhashs32_fnv1, o.testhashs32_fnv1);
+  std::swap(testhashu32_fnv1, o.testhashu32_fnv1);
+  std::swap(testhashs64_fnv1, o.testhashs64_fnv1);
+  std::swap(testhashu64_fnv1, o.testhashu64_fnv1);
+  std::swap(testhashs32_fnv1a, o.testhashs32_fnv1a);
+  std::swap(testhashu32_fnv1a, o.testhashu32_fnv1a);
+  std::swap(testhashs64_fnv1a, o.testhashs64_fnv1a);
+  std::swap(testhashu64_fnv1a, o.testhashu64_fnv1a);
+  std::swap(testarrayofbools, o.testarrayofbools);
+  std::swap(testf, o.testf);
+  std::swap(testf2, o.testf2);
+  std::swap(testf3, o.testf3);
+  std::swap(testarrayofstring2, o.testarrayofstring2);
+  std::swap(testarrayofsortedstruct, o.testarrayofsortedstruct);
+  std::swap(flex, o.flex);
+  std::swap(test5, o.test5);
+  std::swap(vector_of_longs, o.vector_of_longs);
+  std::swap(vector_of_doubles, o.vector_of_doubles);
+  std::swap(parent_namespace_test, o.parent_namespace_test);
+  std::swap(vector_of_referrables, o.vector_of_referrables);
+  std::swap(single_weak_reference, o.single_weak_reference);
+  std::swap(vector_of_weak_references, o.vector_of_weak_references);
+  std::swap(vector_of_strong_referrables, o.vector_of_strong_referrables);
+  std::swap(co_owning_reference, o.co_owning_reference);
+  std::swap(vector_of_co_owning_references, o.vector_of_co_owning_references);
+  std::swap(non_owning_reference, o.non_owning_reference);
+  std::swap(vector_of_non_owning_references, o.vector_of_non_owning_references);
+  std::swap(any_unique, o.any_unique);
+  std::swap(any_ambiguous, o.any_ambiguous);
+  std::swap(vector_of_enums, o.vector_of_enums);
+  std::swap(signed_enum, o.signed_enum);
+  std::swap(testrequirednestedflatbuffer, o.testrequirednestedflatbuffer);
+  std::swap(scalar_key_sorted_tables, o.scalar_key_sorted_tables);
+  return *this;
+}
+
 inline MonsterT *Monster::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::unique_ptr<MonsterT>(new MonsterT());
   UnPackTo(_o.get(), _resolver);
@@ -2982,7 +3092,7 @@ inline flatbuffers::Offset<void> AnyUnion::Pack(flatbuffers::FlatBufferBuilder &
 inline AnyUnion::AnyUnion(const AnyUnion &u) : type(u.type), value(nullptr) {
   switch (type) {
     case Any_Monster: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case Any_TestSimpleTableWithEnum: {
@@ -3095,7 +3205,7 @@ inline flatbuffers::Offset<void> AnyUniqueAliasesUnion::Pack(flatbuffers::FlatBu
 inline AnyUniqueAliasesUnion::AnyUniqueAliasesUnion(const AnyUniqueAliasesUnion &u) : type(u.type), value(nullptr) {
   switch (type) {
     case AnyUniqueAliases_M: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case AnyUniqueAliases_TS: {
@@ -3208,15 +3318,15 @@ inline flatbuffers::Offset<void> AnyAmbiguousAliasesUnion::Pack(flatbuffers::Fla
 inline AnyAmbiguousAliasesUnion::AnyAmbiguousAliasesUnion(const AnyAmbiguousAliasesUnion &u) : type(u.type), value(nullptr) {
   switch (type) {
     case AnyAmbiguousAliases_M1: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case AnyAmbiguousAliases_M2: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case AnyAmbiguousAliases_M3: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     default:

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -66,6 +66,10 @@ struct TableInFirstNST : public flatbuffers::NativeTable {
   NamespaceA::NamespaceB::EnumInNestedNS foo_enum = NamespaceA::NamespaceB::EnumInNestedNS_A;
   NamespaceA::NamespaceB::UnionInNestedNSUnion foo_union{};
   flatbuffers::unique_ptr<NamespaceA::NamespaceB::StructInNestedNS> foo_struct{};
+  TableInFirstNST() = default;
+  TableInFirstNST(const TableInFirstNST &o);
+  TableInFirstNST(TableInFirstNST&&) FLATBUFFERS_NOEXCEPT = default;
+  TableInFirstNST &operator=(TableInFirstNST o) FLATBUFFERS_NOEXCEPT;
 };
 
 struct TableInFirstNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -194,6 +198,10 @@ struct TableInCT : public flatbuffers::NativeTable {
   }
   flatbuffers::unique_ptr<NamespaceA::TableInFirstNST> refer_to_a1{};
   flatbuffers::unique_ptr<NamespaceA::SecondTableInAT> refer_to_a2{};
+  TableInCT() = default;
+  TableInCT(const TableInCT &o);
+  TableInCT(TableInCT&&) FLATBUFFERS_NOEXCEPT = default;
+  TableInCT &operator=(TableInCT o) FLATBUFFERS_NOEXCEPT;
 };
 
 struct TableInC FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -277,6 +285,10 @@ struct SecondTableInAT : public flatbuffers::NativeTable {
     return "NamespaceA.SecondTableInAT";
   }
   flatbuffers::unique_ptr<NamespaceC::TableInCT> refer_to_c{};
+  SecondTableInAT() = default;
+  SecondTableInAT(const SecondTableInAT &o);
+  SecondTableInAT(SecondTableInAT&&) FLATBUFFERS_NOEXCEPT = default;
+  SecondTableInAT &operator=(SecondTableInAT o) FLATBUFFERS_NOEXCEPT;
 };
 
 struct SecondTableInA FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -350,6 +362,21 @@ inline bool operator!=(const TableInFirstNST &lhs, const TableInFirstNST &rhs) {
 }
 
 
+inline TableInFirstNST::TableInFirstNST(const TableInFirstNST &o)
+      : foo_table((o.foo_table) ? new NamespaceA::NamespaceB::TableInNestedNST(*o.foo_table) : nullptr),
+        foo_enum(o.foo_enum),
+        foo_union(o.foo_union),
+        foo_struct((o.foo_struct) ? new NamespaceA::NamespaceB::StructInNestedNS(*o.foo_struct) : nullptr) {
+}
+
+inline TableInFirstNST &TableInFirstNST::operator=(TableInFirstNST o) FLATBUFFERS_NOEXCEPT {
+  std::swap(foo_table, o.foo_table);
+  std::swap(foo_enum, o.foo_enum);
+  std::swap(foo_union, o.foo_union);
+  std::swap(foo_struct, o.foo_struct);
+  return *this;
+}
+
 inline TableInFirstNST *TableInFirstNS::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::unique_ptr<TableInFirstNST>(new TableInFirstNST());
   UnPackTo(_o.get(), _resolver);
@@ -404,6 +431,17 @@ inline bool operator!=(const TableInCT &lhs, const TableInCT &rhs) {
 }
 
 
+inline TableInCT::TableInCT(const TableInCT &o)
+      : refer_to_a1((o.refer_to_a1) ? new NamespaceA::TableInFirstNST(*o.refer_to_a1) : nullptr),
+        refer_to_a2((o.refer_to_a2) ? new NamespaceA::SecondTableInAT(*o.refer_to_a2) : nullptr) {
+}
+
+inline TableInCT &TableInCT::operator=(TableInCT o) FLATBUFFERS_NOEXCEPT {
+  std::swap(refer_to_a1, o.refer_to_a1);
+  std::swap(refer_to_a2, o.refer_to_a2);
+  return *this;
+}
+
 inline TableInCT *TableInC::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::unique_ptr<TableInCT>(new TableInCT());
   UnPackTo(_o.get(), _resolver);
@@ -447,6 +485,15 @@ inline bool operator!=(const SecondTableInAT &lhs, const SecondTableInAT &rhs) {
     return !(lhs == rhs);
 }
 
+
+inline SecondTableInAT::SecondTableInAT(const SecondTableInAT &o)
+      : refer_to_c((o.refer_to_c) ? new NamespaceC::TableInCT(*o.refer_to_c) : nullptr) {
+}
+
+inline SecondTableInAT &SecondTableInAT::operator=(SecondTableInAT o) FLATBUFFERS_NOEXCEPT {
+  std::swap(refer_to_c, o.refer_to_c);
+  return *this;
+}
 
 inline SecondTableInAT *SecondTableInA::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::unique_ptr<SecondTableInAT>(new SecondTableInAT());


### PR DESCRIPTION
Augment the C++ generator to emit C++ copy/move constructors and assignment operators. This is enabled by default when the C++ standard is C++11 or later. These additional functions are only emitted for objects that need it.

The copy ctor and assignment operator are declared in the object table type and are defined as inline functions after table declarations.

When copy/move ctors and assignment operators are declared, a user-defined explicitly-defaulted default ctor is also emitted.
    
```c++
--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -1012,6 +1012,11 @@ struct MonsterT : public flatbuffers::NativeTable {
   MyGame::Example::AnyAmbiguousAliasesUnion any_ambiguous{};
   std::vector<MyGame::Example::Color> vector_of_enums{};
   MyGame::Example::Race signed_enum = MyGame::Example::Race::None;
+  MonsterT() = default;
+  MonsterT(const MonsterT &o);
+  MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+  MonsterT &operator=(const MonsterT &o);
+  MonsterT &operator=(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
 };
 
 /// an example documentation comment: "monster object"
@@ -2285,6 +2290,176 @@ inline flatbuffers::Offset<Referrable> CreateReferrable(flatbuffers::FlatBufferB
       _id);
 }
 
+inline MonsterT::MonsterT(const MonsterT &o)
+      : pos((o.pos) ? new MyGame::Example::Vec3(*o.pos) : nullptr),
+        mana(o.mana),
+        hp(o.hp),
+        name(o.name),
+        color(o.color),
+        test(o.test),
+        enemy((o.enemy) ? new MyGame::Example::MonsterT(*o.enemy) : nullptr),
+        testempty((o.testempty) ? new MyGame::Example::StatT(*o.testempty) : nullptr),
+        testbool(o.testbool),
+        testhashs32_fnv1(o.testhashs32_fnv1),
+        testhashu32_fnv1(o.testhashu32_fnv1),
+        testhashs64_fnv1(o.testhashs64_fnv1),
+        testhashu64_fnv1(o.testhashu64_fnv1),
+        testhashs32_fnv1a(o.testhashs32_fnv1a),
+        testhashu32_fnv1a(o.testhashu32_fnv1a),
+        testhashs64_fnv1a(o.testhashs64_fnv1a),
+        testhashu64_fnv1a(o.testhashu64_fnv1a),
+        testf(o.testf),
+        testf2(o.testf2),
+        testf3(o.testf3),
+        parent_namespace_test((o.parent_namespace_test) ? new MyGame::InParentNamespaceT(*o.parent_namespace_test) : nullptr),
+        single_weak_reference(o.single_weak_reference),
+        co_owning_reference(o.co_owning_reference),
+        non_owning_reference(o.non_owning_reference),
+        any_unique(o.any_unique),
+        any_ambiguous(o.any_ambiguous),
+        signed_enum(o.signed_enum) {
+  inventory.clear();
+  inventory.reserve(o.inventory.size());
+  for (const auto &v : o.inventory) { inventory.emplace_back(v); }
+  test4.clear();
+  test4.reserve(o.test4.size());
+  for (const auto &v : o.test4) { test4.emplace_back(v); }
+  testarrayofstring.clear();
+  testarrayofstring.reserve(o.testarrayofstring.size());
+  for (const auto &v : o.testarrayofstring) { testarrayofstring.emplace_back(v); }
+  testarrayoftables.clear();
+  testarrayoftables.reserve(o.testarrayoftables.size());
+  for (const auto &v : o.testarrayoftables) { testarrayoftables.emplace_back((v) ? new MyGame::Example::MonsterT(*v) : nullptr); }
+  testnestedflatbuffer.clear();
+  testnestedflatbuffer.reserve(o.testnestedflatbuffer.size());
+  for (const auto &v : o.testnestedflatbuffer) { testnestedflatbuffer.emplace_back(v); }
+  testarrayofbools.clear();
+  testarrayofbools.reserve(o.testarrayofbools.size());
+  for (const auto &v : o.testarrayofbools) { testarrayofbools.emplace_back(v); }
+  testarrayofstring2.clear();
+  testarrayofstring2.reserve(o.testarrayofstring2.size());
+  for (const auto &v : o.testarrayofstring2) { testarrayofstring2.emplace_back(v); }
+  testarrayofsortedstruct.clear();
+  testarrayofsortedstruct.reserve(o.testarrayofsortedstruct.size());
+  for (const auto &v : o.testarrayofsortedstruct) { testarrayofsortedstruct.emplace_back(v); }
+  flex.clear();
+  flex.reserve(o.flex.size());
+  for (const auto &v : o.flex) { flex.emplace_back(v); }
+  test5.clear();
+  test5.reserve(o.test5.size());
+  for (const auto &v : o.test5) { test5.emplace_back(v); }
+  vector_of_longs.clear();
+  vector_of_longs.reserve(o.vector_of_longs.size());
+  for (const auto &v : o.vector_of_longs) { vector_of_longs.emplace_back(v); }
+  vector_of_doubles.clear();
+  vector_of_doubles.reserve(o.vector_of_doubles.size());
+  for (const auto &v : o.vector_of_doubles) { vector_of_doubles.emplace_back(v); }
+  vector_of_referrables.clear();
+  vector_of_referrables.reserve(o.vector_of_referrables.size());
+  for (const auto &v : o.vector_of_referrables) { vector_of_referrables.emplace_back((v) ? new MyGame::Example::ReferrableT(*v) : nullptr); }
+  vector_of_weak_references.clear();
+  vector_of_weak_references.reserve(o.vector_of_weak_references.size());
+  for (const auto &v : o.vector_of_weak_references) { vector_of_weak_references.emplace_back(v); }
+  vector_of_strong_referrables.clear();
+  vector_of_strong_referrables.reserve(o.vector_of_strong_referrables.size());
+  for (const auto &v : o.vector_of_strong_referrables) { vector_of_strong_referrables.emplace_back((v) ? new MyGame::Example::ReferrableT(*v) : nullptr); }
+  vector_of_co_owning_references.clear();
+  vector_of_co_owning_references.reserve(o.vector_of_co_owning_references.size());
+  for (const auto &v : o.vector_of_co_owning_references) { vector_of_co_owning_references.emplace_back((v) ? new ReferrableT(*v) : nullptr); }
+  vector_of_non_owning_references.clear();
+  vector_of_non_owning_references.reserve(o.vector_of_non_owning_references.size());
+  for (const auto &v : o.vector_of_non_owning_references) { vector_of_non_owning_references.emplace_back(v); }
+  vector_of_enums.clear();
+  vector_of_enums.reserve(o.vector_of_enums.size());
+  for (const auto &v : o.vector_of_enums) { vector_of_enums.emplace_back(v); }
+}
+
+inline MonsterT &MonsterT::operator=(const MonsterT &o) {
+  pos.reset((o.pos) ? new MyGame::Example::Vec3(*o.pos) : nullptr);
+  mana = o.mana;
+  hp = o.hp;
+  name = o.name;
+  color = o.color;
+  test = o.test;
+  enemy.reset((o.enemy) ? new MyGame::Example::MonsterT(*o.enemy) : nullptr);
+  testempty.reset((o.testempty) ? new MyGame::Example::StatT(*o.testempty) : nullptr);
+  testbool = o.testbool;
+  testhashs32_fnv1 = o.testhashs32_fnv1;
+  testhashu32_fnv1 = o.testhashu32_fnv1;
+  testhashs64_fnv1 = o.testhashs64_fnv1;
+  testhashu64_fnv1 = o.testhashu64_fnv1;
+  testhashs32_fnv1a = o.testhashs32_fnv1a;
+  testhashu32_fnv1a = o.testhashu32_fnv1a;
+  testhashs64_fnv1a = o.testhashs64_fnv1a;
+  testhashu64_fnv1a = o.testhashu64_fnv1a;
+  testf = o.testf;
+  testf2 = o.testf2;
+  testf3 = o.testf3;
+  parent_namespace_test.reset((o.parent_namespace_test) ? new MyGame::InParentNamespaceT(*o.parent_namespace_test) : nullptr);
+  single_weak_reference = o.single_weak_reference;
+  co_owning_reference = o.co_owning_reference;
+  non_owning_reference = o.non_owning_reference;
+  any_unique = o.any_unique;
+  any_ambiguous = o.any_ambiguous;
+  signed_enum = o.signed_enum;
+  inventory.clear();
+  inventory.reserve(o.inventory.size());
+  for (const auto &v : o.inventory) { inventory.emplace_back(v); }
+  test4.clear();
+  test4.reserve(o.test4.size());
+  for (const auto &v : o.test4) { test4.emplace_back(v); }
+  testarrayofstring.clear();
+  testarrayofstring.reserve(o.testarrayofstring.size());
+  for (const auto &v : o.testarrayofstring) { testarrayofstring.emplace_back(v); }
+  testarrayoftables.clear();
+  testarrayoftables.reserve(o.testarrayoftables.size());
+  for (const auto &v : o.testarrayoftables) { testarrayoftables.emplace_back((v) ? new MyGame::Example::MonsterT(*v) : nullptr); }
+  testnestedflatbuffer.clear();
+  testnestedflatbuffer.reserve(o.testnestedflatbuffer.size());
+  for (const auto &v : o.testnestedflatbuffer) { testnestedflatbuffer.emplace_back(v); }
+  testarrayofbools.clear();
+  testarrayofbools.reserve(o.testarrayofbools.size());
+  for (const auto &v : o.testarrayofbools) { testarrayofbools.emplace_back(v); }
+  testarrayofstring2.clear();
+  testarrayofstring2.reserve(o.testarrayofstring2.size());
+  for (const auto &v : o.testarrayofstring2) { testarrayofstring2.emplace_back(v); }
+  testarrayofsortedstruct.clear();
+  testarrayofsortedstruct.reserve(o.testarrayofsortedstruct.size());
+  for (const auto &v : o.testarrayofsortedstruct) { testarrayofsortedstruct.emplace_back(v); }
+  flex.clear();
+  flex.reserve(o.flex.size());
+  for (const auto &v : o.flex) { flex.emplace_back(v); }
+  test5.clear();
+  test5.reserve(o.test5.size());
+  for (const auto &v : o.test5) { test5.emplace_back(v); }
+  vector_of_longs.clear();
+  vector_of_longs.reserve(o.vector_of_longs.size());
+  for (const auto &v : o.vector_of_longs) { vector_of_longs.emplace_back(v); }
+  vector_of_doubles.clear();
+  vector_of_doubles.reserve(o.vector_of_doubles.size());
+  for (const auto &v : o.vector_of_doubles) { vector_of_doubles.emplace_back(v); }
+  vector_of_referrables.clear();
+  vector_of_referrables.reserve(o.vector_of_referrables.size());
+  for (const auto &v : o.vector_of_referrables) { vector_of_referrables.emplace_back((v) ? new MyGame::Example::ReferrableT(*v) : nullptr); }
+  vector_of_weak_references.clear();
+  vector_of_weak_references.reserve(o.vector_of_weak_references.size());
+  for (const auto &v : o.vector_of_weak_references) { vector_of_weak_references.emplace_back(v); }
+  vector_of_strong_referrables.clear();
+  vector_of_strong_referrables.reserve(o.vector_of_strong_referrables.size());
+  for (const auto &v : o.vector_of_strong_referrables) { vector_of_strong_referrables.emplace_back((v) ? new MyGame::Example::ReferrableT(*v) : nullptr); }
+  vector_of_co_owning_references.clear();
+  vector_of_co_owning_references.reserve(o.vector_of_co_owning_references.size());
+  for (const auto &v : o.vector_of_co_owning_references) { vector_of_co_owning_references.emplace_back((v) ? new ReferrableT(*v) : nullptr); }
+  vector_of_non_owning_references.clear();
+  vector_of_non_owning_references.reserve(o.vector_of_non_owning_references.size());
+  for (const auto &v : o.vector_of_non_owning_references) { vector_of_non_owning_references.emplace_back(v); }
+  vector_of_enums.clear();
+  vector_of_enums.reserve(o.vector_of_enums.size());
+  for (const auto &v : o.vector_of_enums) { vector_of_enums.emplace_back(v); }
+
+  return *this;
+}
+
 inline MonsterT *Monster::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::make_unique<MonsterT>();
   UnPackTo(_o.get(), _resolver);
@@ -2590,7 +2765,7 @@ inline flatbuffers::Offset<void> AnyUnion::Pack(flatbuffers::FlatBufferBuilder &
 inline AnyUnion::AnyUnion(const AnyUnion &u) : type(u.type), value(nullptr) {
   switch (type) {
     case Any::Monster: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case Any::TestSimpleTableWithEnum: {
@@ -2701,7 +2876,7 @@ inline flatbuffers::Offset<void> AnyUniqueAliasesUnion::Pack(flatbuffers::FlatBu
 inline AnyUniqueAliasesUnion::AnyUniqueAliasesUnion(const AnyUniqueAliasesUnion &u) : type(u.type), value(nullptr) {
   switch (type) {
     case AnyUniqueAliases::M: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case AnyUniqueAliases::TS: {
@@ -2812,15 +2987,15 @@ inline flatbuffers::Offset<void> AnyAmbiguousAliasesUnion::Pack(flatbuffers::Fla
 inline AnyAmbiguousAliasesUnion::AnyAmbiguousAliasesUnion(const AnyAmbiguousAliasesUnion &u) : type(u.type), value(nullptr) {
   switch (type) {
     case AnyAmbiguousAliases::M1: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case AnyAmbiguousAliases::M2: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
     case AnyAmbiguousAliases::M3: {
-      FLATBUFFERS_ASSERT(false);  // MyGame::Example::MonsterT not copyable.
+      value = new MyGame::Example::MonsterT(*reinterpret_cast<MyGame::Example::MonsterT *>(u.value));
       break;
     }
```