### PR TITLE
[Swift] Moving Package.swift to root

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
     targets: [
         .target(
             name: "FlatBuffers",
-            dependencies: []),
+            dependencies: [],
+            path: "swift")
     ]
 )


### PR DESCRIPTION
I believe, based on the doc: https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescription.md#package-dependency that SPM only support Package.swift from root to refer to from PackageDependencyDescription. This PR moved Package.swift from swift/Package.swift to the root so it can be specified properly.

I could be wrong though, still learning SPM (coming from Bazel / Buck background).