### PR TITLE
[Go] GetUOffsetT must get value by GetUint32 not GetInt32

### DIFF
--- a/go/encode.go
+++ b/go/encode.go
@@ -118,7 +118,7 @@ func GetFloat64(buf []byte) float64 {
 
 // GetUOffsetT decodes a little-endian UOffsetT from a byte slice.
 func GetUOffsetT(buf []byte) UOffsetT {
-	return UOffsetT(GetInt32(buf))
+	return UOffsetT(GetUint32(buf))
 }
 
 // GetSOffsetT decodes a little-endian SOffsetT from a byte slice.


### PR DESCRIPTION
Currently, `GetUOffsetT` get value by using `GetInt32` (reference from https://github.com/google/flatbuffers/blob/master/go/encode.go#L121). But UOffsetT in spec said it store unsigned offset of vector data, which means it should get by using `GetUint32` not `GetInt32`.
