### PR TITLE
Rust codegen improvements and lint fixes

### DIFF
--- a/rust/flatbuffers/src/follow.rs
+++ b/rust/flatbuffers/src/follow.rs
@@ -41,7 +41,7 @@ pub fn lifted_follow<'a, T: Follow<'a>>(buf: &'a [u8], loc: usize) -> T::Inner {
 
 /// FollowStart wraps a Follow impl in a struct type. This can make certain
 /// programming patterns more ergonomic.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct FollowStart<T>(PhantomData<T>);
 impl<'a, T: Follow<'a> + 'a> FollowStart<T> {
     #[inline]

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -595,7 +595,7 @@ class RustGenerator : public BaseGenerator {
     // Generate an array of all enumeration values.
     auto num_fields = NumToString(enum_def.size());
     code_ += "#[allow(non_camel_case_types)]";
-    code_ += "pub const ENUM_VALUES_{{ENUM_NAME_CAPS}}:[{{ENUM_NAME}}; " +
+    code_ += "pub const ENUM_VALUES_{{ENUM_NAME_CAPS}}: [{{ENUM_NAME}}; " +
              num_fields + "] = [";
     for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
       const auto &ev = **it;
@@ -616,7 +616,7 @@ class RustGenerator : public BaseGenerator {
     static const uint64_t kMaxSparseness = 5;
     if (range / static_cast<uint64_t>(enum_def.size()) < kMaxSparseness) {
       code_ += "#[allow(non_camel_case_types)]";
-      code_ += "pub const ENUM_NAMES_{{ENUM_NAME_CAPS}}:[&'static str; " +
+      code_ += "pub const ENUM_NAMES_{{ENUM_NAME_CAPS}}: [&str; " +
                NumToString(range + 1) + "] = [";
 
       auto val = enum_def.Vals().front();
@@ -735,8 +735,7 @@ class RustGenerator : public BaseGenerator {
       case ftVectorOfFloat: {
         const auto typname = GetTypeBasic(type.VectorType());
         return "Option<flatbuffers::WIPOffset<flatbuffers::Vector<" + lifetime +
-               ",  " + typname + ">>>";
-               // TODO(cneo): Fix whitespace in generated code.
+               ", " + typname + ">>>";
       }
       case ftVectorOfEnumKey: {
         const auto typname = WrapInNameSpace(*type.enum_def);
@@ -1137,9 +1136,7 @@ class RustGenerator : public BaseGenerator {
     code_ += "    type Inner = {{STRUCT_NAME}}<'a>;";
     code_ += "    #[inline]";
     code_ += "    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {";
-    code_ += "        Self {";
-    code_ += "            _tab: flatbuffers::Table { buf: buf, loc: loc },";
-    code_ += "        }";
+    code_ += "        Self { _tab: flatbuffers::Table { buf, loc } }";
     code_ += "    }";
     code_ += "}";
     code_ += "";
@@ -1335,8 +1332,8 @@ class RustGenerator : public BaseGenerator {
           code_ += "      Some({{U_ELEMENT_TABLE_TYPE}}::init_from_table(u))";
         } else {
           code_ +=
-              "      self.{{FIELD_NAME}}().map(|u| "
-              "{{U_ELEMENT_TABLE_TYPE}}::init_from_table(u))";
+              "      self.{{FIELD_NAME}}().map("
+              "{{U_ELEMENT_TABLE_TYPE}}::init_from_table)";
         }
         code_ += "    } else {";
         code_ += "      None";
@@ -1358,7 +1355,7 @@ class RustGenerator : public BaseGenerator {
       const auto &field = **it;
       if (!field.deprecated) {
         code_.SetValue("PARAM_NAME", Name(field));
-        code_.SetValue("PARAM_TYPE", TableBuilderArgsDefnType(field, "'a "));
+        code_.SetValue("PARAM_TYPE", TableBuilderArgsDefnType(field, "'a"));
         code_ += "    pub {{PARAM_NAME}}: {{PARAM_TYPE}},";
       }
     }
@@ -1523,7 +1520,8 @@ class RustGenerator : public BaseGenerator {
 
     if (parser_.file_identifier_.length()) {
       // Declare the identifier
-      code_ += "pub const {{STRUCT_NAME_CAPS}}_IDENTIFIER: &'static str\\";
+      // (no lifetime needed as constants have static lifetimes by default)
+      code_ += "pub const {{STRUCT_NAME_CAPS}}_IDENTIFIER: &str\\";
       code_ += " = \"" + parser_.file_identifier_ + "\";";
       code_ += "";
 
@@ -1531,22 +1529,22 @@ class RustGenerator : public BaseGenerator {
       code_ += "#[inline]";
       code_ += "pub fn {{STRUCT_NAME_SNAKECASE}}_buffer_has_identifier\\";
       code_ += "(buf: &[u8]) -> bool {";
-      code_ += "  return flatbuffers::buffer_has_identifier(buf, \\";
-      code_ += "{{STRUCT_NAME_CAPS}}_IDENTIFIER, false);";
+      code_ += "  flatbuffers::buffer_has_identifier(buf, \\";
+      code_ += "{{STRUCT_NAME_CAPS}}_IDENTIFIER, false)";
       code_ += "}";
       code_ += "";
       code_ += "#[inline]";
       code_ += "pub fn {{STRUCT_NAME_SNAKECASE}}_size_prefixed\\";
       code_ += "_buffer_has_identifier(buf: &[u8]) -> bool {";
-      code_ += "  return flatbuffers::buffer_has_identifier(buf, \\";
-      code_ += "{{STRUCT_NAME_CAPS}}_IDENTIFIER, true);";
+      code_ += "  flatbuffers::buffer_has_identifier(buf, \\";
+      code_ += "{{STRUCT_NAME_CAPS}}_IDENTIFIER, true)";
       code_ += "}";
       code_ += "";
     }
 
     if (parser_.file_extension_.length()) {
       // Return the extension
-      code_ += "pub const {{STRUCT_NAME_CAPS}}_EXTENSION: &'static str = \\";
+      code_ += "pub const {{STRUCT_NAME_CAPS}}_EXTENSION: &str = \\";
       code_ += "\"" + parser_.file_extension_ + "\";";
       code_ += "";
     }
@@ -1694,7 +1692,7 @@ class RustGenerator : public BaseGenerator {
       const auto &field = **it;
       const auto member_name = Name(field) + "_";
       const auto reference =
-          StructMemberAccessNeedsCopy(field.value.type) ? "" : "&'a ";
+          StructMemberAccessNeedsCopy(field.value.type) ? "" : "&";
       const auto arg_name = "_" + Name(field);
       const auto arg_type = reference + GetTypeGet(field.value.type);
 
@@ -1711,7 +1709,7 @@ class RustGenerator : public BaseGenerator {
 
     code_.SetValue("ARG_LIST", arg_list);
     code_.SetValue("INIT_LIST", init_list);
-    code_ += "  pub fn new<'a>({{ARG_LIST}}) -> Self {";
+    code_ += "  pub fn new({{ARG_LIST}}) -> Self {";
     code_ += "    {{STRUCT_NAME}} {";
     code_ += "{{INIT_LIST}}";
     padding_id = 0;
@@ -1745,12 +1743,16 @@ class RustGenerator : public BaseGenerator {
       code_.SetValue("FIELD_NAME", Name(field));
       code_.SetValue("FIELD_TYPE", field_type);
       code_.SetValue("FIELD_VALUE", value);
-      code_.SetValue("REF", IsStruct(field.value.type) ? "&" : "");
-
       GenComment(field.doc_comment, "  ");
-      code_ += "  pub fn {{FIELD_NAME}}<'a>(&'a self) -> {{FIELD_TYPE}} {";
-      code_ += "    {{REF}}{{FIELD_VALUE}}";
-      code_ += "  }";
+      if (IsStruct(field.value.type)) {
+        code_ += "  pub fn {{FIELD_NAME}}<'a>(&'a self) -> {{FIELD_TYPE}} {";
+        code_ += "    &{{FIELD_VALUE}}";
+        code_ += "  }";
+      } else {
+        code_ += "  pub fn {{FIELD_NAME}}(&self) -> {{FIELD_TYPE}} {";
+        code_ += "    {{FIELD_VALUE}}";
+        code_ += "  }";
+      }
 
       // Generate a comparison function for this field if it is a key.
       if (field.key) { GenKeyFieldMethods(field); }

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -831,7 +831,7 @@ class RustGenerator : public BaseGenerator {
       }
       case ftStruct: {
         const auto typname = WrapInNameSpace(*type.struct_def);
-        return "&" + lifetime + " " + typname + "";
+        return "&" + typname + "";
       }
       case ftTable: {
         const auto typname = WrapInNameSpace(*type.struct_def);
@@ -1745,7 +1745,7 @@ class RustGenerator : public BaseGenerator {
       code_.SetValue("FIELD_VALUE", value);
       GenComment(field.doc_comment, "  ");
       if (IsStruct(field.value.type)) {
-        code_ += "  pub fn {{FIELD_NAME}}<'a>(&'a self) -> {{FIELD_TYPE}} {";
+        code_ += "  pub fn {{FIELD_NAME}}(&self) -> {{FIELD_TYPE}} {";
         code_ += "    &{{FIELD_VALUE}}";
         code_ += "  }";
       } else {

--- a/tests/include_test/include_test1_generated.rs
+++ b/tests/include_test/include_test1_generated.rs
@@ -20,9 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TableA<'a> {
     type Inner = TableA<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -51,7 +49,7 @@ impl<'a> TableA<'a> {
 }
 
 pub struct TableAArgs<'a> {
-    pub b: Option<flatbuffers::WIPOffset<my_game::other_name_space::TableB<'a >>>,
+    pub b: Option<flatbuffers::WIPOffset<my_game::other_name_space::TableB<'a>>>,
 }
 impl<'a> Default for TableAArgs<'a> {
     #[inline]

--- a/tests/include_test/sub/include_test2_generated.rs
+++ b/tests/include_test/sub/include_test2_generated.rs
@@ -71,12 +71,12 @@ impl flatbuffers::Push for FromInclude {
 }
 
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_FROM_INCLUDE:[FromInclude; 1] = [
+pub const ENUM_VALUES_FROM_INCLUDE: [FromInclude; 1] = [
   FromInclude::IncludeVal
 ];
 
 #[allow(non_camel_case_types)]
-pub const ENUM_NAMES_FROM_INCLUDE:[&'static str; 1] = [
+pub const ENUM_NAMES_FROM_INCLUDE: [&str; 1] = [
     "IncludeVal"
 ];
 
@@ -130,13 +130,13 @@ impl<'b> flatbuffers::Push for &'b Unused {
 
 
 impl Unused {
-  pub fn new<'a>(_a: i32) -> Self {
+  pub fn new(_a: i32) -> Self {
     Unused {
       a_: _a.to_little_endian(),
 
     }
   }
-  pub fn a<'a>(&'a self) -> i32 {
+  pub fn a(&self) -> i32 {
     self.a_.from_little_endian()
   }
 }
@@ -152,9 +152,7 @@ impl<'a> flatbuffers::Follow<'a> for TableB<'a> {
     type Inner = TableB<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -183,7 +181,7 @@ impl<'a> TableB<'a> {
 }
 
 pub struct TableBArgs<'a> {
-    pub a: Option<flatbuffers::WIPOffset<super::super::TableA<'a >>>,
+    pub a: Option<flatbuffers::WIPOffset<super::super::TableA<'a>>>,
 }
 impl<'a> Default for TableBArgs<'a> {
     #[inline]

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -667,7 +667,7 @@ impl Vec3 {
   pub fn test2(&self) -> Color {
     self.test2_.from_little_endian()
   }
-  pub fn test3<'a>(&'a self) -> &'a Test {
+  pub fn test3(&self) -> &Test {
     &self.test3_
   }
 }
@@ -1563,7 +1563,7 @@ pub struct MonsterBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
   #[inline]
-  pub fn add_pos(&mut self, pos: &'b  Vec3) {
+  pub fn add_pos(&mut self, pos: &Vec3) {
     self.fbb_.push_slot_always::<&Vec3>(Monster::VT_POS, pos);
   }
   #[inline]

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -32,9 +32,7 @@ impl<'a> flatbuffers::Follow<'a> for InParentNamespace<'a> {
     type Inner = InParentNamespace<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -110,9 +108,7 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
     type Inner = Monster<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -228,14 +224,14 @@ impl flatbuffers::Push for Color {
 }
 
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_COLOR:[Color; 3] = [
+pub const ENUM_VALUES_COLOR: [Color; 3] = [
   Color::Red,
   Color::Green,
   Color::Blue
 ];
 
 #[allow(non_camel_case_types)]
-pub const ENUM_NAMES_COLOR:[&'static str; 8] = [
+pub const ENUM_NAMES_COLOR: [&str; 8] = [
     "Red",
     "Green",
     "",
@@ -297,7 +293,7 @@ impl flatbuffers::Push for Race {
 }
 
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_RACE:[Race; 4] = [
+pub const ENUM_VALUES_RACE: [Race; 4] = [
   Race::None,
   Race::Human,
   Race::Dwarf,
@@ -305,7 +301,7 @@ pub const ENUM_VALUES_RACE:[Race; 4] = [
 ];
 
 #[allow(non_camel_case_types)]
-pub const ENUM_NAMES_RACE:[&'static str; 4] = [
+pub const ENUM_NAMES_RACE: [&str; 4] = [
     "None",
     "Human",
     "Dwarf",
@@ -363,7 +359,7 @@ impl flatbuffers::Push for Any {
 }
 
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_ANY:[Any; 4] = [
+pub const ENUM_VALUES_ANY: [Any; 4] = [
   Any::NONE,
   Any::Monster,
   Any::TestSimpleTableWithEnum,
@@ -371,7 +367,7 @@ pub const ENUM_VALUES_ANY:[Any; 4] = [
 ];
 
 #[allow(non_camel_case_types)]
-pub const ENUM_NAMES_ANY:[&'static str; 4] = [
+pub const ENUM_NAMES_ANY: [&str; 4] = [
     "NONE",
     "Monster",
     "TestSimpleTableWithEnum",
@@ -430,7 +426,7 @@ impl flatbuffers::Push for AnyUniqueAliases {
 }
 
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_ANY_UNIQUE_ALIASES:[AnyUniqueAliases; 4] = [
+pub const ENUM_VALUES_ANY_UNIQUE_ALIASES: [AnyUniqueAliases; 4] = [
   AnyUniqueAliases::NONE,
   AnyUniqueAliases::M,
   AnyUniqueAliases::TS,
@@ -438,7 +434,7 @@ pub const ENUM_VALUES_ANY_UNIQUE_ALIASES:[AnyUniqueAliases; 4] = [
 ];
 
 #[allow(non_camel_case_types)]
-pub const ENUM_NAMES_ANY_UNIQUE_ALIASES:[&'static str; 4] = [
+pub const ENUM_NAMES_ANY_UNIQUE_ALIASES: [&str; 4] = [
     "NONE",
     "M",
     "TS",
@@ -497,7 +493,7 @@ impl flatbuffers::Push for AnyAmbiguousAliases {
 }
 
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_ANY_AMBIGUOUS_ALIASES:[AnyAmbiguousAliases; 4] = [
+pub const ENUM_VALUES_ANY_AMBIGUOUS_ALIASES: [AnyAmbiguousAliases; 4] = [
   AnyAmbiguousAliases::NONE,
   AnyAmbiguousAliases::M1,
   AnyAmbiguousAliases::M2,
@@ -505,7 +501,7 @@ pub const ENUM_VALUES_ANY_AMBIGUOUS_ALIASES:[AnyAmbiguousAliases; 4] = [
 ];
 
 #[allow(non_camel_case_types)]
-pub const ENUM_NAMES_ANY_AMBIGUOUS_ALIASES:[&'static str; 4] = [
+pub const ENUM_NAMES_ANY_AMBIGUOUS_ALIASES: [&str; 4] = [
     "NONE",
     "M1",
     "M2",
@@ -565,7 +561,7 @@ impl<'b> flatbuffers::Push for &'b Test {
 
 
 impl Test {
-  pub fn new<'a>(_a: i16, _b: i8) -> Self {
+  pub fn new(_a: i16, _b: i8) -> Self {
     Test {
       a_: _a.to_little_endian(),
       b_: _b.to_little_endian(),
@@ -577,10 +573,10 @@ impl Test {
         "MyGame.Example.Test"
     }
 
-  pub fn a<'a>(&'a self) -> i16 {
+  pub fn a(&self) -> i16 {
     self.a_.from_little_endian()
   }
-  pub fn b<'a>(&'a self) -> i8 {
+  pub fn b(&self) -> i8 {
     self.b_.from_little_endian()
   }
 }
@@ -638,7 +634,7 @@ impl<'b> flatbuffers::Push for &'b Vec3 {
 
 
 impl Vec3 {
-  pub fn new<'a>(_x: f32, _y: f32, _z: f32, _test1: f64, _test2: Color, _test3: &'a Test) -> Self {
+  pub fn new(_x: f32, _y: f32, _z: f32, _test1: f64, _test2: Color, _test3: &Test) -> Self {
     Vec3 {
       x_: _x.to_little_endian(),
       y_: _y.to_little_endian(),
@@ -656,19 +652,19 @@ impl Vec3 {
         "MyGame.Example.Vec3"
     }
 
-  pub fn x<'a>(&'a self) -> f32 {
+  pub fn x(&self) -> f32 {
     self.x_.from_little_endian()
   }
-  pub fn y<'a>(&'a self) -> f32 {
+  pub fn y(&self) -> f32 {
     self.y_.from_little_endian()
   }
-  pub fn z<'a>(&'a self) -> f32 {
+  pub fn z(&self) -> f32 {
     self.z_.from_little_endian()
   }
-  pub fn test1<'a>(&'a self) -> f64 {
+  pub fn test1(&self) -> f64 {
     self.test1_.from_little_endian()
   }
-  pub fn test2<'a>(&'a self) -> Color {
+  pub fn test2(&self) -> Color {
     self.test2_.from_little_endian()
   }
   pub fn test3<'a>(&'a self) -> &'a Test {
@@ -722,7 +718,7 @@ impl<'b> flatbuffers::Push for &'b Ability {
 
 
 impl Ability {
-  pub fn new<'a>(_id: u32, _distance: u32) -> Self {
+  pub fn new(_id: u32, _distance: u32) -> Self {
     Ability {
       id_: _id.to_little_endian(),
       distance_: _distance.to_little_endian(),
@@ -733,7 +729,7 @@ impl Ability {
         "MyGame.Example.Ability"
     }
 
-  pub fn id<'a>(&'a self) -> u32 {
+  pub fn id(&self) -> u32 {
     self.id_.from_little_endian()
   }
   #[inline]
@@ -746,7 +742,7 @@ impl Ability {
     let key = self.id();
     key.cmp(&val)
   }
-  pub fn distance<'a>(&'a self) -> u32 {
+  pub fn distance(&self) -> u32 {
     self.distance_.from_little_endian()
   }
 }
@@ -762,9 +758,7 @@ impl<'a> flatbuffers::Follow<'a> for TestSimpleTableWithEnum<'a> {
     type Inner = TestSimpleTableWithEnum<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -842,9 +836,7 @@ impl<'a> flatbuffers::Follow<'a> for Stat<'a> {
     type Inner = Stat<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -889,7 +881,7 @@ impl<'a> Stat<'a> {
 }
 
 pub struct StatArgs<'a> {
-    pub id: Option<flatbuffers::WIPOffset<&'a  str>>,
+    pub id: Option<flatbuffers::WIPOffset<&'a str>>,
     pub val: i64,
     pub count: u16,
 }
@@ -946,9 +938,7 @@ impl<'a> flatbuffers::Follow<'a> for Referrable<'a> {
     type Inner = Referrable<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -1037,9 +1027,7 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
     type Inner = Monster<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -1376,7 +1364,7 @@ impl<'a> Monster<'a> {
   #[allow(non_snake_case)]
   pub fn test_as_monster(&self) -> Option<Monster<'a>> {
     if self.test_type() == Any::Monster {
-      self.test().map(|u| Monster::init_from_table(u))
+      self.test().map(Monster::init_from_table)
     } else {
       None
     }
@@ -1386,7 +1374,7 @@ impl<'a> Monster<'a> {
   #[allow(non_snake_case)]
   pub fn test_as_test_simple_table_with_enum(&self) -> Option<TestSimpleTableWithEnum<'a>> {
     if self.test_type() == Any::TestSimpleTableWithEnum {
-      self.test().map(|u| TestSimpleTableWithEnum::init_from_table(u))
+      self.test().map(TestSimpleTableWithEnum::init_from_table)
     } else {
       None
     }
@@ -1396,7 +1384,7 @@ impl<'a> Monster<'a> {
   #[allow(non_snake_case)]
   pub fn test_as_my_game_example_2_monster(&self) -> Option<super::example_2::Monster<'a>> {
     if self.test_type() == Any::MyGame_Example2_Monster {
-      self.test().map(|u| super::example_2::Monster::init_from_table(u))
+      self.test().map(super::example_2::Monster::init_from_table)
     } else {
       None
     }
@@ -1406,7 +1394,7 @@ impl<'a> Monster<'a> {
   #[allow(non_snake_case)]
   pub fn any_unique_as_m(&self) -> Option<Monster<'a>> {
     if self.any_unique_type() == AnyUniqueAliases::M {
-      self.any_unique().map(|u| Monster::init_from_table(u))
+      self.any_unique().map(Monster::init_from_table)
     } else {
       None
     }
@@ -1416,7 +1404,7 @@ impl<'a> Monster<'a> {
   #[allow(non_snake_case)]
   pub fn any_unique_as_ts(&self) -> Option<TestSimpleTableWithEnum<'a>> {
     if self.any_unique_type() == AnyUniqueAliases::TS {
-      self.any_unique().map(|u| TestSimpleTableWithEnum::init_from_table(u))
+      self.any_unique().map(TestSimpleTableWithEnum::init_from_table)
     } else {
       None
     }
@@ -1426,7 +1414,7 @@ impl<'a> Monster<'a> {
   #[allow(non_snake_case)]
   pub fn any_unique_as_m2(&self) -> Option<super::example_2::Monster<'a>> {
     if self.any_unique_type() == AnyUniqueAliases::M2 {
-      self.any_unique().map(|u| super::example_2::Monster::init_from_table(u))
+      self.any_unique().map(super::example_2::Monster::init_from_table)
     } else {
       None
     }
@@ -1436,7 +1424,7 @@ impl<'a> Monster<'a> {
   #[allow(non_snake_case)]
   pub fn any_ambiguous_as_m1(&self) -> Option<Monster<'a>> {
     if self.any_ambiguous_type() == AnyAmbiguousAliases::M1 {
-      self.any_ambiguous().map(|u| Monster::init_from_table(u))
+      self.any_ambiguous().map(Monster::init_from_table)
     } else {
       None
     }
@@ -1446,7 +1434,7 @@ impl<'a> Monster<'a> {
   #[allow(non_snake_case)]
   pub fn any_ambiguous_as_m2(&self) -> Option<Monster<'a>> {
     if self.any_ambiguous_type() == AnyAmbiguousAliases::M2 {
-      self.any_ambiguous().map(|u| Monster::init_from_table(u))
+      self.any_ambiguous().map(Monster::init_from_table)
     } else {
       None
     }
@@ -1456,7 +1444,7 @@ impl<'a> Monster<'a> {
   #[allow(non_snake_case)]
   pub fn any_ambiguous_as_m3(&self) -> Option<Monster<'a>> {
     if self.any_ambiguous_type() == AnyAmbiguousAliases::M3 {
-      self.any_ambiguous().map(|u| Monster::init_from_table(u))
+      self.any_ambiguous().map(Monster::init_from_table)
     } else {
       None
     }
@@ -1465,20 +1453,20 @@ impl<'a> Monster<'a> {
 }
 
 pub struct MonsterArgs<'a> {
-    pub pos: Option<&'a  Vec3>,
+    pub pos: Option<&'a Vec3>,
     pub mana: i16,
     pub hp: i16,
-    pub name: Option<flatbuffers::WIPOffset<&'a  str>>,
-    pub inventory: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u8>>>,
+    pub name: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub inventory: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
     pub color: Color,
     pub test_type: Any,
     pub test: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
-    pub test4: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , Test>>>,
-    pub testarrayofstring: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<&'a  str>>>>,
-    pub testarrayoftables: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Monster<'a >>>>>,
-    pub enemy: Option<flatbuffers::WIPOffset<Monster<'a >>>,
-    pub testnestedflatbuffer: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u8>>>,
-    pub testempty: Option<flatbuffers::WIPOffset<Stat<'a >>>,
+    pub test4: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, Test>>>,
+    pub testarrayofstring: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>>>,
+    pub testarrayoftables: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Monster<'a>>>>>,
+    pub enemy: Option<flatbuffers::WIPOffset<Monster<'a>>>,
+    pub testnestedflatbuffer: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub testempty: Option<flatbuffers::WIPOffset<Stat<'a>>>,
     pub testbool: bool,
     pub testhashs32_fnv1: i32,
     pub testhashu32_fnv1: u32,
@@ -1488,30 +1476,30 @@ pub struct MonsterArgs<'a> {
     pub testhashu32_fnv1a: u32,
     pub testhashs64_fnv1a: i64,
     pub testhashu64_fnv1a: u64,
-    pub testarrayofbools: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  bool>>>,
+    pub testarrayofbools: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, bool>>>,
     pub testf: f32,
     pub testf2: f32,
     pub testf3: f32,
-    pub testarrayofstring2: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<&'a  str>>>>,
-    pub testarrayofsortedstruct: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , Ability>>>,
-    pub flex: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u8>>>,
-    pub test5: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , Test>>>,
-    pub vector_of_longs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  i64>>>,
-    pub vector_of_doubles: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  f64>>>,
-    pub parent_namespace_test: Option<flatbuffers::WIPOffset<super::InParentNamespace<'a >>>,
-    pub vector_of_referrables: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Referrable<'a >>>>>,
+    pub testarrayofstring2: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>>>,
+    pub testarrayofsortedstruct: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, Ability>>>,
+    pub flex: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub test5: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, Test>>>,
+    pub vector_of_longs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, i64>>>,
+    pub vector_of_doubles: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, f64>>>,
+    pub parent_namespace_test: Option<flatbuffers::WIPOffset<super::InParentNamespace<'a>>>,
+    pub vector_of_referrables: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Referrable<'a>>>>>,
     pub single_weak_reference: u64,
-    pub vector_of_weak_references: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u64>>>,
-    pub vector_of_strong_referrables: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Referrable<'a >>>>>,
+    pub vector_of_weak_references: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u64>>>,
+    pub vector_of_strong_referrables: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Referrable<'a>>>>>,
     pub co_owning_reference: u64,
-    pub vector_of_co_owning_references: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u64>>>,
+    pub vector_of_co_owning_references: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u64>>>,
     pub non_owning_reference: u64,
-    pub vector_of_non_owning_references: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u64>>>,
+    pub vector_of_non_owning_references: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u64>>>,
     pub any_unique_type: AnyUniqueAliases,
     pub any_unique: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
     pub any_ambiguous_type: AnyAmbiguousAliases,
     pub any_ambiguous: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
-    pub vector_of_enums: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , Color>>>,
+    pub vector_of_enums: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, Color>>>,
     pub signed_enum: Race,
 }
 impl<'a> Default for MonsterArgs<'a> {
@@ -1793,9 +1781,7 @@ impl<'a> flatbuffers::Follow<'a> for TypeAliases<'a> {
     type Inner = TypeAliases<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -1904,8 +1890,8 @@ pub struct TypeAliasesArgs<'a> {
     pub u64_: u64,
     pub f32_: f32,
     pub f64_: f64,
-    pub v8: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  i8>>>,
-    pub vf64: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  f64>>>,
+    pub v8: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, i8>>>,
+    pub vf64: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, f64>>>,
 }
 impl<'a> Default for TypeAliasesArgs<'a> {
     #[inline]
@@ -2004,19 +1990,19 @@ pub fn get_size_prefixed_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
   flatbuffers::get_size_prefixed_root::<Monster<'a>>(buf)
 }
 
-pub const MONSTER_IDENTIFIER: &'static str = "MONS";
+pub const MONSTER_IDENTIFIER: &str = "MONS";
 
 #[inline]
 pub fn monster_buffer_has_identifier(buf: &[u8]) -> bool {
-  return flatbuffers::buffer_has_identifier(buf, MONSTER_IDENTIFIER, false);
+  flatbuffers::buffer_has_identifier(buf, MONSTER_IDENTIFIER, false)
 }
 
 #[inline]
 pub fn monster_size_prefixed_buffer_has_identifier(buf: &[u8]) -> bool {
-  return flatbuffers::buffer_has_identifier(buf, MONSTER_IDENTIFIER, true);
+  flatbuffers::buffer_has_identifier(buf, MONSTER_IDENTIFIER, true)
 }
 
-pub const MONSTER_EXTENSION: &'static str = "mon";
+pub const MONSTER_EXTENSION: &str = "mon";
 
 #[inline]
 pub fn finish_monster_buffer<'a, 'b>(

--- a/tests/namespace_test/namespace_test1_generated.rs
+++ b/tests/namespace_test/namespace_test1_generated.rs
@@ -70,14 +70,14 @@ impl flatbuffers::Push for EnumInNestedNS {
 }
 
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_ENUM_IN_NESTED_NS:[EnumInNestedNS; 3] = [
+pub const ENUM_VALUES_ENUM_IN_NESTED_NS: [EnumInNestedNS; 3] = [
   EnumInNestedNS::A,
   EnumInNestedNS::B,
   EnumInNestedNS::C
 ];
 
 #[allow(non_camel_case_types)]
-pub const ENUM_NAMES_ENUM_IN_NESTED_NS:[&'static str; 3] = [
+pub const ENUM_NAMES_ENUM_IN_NESTED_NS: [&str; 3] = [
     "A",
     "B",
     "C"
@@ -134,17 +134,17 @@ impl<'b> flatbuffers::Push for &'b StructInNestedNS {
 
 
 impl StructInNestedNS {
-  pub fn new<'a>(_a: i32, _b: i32) -> Self {
+  pub fn new(_a: i32, _b: i32) -> Self {
     StructInNestedNS {
       a_: _a.to_little_endian(),
       b_: _b.to_little_endian(),
 
     }
   }
-  pub fn a<'a>(&'a self) -> i32 {
+  pub fn a(&self) -> i32 {
     self.a_.from_little_endian()
   }
-  pub fn b<'a>(&'a self) -> i32 {
+  pub fn b(&self) -> i32 {
     self.b_.from_little_endian()
   }
 }
@@ -160,9 +160,7 @@ impl<'a> flatbuffers::Follow<'a> for TableInNestedNS<'a> {
     type Inner = TableInNestedNS<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 

--- a/tests/namespace_test/namespace_test2_generated.rs
+++ b/tests/namespace_test/namespace_test2_generated.rs
@@ -30,9 +30,7 @@ impl<'a> flatbuffers::Follow<'a> for TableInFirstNS<'a> {
     type Inner = TableInFirstNS<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -73,9 +71,9 @@ impl<'a> TableInFirstNS<'a> {
 }
 
 pub struct TableInFirstNSArgs<'a> {
-    pub foo_table: Option<flatbuffers::WIPOffset<namespace_b::TableInNestedNS<'a >>>,
+    pub foo_table: Option<flatbuffers::WIPOffset<namespace_b::TableInNestedNS<'a>>>,
     pub foo_enum: namespace_b::EnumInNestedNS,
-    pub foo_struct: Option<&'a  namespace_b::StructInNestedNS>,
+    pub foo_struct: Option<&'a namespace_b::StructInNestedNS>,
 }
 impl<'a> Default for TableInFirstNSArgs<'a> {
     #[inline]
@@ -130,9 +128,7 @@ impl<'a> flatbuffers::Follow<'a> for SecondTableInA<'a> {
     type Inner = SecondTableInA<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -161,7 +157,7 @@ impl<'a> SecondTableInA<'a> {
 }
 
 pub struct SecondTableInAArgs<'a> {
-    pub refer_to_c: Option<flatbuffers::WIPOffset<super::namespace_c::TableInC<'a >>>,
+    pub refer_to_c: Option<flatbuffers::WIPOffset<super::namespace_c::TableInC<'a>>>,
 }
 impl<'a> Default for SecondTableInAArgs<'a> {
     #[inline]
@@ -218,9 +214,7 @@ impl<'a> flatbuffers::Follow<'a> for TableInC<'a> {
     type Inner = TableInC<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 
@@ -255,8 +249,8 @@ impl<'a> TableInC<'a> {
 }
 
 pub struct TableInCArgs<'a> {
-    pub refer_to_a1: Option<flatbuffers::WIPOffset<super::namespace_a::TableInFirstNS<'a >>>,
-    pub refer_to_a2: Option<flatbuffers::WIPOffset<super::namespace_a::SecondTableInA<'a >>>,
+    pub refer_to_a1: Option<flatbuffers::WIPOffset<super::namespace_a::TableInFirstNS<'a>>>,
+    pub refer_to_a2: Option<flatbuffers::WIPOffset<super::namespace_a::SecondTableInA<'a>>>,
 }
 impl<'a> Default for TableInCArgs<'a> {
     #[inline]

--- a/tests/namespace_test/namespace_test2_generated.rs
+++ b/tests/namespace_test/namespace_test2_generated.rs
@@ -99,7 +99,7 @@ impl<'a: 'b, 'b> TableInFirstNSBuilder<'a, 'b> {
     self.fbb_.push_slot::<namespace_b::EnumInNestedNS>(TableInFirstNS::VT_FOO_ENUM, foo_enum, namespace_b::EnumInNestedNS::A);
   }
   #[inline]
-  pub fn add_foo_struct(&mut self, foo_struct: &'b  namespace_b::StructInNestedNS) {
+  pub fn add_foo_struct(&mut self, foo_struct: &namespace_b::StructInNestedNS) {
     self.fbb_.push_slot_always::<&namespace_b::StructInNestedNS>(TableInFirstNS::VT_FOO_STRUCT, foo_struct);
   }
   #[inline]

--- a/tests/optional_scalars_generated.rs
+++ b/tests/optional_scalars_generated.rs
@@ -28,9 +28,7 @@ impl<'a> flatbuffers::Follow<'a> for ScalarStuff<'a> {
     type Inner = ScalarStuff<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf, loc } }
     }
 }
 


### PR DESCRIPTION
Hi @rw, 

This PR makes some improvements to the Rust codegen by:
- Fixing some whitespace
- Removing unnecessary lifetime specifications
- Removing unnecessary `'static` specifications
- Removed unneeded `return` at the end of scope
- Removing redundant field names in struct initialization
- Removing an unnecessary closure

To measure improvements via `cargo clippy` lints, the errors and warnings go from 132 to 27. The remaining ones are:
- ` 6 approx_constant`: we use low precision PI as a default float in the monster_test schema so its intended behavior
- ` 2 cognitive_complexity`: generated code is complex, yea. We could generate an `allow` for this.
- ` 1 float_cmp`: I used assert_eq in a float in samples/flexbuffers.rs. Fixing it might hurt the readability of the sample.
- `18 trivially_copy_pass_by_ref`: These are <=8byte structs that are pass-by-reference. They should be Copy and pass-by-value. Fixing this in codegen is hard but probably worth a tiny performance boost.