### PR TITLE
Added support for JSON schema integer type

### DIFF
--- a/src/idl_gen_json_schema.cpp
+++ b/src/idl_gen_json_schema.cpp
@@ -34,7 +34,7 @@ std::string GenNativeType(BaseType type) {
     case BASE_TYPE_INT:
     case BASE_TYPE_UINT:
     case BASE_TYPE_LONG:
-    case BASE_TYPE_ULONG:
+    case BASE_TYPE_ULONG: return "integer";
     case BASE_TYPE_FLOAT:
     case BASE_TYPE_DOUBLE: return "number";
     case BASE_TYPE_STRING: return "string";


### PR DESCRIPTION
This change adds support for the JSON schema integer type as described here: https://json-schema.org/understanding-json-schema/reference/numeric.html#integer

It offers a solution for the issue as described here: https://github.com/google/flatbuffers/issues/6066
