### PR TITLE
[Rust] Flexbuffers dependency cleanup and fixes

### DIFF
--- a/rust/flexbuffers/Cargo.toml
+++ b/rust/flexbuffers/Cargo.toml
@@ -15,6 +15,5 @@ serde = "1.0"
 serde_derive = "1.0"
 byteorder = "1.3.2"
 num_enum = "0.5.0"
-debug_stub_derive = "0.3.0"
 bitflags = "1.2.1"
 

--- a/rust/flexbuffers/Cargo.toml
+++ b/rust/flexbuffers/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["encoding", "data-structures", "memory-management"]
 serde = "1.0"
 serde_derive = "1.0"
 byteorder = "1.3.2"
-num_enum = "0.4.1"
+num_enum = "0.5.0"
 debug_stub_derive = "0.3.0"
 bitflags = "1.2.1"
 

--- a/rust/flexbuffers/src/flexbuffer_type.rs
+++ b/rust/flexbuffers/src/flexbuffer_type.rs
@@ -181,60 +181,60 @@ impl FlexBufferType {
             _ => None,
         }
     }
-    /// returns true if and only if the flexbuffer type is `Null`.
+    // returns true if and only if the flexbuffer type is `Null`.
     is_ty!(is_null, Null);
-    /// returns true if and only if the flexbuffer type is `Int`.
+    // returns true if and only if the flexbuffer type is `Int`.
     is_ty!(is_int, Int);
-    /// returns true if and only if the flexbuffer type is `UInt`.
+    // returns true if and only if the flexbuffer type is `UInt`.
     is_ty!(is_uint, UInt);
-    /// returns true if and only if the flexbuffer type is `Float`.
+    // returns true if and only if the flexbuffer type is `Float`.
     is_ty!(is_float, Float);
-    /// returns true if and only if the flexbuffer type is `Bool`.
+    // returns true if and only if the flexbuffer type is `Bool`.
     is_ty!(is_bool, Bool);
-    /// returns true if and only if the flexbuffer type is `Key`.
+    // returns true if and only if the flexbuffer type is `Key`.
     is_ty!(is_key, Key);
-    /// returns true if and only if the flexbuffer type is `String`.
+    // returns true if and only if the flexbuffer type is `String`.
     is_ty!(is_string, String);
-    /// returns true if and only if the flexbuffer type is `IndirectInt`.
+    // returns true if and only if the flexbuffer type is `IndirectInt`.
     is_ty!(is_indirect_int, IndirectInt);
-    /// returns true if and only if the flexbuffer type is `IndirectUInt`.
+    // returns true if and only if the flexbuffer type is `IndirectUInt`.
     is_ty!(is_indirect_uint, IndirectUInt);
-    /// returns true if and only if the flexbuffer type is `IndirectFloat`.
+    // returns true if and only if the flexbuffer type is `IndirectFloat`.
     is_ty!(is_indirect_float, IndirectFloat);
-    /// returns true if and only if the flexbuffer type is `Map`.
+    // returns true if and only if the flexbuffer type is `Map`.
     is_ty!(is_map, Map);
-    /// returns true if and only if the flexbuffer type is `Vector`.
+    // returns true if and only if the flexbuffer type is `Vector`.
     is_ty!(is_heterogenous_vector, Vector);
-    /// returns true if and only if the flexbuffer type is `VectorInt`.
+    // returns true if and only if the flexbuffer type is `VectorInt`.
     is_ty!(is_vector_int, VectorInt);
-    /// returns true if and only if the flexbuffer type is `VectorUInt`.
+    // returns true if and only if the flexbuffer type is `VectorUInt`.
     is_ty!(is_vector_uint, VectorUInt);
-    /// returns true if and only if the flexbuffer type is `VectorFloat`.
+    // returns true if and only if the flexbuffer type is `VectorFloat`.
     is_ty!(is_vector_float, VectorFloat);
-    /// returns true if and only if the flexbuffer type is `VectorKey`.
+    // returns true if and only if the flexbuffer type is `VectorKey`.
     is_ty!(is_vector_key, VectorKey);
-    /// returns true if and only if the flexbuffer type is `VectorString`.
+    // returns true if and only if the flexbuffer type is `VectorString`.
     is_ty!(is_vector_string, VectorString);
-    /// returns true if and only if the flexbuffer type is `VectorBool`.
+    // returns true if and only if the flexbuffer type is `VectorBool`.
     is_ty!(is_vector_bool, VectorBool);
-    /// returns true if and only if the flexbuffer type is `VectorInt2`.
+    // returns true if and only if the flexbuffer type is `VectorInt2`.
     is_ty!(is_vector_int2, VectorInt2);
-    /// returns true if and only if the flexbuffer type is `VectorUInt2`.
+    // returns true if and only if the flexbuffer type is `VectorUInt2`.
     is_ty!(is_vector_uint2, VectorUInt2);
-    /// returns true if and only if the flexbuffer type is `VectorFloat2`.
+    // returns true if and only if the flexbuffer type is `VectorFloat2`.
     is_ty!(is_vector_float2, VectorFloat2);
-    /// returns true if and only if the flexbuffer type is `VectorInt3`.
+    // returns true if and only if the flexbuffer type is `VectorInt3`.
     is_ty!(is_vector_int3, VectorInt3);
-    /// returns true if and only if the flexbuffer type is `VectorUInt3`.
+    // returns true if and only if the flexbuffer type is `VectorUInt3`.
     is_ty!(is_vector_uint3, VectorUInt3);
