### PR TITLE
[Swift] FlatBuffers createMonster method doesn't treat struct properly

### DIFF
--- a/samples/sample_binary.swift
+++ b/samples/sample_binary.swift
@@ -1,5 +1,5 @@
  // THIS IS JUST TO SHOW THE CODE, PLEASE DO IMPORT FLATBUFFERS WITH SPM..
-import Flatbuffers
+import FlatBuffers
 
 typealias Monster = MyGame.Sample.Monster
 typealias Weapon = MyGame.Sample.Weapon
@@ -10,29 +10,28 @@ func main() {
     let expectedDMG: [Int16] = [3, 5]
     let expectedNames = ["Sword", "Axe"]
 
-    let builder = FlatBufferBuilder(initialSize: 1024)
+    var builder = FlatBufferBuilder(initialSize: 1024)
     let weapon1Name = builder.create(string: expectedNames[0])
     let weapon2Name = builder.create(string: expectedNames[1])
         
-    let weapon1Start = Weapon.startWeapon(builder)
-    Weapon.add(name: weapon1Name, builder)
-    Weapon.add(damage: expectedDMG[0], builder)
-    let sword = Weapon.endWeapon(builder, start: weapon1Start)
-    let weapon2Start = Weapon.startWeapon(builder)
-    Weapon.add(name: weapon2Name, builder)
-    Weapon.add(damage: expectedDMG[1], builder)
-    let axe = Weapon.endWeapon(builder, start: weapon2Start)
+    let weapon1Start = Weapon.startWeapon(&builder)
+    Weapon.add(name: weapon1Name, &builder)
+    Weapon.add(damage: expectedDMG[0], &builder)
+    let sword = Weapon.endWeapon(&builder, start: weapon1Start)
+    let weapon2Start = Weapon.startWeapon(&builder)
+    Weapon.add(name: weapon2Name, &builder)
+    Weapon.add(damage: expectedDMG[1], &builder)
+    let axe = Weapon.endWeapon(&builder, start: weapon2Start)
     
     let name = builder.create(string: "Orc")
     let inventory: [Byte] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     let inventoryOffset = builder.createVector(inventory)
 
     let weaponsOffset = builder.createVector(ofOffsets: [sword, axe])
-    let pos = builder.create(struct: MyGame.Sample.createVec3(x: 1, y: 2, z: 3), type: Vec3.self)
-    
-    
-    let orc = Monster.createMonster(builder, 
-                                    offsetOfPos: pos,
+    let pos = MyGame.Sample.createVec3(x: 1, y: 2, z: 3)
+
+    let orc = Monster.createMonster(&builder,
+                                    structOfPos: pos,
                                     hp: 300,
                                     offsetOfName: name,
                                     vectorOfInventory: inventoryOffset,
@@ -42,8 +41,8 @@ func main() {
                                     offsetOfEquipped: axe)
     builder.finish(offset: orc)
     
-    var buf = builder.sizedByteArray
-    var monster = Monster.getRootAsMonster(bb: ByteBuffer(bytes: buf))
+    let buf = builder.sizedByteArray
+    let monster = Monster.getRootAsMonster(bb: ByteBuffer(bytes: buf))
 
     assert(monster.mana == 150)
     assert(monster.hp == 300)

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -879,16 +879,17 @@ class SwiftGenerator : public BaseGenerator {
         case BASE_TYPE_STRUCT: {
           if (field.value.type.struct_def &&
               field.value.type.struct_def->fixed) {
-            std::string struct_builder =
-                type + ".pack(&builder, obj: &obj." + name + ")";
-            unpack_body.push_back("{{STRUCTNAME}}." + body + struct_builder +
-                                  builder);
+            // This is a Struct (IsStruct), not a table. We create UnsafeMutableRawPointer in this case.
+            std::string code;
+            GenerateStructArgs(*field.value.type.struct_def, &code, "", "", "$0", true);
+            code = code.substr(0, code.size() - 2);
+            code_ += "let __" + name + " = obj." + name + ".map { create" + field.value.type.struct_def->name + "(" + code + ") }";
           } else {
-            unpack_body.push_back("{{STRUCTNAME}}." + body + "__" + name +
-                                  builder);
             code_ += "let __" + name + " = " + type +
                      ".pack(&builder, obj: &obj." + name + ")";
           }
+          unpack_body.push_back("{{STRUCTNAME}}." + body + "__" + name +
+                                builder);
           break;
         }
         case BASE_TYPE_STRING: {

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
@@ -44,6 +44,27 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
         let newBuf = FlatBuffersUtils.removeSizePrefix(bb: bytes.buffer)
         readMonster(fb: newBuf)
     }
+
+    func testCreateMonsterUsingCreateMonsterMethodWithNilPos() {
+        var fbb = FlatBufferBuilder(initialSize: 1)
+        let name = fbb.create(string: "Frodo")
+        let monster = Monster.createMonster(&fbb, offsetOfName: name)
+        fbb.finish(offset: monster)
+        let newMonster = Monster.getRootAsMonster(bb: fbb.sizedBuffer)
+        XCTAssertNil(newMonster.pos)
+        XCTAssertEqual(newMonster.name, "Frodo")
+    }
+
+    func testCreateMonsterUsingCreateMonsterMethodWithPosX() {
+        var fbb = FlatBufferBuilder(initialSize: 1)
+        let pos = MyGame.Example.createVec3(x: 10, test2: .blue)
+        let name = fbb.create(string: "Barney")
+        let monster = Monster.createMonster(&fbb, structOfPos: pos, offsetOfName: name)
+        fbb.finish(offset: monster)
+        let newMonster = Monster.getRootAsMonster(bb: fbb.sizedBuffer)
+        XCTAssertEqual(newMonster.pos!.x, 10)
+        XCTAssertEqual(newMonster.name, "Barney")
+    }
     
     func readMonster(fb: ByteBuffer) {
         var monster = Monster.getRootAsMonster(bb: fb)
@@ -88,9 +109,9 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
                                      type: Test.self)
         
         let stringTestVector = fbb.createVector(ofOffsets: [test1, test2])
-        
-        let mStart = Monster.startMonster(&fbb)
+
         let posStruct = MyGame.Example.createVec3(x: 1, y: 2, z: 3, test1: 3, test2: .green, test3a: 5, test3b: 6)
+        let mStart = Monster.startMonster(&fbb)
         Monster.add(pos: posStruct, &fbb)
         Monster.add(hp: 80, &fbb)
         Monster.add(name: str, &fbb)

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
@@ -90,8 +90,8 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
         let stringTestVector = fbb.createVector(ofOffsets: [test1, test2])
         
         let mStart = Monster.startMonster(&fbb)
-        let posOffset = fbb.create(struct: MyGame.Example.createVec3(x: 1, y: 2, z: 3, test1: 3, test2: .green, test3a: 5, test3b: 6), type: Vec3.self)
-        Monster.add(pos: posOffset, &fbb)
+        let posStruct = MyGame.Example.createVec3(x: 1, y: 2, z: 3, test1: 3, test2: .green, test3a: 5, test3b: 6)
+        Monster.add(pos: posStruct, &fbb)
         Monster.add(hp: 80, &fbb)
         Monster.add(name: str, &fbb)
         Monster.addVectorOf(inventory: inv, &fbb)

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/XCTestManifests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/XCTestManifests.swift
@@ -20,6 +20,8 @@ extension FlatBuffersMonsterWriterTests {
         ("testCreateMonster", testCreateMonster),
         ("testCreateMonsterPrefixed", testCreateMonsterPrefixed),
         ("testCreateMonsterResizedBuffer", testCreateMonsterResizedBuffer),
+        ("testCreateMonsterUsingCreateMonsterMethodWithNilPos", testCreateMonsterUsingCreateMonsterMethodWithNilPos),
+        ("testCreateMonsterUsingCreateMonsterMethodWithPosX", testCreateMonsterUsingCreateMonsterMethodWithPosX),
         ("testData", testData),
         ("testReadFromOtherLangagues", testReadFromOtherLangagues),
     ]

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
@@ -825,7 +825,7 @@ public struct Monster: FlatBufferObject {
     public var signedEnum: MyGame.Example.Race { let o = _accessor.offset(VTOFFSET.signedEnum.v); return o == 0 ? .none_ : MyGame.Example.Race(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .none_ }
     @discardableResult public func mutate(signedEnum: MyGame.Example.Race) -> Bool {let o = _accessor.offset(VTOFFSET.signedEnum.v);  return _accessor.mutate(signedEnum.rawValue, index: o) }
     public static func startMonster(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 49) }
-    public static func add(pos: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(structOffset: VTOFFSET.pos.p) }
+    public static func add(pos: UnsafeMutableRawPointer?, _ fbb: inout FlatBufferBuilder) { guard let pos = pos else { return }; fbb.create(struct: pos, type: MyGame.Example.Vec3.self); fbb.add(structOffset: VTOFFSET.pos.p) }
     public static func add(mana: Int16, _ fbb: inout FlatBufferBuilder) { fbb.add(element: mana, def: 150, at: VTOFFSET.mana.p) }
     public static func add(hp: Int16, _ fbb: inout FlatBufferBuilder) { fbb.add(element: hp, def: 100, at: VTOFFSET.hp.p) }
     public static func add(name: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: name, at: VTOFFSET.name.p)  }
@@ -875,7 +875,7 @@ public struct Monster: FlatBufferObject {
     public static func add(signedEnum: MyGame.Example.Race, _ fbb: inout FlatBufferBuilder) { fbb.add(element: signedEnum.rawValue, def: -1, at: VTOFFSET.signedEnum.p) }
     public static func endMonster(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); fbb.require(table: end, fields: [10]); return end }
     public static func createMonster(_ fbb: inout FlatBufferBuilder,
-    offsetOfPos pos: Offset<UOffset> = Offset(),
+    structOfPos pos: UnsafeMutableRawPointer? = nil,
     mana: Int16 = 150,
     hp: Int16 = 100,
     offsetOfName name: Offset<String> = Offset(),
@@ -1010,6 +1010,7 @@ public struct Monster: FlatBufferObject {
     }
 
     public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MonsterT) -> Offset<UOffset> {
+        let __pos = obj.pos.map { createVec3(x: $0.x, y: $0.y, z: $0.z, test1: $0.test1, test2: $0.test2, test3a: $0.test3.a, test3b: $0.test3.b) }
         let __name = builder.create(string: obj.name)
         let __inventory = builder.createVector(obj.inventory)
         let __test = obj.test?.pack(builder: &builder) ?? Offset()
@@ -1063,7 +1064,7 @@ public struct Monster: FlatBufferObject {
         let __anyAmbiguous = obj.anyAmbiguous?.pack(builder: &builder) ?? Offset()
         let __vectorOfEnums = builder.createVector(obj.vectorOfEnums)
         let __root = Monster.startMonster(&builder)
-        Monster.add(pos: MyGame.Example.Vec3.pack(&builder, obj: &obj.pos), &builder)
+        Monster.add(pos: __pos, &builder)
         Monster.add(mana: obj.mana, &builder)
         Monster.add(hp: obj.hp, &builder)
         Monster.add(name: __name, &builder)


### PR DESCRIPTION
This PR fixed a issue where a struct is not treated properly when use
create inside.

A example would be the pos inside Monster. The createMonster method
takes an Offset for pos. However, FlatBuffersBuilder.add(struct:)
doesn't really take Offset argument. That means we don't really add a
struct at all for Monster.

It will show up as the pos never set.

This doesn't show up in FlatBuffersMonsterWriterTests.swift because it
implements its own createMonster method, which happens do the dance
properly (i.e. first call create(struct) and then immediately call
add:).

This PR modified the `add(pos:)` interface such that it takes the
UnsafeMutableRawPointer directly, calling `create(struct:)` under the hood.

I can add unit tests once the direction of this PR approved.
