### PR TITLE
support deprecated flag in json schema

### DIFF
--- a/src/idl_gen_json_schema.cpp
+++ b/src/idl_gen_json_schema.cpp
@@ -127,7 +127,7 @@ class JsonSchemaGenerator : public BaseGenerator {
     if (parser_.root_struct_def_ == nullptr) { return false; }
     code_.Clear();
     code_ += "{";
-    code_ += "  \"$schema\": \"http://json-schema.org/draft-04/schema#\",";
+    code_ += "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",";
     code_ += "  \"definitions\": {";
     for (auto e = parser_.enums_.vec.cbegin(); e != parser_.enums_.vec.cend();
          ++e) {
@@ -174,9 +174,16 @@ class JsonSchemaGenerator : public BaseGenerator {
                       ",\n                \"maxItems\": " +
                       NumToString(property->value.type.fixed_length);
         }
+        std::string deprecated_info = "";
+        if (property->deprecated) {
+          deprecated_info = ",\n                \"deprecated\" : true,";
+        }
         std::string typeLine =
-            "        \"" + property->name + "\" : {\n" + "                " +
-            GenType(property->value.type) + arrayInfo + "\n              }";
+            "        \"" + property->name + "\" : {\n" + "                ";
+        typeLine += GenType(property->value.type);
+        typeLine += arrayInfo;
+        typeLine += deprecated_info;
+        typeLine += "\n              }";
         if (property != properties.back()) { typeLine.append(","); }
         code_ += typeLine;
       }

--- a/tests/arrays_test.schema.json
+++ b/tests/arrays_test.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "definitions": {
     "MyGame_Example_TestEnum" : {
       "type" : "string",

--- a/tests/monster_test.schema.json
+++ b/tests/monster_test.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "definitions": {
     "MyGame_OtherNameSpace_FromInclude" : {
       "type" : "string",
@@ -162,7 +162,8 @@
                 "type" : "string"
               },
         "friendly" : {
-                "type" : "boolean"
+                "type" : "boolean",
+                "deprecated" : true,
               },
         "inventory" : {
                 "type" : "array", "items" : { "type" : "number" }


### PR DESCRIPTION
Hello!
I've added support for json schema deprecated flag requested in #5679 and specified [here](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.3). 

Also updated json schema version. Compatibility changes between versions are described [here](https://json-schema.org/draft/2019-09/release-notes.html#incompatible-changes). In semi-incompatible changes I see backward compatible change in naming: defenitions to defs. I haven't changed it, should I?
