### PR TITLE
[C#]Change to ENABLE_SPAN_T that doesn't require UNSAFE_BYTEBUFFER.

### DIFF
--- a/net/FlatBuffers/ByteBuffer.cs
+++ b/net/FlatBuffers/ByteBuffer.cs
@@ -42,7 +42,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
 using System.Buffers.Binary;
 #endif
 
@@ -50,7 +50,7 @@ namespace FlatBuffers
 {
     public abstract class ByteBufferAllocator
     {
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
         public abstract Span<byte> Span { get; }
         public abstract ReadOnlySpan<byte> ReadOnlySpan { get; }
         public abstract Memory<byte> Memory { get; }
@@ -98,7 +98,7 @@ namespace FlatBuffers
             InitBuffer();
         }
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
         public override Span<byte> Span => _buffer;
         public override ReadOnlySpan<byte> ReadOnlySpan => _buffer;
         public override Memory<byte> Memory => _buffer;
@@ -108,7 +108,7 @@ namespace FlatBuffers
         private void InitBuffer()
         {
             Length = _buffer.Length;
-#if !ENABLE_SPAN_T
+#if !ENABLE_SPAN_T || !NETSTANDARD2_1
             Buffer = _buffer;
 #endif
         }
@@ -220,7 +220,7 @@ namespace FlatBuffers
             return SizeOf<T>() * x.Length;
         }
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
         public static int ArraySize<T>(Span<T> x)
         {
             return SizeOf<T>() * x.Length;
@@ -229,7 +229,7 @@ namespace FlatBuffers
 
         // Get a portion of the buffer casted into an array of type T, given
         // the buffer position and length.
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
         public T[] ToArray<T>(int pos, int len)
             where T : struct
         {
@@ -257,7 +257,7 @@ namespace FlatBuffers
             return ToArray<byte>(0, Length);
         }
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
         public ReadOnlyMemory<byte> ToReadOnlyMemory(int pos, int len)
         {
             return _buffer.ReadOnlyMemory.Slice(pos, len);
@@ -360,7 +360,7 @@ namespace FlatBuffers
             }
             return r;
         }
-#elif ENABLE_SPAN_T
+#elif ENABLE_SPAN_T && NETSTANDARD2_1
         protected void WriteLittleEndian(int offset, int count, ulong data)
         {
             if (BitConverter.IsLittleEndian)
@@ -410,7 +410,7 @@ namespace FlatBuffers
 #endif
         }
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
 
         public void PutSbyte(int offset, sbyte value)
         {
@@ -458,7 +458,7 @@ namespace FlatBuffers
             PutByte(offset, value);
         }
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
         public void PutStringUTF8(int offset, string value)
         {
             AssertOffsetAndLength(offset, value.Length);
@@ -484,7 +484,7 @@ namespace FlatBuffers
         public unsafe void PutUshort(int offset, ushort value)
         {
             AssertOffsetAndLength(offset, sizeof(ushort));
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
             Span<byte> span = _buffer.Span.Slice(offset);
             BinaryPrimitives.WriteUInt16LittleEndian(span, value);
 #else
@@ -505,7 +505,7 @@ namespace FlatBuffers
         public unsafe void PutUint(int offset, uint value)
         {
             AssertOffsetAndLength(offset, sizeof(uint));
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
             Span<byte> span = _buffer.Span.Slice(offset);
             BinaryPrimitives.WriteUInt32LittleEndian(span, value);
 #else
@@ -526,7 +526,7 @@ namespace FlatBuffers
         public unsafe void PutUlong(int offset, ulong value)
         {
             AssertOffsetAndLength(offset, sizeof(ulong));
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
             Span<byte> span = _buffer.Span.Slice(offset);
             BinaryPrimitives.WriteUInt64LittleEndian(span, value);
 #else
@@ -542,7 +542,7 @@ namespace FlatBuffers
         public unsafe void PutFloat(int offset, float value)
         {
             AssertOffsetAndLength(offset, sizeof(float));
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
             fixed (byte* ptr = &MemoryMarshal.GetReference(_buffer.Span))
 #else
             fixed (byte* ptr = _buffer.Buffer)
@@ -562,7 +562,7 @@ namespace FlatBuffers
         public unsafe void PutDouble(int offset, double value)
         {
             AssertOffsetAndLength(offset, sizeof(double));
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
             fixed (byte* ptr = &MemoryMarshal.GetReference(_buffer.Span))
 #else
             fixed (byte* ptr = _buffer.Buffer)
@@ -635,7 +635,7 @@ namespace FlatBuffers
 
 #endif // UNSAFE_BYTEBUFFER
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
         public sbyte GetSbyte(int index)
         {
             AssertOffsetAndLength(index, sizeof(sbyte));
@@ -661,7 +661,7 @@ namespace FlatBuffers
         }
 #endif
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
         public string GetStringUTF8(int startPos, int len)
         {
             return Encoding.UTF8.GetString(_buffer.Span.Slice(startPos, len));
@@ -683,7 +683,7 @@ namespace FlatBuffers
         public unsafe ushort GetUshort(int offset)
         {
             AssertOffsetAndLength(offset, sizeof(ushort));
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
             ReadOnlySpan<byte> span = _buffer.ReadOnlySpan.Slice(offset);
             return BinaryPrimitives.ReadUInt16LittleEndian(span);
 #else
@@ -704,7 +704,7 @@ namespace FlatBuffers
         public unsafe uint GetUint(int offset)
         {
             AssertOffsetAndLength(offset, sizeof(uint));
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
             ReadOnlySpan<byte> span = _buffer.ReadOnlySpan.Slice(offset);
             return BinaryPrimitives.ReadUInt32LittleEndian(span);
 #else
@@ -725,7 +725,7 @@ namespace FlatBuffers
         public unsafe ulong GetUlong(int offset)
         {
             AssertOffsetAndLength(offset, sizeof(ulong));
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
             ReadOnlySpan<byte> span = _buffer.ReadOnlySpan.Slice(offset);
             return BinaryPrimitives.ReadUInt64LittleEndian(span);
 #else            
@@ -741,7 +741,7 @@ namespace FlatBuffers
         public unsafe float GetFloat(int offset)
         {
             AssertOffsetAndLength(offset, sizeof(float));
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
             fixed (byte* ptr = &MemoryMarshal.GetReference(_buffer.ReadOnlySpan))
 #else
             fixed (byte* ptr = _buffer.Buffer)
@@ -762,7 +762,7 @@ namespace FlatBuffers
         public unsafe double GetDouble(int offset)
         {
             AssertOffsetAndLength(offset, sizeof(double));
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
             fixed (byte* ptr = &MemoryMarshal.GetReference(_buffer.ReadOnlySpan))
 #else
             fixed (byte* ptr = _buffer.Buffer)
@@ -861,7 +861,7 @@ namespace FlatBuffers
                 offset -= numBytes;
                 AssertOffsetAndLength(offset, numBytes);
                 // if we are LE, just do a block copy
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
                 MemoryMarshal.Cast<T, byte>(x).CopyTo(_buffer.Span.Slice(offset, numBytes));
 #else
                 Buffer.BlockCopy(x, 0, _buffer.Buffer, offset, numBytes);
@@ -880,7 +880,7 @@ namespace FlatBuffers
             return offset;
         }
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && NETSTANDARD2_1
         public int Put<T>(int offset, Span<T> x)
             where T : struct
         {

--- a/net/FlatBuffers/FlatBuffers.Core.csproj
+++ b/net/FlatBuffers/FlatBuffers.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/FlatBuffers.Test/FlatBuffers.Core.Test.csproj
+++ b/tests/FlatBuffers.Test/FlatBuffers.Core.Test.csproj
@@ -1,0 +1,156 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(UnsafeByteBuffer)' == 'true'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);UNSAFE_BYTEBUFFER</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(EnableSpanT)' == 'true'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);ENABLE_SPAN_T</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\net\FlatBuffers\ByteBuffer.cs">
+      <Link>FlatBuffers\ByteBuffer.cs</Link>
+    </Compile>
+    <Compile Include="..\..\net\FlatBuffers\ByteBufferUtil.cs">
+      <Link>FlatBuffers\ByteBufferUtil.cs</Link>
+    </Compile>
+    <Compile Include="..\..\net\FlatBuffers\IFlatbufferObject.cs">
+      <Link>FlatBuffers\IFlatbufferObject.cs</Link>
+    </Compile>
+    <Compile Include="..\..\net\FlatBuffers\Offset.cs">
+      <Link>FlatBuffers\Offset.cs</Link>
+    </Compile>
+    <Compile Include="..\..\net\FlatBuffers\FlatBufferBuilder.cs">
+      <Link>FlatBuffers\FlatBufferBuilder.cs</Link>
+    </Compile>
+    <Compile Include="..\..\net\FlatBuffers\FlatBufferConstants.cs">
+      <Link>FlatBuffers\FlatBufferConstants.cs</Link>
+    </Compile>
+    <Compile Include="..\..\net\FlatBuffers\Struct.cs">
+      <Link>FlatBuffers\Struct.cs</Link>
+    </Compile>
+    <Compile Include="..\..\net\FlatBuffers\Table.cs">
+      <Link>FlatBuffers\Table.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example2\Monster.cs">
+      <Link>MyGame\Example2\Monster.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\Any.cs">
+      <Link>MyGame\Example\Any.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\AnyAmbiguousAliases.cs">
+      <Link>MyGame\Example\AnyAmbiguousAliases.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\AnyUniqueAliases.cs">
+      <Link>MyGame\Example\AnyUniqueAliases.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\Color.cs">
+      <Link>MyGame\Example\Color.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\Race.cs">
+      <Link>MyGame\Example\Race.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\Monster.cs">
+      <Link>MyGame\Example\Monster.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\Referrable.cs">
+      <Link>MyGame\Example\Referrable.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\Stat.cs">
+      <Link>MyGame\Example\Stat.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\Test.cs">
+      <Link>MyGame\Example\Test.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\TestSimpleTableWithEnum.cs">
+      <Link>MyGame\Example\TestSimpleTableWithEnum.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\TypeAliases.cs">
+      <Link>MyGame\Example\TypeAliases.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\Vec3.cs">
+      <Link>MyGame\Example\Vec3.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\Ability.cs">
+      <Link>MyGame\Example\Ability.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\ArrayTable.cs">
+      <Link>MyGame\Example\ArrayTable.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\ArrayStruct.cs">
+      <Link>MyGame\Example\ArrayStruct.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\NestedStruct.cs">
+      <Link>MyGame\Example\NestedStruct.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\Example\TestEnum.cs">
+      <Link>MyGame\Example\TestEnum.cs</Link>
+    </Compile>
+    <Compile Include="..\MyGame\InParentNamespace.cs">
+      <Link>MyGame\InParentNamespace.cs</Link>
+    </Compile>
+    <Compile Include="..\namespace_test\NamespaceA\NamespaceB\EnumInNestedNS.cs">
+      <Link>NamespaceA\NamespaceB\EnumInNestedNS.cs</Link>
+    </Compile>
+    <Compile Include="..\namespace_test\NamespaceA\NamespaceB\StructInNestedNS.cs">
+      <Link>NamespaceA\NamespaceB\StructInNestedNS.cs</Link>
+    </Compile>
+    <Compile Include="..\namespace_test\NamespaceA\NamespaceB\TableInNestedNS.cs">
+      <Link>NamespaceA\NamespaceB\TableInNestedNS.cs</Link>
+    </Compile>
+    <Compile Include="..\namespace_test\NamespaceA\TableInFirstNS.cs">
+      <Link>NamespaceA\TableInFirstNS.cs</Link>
+    </Compile>
+    <Compile Include="..\union_vector\Attacker.cs">
+      <Link>union_vector\Attacker.cs</Link>
+    </Compile>
+    <Compile Include="..\union_vector\BookReader.cs">
+      <Link>union_vector\BookReader.cs</Link>
+    </Compile>
+    <Compile Include="..\union_vector\Character.cs">
+      <Link>union_vector\Character.cs</Link>
+    </Compile>
+    <Compile Include="..\union_vector\Movie.cs">
+      <Link>union_vector\Movie.cs</Link>
+    </Compile>
+    <Compile Include="..\union_vector\Rapunzel.cs">
+      <Link>union_vector\Rapunzel.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove=".gitignore" />
+    <None Remove="clean.sh" />
+    <None Remove="NetTest.sh" />
+    <None Remove="packages.config" />
+    <None Remove="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\monsterdata_test.mon">
+      <Link>Resources\monsterdata_test.mon</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\monsterdata_test.json">
+      <Link>Resources\monsterdata_test.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/tests/FlatBuffers.Test/NetTest.sh
+++ b/tests/FlatBuffers.Test/NetTest.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 PROJ_FILE=FlatBuffers.Test.csproj
+CORE_PROJ_FILE=FlatBuffers.Core.Test.csproj
 
 TEMP_DOTNET_DIR=.dotnet_tmp
 TEMP_BIN=.tmp
@@ -28,4 +29,26 @@ mono $TEMP_BIN/FlatBuffers.Test.exe
 rm -fr $TEMP_BIN
 
 rm FlatBuffers.Test.sln
+rm -rf obj
+
+$DOTNET new sln
+$DOTNET sln add $CORE_PROJ_FILE
+$DOTNET restore -r linux-x64 $CORE_PROJ_FILE
+
+# Testing C# on Linux using .Net Core.
+msbuild -property:Configuration=Release,OutputPath=$TEMP_BIN -verbosity:minimal $CORE_PROJ_FILE
+$TEMP_BIN/FlatBuffers.Core.Test.exe
+rm -fr $TEMP_BIN
+
+# Repeat with unsafe versions
+msbuild -property:Configuration=Release,UnsafeByteBuffer=true,OutputPath=$TEMP_BIN -verbosity:minimal $CORE_PROJ_FILE
+$TEMP_BIN/FlatBuffers.Core.Test.exe
+rm -fr $TEMP_BIN
+
+# Repeat with SpanT versions
+msbuild -property:Configuration=Release,EnableSpanT=true,OutputPath=$TEMP_BIN -verbosity:minimal $CORE_PROJ_FILE
+$TEMP_BIN/FlatBuffers.Core.Test.exe
+rm -fr $TEMP_BIN
+
+rm FlatBuffers.Core.Test.sln
 rm -rf obj


### PR DESCRIPTION
A small change removes the need for UNSAFE_BYTEBUFFER when using ENABLE_SPAN_T.