### PR TITLE
[Swift] Correct some flatbuffers namespace handling for Swift generator

### DIFF
--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -1432,7 +1432,7 @@ class SwiftGenerator : public BaseGenerator {
     for (size_t j = 0; j < common_prefix_size; ++j) {
       prefix += ns->components[j] + ".";
     }
-    ssize_t unseen_namespace_pos = -1;
+    size_t unseen_namespace_pos = new_size;
     size_t extension_size = 0;
     for (auto j = common_prefix_size; j < new_size; ++j) {
       std::string name = ns->components[j];
@@ -1456,15 +1456,13 @@ class SwiftGenerator : public BaseGenerator {
       code_ += "extension {{EXTENSION}} {";
       namespace_depth = 1;
     }
-    if (unseen_namespace_pos >= 0) {
-      for (size_t j = unseen_namespace_pos; j < new_size; ++j) {
-        std::string name = ns->components[j];
-        std::string fully_qualified_name = prefix + name;
-        namespaces_.insert(fully_qualified_name);
-        prefix += name + ".";
-        code_ += "public enum " + name + " {";
-        namespace_depth += 1;
-      }
+    for (auto j = unseen_namespace_pos; j < new_size; ++j) {
+      std::string name = ns->components[j];
+      std::string fully_qualified_name = prefix + name;
+      namespaces_.insert(fully_qualified_name);
+      prefix += name + ".";
+      code_ += "public enum " + name + " {";
+      namespace_depth += 1;
     }
 
     if (new_size != common_prefix_size) { code_ += ""; }

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -1457,7 +1457,7 @@ class SwiftGenerator : public BaseGenerator {
       namespace_depth = 1;
     }
     if (unseen_namespace_pos >= 0) {
-      for (auto j = (size_t)unseen_namespace_pos; j < new_size; ++j) {
+      for (size_t j = unseen_namespace_pos; j < new_size; ++j) {
         std::string name = ns->components[j];
         std::string fully_qualified_name = prefix + name;
         namespaces_.insert(fully_qualified_name);

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -1433,8 +1433,8 @@ class SwiftGenerator : public BaseGenerator {
     size_t unseen_namespace_pos = new_size;
     size_t extension_size = 0;
     for (auto j = common_prefix_size; j < new_size; ++j) {
-      std::string name = ns->components[j];
-      std::string fully_qualified_name = prefix + name;
+      auto name = ns->components[j];
+      auto fully_qualified_name = prefix + name;
       // Use full namespace to verify whether we have this namespace declared before or not.
       if (namespaces_.find(fully_qualified_name) == namespaces_.end()) {
         // If we never see this namespace, we will declare this namespace with public enum.

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -1457,7 +1457,7 @@ class SwiftGenerator : public BaseGenerator {
       namespace_depth = 1;
     }
     if (unseen_namespace_pos >= 0) {
-      for (auto j = unseen_namespace_pos; j < new_size; ++j) {
+      for (auto j = (size_t)unseen_namespace_pos; j < new_size; ++j) {
         std::string name = ns->components[j];
         std::string fully_qualified_name = prefix + name;
         namespaces_.insert(fully_qualified_name);

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
@@ -421,6 +421,7 @@ public class MonsterT: NativeTable {
 
 
 }
+
 extension MyGame.Example {
 
 public struct TestSimpleTableWithEnum: FlatBufferObject {


### PR DESCRIPTION
This PR is to correct some of the Swift flatbuffers namespace handling.
It doesn't introduce any new behaviors which I put up an issue for
discussion.

This PR fixed a few issues regarding to namespace handling, mostly
related to how `public enum` and `extension` works in Swift.

 1. namespace_depth count when closing is not correct. The check should
    be `namespace_depth > 0` so we close the same number we open.

 2. Our namespaces_ cannot differentiate same name but under different
    prefix namespace. Thus, if you have:

```
namespace V1.Evolution;
table A {
}
namespace V2.Evolution;
table B {
}
```

The generated code before this PR will do `extension V2.Evolution {`
because Evolution matches existing namespace. This PR changed to use
fully qualified namespace for matching.

 3. Because of the changes related to 2., we will have `extension XXX.YYY
    {` and additional `public enum MoreNamespace {`, previously, it is not possible.
