### PR TITLE
[C++] Fix compiler error from deleted assignment operator (#6036)

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1879,10 +1879,7 @@ class FlatBufferBuilder {
     vector_downward &buf_;
 
    private:
-    TableKeyComparator &operator=(const TableKeyComparator &other) {
-      buf_ = other.buf_;
-      return *this;
-    }
+    FLATBUFFERS_DELETE_FUNC(TableKeyComparator &operator=(const TableKeyComparator &other));
   };
   /// @endcond
 

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1879,7 +1879,7 @@ class FlatBufferBuilder {
     vector_downward &buf_;
 
    private:
-    FLATBUFFERS_DELETE_FUNC(TableKeyComparator &operator=(const TableKeyComparator &other));
+    FLATBUFFERS_DELETE_FUNC(TableKeyComparator &operator=(const TableKeyComparator &other))
   };
   /// @endcond
 


### PR DESCRIPTION
The assignment operator of the `buf_` member is deleted, we cannot call it from the assignment operator of the `TableKeyComparator` struct.

=> Also delete the assignment operator of the `TableKeyComparator` struct (already private anyhow).
