### PR TITLE
[Dart] Generate constant values map for enums

### DIFF
--- a/dart/test/flat_buffers_test.dart
+++ b/dart/test/flat_buffers_test.dart
@@ -17,6 +17,7 @@ main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(BuilderTest);
     defineReflectiveTests(CheckOtherLangaugesData);
+    defineReflectiveTests(GeneratorTest);
   });
 }
 
@@ -629,5 +630,16 @@ class TestPointReader extends TableReader<TestPointImpl> {
   @override
   TestPointImpl createObject(BufferContext object, int offset) {
     return new TestPointImpl(object, offset);
+  }
+}
+
+@reflectiveTest
+class GeneratorTest {
+  void test_constantEnumValues() async {
+    expect(example.Color.values, same(example.Color.values));
+    expect(example.Race.values, same(example.Race.values));
+    expect(example.AnyTypeId.values, same(example.AnyTypeId.values));
+    expect(example.AnyUniqueAliasesTypeId.values, same(example.AnyUniqueAliasesTypeId.values));
+    expect(example.AnyAmbiguousAliasesTypeId.values, same(example.AnyAmbiguousAliasesTypeId.values));
   }
 }

--- a/dart/test/monster_test_my_game.example_generated.dart
+++ b/dart/test/monster_test_my_game.example_generated.dart
@@ -32,7 +32,7 @@ class Color {
 
   ///  \brief color Blue (1u << 3)
   static const Color Blue = const Color._(8);
-  static get values => {1: Red,2: Green,8: Blue,};
+  static const values = {1: Red,2: Green,8: Blue,};
 
   static const fb.Reader<Color> reader = const _ColorReader();
 
@@ -73,7 +73,7 @@ class Race {
   static const Race Human = const Race._(0);
   static const Race Dwarf = const Race._(1);
   static const Race Elf = const Race._(2);
-  static get values => {-1: None,0: Human,1: Dwarf,2: Elf,};
+  static const values = {-1: None,0: Human,1: Dwarf,2: Elf,};
 
   static const fb.Reader<Race> reader = const _RaceReader();
 
@@ -114,7 +114,7 @@ class AnyTypeId {
   static const AnyTypeId Monster = const AnyTypeId._(1);
   static const AnyTypeId TestSimpleTableWithEnum = const AnyTypeId._(2);
   static const AnyTypeId MyGame_Example2_Monster = const AnyTypeId._(3);
-  static get values => {0: NONE,1: Monster,2: TestSimpleTableWithEnum,3: MyGame_Example2_Monster,};
+  static const values = {0: NONE,1: Monster,2: TestSimpleTableWithEnum,3: MyGame_Example2_Monster,};
 
   static const fb.Reader<AnyTypeId> reader = const _AnyTypeIdReader();
 
@@ -155,7 +155,7 @@ class AnyUniqueAliasesTypeId {
   static const AnyUniqueAliasesTypeId M = const AnyUniqueAliasesTypeId._(1);
   static const AnyUniqueAliasesTypeId TS = const AnyUniqueAliasesTypeId._(2);
   static const AnyUniqueAliasesTypeId M2 = const AnyUniqueAliasesTypeId._(3);
-  static get values => {0: NONE,1: M,2: TS,3: M2,};
+  static const values = {0: NONE,1: M,2: TS,3: M2,};
 
   static const fb.Reader<AnyUniqueAliasesTypeId> reader = const _AnyUniqueAliasesTypeIdReader();
 
@@ -196,7 +196,7 @@ class AnyAmbiguousAliasesTypeId {
   static const AnyAmbiguousAliasesTypeId M1 = const AnyAmbiguousAliasesTypeId._(1);
   static const AnyAmbiguousAliasesTypeId M2 = const AnyAmbiguousAliasesTypeId._(2);
   static const AnyAmbiguousAliasesTypeId M3 = const AnyAmbiguousAliasesTypeId._(3);
-  static get values => {0: NONE,1: M1,2: M2,3: M3,};
+  static const values = {0: NONE,1: M1,2: M2,3: M3,};
 
   static const fb.Reader<AnyAmbiguousAliasesTypeId> reader = const _AnyAmbiguousAliasesTypeIdReader();
 

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -267,7 +267,7 @@ class DartGenerator : public BaseGenerator {
       code += "const " + name + "._(" + enum_def.ToString(ev) + ");\n";
     }
 
-    code += "  static get values => {";
+    code += "  static const values = {";
     for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
       auto &ev = **it;
       code += enum_def.ToString(ev) + ": " + ev.name + ",";

--- a/tests/monster_test_my_game.example_generated.dart
+++ b/tests/monster_test_my_game.example_generated.dart
@@ -32,7 +32,7 @@ class Color {
 
   ///  \brief color Blue (1u << 3)
   static const Color Blue = const Color._(8);
-  static get values => {1: Red,2: Green,8: Blue,};
+  static const values = {1: Red,2: Green,8: Blue,};
 
   static const fb.Reader<Color> reader = const _ColorReader();
 
@@ -73,7 +73,7 @@ class Race {
   static const Race Human = const Race._(0);
   static const Race Dwarf = const Race._(1);
   static const Race Elf = const Race._(2);
-  static get values => {-1: None,0: Human,1: Dwarf,2: Elf,};
+  static const values = {-1: None,0: Human,1: Dwarf,2: Elf,};
 
   static const fb.Reader<Race> reader = const _RaceReader();
 
@@ -114,7 +114,7 @@ class AnyTypeId {
   static const AnyTypeId Monster = const AnyTypeId._(1);
   static const AnyTypeId TestSimpleTableWithEnum = const AnyTypeId._(2);
   static const AnyTypeId MyGame_Example2_Monster = const AnyTypeId._(3);
-  static get values => {0: NONE,1: Monster,2: TestSimpleTableWithEnum,3: MyGame_Example2_Monster,};
+  static const values = {0: NONE,1: Monster,2: TestSimpleTableWithEnum,3: MyGame_Example2_Monster,};
 
   static const fb.Reader<AnyTypeId> reader = const _AnyTypeIdReader();
 
@@ -155,7 +155,7 @@ class AnyUniqueAliasesTypeId {
   static const AnyUniqueAliasesTypeId M = const AnyUniqueAliasesTypeId._(1);
   static const AnyUniqueAliasesTypeId TS = const AnyUniqueAliasesTypeId._(2);
   static const AnyUniqueAliasesTypeId M2 = const AnyUniqueAliasesTypeId._(3);
-  static get values => {0: NONE,1: M,2: TS,3: M2,};
+  static const values = {0: NONE,1: M,2: TS,3: M2,};
 
   static const fb.Reader<AnyUniqueAliasesTypeId> reader = const _AnyUniqueAliasesTypeIdReader();
 
@@ -196,7 +196,7 @@ class AnyAmbiguousAliasesTypeId {
   static const AnyAmbiguousAliasesTypeId M1 = const AnyAmbiguousAliasesTypeId._(1);
   static const AnyAmbiguousAliasesTypeId M2 = const AnyAmbiguousAliasesTypeId._(2);
   static const AnyAmbiguousAliasesTypeId M3 = const AnyAmbiguousAliasesTypeId._(3);
-  static get values => {0: NONE,1: M1,2: M2,3: M3,};
+  static const values = {0: NONE,1: M1,2: M2,3: M3,};
 
   static const fb.Reader<AnyAmbiguousAliasesTypeId> reader = const _AnyAmbiguousAliasesTypeIdReader();
 

--- a/tests/namespace_test/namespace_test1_namespace_a.namespace_b_generated.dart
+++ b/tests/namespace_test/namespace_test1_namespace_a.namespace_b_generated.dart
@@ -26,7 +26,7 @@ class EnumInNestedNS {
   static const EnumInNestedNS A = const EnumInNestedNS._(0);
   static const EnumInNestedNS B = const EnumInNestedNS._(1);
   static const EnumInNestedNS C = const EnumInNestedNS._(2);
-  static get values => {0: A,1: B,2: C,};
+  static const values = {0: A,1: B,2: C,};
 
   static const fb.Reader<EnumInNestedNS> reader = const _EnumInNestedNSReader();
 


### PR DESCRIPTION
Dart schema compiler generated a static getter for enum values, which
always created a new map instance for its callers. See #5819 .
Now it generates const map for better performance
and readability.