### PR TITLE
[Kotlin] Fix Access to union of vector element

### DIFF
--- a/src/idl_gen_kotlin.cpp
+++ b/src/idl_gen_kotlin.cpp
@@ -942,7 +942,7 @@ class KotlinGenerator : public BaseGenerator {
                   break;
                 }
                 case BASE_TYPE_UNION:
-                  found = "{{bbgetter}}(obj, {{index}} - bb_pos){{ucast}}";
+                  found = "{{bbgetter}}(obj, {{index}}){{ucast}}";
                   break;
                 default: found = "{{bbgetter}}({{index}}){{ucast}}";
               }

--- a/tests/KotlinTest.kt
+++ b/tests/KotlinTest.kt
@@ -146,7 +146,7 @@ class KotlinTest {
 
         val monster = Monster.getRootAsMonster(bb)
 
-        assert(monster.testhashu32Fnv1 == (1u + Integer.MAX_VALUE.toUInt()))
+        assert(monster.testhashu32Fnv1 == (Integer.MAX_VALUE + 1L).toUInt())
     }
 
     fun TestNamespaceNesting() {
@@ -331,7 +331,7 @@ class KotlinTest {
         Monster.addTest4(fbb, test4)
         Monster.addTestarrayofstring(fbb, testArrayOfString)
         Monster.addTestbool(fbb, true)
-        Monster.addTesthashu32Fnv1(fbb, UInt.MAX_VALUE + 1u)
+        Monster.addTesthashu32Fnv1(fbb, (Integer.MAX_VALUE + 1L).toUInt())
         Monster.addTestarrayoftables(fbb, sortMons)
         val mon = Monster.endMonster(fbb)
 

--- a/tests/KotlinTest.sh
+++ b/tests/KotlinTest.sh
@@ -40,7 +40,7 @@ kotlinc $all_kt_files -classpath $targetdir -include-runtime -d $targetdir
 # Make jar
 jar cvf ${testdir}/kotlin_test.jar -C $targetdir . > /dev/null
 # Run test
-kotlin -cp ${testdir}/kotlin_test.jar KotlinTest
+kotlin -J"-ea" -cp ${testdir}/kotlin_test.jar KotlinTest
 # clean up
 rm -rf $targetdir
 rm ${testdir}/kotlin_test.jar

--- a/tests/union_vector/Movie.kt
+++ b/tests/union_vector/Movie.kt
@@ -58,7 +58,7 @@ class Movie : Table() {
     fun characters(obj: Table, j: Int) : Table? {
         val o = __offset(10)
         return if (o != 0) {
-            __union(obj, __vector(o) + j * 4 - bb_pos)
+            __union(obj, __vector(o) + j * 4)
         } else {
             null
         }


### PR DESCRIPTION
Kotlin code generation was producing wrong logic for accessors
of vector of union elements. This was shadowed by the fact[1] that asserts
in Kotlin are silently ignored unless the flag "-ea" is passed to the JVM.

The tests are also updated to enable asserts.

1 - https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/assert.html
