### PR TITLE
Serde with bytes maps to Blob

### DIFF
--- a/rust/flexbuffers/Cargo.toml
+++ b/rust/flexbuffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flexbuffers"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Casper Neo <cneo@google.com>", "FlatBuffers Maintainers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/rust/flexbuffers/Cargo.toml
+++ b/rust/flexbuffers/Cargo.toml
@@ -16,4 +16,3 @@ serde_derive = "1.0"
 byteorder = "1.3.2"
 num_enum = "0.5.0"
 bitflags = "1.2.1"
-

--- a/rust/flexbuffers/src/builder/ser.rs
+++ b/rust/flexbuffers/src/builder/ser.rs
@@ -270,7 +270,7 @@ impl<'a> ser::Serializer for &'a mut FlexbufferSerializer {
         self.finish_if_not_nested()
     }
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        self.builder.push(v);
+        self.builder.push(crate::Blob(v));
         self.finish_if_not_nested()
     }
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {

--- a/tests/rust_usage_test/Cargo.toml
+++ b/tests/rust_usage_test/Cargo.toml
@@ -8,6 +8,7 @@ flatbuffers = { path = "../../rust/flatbuffers" }
 flexbuffers = { path = "../../rust/flexbuffers" }
 serde_derive = "1.0"
 serde = "1.0"
+serde_bytes = "0.11"
 
 [[bin]]
 name = "monster_example"

--- a/tests/rust_usage_test/tests/flexbuffers_tests/qc_serious.rs
+++ b/tests/rust_usage_test/tests/flexbuffers_tests/qc_serious.rs
@@ -1,5 +1,3 @@
-#![allow(unused_imports)]
-
 use super::rwyw::NonNullString;
 use flexbuffers::*;
 use quickcheck::{Arbitrary, Gen};
@@ -30,6 +28,7 @@ enum Enum {
         b: Array4<i32>,
         c: Array2<f64>,
     },
+    Blobs(#[serde(with = "serde_bytes")] Vec<u8>),
 }
 
 // There is some upstream bug in deriving Arbitrary for Enum so we manually implement it here.

--- a/tests/rust_usage_test/tests/flexbuffers_tests/rwyw.rs
+++ b/tests/rust_usage_test/tests/flexbuffers_tests/rwyw.rs
@@ -432,7 +432,16 @@ fn serde_serious() {
     let read = MyTupleStruct::deserialize(reader).unwrap();
     assert_eq!(data, read);
 }
-
+#[test]
+fn serialize_serde_with_bytes_as_blob() {
+    #[derive(Serialize, Deserialize)]
+    struct Foo(#[serde(with = "serde_bytes")] Vec<u8>);
+    let mut s = FlexbufferSerializer::new();
+    Foo(vec![5, 6, 7, 8]).serialize(&mut s).unwrap();
+    let reader = Reader::get_root(s.view()).unwrap();
+    assert_eq!(reader.flexbuffer_type(), FlexBufferType::Blob);
+    assert_eq!(reader.as_blob(), Blob(&[5, 6, 7, 8]));
+}
 #[test]
 fn iter() {
     let mut fxb = Builder::default();


### PR DESCRIPTION
This should fix issue #5990 

Serde's `#[serde(with = "serde_bytes")]` field attribute signals that `Vec<u8>` is meant to be binary data and should map to Flexbuffer's Blob instead of `VectorUint`. After this PR, I will publish the crate as version `0.1.1`.

@rw