### PR TITLE
[Swift] Adds a serialize helper function to native table

### DIFF
--- a/swift/FlatBuffers.podspec
+++ b/swift/FlatBuffers.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FlatBuffers'
-  s.version          = '0.7.0'
+  s.version          = '0.7.1'
   s.summary          = 'FlatBuffers: Memory Efficient Serialization Library'
 
   s.description      = "FlatBuffers is a cross platform serialization library architected for

--- a/swift/Sources/FlatBuffers/FlatBufferObject.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferObject.swift
@@ -6,8 +6,6 @@ public protocol FlatBufferObject {
     init(_ bb: ByteBuffer, o: Int32)
 }
 
-public protocol NativeTable {}
-
 public protocol ObjectAPI {
     associatedtype T
     static func pack(_ builder: inout FlatBufferBuilder, obj: inout T) -> Offset<UOffset>

--- a/swift/Sources/FlatBuffers/NativeTable.swift
+++ b/swift/Sources/FlatBuffers/NativeTable.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public protocol NativeTable {}
+
+extension NativeTable {
+    
+    /// Serialize is a helper function that serailizes the data from the Object API to a bytebuffer directly th
+    /// - Parameter type: Type of the Flatbuffer object
+    /// - Returns: returns the encoded sized ByteBuffer
+    public func serialize<T: ObjectAPI>(type: T.Type) -> ByteBuffer where T.T == Self {
+        var builder = FlatBufferBuilder(initialSize: 1024)
+        return serialize(builder: &builder, type: type.self)
+    }
+    
+    /// Serialize is a helper function that serailizes the data from the Object API to a bytebuffer directly.
+    ///
+    /// - Parameters:
+    ///   - builder: A FlatBufferBuilder
+    ///   - type: Type of the Flatbuffer object
+    /// - Returns: returns the encoded sized ByteBuffer
+    /// - Note: The `serialize(builder:type)` can be considered as a function that allows you to create smaller builder instead of the default `1024`.
+    ///  It can be considered less expensive in terms of memory allocation
+    public func serialize<T: ObjectAPI>(builder: inout FlatBufferBuilder, type: T.Type) -> ByteBuffer where T.T == Self {
+        var s = self
+        let root = type.pack(&builder, obj: &s)
+        builder.finish(offset: root)
+        return builder.sizedBuffer
+    }
+}

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
@@ -81,12 +81,10 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     func readMonster(fb: ByteBuffer) {
         var monster = Monster.getRootAsMonster(bb: fb)
         readFlatbufferMonster(monster: &monster)
-        var unpacked: MyGame_Example_MonsterT? = monster.unpack()
+        let unpacked: MyGame_Example_MonsterT? = monster.unpack()
         readObjectApi(monster: unpacked!)
-        var builder = FlatBufferBuilder()
-        let root = Monster.pack(&builder, obj: &unpacked)
-        builder.finish(offset: root)
-        var newMonster = Monster.getRootAsMonster(bb: builder.sizedBuffer)
+        guard let buffer = unpacked?.serialize() else { fatalError("Couldnt generate bytebuffer") }
+        var newMonster = Monster.getRootAsMonster(bb: buffer)
         readFlatbufferMonster(monster: &newMonster)
     }
     

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
@@ -334,7 +334,7 @@ extension MyGame_Example_Ability {
 
 }
 
-public struct MyGame_InParentNamespace: FlatBufferObject {
+public struct MyGame_InParentNamespace: FlatBufferObject, ObjectAPI {
 
     static func validateVersion() { FlatBuffersVersion_1_12_0() }
     public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -373,8 +373,10 @@ public class MyGame_InParentNamespaceT: NativeTable {
     init() {
     }
 
+    func serialize() -> ByteBuffer { return serialize(type: MyGame_InParentNamespace.self) }
+
 }
-public struct MyGame_Example2_Monster: FlatBufferObject {
+public struct MyGame_Example2_Monster: FlatBufferObject, ObjectAPI {
 
     static func validateVersion() { FlatBuffersVersion_1_12_0() }
     public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -413,8 +415,10 @@ public class MyGame_Example2_MonsterT: NativeTable {
     init() {
     }
 
+    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example2_Monster.self) }
+
 }
-public struct MyGame_Example_TestSimpleTableWithEnum: FlatBufferObject {
+public struct MyGame_Example_TestSimpleTableWithEnum: FlatBufferObject, ObjectAPI {
 
     static func validateVersion() { FlatBuffersVersion_1_12_0() }
     public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -474,8 +478,10 @@ public class MyGame_Example_TestSimpleTableWithEnumT: NativeTable {
         color = .green
     }
 
+    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_TestSimpleTableWithEnum.self) }
+
 }
-public struct MyGame_Example_Stat: FlatBufferObject {
+public struct MyGame_Example_Stat: FlatBufferObject, ObjectAPI {
 
     static func validateVersion() { FlatBuffersVersion_1_12_0() }
     public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -561,8 +567,10 @@ public class MyGame_Example_StatT: NativeTable {
         count = 0
     }
 
+    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_Stat.self) }
+
 }
-public struct MyGame_Example_Referrable: FlatBufferObject {
+public struct MyGame_Example_Referrable: FlatBufferObject, ObjectAPI {
 
     static func validateVersion() { FlatBuffersVersion_1_12_0() }
     public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -646,9 +654,11 @@ public class MyGame_Example_ReferrableT: NativeTable {
         id = 0
     }
 
+    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_Referrable.self) }
+
 }
 ///  an example documentation comment: "monster object"
