### PR TITLE
MIN, MAX in enum names are marked as illegal (for all languages)

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2021,6 +2021,7 @@ struct EnumValBuilder {
                        (temp->union_type.enum_def == &enum_def));
     auto not_unique = enum_def.vals.Add(name, temp);
     temp = nullptr;
+    if (name == "MIN" || name == "MAX") return parser.Error("enum value reserved: " + name);
     if (not_unique) return parser.Error("enum value already exists: " + name);
     return NoError();
   }


### PR DESCRIPTION
"NONE" in unions is illegal as it throws an error it already exists but similarly it should applied to "MIN", "MAX"  **FOR C++** since it generate entries with those names
```
enum Color:byte { MIN = 0, Green, Blue = 2 }
```
```cpp
enum Color {
  Color_MIN = 0,
  Color_Green = 1,
  Color_Blue = 2,
  Color_MIN = Color_MIN,
  Color_MAX = Color_Blue
};
```

The problem is that "NONE" added to the union when the schema parsing and it applies to all the languages but MIN, MAX are only applicable to c++ and it'll added when cpp code generation. Marking MIN, MAX only illegal for c++ makes in consistence between languages. 