### PR TITLE
[Swift] Append namespace for Swift Grpc implementation

### DIFF
--- a/grpc/src/compiler/schema_interface.h
+++ b/grpc/src/compiler/schema_interface.h
@@ -62,7 +62,9 @@ struct Method : public CommentHolder {
       grpc::string *str, grpc::string generator_file_name,
       bool generate_in_pb2_grpc, grpc::string import_prefix) const = 0;
 
+  virtual std::vector<grpc::string> get_input_namespace_parts() const = 0;
   virtual grpc::string get_input_type_name() const = 0;
+  virtual std::vector<grpc::string> get_output_namespace_parts() const = 0;
   virtual grpc::string get_output_type_name() const = 0;
 
   virtual grpc::string get_fb_builder() const = 0;
@@ -77,6 +79,7 @@ struct Method : public CommentHolder {
 struct Service : public CommentHolder {
   virtual ~Service() {}
 
+  virtual std::vector<grpc::string> namespace_parts() const = 0;
   virtual grpc::string name() const = 0;
 
   virtual int method_count() const = 0;

--- a/grpc/src/compiler/swift_generator.cc
+++ b/grpc/src/compiler/swift_generator.cc
@@ -29,8 +29,15 @@
 
 namespace grpc_swift_generator {
 
-grpc::string GenerateMessage(const grpc::string &name) {
-  return "Message<" + name + ">";
+std::string WrapInNameSpace(const std::vector<std::string> &components, const grpc::string &name) {
+  std::string qualified_name;
+  for (auto it = components.begin(); it != components.end(); ++it)
+    qualified_name += *it + "_";
+  return qualified_name + name;
+}
+
+grpc::string GenerateMessage(const std::vector<std::string> &components, const grpc::string &name) {
+  return "Message<" + WrapInNameSpace(components, name) + ">";
 }
 
 // MARK: - Client
@@ -89,8 +96,8 @@ void GenerateClientProtocol(const grpc_generator::Service *service,
   vars["GenAccess"] = "";
   for (auto it = 0; it < service->method_count(); it++) {
     auto method = service->method(it);
-    vars["Input"] = GenerateMessage(method->get_input_type_name());
-    vars["Output"] = GenerateMessage(method->get_output_type_name());
+    vars["Input"] = GenerateMessage(method->get_input_namespace_parts(), method->get_input_type_name());
+    vars["Output"] = GenerateMessage(method->get_output_namespace_parts(), method->get_output_type_name());
     vars["MethodName"] = method->name();
     vars["isNil"] = "";
     printer->Print("\t");
@@ -121,8 +128,8 @@ void GenerateClientClass(const grpc_generator::Service *service,
   vars["GenAccess"] = "public";
   for (auto it = 0; it < service->method_count(); it++) {
     auto method = service->method(it);
-    vars["Input"] = GenerateMessage(method->get_input_type_name());
-    vars["Output"] = GenerateMessage(method->get_output_type_name());
+    vars["Input"] = GenerateMessage(method->get_input_namespace_parts(), method->get_input_type_name());
+    vars["Output"] = GenerateMessage(method->get_output_namespace_parts(), method->get_output_type_name());
     vars["MethodName"] = method->name();
     vars["isNil"] = " = nil";
     printer->Print("\n\t");
@@ -211,8 +218,8 @@ void GenerateServerProtocol(const grpc_generator::Service *service,
       vars, "$ACCESS$ protocol $ServiceName$Provider: CallHandlerProvider {\n");
   for (auto it = 0; it < service->method_count(); it++) {
     auto method = service->method(it);
-    vars["Input"] = GenerateMessage(method->get_input_type_name());
-    vars["Output"] = GenerateMessage(method->get_output_type_name());
+    vars["Input"] = GenerateMessage(method->get_input_namespace_parts(), method->get_input_type_name());
+    vars["Output"] = GenerateMessage(method->get_output_namespace_parts(), method->get_output_type_name());
     vars["MethodName"] = method->name();
     printer->Print("\t");
     auto func = GenerateServerFuncName(method.get());
@@ -231,8 +238,8 @@ void GenerateServerProtocol(const grpc_generator::Service *service,
   printer->Print("\t\tswitch methodName {\n");
   for (auto it = 0; it < service->method_count(); it++) {
     auto method = service->method(it);
-    vars["Input"] = GenerateMessage(method->get_input_type_name());
-    vars["Output"] = GenerateMessage(method->get_output_type_name());
+    vars["Input"] = GenerateMessage(method->get_input_namespace_parts(), method->get_input_type_name());
+    vars["Output"] = GenerateMessage(method->get_output_namespace_parts(), method->get_output_type_name());
     vars["MethodName"] = method->name();
     auto body = GenerateServerExtensionBody(method.get());
     printer->Print(vars, body.c_str());
@@ -250,7 +257,7 @@ grpc::string Generate(grpc_generator::File *file,
   std::map<grpc::string, grpc::string> vars;
   vars["PATH"] = file->package();
   if (!file->package().empty()) { vars["PATH"].append("."); }
-  vars["ServiceName"] = service->name();
+  vars["ServiceName"] = WrapInNameSpace(service->namespace_parts(), service->name());
   vars["ACCESS"] = "public";
   auto printer = file->CreatePrinter(&output);
   printer->Print(vars,

--- a/grpc/src/compiler/swift_generator.cc
+++ b/grpc/src/compiler/swift_generator.cc
@@ -92,7 +92,7 @@ void GenerateClientProtocol(const grpc_generator::Service *service,
                             grpc_generator::Printer *printer,
                             std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
-  printer->Print(vars, "$ACCESS$ protocol $ServiceName$Service {\n");
+  printer->Print(vars, "$ACCESS$ protocol $ServiceQualifiedName$Service {\n");
   vars["GenAccess"] = "";
   for (auto it = 0; it < service->method_count(); it++) {
     auto method = service->method(it);
@@ -113,8 +113,8 @@ void GenerateClientClass(const grpc_generator::Service *service,
                          std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
   printer->Print(vars,
-                 "$ACCESS$ final class $ServiceName$ServiceClient: GRPCClient, "
-                 "$ServiceName$Service {\n");
+                 "$ACCESS$ final class $ServiceQualifiedName$ServiceClient: GRPCClient, "
+                 "$ServiceQualifiedName$Service {\n");
   printer->Print(vars, "\t$ACCESS$ let channel: GRPCChannel\n");
   printer->Print(vars, "\t$ACCESS$ var defaultCallOptions: CallOptions\n");
   printer->Print("\n");
@@ -215,7 +215,7 @@ void GenerateServerProtocol(const grpc_generator::Service *service,
                             std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
   printer->Print(
-      vars, "$ACCESS$ protocol $ServiceName$Provider: CallHandlerProvider {\n");
+      vars, "$ACCESS$ protocol $ServiceQualifiedName$Provider: CallHandlerProvider {\n");
   for (auto it = 0; it < service->method_count(); it++) {
     auto method = service->method(it);
     vars["Input"] = GenerateMessage(method->get_input_namespace_parts(), method->get_input_type_name());
@@ -228,7 +228,7 @@ void GenerateServerProtocol(const grpc_generator::Service *service,
   }
   printer->Print("}\n\n");
 
-  printer->Print(vars, "$ACCESS$ extension $ServiceName$Provider {\n");
+  printer->Print(vars, "$ACCESS$ extension $ServiceQualifiedName$Provider {\n");
   printer->Print(vars,
                  "\tvar serviceName: String { return "
                  "\"$PATH$$ServiceName$\" }\n");
@@ -257,11 +257,12 @@ grpc::string Generate(grpc_generator::File *file,
   std::map<grpc::string, grpc::string> vars;
   vars["PATH"] = file->package();
   if (!file->package().empty()) { vars["PATH"].append("."); }
-  vars["ServiceName"] = WrapInNameSpace(service->namespace_parts(), service->name());
+  vars["ServiceQualifiedName"] = WrapInNameSpace(service->namespace_parts(), service->name());
+  vars["ServiceName"] = service->name();
   vars["ACCESS"] = "public";
   auto printer = file->CreatePrinter(&output);
   printer->Print(vars,
-                 "/// Usage: instantiate $ServiceName$ServiceClient, then call "
+                 "/// Usage: instantiate $ServiceQualifiedName$ServiceClient, then call "
                  "methods of this protocol to make API calls.\n");
   GenerateClientProtocol(service, &*printer, &vars);
   GenerateClientClass(service, &*printer, &vars);

--- a/src/idl_gen_grpc.cpp
+++ b/src/idl_gen_grpc.cpp
@@ -59,11 +59,17 @@ class FlatBufMethod : public grpc_generator::Method {
 
   std::string name() const { return method_->name; }
 
+  // TODO: This method need to incorporate namespace for C++ side. Other language bindings
+  // simply don't use this method.
   std::string GRPCType(const StructDef &sd) const {
     return "flatbuffers::grpc::Message<" + sd.name + ">";
   }
 
+  std::vector<std::string> get_input_namespace_parts() const { return (*method_->request).defined_namespace->components; }
+
   std::string get_input_type_name() const { return (*method_->request).name; }
+
+  std::vector<std::string>  get_output_namespace_parts() const { return (*method_->response).defined_namespace->components; }
 
   std::string get_output_type_name() const { return (*method_->response).name; }
 
@@ -110,6 +116,8 @@ class FlatBufService : public grpc_generator::Service {
   std::vector<grpc::string> GetAllComments() const {
     return service_->doc_comment;
   }
+
+  std::vector<grpc::string> namespace_parts() const { return service_->defined_namespace->components; }
 
   std::string name() const { return service_->name; }
 

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test.grpc.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test.grpc.swift
@@ -37,19 +37,19 @@ public final class MyGame_Example_MonsterStorageServiceClient: GRPCClient, MyGam
 	}
 
 	public func Store(_ request: Message<MyGame_Example_Monster>, callOptions: CallOptions? = nil) -> UnaryCall<Message<MyGame_Example_Monster>,Message<MyGame_Example_Stat>> {
-		return self.makeUnaryCall(path: "/MyGame.Example.MyGame_Example_MonsterStorage/Store", request: request, callOptions: callOptions ?? self.defaultCallOptions)
+		return self.makeUnaryCall(path: "/MyGame.Example.MonsterStorage/Store", request: request, callOptions: callOptions ?? self.defaultCallOptions)
 	}
 
 	public func Retrieve(_ request: Message<MyGame_Example_Stat>, callOptions: CallOptions? = nil, handler: @escaping (Message<MyGame_Example_Monster>) -> Void) -> ServerStreamingCall<Message<MyGame_Example_Stat>, Message<MyGame_Example_Monster>> {
-		return self.makeServerStreamingCall(path: "/MyGame.Example.MyGame_Example_MonsterStorage/Retrieve", request: request, callOptions: callOptions ?? self.defaultCallOptions, handler: handler)
+		return self.makeServerStreamingCall(path: "/MyGame.Example.MonsterStorage/Retrieve", request: request, callOptions: callOptions ?? self.defaultCallOptions, handler: handler)
 	}
 
 	public func GetMaxHitPoint(callOptions: CallOptions? = nil) -> ClientStreamingCall<Message<MyGame_Example_Monster>,Message<MyGame_Example_Stat>> {
-		return self.makeClientStreamingCall(path: "/MyGame.Example.MyGame_Example_MonsterStorage/GetMaxHitPoint", callOptions: callOptions ?? self.defaultCallOptions)
+		return self.makeClientStreamingCall(path: "/MyGame.Example.MonsterStorage/GetMaxHitPoint", callOptions: callOptions ?? self.defaultCallOptions)
 	}
 
 	public func GetMinMaxHitPoints(callOptions: CallOptions? = nil, handler: @escaping (Message<MyGame_Example_Stat>) -> Void) -> BidirectionalStreamingCall<Message<MyGame_Example_Monster>, Message<MyGame_Example_Stat>> {
-		return self.makeBidirectionalStreamingCall(path: "/MyGame.Example.MyGame_Example_MonsterStorage/GetMinMaxHitPoints", callOptions: callOptions ?? self.defaultCallOptions, handler: handler)
+		return self.makeBidirectionalStreamingCall(path: "/MyGame.Example.MonsterStorage/GetMinMaxHitPoints", callOptions: callOptions ?? self.defaultCallOptions, handler: handler)
 	}
 }
 
@@ -61,7 +61,7 @@ public protocol MyGame_Example_MonsterStorageProvider: CallHandlerProvider {
 }
 
 public extension MyGame_Example_MonsterStorageProvider {
-	var serviceName: String { return "MyGame.Example.MyGame_Example_MonsterStorage" }
+	var serviceName: String { return "MyGame.Example.MonsterStorage" }
 	func handleMethod(_ methodName: String, callHandlerContext: CallHandlerContext) -> GRPCCallHandler? {
 		switch methodName {
 		case "Store":

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test.grpc.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test.grpc.swift
@@ -19,15 +19,15 @@ public extension GRPCFlatBufPayload {
 }
 extension Message: GRPCFlatBufPayload {}
 
-/// Usage: instantiate MonsterStorageServiceClient, then call methods of this protocol to make API calls.
-public protocol MonsterStorageService {
-	 func Store(_ request: Message<Monster>, callOptions: CallOptions?) -> UnaryCall<Message<Monster>,Message<Stat>>
-	 func Retrieve(_ request: Message<Stat>, callOptions: CallOptions?, handler: @escaping (Message<Monster>) -> Void) -> ServerStreamingCall<Message<Stat>, Message<Monster>>
-	 func GetMaxHitPoint(callOptions: CallOptions?) -> ClientStreamingCall<Message<Monster>,Message<Stat>>
-	 func GetMinMaxHitPoints(callOptions: CallOptions?, handler: @escaping (Message<Stat>) -> Void) -> BidirectionalStreamingCall<Message<Monster>, Message<Stat>>
+/// Usage: instantiate MyGame_Example_MonsterStorageServiceClient, then call methods of this protocol to make API calls.
+public protocol MyGame_Example_MonsterStorageService {
+	 func Store(_ request: Message<MyGame_Example_Monster>, callOptions: CallOptions?) -> UnaryCall<Message<MyGame_Example_Monster>,Message<MyGame_Example_Stat>>
+	 func Retrieve(_ request: Message<MyGame_Example_Stat>, callOptions: CallOptions?, handler: @escaping (Message<MyGame_Example_Monster>) -> Void) -> ServerStreamingCall<Message<MyGame_Example_Stat>, Message<MyGame_Example_Monster>>
+	 func GetMaxHitPoint(callOptions: CallOptions?) -> ClientStreamingCall<Message<MyGame_Example_Monster>,Message<MyGame_Example_Stat>>
+	 func GetMinMaxHitPoints(callOptions: CallOptions?, handler: @escaping (Message<MyGame_Example_Stat>) -> Void) -> BidirectionalStreamingCall<Message<MyGame_Example_Monster>, Message<MyGame_Example_Stat>>
 }
 
-public final class MonsterStorageServiceClient: GRPCClient, MonsterStorageService {
+public final class MyGame_Example_MonsterStorageServiceClient: GRPCClient, MyGame_Example_MonsterStorageService {
 	public let channel: GRPCChannel
 	public var defaultCallOptions: CallOptions
 
@@ -36,32 +36,32 @@ public final class MonsterStorageServiceClient: GRPCClient, MonsterStorageServic
 		self.defaultCallOptions = defaultCallOptions
 	}
 
-	public func Store(_ request: Message<Monster>, callOptions: CallOptions? = nil) -> UnaryCall<Message<Monster>,Message<Stat>> {
-		return self.makeUnaryCall(path: "/MyGame.Example.MonsterStorage/Store", request: request, callOptions: callOptions ?? self.defaultCallOptions)
+	public func Store(_ request: Message<MyGame_Example_Monster>, callOptions: CallOptions? = nil) -> UnaryCall<Message<MyGame_Example_Monster>,Message<MyGame_Example_Stat>> {
+		return self.makeUnaryCall(path: "/MyGame.Example.MyGame_Example_MonsterStorage/Store", request: request, callOptions: callOptions ?? self.defaultCallOptions)
 	}
 
-	public func Retrieve(_ request: Message<Stat>, callOptions: CallOptions? = nil, handler: @escaping (Message<Monster>) -> Void) -> ServerStreamingCall<Message<Stat>, Message<Monster>> {
-		return self.makeServerStreamingCall(path: "/MyGame.Example.MonsterStorage/Retrieve", request: request, callOptions: callOptions ?? self.defaultCallOptions, handler: handler)
+	public func Retrieve(_ request: Message<MyGame_Example_Stat>, callOptions: CallOptions? = nil, handler: @escaping (Message<MyGame_Example_Monster>) -> Void) -> ServerStreamingCall<Message<MyGame_Example_Stat>, Message<MyGame_Example_Monster>> {
+		return self.makeServerStreamingCall(path: "/MyGame.Example.MyGame_Example_MonsterStorage/Retrieve", request: request, callOptions: callOptions ?? self.defaultCallOptions, handler: handler)
 	}
 
-	public func GetMaxHitPoint(callOptions: CallOptions? = nil) -> ClientStreamingCall<Message<Monster>,Message<Stat>> {
-		return self.makeClientStreamingCall(path: "/MyGame.Example.MonsterStorage/GetMaxHitPoint", callOptions: callOptions ?? self.defaultCallOptions)
+	public func GetMaxHitPoint(callOptions: CallOptions? = nil) -> ClientStreamingCall<Message<MyGame_Example_Monster>,Message<MyGame_Example_Stat>> {
+		return self.makeClientStreamingCall(path: "/MyGame.Example.MyGame_Example_MonsterStorage/GetMaxHitPoint", callOptions: callOptions ?? self.defaultCallOptions)
 	}
 
-	public func GetMinMaxHitPoints(callOptions: CallOptions? = nil, handler: @escaping (Message<Stat>) -> Void) -> BidirectionalStreamingCall<Message<Monster>, Message<Stat>> {
-		return self.makeBidirectionalStreamingCall(path: "/MyGame.Example.MonsterStorage/GetMinMaxHitPoints", callOptions: callOptions ?? self.defaultCallOptions, handler: handler)
+	public func GetMinMaxHitPoints(callOptions: CallOptions? = nil, handler: @escaping (Message<MyGame_Example_Stat>) -> Void) -> BidirectionalStreamingCall<Message<MyGame_Example_Monster>, Message<MyGame_Example_Stat>> {
+		return self.makeBidirectionalStreamingCall(path: "/MyGame.Example.MyGame_Example_MonsterStorage/GetMinMaxHitPoints", callOptions: callOptions ?? self.defaultCallOptions, handler: handler)
 	}
 }
 
-public protocol MonsterStorageProvider: CallHandlerProvider {
-	func Store(_ request: Message<Monster>, context: StatusOnlyCallContext) -> EventLoopFuture<Message<Stat>>
-	func Retrieve(request: Message<Stat>, context: StreamingResponseCallContext<Message<Monster>>) -> EventLoopFuture<GRPCStatus>
-	func GetMaxHitPoint(context: UnaryResponseCallContext<Message<Stat>>) -> EventLoopFuture<(StreamEvent<Message<Monster>>) -> Void>
-	func GetMinMaxHitPoints(context: StreamingResponseCallContext<Message<Stat>>) -> EventLoopFuture<(StreamEvent<Message<Monster>>) -> Void>
+public protocol MyGame_Example_MonsterStorageProvider: CallHandlerProvider {
+	func Store(_ request: Message<MyGame_Example_Monster>, context: StatusOnlyCallContext) -> EventLoopFuture<Message<MyGame_Example_Stat>>
+	func Retrieve(request: Message<MyGame_Example_Stat>, context: StreamingResponseCallContext<Message<MyGame_Example_Monster>>) -> EventLoopFuture<GRPCStatus>
+	func GetMaxHitPoint(context: UnaryResponseCallContext<Message<MyGame_Example_Stat>>) -> EventLoopFuture<(StreamEvent<Message<MyGame_Example_Monster>>) -> Void>
+	func GetMinMaxHitPoints(context: StreamingResponseCallContext<Message<MyGame_Example_Stat>>) -> EventLoopFuture<(StreamEvent<Message<MyGame_Example_Monster>>) -> Void>
 }
 
-public extension MonsterStorageProvider {
-	var serviceName: String { return "MyGame.Example.MonsterStorage" }
+public extension MyGame_Example_MonsterStorageProvider {
+	var serviceName: String { return "MyGame.Example.MyGame_Example_MonsterStorage" }
 	func handleMethod(_ methodName: String, callHandlerContext: CallHandlerContext) -> GRPCCallHandler? {
 		switch methodName {
 		case "Store":


### PR DESCRIPTION
This PR changed schema_interface.h, idl_gen_grpc.cpp to include
get_input_namespace_parts, get_output_namespace_parts and
namespace_parts method into FlatBufMethod, FlatBufService.
    
It looks like the schema_interface.h doesn't have dependency on
flatbuffers, I am not certain where it comes from and whether it is safe
for such change, but made the change anyway.
    
You can take a look at PR:
https://github.com/google/flatbuffers/pull/6045 for more discussions on
why this change is needed.