-public struct MyGame_Example_Monster: FlatBufferObject {
+public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPI {
 
     static func validateVersion() { FlatBuffersVersion_1_12_0() }
     public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1364,8 +1374,10 @@ public class MyGame_Example_MonsterT: NativeTable {
         signedEnum = .none_
     }
 
+    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_Monster.self) }
+
 }
-public struct MyGame_Example_TypeAliases: FlatBufferObject {
+public struct MyGame_Example_TypeAliases: FlatBufferObject, ObjectAPI {
 
     static func validateVersion() { FlatBuffersVersion_1_12_0() }
     public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1546,5 +1558,7 @@ public class MyGame_Example_TypeAliasesT: NativeTable {
         v8 = []
         vf64 = []
     }
+
+    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_TypeAliases.self) }
 
 }

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
@@ -145,7 +145,7 @@ extension BookReader {
 
 }
 
-public struct Attacker: FlatBufferObject {
+public struct Attacker: FlatBufferObject, ObjectAPI {
 
     static func validateVersion() { FlatBuffersVersion_1_12_0() }
     public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -205,8 +205,10 @@ public class AttackerT: NativeTable {
         swordAttackDamage = 0
     }
 
+    func serialize() -> ByteBuffer { return serialize(type: Attacker.self) }
+
 }
-public struct Movie: FlatBufferObject {
+public struct Movie: FlatBufferObject, ObjectAPI {
 
     static func validateVersion() { FlatBuffersVersion_1_12_0() }
     public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -328,5 +330,7 @@ public class MovieT: NativeTable {
     init() {
         characters = []
     }
+
+    func serialize() -> ByteBuffer { return serialize(type: Movie.self) }
 
 }


### PR DESCRIPTION
The following adds the function serialize to the `object-api` classes:

changes:
1- adds `func serialize() -> ByteBuffer { return serialize(type: flatbuffers_object.self) }` into the generated code

2- creates the helper methods:

```swift
public func serialize<T: ObjectAPI>(type: T.Type) -> ByteBuffer where T.T == Self
/// Allows devs to pass in their own builders, in case they have them in a singletons, instead of reallocating the space each time
public func serialize<T: ObjectAPI>(builder: inout FlatBufferBuilder, type: T.Type) -> ByteBuffer where T.T == Self
```

where the second serialize function gives the developer more control over the builder that's being passed to it
@jackflips

Closes #6058