-    /// returns true if and only if the flexbuffer type is `VectorFloat3`.
+    // returns true if and only if the flexbuffer type is `VectorFloat3`.
     is_ty!(is_vector_float3, VectorFloat3);
-    /// returns true if and only if the flexbuffer type is `VectorInt4`.
+    // returns true if and only if the flexbuffer type is `VectorInt4`.
     is_ty!(is_vector_int4, VectorInt4);
-    /// returns true if and only if the flexbuffer type is `VectorUInt4`.
+    // returns true if and only if the flexbuffer type is `VectorUInt4`.
     is_ty!(is_vector_uint4, VectorUInt4);
-    /// returns true if and only if the flexbuffer type is `VectorFloat4`.
+    // returns true if and only if the flexbuffer type is `VectorFloat4`.
     is_ty!(is_vector_float4, VectorFloat4);
-    /// returns true if and only if the flexbuffer type is `Blob`.
+    // returns true if and only if the flexbuffer type is `Blob`.
     is_ty!(is_blob, Blob);
 }

--- a/rust/flexbuffers/src/lib.rs
+++ b/rust/flexbuffers/src/lib.rs
@@ -34,7 +34,6 @@ extern crate byteorder;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
-extern crate debug_stub_derive;
 extern crate num_enum;
 extern crate serde;
 

--- a/rust/flexbuffers/src/lib.rs
+++ b/rust/flexbuffers/src/lib.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(test, feature(test))]
 //! Flexbuffers is a high performance schemaless binary data format designed at Google.
 //! It is complementary to the schema-ed format [Flatbuffers](http://docs.rs/flatbuffers/).
 //! See [Flexbuffer Internals](https://google.github.io/flatbuffers/flatbuffers_internals.html)
@@ -37,15 +36,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate debug_stub_derive;
 extern crate num_enum;
-#[cfg(test)]
-extern crate quickcheck;
-#[cfg(test)]
-extern crate quickcheck_derive;
-#[cfg(test)]
-extern crate rand;
 extern crate serde;
-#[cfg(test)]
-extern crate test;
 
 mod bitwidth;
 mod builder;

--- a/rust/flexbuffers/src/reader/map.rs
+++ b/rust/flexbuffers/src/reader/map.rs
@@ -22,15 +22,28 @@ use std::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator}
 /// MapReaders may be indexed with strings or usizes. `index` returns a result type,
 /// which may indicate failure due to a missing key or bad data, `idx` returns an Null Reader in
 /// cases of error.
-#[derive(DebugStub, Default, Clone)]
+#[derive(Default, Clone)]
 pub struct MapReader<'de> {
-    #[debug_stub = "&[..]"]
     pub(super) buffer: &'de [u8],
     pub(super) values_address: usize,
     pub(super) keys_address: usize,
     pub(super) values_width: BitWidth,
     pub(super) keys_width: BitWidth,
     pub(super) length: usize,
+}
+
+// manual implementation of Debug because buffer slice can't be automatically displayed
+impl<'de> std::fmt::Debug for MapReader<'de> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // skips buffer field
+        f.debug_struct("MapReader")
+            .field("values_address", &self.values_address)
+            .field("keys_address", &self.keys_address)
+            .field("values_width", &self.values_width)
+            .field("keys_width", &self.keys_width)
+            .field("length", &self.length)
+            .finish()
+    }
 }
 
 impl<'de> MapReader<'de> {

--- a/rust/flexbuffers/src/reader/mod.rs
+++ b/rust/flexbuffers/src/reader/mod.rs
@@ -143,14 +143,26 @@ macro_rules! as_default {
 /// - The `as_T` methods will try their best to return to a value of type `T`
 /// (by casting or even parsing a string if necessary) but ultimately returns `T::default` if it
 /// fails. This behavior is analogous to that of flexbuffers C++.
-#[derive(DebugStub, Default, Clone)]
+#[derive(Default, Clone)]
 pub struct Reader<'de> {
     fxb_type: FlexBufferType,
     width: BitWidth,
     address: usize,
-    #[debug_stub = "&[..]"]
     buffer: &'de [u8],
 }
+
+// manual implementation of Debug because buffer slice can't be automatically displayed
+impl<'de> std::fmt::Debug for Reader<'de> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // skips buffer field
+        f.debug_struct("Reader")
+            .field("fxb_type", &self.fxb_type)
+            .field("width", &self.width)
+            .field("address", &self.address)
+            .finish()
+    }
+}
+
 
 macro_rules! try_cast_fn {
     ($name: ident, $full_width: ident, $Ty: ident) => {


### PR DESCRIPTION
This contains multiple fixes wrt to the dependencies that the `flexbuffers` crate use:

- Removes usage of the `debug_stub_derive` crate, it has not been updated in 3 years and looks abandoned and pulls in the old pre-v1 `syn` and `quote` crates which significantly adds compile times. And was only used for simplifying two `Debug` trait implementations, which I've implemented manually in here instead.
- Upgrades `num_enum` from 0.4.1 to latest 0.5.0, no changes was needed.
- Fix compile warnings from doc comments on macros
- Fix compile for test configuration (although no tests are used in the crate).

Looking forward to using this crate more in our projects! Thanks for the great work on it!

This cleanup makes it possible for us to use it in our projects as we do not allow old, duplicate or abandoned crate dependencies.