### PR TITLE
[Swift] Adds proper access types for swift object api & flatbuffers & grpc

### DIFF
--- a/grpc/src/compiler/schema_interface.h
+++ b/grpc/src/compiler/schema_interface.h
@@ -81,6 +81,7 @@ struct Service : public CommentHolder {
 
   virtual std::vector<grpc::string> namespace_parts() const = 0;
   virtual grpc::string name() const = 0;
+  virtual bool is_internal() const = 0;
 
   virtual int method_count() const = 0;
   virtual std::unique_ptr<const Method> method(int i) const = 0;

--- a/grpc/src/compiler/swift_generator.cc
+++ b/grpc/src/compiler/swift_generator.cc
@@ -125,7 +125,7 @@ void GenerateClientClass(const grpc_generator::Service *service,
   printer->Print("\t\tself.defaultCallOptions = defaultCallOptions\n");
   printer->Print("\t}");
   printer->Print("\n");
-  vars["GenAccess"] = "public";
+  vars["GenAccess"] = service->is_internal() ? "internal" : "public";
   for (auto it = 0; it < service->method_count(); it++) {
     auto method = service->method(it);
     vars["Input"] = GenerateMessage(method->get_input_namespace_parts(), method->get_input_type_name());
@@ -259,7 +259,7 @@ grpc::string Generate(grpc_generator::File *file,
   if (!file->package().empty()) { vars["PATH"].append("."); }
   vars["ServiceQualifiedName"] = WrapInNameSpace(service->namespace_parts(), service->name());
   vars["ServiceName"] = service->name();
-  vars["ACCESS"] = "public";
+  vars["ACCESS"] = service->is_internal() ? "internal" : "public";
   auto printer = file->CreatePrinter(&output);
   printer->Print(vars,
                  "/// Usage: instantiate $ServiceQualifiedName$ServiceClient, then call "

--- a/src/idl_gen_grpc.cpp
+++ b/src/idl_gen_grpc.cpp
@@ -59,17 +59,21 @@ class FlatBufMethod : public grpc_generator::Method {
 
   std::string name() const { return method_->name; }
 
-  // TODO: This method need to incorporate namespace for C++ side. Other language bindings
-  // simply don't use this method.
+  // TODO: This method need to incorporate namespace for C++ side. Other
+  // language bindings simply don't use this method.
   std::string GRPCType(const StructDef &sd) const {
     return "flatbuffers::grpc::Message<" + sd.name + ">";
   }
 
-  std::vector<std::string> get_input_namespace_parts() const { return (*method_->request).defined_namespace->components; }
+  std::vector<std::string> get_input_namespace_parts() const {
+    return (*method_->request).defined_namespace->components;
+  }
 
   std::string get_input_type_name() const { return (*method_->request).name; }
 
-  std::vector<std::string>  get_output_namespace_parts() const { return (*method_->response).defined_namespace->components; }
+  std::vector<std::string> get_output_namespace_parts() const {
+    return (*method_->response).defined_namespace->components;
+  }
 
   std::string get_output_type_name() const { return (*method_->response).name; }
 
@@ -117,9 +121,14 @@ class FlatBufService : public grpc_generator::Service {
     return service_->doc_comment;
   }
 
-  std::vector<grpc::string> namespace_parts() const { return service_->defined_namespace->components; }
+  std::vector<grpc::string> namespace_parts() const {
+    return service_->defined_namespace->components;
+  }
 
   std::string name() const { return service_->name; }
+  bool is_internal() const {
+    return service_->Definition::attributes.Lookup("private") ? true : false;
+  }
 
   int method_count() const {
     return static_cast<int>(service_->calls.vec.size());

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -31,7 +31,8 @@ inline std::string GenIndirect(const std::string &reading) {
 }
 
 inline std::string GenArrayMainBody(const std::string &optional) {
-  return "public func {{VALUENAME}}(at index: Int32) -> {{VALUETYPE}}" +
+  return "{{ACCESS_TYPE}} func {{VALUENAME}}(at index: Int32) -> "
+         "{{VALUETYPE}}" +
          optional + " { ";
 }
 
@@ -192,11 +193,13 @@ class SwiftGenerator : public BaseGenerator {
 
   // Generates the create function for swift
   void GenStructWriter(const StructDef &struct_def) {
+    auto is_private_access = struct_def.attributes.Lookup("private");
+    code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");
     code_.SetValue("STRUCTNAME", NameWrappedInNameSpace(struct_def));
     code_.SetValue("SHORT_STRUCTNAME", Name(struct_def));
     code_ += "extension {{STRUCTNAME}} {";
     Indent();
-    code_ += "public static func create{{SHORT_STRUCTNAME}}(\\";
+    code_ += "{{ACCESS_TYPE}} static func create{{SHORT_STRUCTNAME}}(\\";
     std::string func_header = "";
     GenerateStructArgs(struct_def, &func_header, "", "");
     code_ += func_header.substr(0, func_header.size() - 2) + "\\";
@@ -282,37 +285,40 @@ class SwiftGenerator : public BaseGenerator {
     code_.SetValue("PROTOCOL",
                    struct_def.fixed ? "Readable" : "FlatBufferObject");
     code_.SetValue("OBJECTTYPE", struct_def.fixed ? "Struct" : "Table");
-    code_ += "public struct {{STRUCTNAME}}: {{PROTOCOL}}\\";
+    code_ += "{{ACCESS_TYPE}} struct {{STRUCTNAME}}: {{PROTOCOL}}\\";
     if (!struct_def.fixed && parser_.opts.generate_object_based_api)
       code_ += ", ObjectAPI\\";
     code_ += " {\n";
     Indent();
     code_ += ValidateFunc();
-    code_ += "public var __buffer: ByteBuffer! { return {{ACCESS}}.bb }";
+    code_ +=
+        "{{ACCESS_TYPE}} var __buffer: ByteBuffer! { return {{ACCESS}}.bb }";
     code_ += "private var {{ACCESS}}: {{OBJECTTYPE}}\n";
     if (struct_def.fixed) {
       code_.SetValue("BYTESIZE", NumToString(struct_def.bytesize));
       code_.SetValue("MINALIGN", NumToString(struct_def.minalign));
-      code_ += "public static var size = {{BYTESIZE}}";
-      code_ += "public static var alignment = {{MINALIGN}}";
+      code_ += "{{ACCESS_TYPE}} static var size = {{BYTESIZE}}";
+      code_ += "{{ACCESS_TYPE}} static var alignment = {{MINALIGN}}";
     } else {
       if (parser_.file_identifier_.length()) {
         code_.SetValue("FILENAME", parser_.file_identifier_);
         code_ +=
-            "public static func finish(_ fbb: inout FlatBufferBuilder, end: "
+            "{{ACCESS_TYPE}} static func finish(_ fbb: inout "
+            "FlatBufferBuilder, end: "
             "Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, "
             "fileId: "
             "\"{{FILENAME}}\", addPrefix: prefix) }";
       }
       code_ +=
-          "public static func getRootAs{{SHORT_STRUCTNAME}}(bb: ByteBuffer) -> "
+          "{{ACCESS_TYPE}} static func getRootAs{{SHORT_STRUCTNAME}}(bb: "
+          "ByteBuffer) -> "
           "{{STRUCTNAME}} { return {{STRUCTNAME}}(Table(bb: bb, position: "
           "Int32(bb.read(def: UOffset.self, position: bb.reader)) + "
           "Int32(bb.reader))) }\n";
       code_ += "private init(_ t: Table) { {{ACCESS}} = t }";
     }
     code_ +=
-        "public init(_ bb: ByteBuffer, o: Int32) { {{ACCESS}} = "
+        "{{ACCESS_TYPE}} init(_ bb: ByteBuffer, o: Int32) { {{ACCESS}} = "
         "{{OBJECTTYPE}}(bb: "
         "bb, position: o) }";
     code_ += "";
@@ -320,6 +326,9 @@ class SwiftGenerator : public BaseGenerator {
 
   // Generates the reader for swift
   void GenTable(const StructDef &struct_def) {
+    auto is_private_access = struct_def.attributes.Lookup("private");
+    code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");
+
     GenObjectHeader(struct_def);
     GenTableAccessors(struct_def);
     GenTableReader(struct_def);
@@ -334,7 +343,7 @@ class SwiftGenerator : public BaseGenerator {
   void GenTableAccessors(const StructDef &struct_def) {
     // Generate field id constants.
     if (struct_def.fields.vec.size() > 0) {
-      code_ += "enum {{TABLEOFFSET}}: VOffset {";
+      code_ += "private enum {{TABLEOFFSET}}: VOffset {";
       Indent();
       for (auto it = struct_def.fields.vec.begin();
            it != struct_def.fields.vec.end(); ++it) {
@@ -354,14 +363,15 @@ class SwiftGenerator : public BaseGenerator {
 
   void GenerateObjectAPIExtensionHeader() {
     code_ += "\n";
-    code_ += "public mutating func unpack() -> " +
+    code_ += "{{ACCESS_TYPE}} mutating func unpack() -> " +
              ObjectAPIName("{{STRUCTNAME}}") + " {";
     Indent();
     code_ += "return " + ObjectAPIName("{{STRUCTNAME}}") + "(&self)";
     Outdent();
     code_ += "}";
     code_ +=
-        "public static func pack(_ builder: inout FlatBufferBuilder, obj: "
+        "{{ACCESS_TYPE}} static func pack(_ builder: inout FlatBufferBuilder, "
+        "obj: "
         "inout " +
         ObjectAPIName("{{STRUCTNAME}}") + "?) -> Offset<UOffset> {";
     Indent();
@@ -371,7 +381,8 @@ class SwiftGenerator : public BaseGenerator {
     code_ += "}";
     code_ += "";
     code_ +=
-        "public static func pack(_ builder: inout FlatBufferBuilder, obj: "
+        "{{ACCESS_TYPE}} static func pack(_ builder: inout FlatBufferBuilder, "
+        "obj: "
         "inout " +
         ObjectAPIName("{{STRUCTNAME}}") + ") -> Offset<UOffset> {";
     Indent();
@@ -406,7 +417,7 @@ class SwiftGenerator : public BaseGenerator {
 
     code_.SetValue("NUMBEROFFIELDS", NumToString(struct_def.fields.vec.size()));
     code_ +=
-        "public static func start{{SHORT_STRUCTNAME}}(_ fbb: inout "
+        "{{ACCESS_TYPE}} static func start{{SHORT_STRUCTNAME}}(_ fbb: inout "
         "FlatBufferBuilder) -> "
         "UOffset { fbb.startTable(with: {{NUMBEROFFIELDS}}) }";
 
@@ -421,7 +432,7 @@ class SwiftGenerator : public BaseGenerator {
       GenTableWriterFields(field, &create_func_body, &create_func_header);
     }
     code_ +=
-        "public static func end{{SHORT_STRUCTNAME}}(_ fbb: inout "
+        "{{ACCESS_TYPE}} static func end{{SHORT_STRUCTNAME}}(_ fbb: inout "
         "FlatBufferBuilder, "
         "start: "
         "UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: "
@@ -436,7 +447,7 @@ class SwiftGenerator : public BaseGenerator {
     code_ += "; return end }";
 
     if (should_generate_create) {
-      code_ += "public static func create{{SHORT_STRUCTNAME}}(";
+      code_ += "{{ACCESS_TYPE}} static func create{{SHORT_STRUCTNAME}}(";
       Indent();
       code_ += "_ fbb: inout FlatBufferBuilder,";
       for (auto it = create_func_header.begin(); it < create_func_header.end();
@@ -467,7 +478,7 @@ class SwiftGenerator : public BaseGenerator {
       code_.SetValue("VOFFSET", NumToString(key_field->value.offset));
 
       code_ +=
-          "public static func "
+          "{{ACCESS_TYPE}} static func "
           "sortVectorOf{{SHORT_VALUENAME}}(offsets:[Offset<UOffset>], "
           "_ fbb: inout FlatBufferBuilder) -> Offset<UOffset> {";
       Indent();
@@ -503,7 +514,7 @@ class SwiftGenerator : public BaseGenerator {
             ? "VectorOf("
             : "(";
     auto body = "add" + check_if_vector + name + ": ";
-    code_ += "public static func " + body + "\\";
+    code_ += "{{ACCESS_TYPE}} static func " + body + "\\";
 
     create_func_body.push_back("{{STRUCTNAME}}." + body + name + ", &fbb)");
 
@@ -639,7 +650,8 @@ class SwiftGenerator : public BaseGenerator {
         code_.SetValue("CONSTANT", "nil");
         code_ += GenReaderMainBody(is_required) + GenOffset() +
                  required_reader + "{{ACCESS}}.string(at: o) }";
-        code_ += "public var {{VALUENAME}}SegmentArray: [UInt8]" + is_required +
+        code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}SegmentArray: [UInt8]" +
+                 is_required +
                  " { return "
                  "{{ACCESS}}.getVector(at: {{TABLEOFFSET}}.{{OFFSET}}.v) }";
         break;
@@ -651,7 +663,7 @@ class SwiftGenerator : public BaseGenerator {
       case BASE_TYPE_UNION:
         code_.SetValue("CONSTANT", "nil");
         code_ +=
-            "public func {{VALUENAME}}<T: FlatBufferObject>(type: "
+            "{{ACCESS_TYPE}} func {{VALUENAME}}<T: FlatBufferObject>(type: "
             "T.Type) -> T" +
             is_required + " { " + GenOffset() + required_reader +
             "{{ACCESS}}.union(o) }";
@@ -664,7 +676,7 @@ class SwiftGenerator : public BaseGenerator {
                                   const std::string &const_string) {
     auto vectortype = field.value.type.VectorType();
     code_.SetValue("SIZE", NumToString(InlineSize(vectortype)));
-    code_ += "public var {{VALUENAME}}Count: Int32 { " + GenOffset() +
+    code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}Count: Int32 { " + GenOffset() +
              const_string + "{{ACCESS}}.vector(count: o) }";
     code_.SetValue("CONSTANT", IsScalar(vectortype.base_type) == true
                                    ? field.value.constant
@@ -675,7 +687,7 @@ class SwiftGenerator : public BaseGenerator {
       code_ += GenArrayMainBody(nullable) + GenOffset() + "\\";
     } else {
       code_ +=
-          "public func {{VALUENAME}}<T: FlatBufferObject>(at index: "
+          "{{ACCESS_TYPE}} func {{VALUENAME}}<T: FlatBufferObject>(at index: "
           "Int32, type: T.Type) -> T? { " +
           GenOffset() + "\\";
     }
@@ -694,7 +706,7 @@ class SwiftGenerator : public BaseGenerator {
           "{{ACCESS}}.directRead(of: {{VALUETYPE}}.self, offset: "
           "{{ACCESS}}.vector(at: o) + index * {{SIZE}}) }";
       code_ +=
-          "public var {{VALUENAME}}: [{{VALUETYPE}}] { return "
+          "{{ACCESS_TYPE}} var {{VALUENAME}}: [{{VALUETYPE}}] { return "
           "{{ACCESS}}.getVector(at: {{TABLEOFFSET}}.{{OFFSET}}.v) ?? [] }";
       if (parser_.opts.mutable_buffer) code_ += GenMutateArray();
       return;
@@ -747,7 +759,8 @@ class SwiftGenerator : public BaseGenerator {
   void GenByKeyFunctions(const FieldDef &key_field) {
     code_.SetValue("TYPE", GenType(key_field.value.type));
     code_ +=
-        "public func {{VALUENAME}}By(key: {{TYPE}}) -> {{VALUETYPE}}? { \\";
+        "{{ACCESS_TYPE}} func {{VALUENAME}}By(key: {{TYPE}}) -> {{VALUETYPE}}? "
+        "{ \\";
     code_ += GenOffset() +
              "return o == 0 ? nil : {{VALUETYPE}}.lookupByKey(vector: "
              "{{ACCESS}}.vector(at: o), key: key, fbb: {{ACCESS}}.bb) }";
@@ -755,6 +768,9 @@ class SwiftGenerator : public BaseGenerator {
 
   // Generates the reader for swift
   void GenStructReader(const StructDef &struct_def) {
+    auto is_private_access = struct_def.attributes.Lookup("private");
+    code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");
+
     GenObjectHeader(struct_def);
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
@@ -790,17 +806,20 @@ class SwiftGenerator : public BaseGenerator {
 
   void GenEnum(const EnumDef &enum_def) {
     if (enum_def.generated) return;
+    auto is_private_access = enum_def.attributes.Lookup("private");
+    code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");
     code_.SetValue("ENUM_NAME", NameWrappedInNameSpace(enum_def));
     code_.SetValue("BASE_TYPE", GenTypeBasic(enum_def.underlying_type, false));
     GenComment(enum_def.doc_comment);
-    code_ += "public enum {{ENUM_NAME}}: {{BASE_TYPE}}, Enum { ";
+    code_ += "{{ACCESS_TYPE}} enum {{ENUM_NAME}}: {{BASE_TYPE}}, Enum { ";
     Indent();
-    code_ += "public typealias T = {{BASE_TYPE}}";
+    code_ += "{{ACCESS_TYPE}} typealias T = {{BASE_TYPE}}";
     code_ +=
-        "public static var byteSize: Int { return "
+        "{{ACCESS_TYPE}} static var byteSize: Int { return "
         "MemoryLayout<{{BASE_TYPE}}>.size "
         "}";
-    code_ += "public var value: {{BASE_TYPE}} { return self.rawValue }";
+    code_ +=
+        "{{ACCESS_TYPE}} var value: {{BASE_TYPE}} { return self.rawValue }";
     for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
       const auto &ev = **it;
       auto name = Name(ev);
@@ -815,18 +834,19 @@ class SwiftGenerator : public BaseGenerator {
     Outdent();
     code_ += "}\n";
     if (parser_.opts.generate_object_based_api && enum_def.is_union) {
-      code_ += "struct {{ENUM_NAME}}Union {";
+      code_ += "{{ACCESS_TYPE}} struct {{ENUM_NAME}}Union {";
       Indent();
-      code_ += "var type: {{ENUM_NAME}}";
-      code_ += "var value: NativeTable?";
-      code_ += "init(_ v: NativeTable?, type: {{ENUM_NAME}}) {";
+      code_ += "{{ACCESS_TYPE}} var type: {{ENUM_NAME}}";
+      code_ += "{{ACCESS_TYPE}} var value: NativeTable?";
+      code_ += "{{ACCESS_TYPE}} init(_ v: NativeTable?, type: {{ENUM_NAME}}) {";
       Indent();
       code_ += "self.type = type";
       code_ += "self.value = v";
       Outdent();
       code_ += "}";
       code_ +=
-          "func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {";
+          "{{ACCESS_TYPE}} func pack(builder: inout FlatBufferBuilder) -> "
+          "Offset<UOffset> {";
       Indent();
       BuildUnionEnumSwitchCaseWritter(enum_def);
       Outdent();
@@ -837,8 +857,8 @@ class SwiftGenerator : public BaseGenerator {
   }
 
   void GenObjectAPI(const StructDef &struct_def) {
-    code_ +=
-        "public class " + ObjectAPIName("{{STRUCTNAME}}") + ": NativeTable {\n";
+    code_ += "{{ACCESS_TYPE}} class " + ObjectAPIName("{{STRUCTNAME}}") +
+             ": NativeTable {\n";
     std::vector<std::string> buffer_constructor;
     std::vector<std::string> base_constructor;
     Indent();
@@ -856,7 +876,8 @@ class SwiftGenerator : public BaseGenerator {
     BuildObjectAPIConstructor(base_constructor);
     if (!struct_def.fixed)
       code_ +=
-          "func serialize() -> ByteBuffer { return serialize(type: "
+          "{{ACCESS_TYPE}} func serialize() -> ByteBuffer { return "
+          "serialize(type: "
           "{{STRUCTNAME}}.self) }\n";
     Outdent();
     code_ += "}";
@@ -1029,7 +1050,7 @@ class SwiftGenerator : public BaseGenerator {
   void BuildObjectAPIConstructor(const std::vector<std::string> &body,
                                  const std::string &header = "") {
     code_.SetValue("HEADER", header);
-    code_ += "init({{HEADER}}) {";
+    code_ += "{{ACCESS_TYPE}} init({{HEADER}}) {";
     Indent();
     for (auto it = body.begin(); it < body.end(); ++it) code_ += *it;
     Outdent();
@@ -1056,7 +1077,8 @@ class SwiftGenerator : public BaseGenerator {
         std::string question_mark =
             (field.required || (optional && is_fixed) ? "" : "?");
 
-        code_ += "var {{VALUENAME}}: {{VALUETYPE}}" + question_mark;
+        code_ +=
+            "{{ACCESS_TYPE}} var {{VALUENAME}}: {{VALUETYPE}}" + question_mark;
         buffer_constructor.push_back("" + name + " = __" + name +
                                      (field.required ? "!" : question_mark) +
                                      ".unpack()");
@@ -1070,7 +1092,7 @@ class SwiftGenerator : public BaseGenerator {
         break;
       }
       case BASE_TYPE_STRING: {
-        code_ += "var {{VALUENAME}}: String" + is_required;
+        code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: String" + is_required;
         buffer_constructor.push_back(name + " = _t." + name);
         if (field.required) base_constructor.push_back(name + " = \"\"");
         break;
@@ -1086,7 +1108,8 @@ class SwiftGenerator : public BaseGenerator {
         std::string nullable = field.nullable ? "?" : "";
         if (IsScalar(field.value.type.base_type) &&
             !IsBool(field.value.type.base_type) && !IsEnum(field.value.type)) {
-          code_ += "var {{VALUENAME}}: {{VALUETYPE}}" + nullable;
+          code_ +=
+              "{{ACCESS_TYPE}} var {{VALUENAME}}: {{VALUETYPE}}" + nullable;
           if (!field.nullable)
             base_constructor.push_back(name + " = " + field.value.constant);
           break;
@@ -1096,13 +1119,13 @@ class SwiftGenerator : public BaseGenerator {
           auto default_value = IsEnum(field.value.type)
                                    ? GenEnumDefaultValue(field)
                                    : field.value.constant;
-          code_ += "var {{VALUENAME}}: {{VALUETYPE}}";
+          code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: {{VALUETYPE}}";
           base_constructor.push_back(name + " = " + default_value);
           break;
         }
 
         if (IsBool(field.value.type.base_type)) {
-          code_ += "var {{VALUENAME}}: Bool" + nullable;
+          code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: Bool" + nullable;
           std::string default_value =
               "0" == field.value.constant ? "false" : "true";
           if (!field.nullable)
@@ -1128,7 +1151,7 @@ class SwiftGenerator : public BaseGenerator {
     switch (vectortype.base_type) {
       case BASE_TYPE_STRUCT: {
         code_.SetValue("VALUETYPE", GenType(vectortype, true));
-        code_ += "var {{VALUENAME}}: [{{VALUETYPE}}?]";
+        code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: [{{VALUETYPE}}?]";
         buffer_constructor.push_back(indentation + "var __v_ = _t." + name +
                                      "(at: index)");
         buffer_constructor.push_back(indentation + name +
@@ -1149,7 +1172,7 @@ class SwiftGenerator : public BaseGenerator {
         code_.SetValue("VALUETYPE", (vectortype.base_type == BASE_TYPE_STRING
                                          ? "String?"
                                          : GenType(vectortype)));
-        code_ += "var {{VALUENAME}}: [{{VALUETYPE}}]";
+        code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: [{{VALUETYPE}}]";
 
         if (IsEnum(vectortype) && vectortype.base_type != BASE_TYPE_UNION) {
           auto default_value = IsEnum(field.value.type)
@@ -1197,7 +1220,7 @@ class SwiftGenerator : public BaseGenerator {
                                 const bool is_vector = false) {
     auto field_name = NameWrappedInNameSpace(ev);
     code_.SetValue("VALUETYPE", field_name);
-    code_ += "var {{VALUENAME}}: \\";
+    code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: \\";
     code_ += is_vector ? "[{{VALUETYPE}}Union?]" : "{{VALUETYPE}}Union?";
 
     auto vector_reader = is_vector ? "(at: index" : "";
@@ -1229,8 +1252,8 @@ class SwiftGenerator : public BaseGenerator {
   void AddMinOrMaxEnumValue(const std::string &str, const std::string &type) {
     auto current_value = str;
     code_.SetValue(type, current_value);
-    code_ += "public static var " + type + ": {{ENUM_NAME}} { return .{{" +
-             type + "}} }";
+    code_ += "{{ACCESS_TYPE}} static var " + type +
+             ": {{ENUM_NAME}} { return .{{" + type + "}} }";
   }
 
   void GenLookup(const FieldDef &key_field) {
@@ -1296,7 +1319,8 @@ class SwiftGenerator : public BaseGenerator {
   }
 
   std::string GenReaderMainBody(const std::string &optional = "") {
-    return "public var {{VALUENAME}}: {{VALUETYPE}}" + optional + " { ";
+    return "{{ACCESS_TYPE}} var {{VALUENAME}}: {{VALUETYPE}}" + optional +
+           " { ";
   }
 
   std::string GenReader(const std::string &type,
@@ -1310,14 +1334,15 @@ class SwiftGenerator : public BaseGenerator {
 
   std::string GenMutate(const std::string &offset,
                         const std::string &get_offset, bool isRaw = false) {
-    return "@discardableResult public func mutate({{VALUENAME}}: "
+    return "@discardableResult {{ACCESS_TYPE}} func mutate({{VALUENAME}}: "
            "{{VALUETYPE}}) -> Bool {" +
            get_offset + " return {{ACCESS}}.mutate({{VALUENAME}}" +
            (isRaw ? ".rawValue" : "") + ", index: " + offset + ") }";
   }
 
   std::string GenMutateArray() {
-    return "public func mutate({{VALUENAME}}: {{VALUETYPE}}, at index: "
+    return "{{ACCESS_TYPE}} func mutate({{VALUENAME}}: {{VALUETYPE}}, at "
+           "index: "
            "Int32) -> Bool { " +
            GenOffset() +
            "return {{ACCESS}}.directMutate({{VALUENAME}}, index: "

--- a/tests/FlatBuffers.GRPC.Swift/Sources/Model/greeter_generated.swift
+++ b/tests/FlatBuffers.GRPC.Swift/Sources/Model/greeter_generated.swift
@@ -14,7 +14,7 @@ public struct HelloReply: FlatBufferObject {
     private init(_ t: Table) { _accessor = t }
     public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-    enum VTOFFSET: VOffset {
+    private enum VTOFFSET: VOffset {
         case message = 4
         var v: Int32 { Int32(self.rawValue) }
         var p: VOffset { self.rawValue }
@@ -46,7 +46,7 @@ public struct HelloRequest: FlatBufferObject {
     private init(_ t: Table) { _accessor = t }
     public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-    enum VTOFFSET: VOffset {
+    private enum VTOFFSET: VOffset {
         case name = 4
         var v: Int32 { Int32(self.rawValue) }
         var p: VOffset { self.rawValue }
@@ -78,7 +78,7 @@ public struct ManyHellosRequest: FlatBufferObject {
     private init(_ t: Table) { _accessor = t }
     public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-    enum VTOFFSET: VOffset {
+    private enum VTOFFSET: VOffset {
         case name = 4
         case numGreetings = 6
         var v: Int32 { Int32(self.rawValue) }

--- a/tests/FlatBuffers.Test.Swift/Package.swift
+++ b/tests/FlatBuffers.Test.Swift/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../../swift/"),
-        .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0-alpha.17")
+        .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0-alpha.18")
     ],
     targets: [
         .target(name: "SwiftFlatBuffers"),

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
@@ -2,10 +2,10 @@ import XCTest
 import Foundation
 @testable import FlatBuffers
 
-public typealias Test = MyGame_Example_Test
-public typealias Monster = MyGame_Example_Monster
-public typealias Vec3 = MyGame_Example_Vec3
-public typealias Stat = MyGame_Example_Stat
+typealias Test = MyGame_Example_Test
+typealias Monster = MyGame_Example_Monster
+typealias Vec3 = MyGame_Example_Vec3
+typealias Stat = MyGame_Example_Stat
 
 class FlatBuffersMonsterWriterTests: XCTestCase {
     

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
@@ -48,14 +48,14 @@ public enum MyGame_Example_Any_: UInt8, Enum {
     public static var min: MyGame_Example_Any_ { return .none_ }
 }
 
-struct MyGame_Example_Any_Union {
-    var type: MyGame_Example_Any_
-    var value: NativeTable?
-    init(_ v: NativeTable?, type: MyGame_Example_Any_) {
+public struct MyGame_Example_Any_Union {
+    public var type: MyGame_Example_Any_
+    public var value: NativeTable?
+    public init(_ v: NativeTable?, type: MyGame_Example_Any_) {
         self.type = type
         self.value = v
     }
-    func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
+    public func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
         switch type {
         case .monster:
             var __obj = value as? MyGame_Example_MonsterT
@@ -84,14 +84,14 @@ public enum MyGame_Example_AnyUniqueAliases: UInt8, Enum {
     public static var min: MyGame_Example_AnyUniqueAliases { return .none_ }
 }
 
-struct MyGame_Example_AnyUniqueAliasesUnion {
-    var type: MyGame_Example_AnyUniqueAliases
-    var value: NativeTable?
-    init(_ v: NativeTable?, type: MyGame_Example_AnyUniqueAliases) {
+public struct MyGame_Example_AnyUniqueAliasesUnion {
+    public var type: MyGame_Example_AnyUniqueAliases
+    public var value: NativeTable?
+    public init(_ v: NativeTable?, type: MyGame_Example_AnyUniqueAliases) {
         self.type = type
         self.value = v
     }
-    func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
+    public func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
         switch type {
         case .m:
             var __obj = value as? MyGame_Example_MonsterT
@@ -120,14 +120,14 @@ public enum MyGame_Example_AnyAmbiguousAliases: UInt8, Enum {
     public static var min: MyGame_Example_AnyAmbiguousAliases { return .none_ }
 }
 
-struct MyGame_Example_AnyAmbiguousAliasesUnion {
-    var type: MyGame_Example_AnyAmbiguousAliases
-    var value: NativeTable?
-    init(_ v: NativeTable?, type: MyGame_Example_AnyAmbiguousAliases) {
+public struct MyGame_Example_AnyAmbiguousAliasesUnion {
+    public var type: MyGame_Example_AnyAmbiguousAliases
+    public var value: NativeTable?
+    public init(_ v: NativeTable?, type: MyGame_Example_AnyAmbiguousAliases) {
         self.type = type
         self.value = v
     }
-    func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
+    public func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
         switch type {
         case .m1:
             var __obj = value as? MyGame_Example_MonsterT
@@ -173,15 +173,15 @@ public struct MyGame_Example_Test: Readable {
 
 public class MyGame_Example_TestT: NativeTable {
 
-    var a: Int16
-    var b: Int8
+    public var a: Int16
+    public var b: Int8
 
-    init(_ _t: inout MyGame_Example_Test) {
+    public init(_ _t: inout MyGame_Example_Test) {
         a = _t.a
         b = _t.b
     }
 
-    init() {
+    public init() {
         a = 0
         b = 0
     }
@@ -224,14 +224,14 @@ public struct MyGame_Example_Vec3: Readable {
 
 public class MyGame_Example_Vec3T: NativeTable {
 
-    var x: Float32
-    var y: Float32
-    var z: Float32
-    var test1: Double
-    var test2: MyGame_Example_Color
-    var test3: MyGame_Example_TestT
+    public var x: Float32
+    public var y: Float32
+    public var z: Float32
+    public var test1: Double
+    public var test2: MyGame_Example_Color
+    public var test3: MyGame_Example_TestT
 
-    init(_ _t: inout MyGame_Example_Vec3) {
+    public init(_ _t: inout MyGame_Example_Vec3) {
         x = _t.x
         y = _t.y
         z = _t.z
@@ -241,7 +241,7 @@ public class MyGame_Example_Vec3T: NativeTable {
         test3 = __test3.unpack()
     }
 
-    init() {
+    public init() {
         x = 0.0
         y = 0.0
         z = 0.0
@@ -282,15 +282,15 @@ public struct MyGame_Example_Ability: Readable {
 
 public class MyGame_Example_AbilityT: NativeTable {
 
-    var id: UInt32
-    var distance: UInt32
+    public var id: UInt32
+    public var distance: UInt32
 
-    init(_ _t: inout MyGame_Example_Ability) {
+    public init(_ _t: inout MyGame_Example_Ability) {
         id = _t.id
         distance = _t.distance
     }
 
-    init() {
+    public init() {
         id = 0
         distance = 0
     }
@@ -367,13 +367,13 @@ public struct MyGame_InParentNamespace: FlatBufferObject, ObjectAPI {
 public class MyGame_InParentNamespaceT: NativeTable {
 
 
-    init(_ _t: inout MyGame_InParentNamespace) {
+    public init(_ _t: inout MyGame_InParentNamespace) {
     }
 
-    init() {
+    public init() {
     }
 
-    func serialize() -> ByteBuffer { return serialize(type: MyGame_InParentNamespace.self) }
+    public func serialize() -> ByteBuffer { return serialize(type: MyGame_InParentNamespace.self) }
 
 }
 public struct MyGame_Example2_Monster: FlatBufferObject, ObjectAPI {
@@ -409,39 +409,39 @@ public struct MyGame_Example2_Monster: FlatBufferObject, ObjectAPI {
 public class MyGame_Example2_MonsterT: NativeTable {
 
 
-    init(_ _t: inout MyGame_Example2_Monster) {
+    public init(_ _t: inout MyGame_Example2_Monster) {
     }
 
-    init() {
+    public init() {
     }
 
-    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example2_Monster.self) }
+    public func serialize() -> ByteBuffer { return serialize(type: MyGame_Example2_Monster.self) }
 
 }
-public struct MyGame_Example_TestSimpleTableWithEnum: FlatBufferObject, ObjectAPI {
+internal struct MyGame_Example_TestSimpleTableWithEnum: FlatBufferObject, ObjectAPI {
 
     static func validateVersion() { FlatBuffersVersion_1_12_0() }
-    public var __buffer: ByteBuffer! { return _accessor.bb }
+    internal var __buffer: ByteBuffer! { return _accessor.bb }
     private var _accessor: Table
 
-    public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
-    public static func getRootAsTestSimpleTableWithEnum(bb: ByteBuffer) -> MyGame_Example_TestSimpleTableWithEnum { return MyGame_Example_TestSimpleTableWithEnum(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
+    internal static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+    internal static func getRootAsTestSimpleTableWithEnum(bb: ByteBuffer) -> MyGame_Example_TestSimpleTableWithEnum { return MyGame_Example_TestSimpleTableWithEnum(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
     private init(_ t: Table) { _accessor = t }
-    public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
+    internal init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-    enum VTOFFSET: VOffset {
+    private enum VTOFFSET: VOffset {
         case color = 4
         var v: Int32 { Int32(self.rawValue) }
         var p: VOffset { self.rawValue }
     }
 
-    public var color: MyGame_Example_Color { let o = _accessor.offset(VTOFFSET.color.v); return o == 0 ? .green : MyGame_Example_Color(rawValue: _accessor.readBuffer(of: UInt8.self, at: o)) ?? .green }
-    @discardableResult public func mutate(color: MyGame_Example_Color) -> Bool {let o = _accessor.offset(VTOFFSET.color.v);  return _accessor.mutate(color.rawValue, index: o) }
-    public static func startTestSimpleTableWithEnum(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
-    public static func add(color: MyGame_Example_Color, _ fbb: inout FlatBufferBuilder) { fbb.add(element: color.rawValue, def: 2, at: VTOFFSET.color.p) }
-    public static func endTestSimpleTableWithEnum(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
-    public static func createTestSimpleTableWithEnum(
+    internal var color: MyGame_Example_Color { let o = _accessor.offset(VTOFFSET.color.v); return o == 0 ? .green : MyGame_Example_Color(rawValue: _accessor.readBuffer(of: UInt8.self, at: o)) ?? .green }
+    @discardableResult internal func mutate(color: MyGame_Example_Color) -> Bool {let o = _accessor.offset(VTOFFSET.color.v);  return _accessor.mutate(color.rawValue, index: o) }
+    internal static func startTestSimpleTableWithEnum(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
+    internal static func add(color: MyGame_Example_Color, _ fbb: inout FlatBufferBuilder) { fbb.add(element: color.rawValue, def: 2, at: VTOFFSET.color.p) }
+    internal static func endTestSimpleTableWithEnum(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+    internal static func createTestSimpleTableWithEnum(
         _ fbb: inout FlatBufferBuilder,
         color: MyGame_Example_Color = .green
     ) -> Offset<UOffset> {
@@ -451,34 +451,34 @@ public struct MyGame_Example_TestSimpleTableWithEnum: FlatBufferObject, ObjectAP
     }
     
 
-    public mutating func unpack() -> MyGame_Example_TestSimpleTableWithEnumT {
+    internal mutating func unpack() -> MyGame_Example_TestSimpleTableWithEnumT {
         return MyGame_Example_TestSimpleTableWithEnumT(&self)
     }
-    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TestSimpleTableWithEnumT?) -> Offset<UOffset> {
+    internal static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TestSimpleTableWithEnumT?) -> Offset<UOffset> {
         guard var obj = obj else { return Offset<UOffset>() }
         return pack(&builder, obj: &obj)
     }
 
-    public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TestSimpleTableWithEnumT) -> Offset<UOffset> {
+    internal static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TestSimpleTableWithEnumT) -> Offset<UOffset> {
         let __root = MyGame_Example_TestSimpleTableWithEnum.startTestSimpleTableWithEnum(&builder)
         MyGame_Example_TestSimpleTableWithEnum.add(color: obj.color, &builder)
         return MyGame_Example_TestSimpleTableWithEnum.endTestSimpleTableWithEnum(&builder, start: __root)
     }
 }
 
-public class MyGame_Example_TestSimpleTableWithEnumT: NativeTable {
+internal class MyGame_Example_TestSimpleTableWithEnumT: NativeTable {
 
-    var color: MyGame_Example_Color
+    internal var color: MyGame_Example_Color
 
-    init(_ _t: inout MyGame_Example_TestSimpleTableWithEnum) {
+    internal init(_ _t: inout MyGame_Example_TestSimpleTableWithEnum) {
         color = _t.color
     }
 
-    init() {
+    internal init() {
         color = .green
     }
 
-    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_TestSimpleTableWithEnum.self) }
+    internal func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_TestSimpleTableWithEnum.self) }
 
 }
 public struct MyGame_Example_Stat: FlatBufferObject, ObjectAPI {
@@ -493,7 +493,7 @@ public struct MyGame_Example_Stat: FlatBufferObject, ObjectAPI {
     private init(_ t: Table) { _accessor = t }
     public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-    enum VTOFFSET: VOffset {
+    private enum VTOFFSET: VOffset {
         case id = 4
         case val = 6
         case count = 8
@@ -552,22 +552,22 @@ public struct MyGame_Example_Stat: FlatBufferObject, ObjectAPI {
 
 public class MyGame_Example_StatT: NativeTable {
 
-    var id: String?
-    var val: Int64
-    var count: UInt16
+    public var id: String?
+    public var val: Int64
+    public var count: UInt16
 
-    init(_ _t: inout MyGame_Example_Stat) {
+    public init(_ _t: inout MyGame_Example_Stat) {
         id = _t.id
         val = _t.val
         count = _t.count
     }
 
-    init() {
+    public init() {
         val = 0
         count = 0
     }
 
-    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_Stat.self) }
+    public func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_Stat.self) }
 
 }
 public struct MyGame_Example_Referrable: FlatBufferObject, ObjectAPI {
@@ -582,7 +582,7 @@ public struct MyGame_Example_Referrable: FlatBufferObject, ObjectAPI {
     private init(_ t: Table) { _accessor = t }
     public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-    enum VTOFFSET: VOffset {
+    private enum VTOFFSET: VOffset {
         case id = 4
         var v: Int32 { Int32(self.rawValue) }
         var p: VOffset { self.rawValue }
@@ -644,17 +644,17 @@ public struct MyGame_Example_Referrable: FlatBufferObject, ObjectAPI {
 
 public class MyGame_Example_ReferrableT: NativeTable {
 
-    var id: UInt64
+    public var id: UInt64
 
-    init(_ _t: inout MyGame_Example_Referrable) {
+    public init(_ _t: inout MyGame_Example_Referrable) {
         id = _t.id
     }
 
-    init() {
+    public init() {
         id = 0
     }
 
-    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_Referrable.self) }
+    public func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_Referrable.self) }
 
 }
 ///  an example documentation comment: "monster object"
@@ -670,7 +670,7 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPI {
     private init(_ t: Table) { _accessor = t }
     public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-    enum VTOFFSET: VOffset {
+    private enum VTOFFSET: VOffset {
         case pos = 4
         case mana = 6
         case hp = 8
@@ -1138,53 +1138,53 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPI {
 
 public class MyGame_Example_MonsterT: NativeTable {
 
-    var pos: MyGame_Example_Vec3T?
-    var mana: Int16
-    var hp: Int16
-    var name: String
-    var inventory: [UInt8]
-    var color: MyGame_Example_Color
-    var test: MyGame_Example_Any_Union?
-    var test4: [MyGame_Example_TestT?]
-    var testarrayofstring: [String?]
-    var testarrayoftables: [MyGame_Example_MonsterT?]
-    var enemy: MyGame_Example_MonsterT?
-    var testnestedflatbuffer: [UInt8]
-    var testempty: MyGame_Example_StatT?
-    var testbool: Bool
-    var testhashs32Fnv1: Int32
-    var testhashu32Fnv1: UInt32
-    var testhashs64Fnv1: Int64
-    var testhashu64Fnv1: UInt64
-    var testhashs32Fnv1a: Int32
-    var testhashu32Fnv1a: UInt32
-    var testhashs64Fnv1a: Int64
-    var testhashu64Fnv1a: UInt64
-    var testarrayofbools: [Bool]
-    var testf: Float32
-    var testf2: Float32
-    var testf3: Float32
-    var testarrayofstring2: [String?]
-    var testarrayofsortedstruct: [MyGame_Example_AbilityT?]
-    var flex: [UInt8]
-    var test5: [MyGame_Example_TestT?]
-    var vectorOfLongs: [Int64]
-    var vectorOfDoubles: [Double]
-    var parentNamespaceTest: MyGame_InParentNamespaceT?
-    var vectorOfReferrables: [MyGame_Example_ReferrableT?]
-    var singleWeakReference: UInt64
-    var vectorOfWeakReferences: [UInt64]
-    var vectorOfStrongReferrables: [MyGame_Example_ReferrableT?]
-    var coOwningReference: UInt64
-    var vectorOfCoOwningReferences: [UInt64]
-    var nonOwningReference: UInt64
-    var vectorOfNonOwningReferences: [UInt64]
-    var anyUnique: MyGame_Example_AnyUniqueAliasesUnion?
-    var anyAmbiguous: MyGame_Example_AnyAmbiguousAliasesUnion?
-    var vectorOfEnums: [MyGame_Example_Color]
-    var signedEnum: MyGame_Example_Race
+    public var pos: MyGame_Example_Vec3T?
+    public var mana: Int16
+    public var hp: Int16
+    public var name: String
+    public var inventory: [UInt8]
+    public var color: MyGame_Example_Color
+    public var test: MyGame_Example_Any_Union?
+    public var test4: [MyGame_Example_TestT?]
+    public var testarrayofstring: [String?]
+    public var testarrayoftables: [MyGame_Example_MonsterT?]
+    public var enemy: MyGame_Example_MonsterT?
+    public var testnestedflatbuffer: [UInt8]
+    public var testempty: MyGame_Example_StatT?
+    public var testbool: Bool
+    public var testhashs32Fnv1: Int32
+    public var testhashu32Fnv1: UInt32
+    public var testhashs64Fnv1: Int64
+    public var testhashu64Fnv1: UInt64
+    public var testhashs32Fnv1a: Int32
+    public var testhashu32Fnv1a: UInt32
+    public var testhashs64Fnv1a: Int64
+    public var testhashu64Fnv1a: UInt64
+    public var testarrayofbools: [Bool]
+    public var testf: Float32
+    public var testf2: Float32
+    public var testf3: Float32
+    public var testarrayofstring2: [String?]
+    public var testarrayofsortedstruct: [MyGame_Example_AbilityT?]
+    public var flex: [UInt8]
+    public var test5: [MyGame_Example_TestT?]
+    public var vectorOfLongs: [Int64]
+    public var vectorOfDoubles: [Double]
+    public var parentNamespaceTest: MyGame_InParentNamespaceT?
+    public var vectorOfReferrables: [MyGame_Example_ReferrableT?]
+    public var singleWeakReference: UInt64
+    public var vectorOfWeakReferences: [UInt64]
+    public var vectorOfStrongReferrables: [MyGame_Example_ReferrableT?]
+    public var coOwningReference: UInt64
+    public var vectorOfCoOwningReferences: [UInt64]
+    public var nonOwningReference: UInt64
+    public var vectorOfNonOwningReferences: [UInt64]
+    public var anyUnique: MyGame_Example_AnyUniqueAliasesUnion?
+    public var anyAmbiguous: MyGame_Example_AnyAmbiguousAliasesUnion?
+    public var vectorOfEnums: [MyGame_Example_Color]
+    public var signedEnum: MyGame_Example_Race
 
-    init(_ _t: inout MyGame_Example_Monster) {
+    public init(_ _t: inout MyGame_Example_Monster) {
         var __pos = _t.pos
         pos = __pos?.unpack()
         mana = _t.mana
@@ -1329,7 +1329,7 @@ public class MyGame_Example_MonsterT: NativeTable {
         signedEnum = _t.signedEnum
     }
 
-    init() {
+    public init() {
         pos = MyGame_Example_Vec3T()
         mana = 150
         hp = 100
@@ -1374,7 +1374,7 @@ public class MyGame_Example_MonsterT: NativeTable {
         signedEnum = .none_
     }
 
-    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_Monster.self) }
+    public func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_Monster.self) }
 
 }
 public struct MyGame_Example_TypeAliases: FlatBufferObject, ObjectAPI {
@@ -1389,7 +1389,7 @@ public struct MyGame_Example_TypeAliases: FlatBufferObject, ObjectAPI {
     private init(_ t: Table) { _accessor = t }
     public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-    enum VTOFFSET: VOffset {
+    private enum VTOFFSET: VOffset {
         case i8 = 4
         case u8 = 6
         case i16 = 8
@@ -1510,20 +1510,20 @@ public struct MyGame_Example_TypeAliases: FlatBufferObject, ObjectAPI {
 
 public class MyGame_Example_TypeAliasesT: NativeTable {
 
-    var i8: Int8
-    var u8: UInt8
-    var i16: Int16
-    var u16: UInt16
-    var i32: Int32
-    var u32: UInt32
-    var i64: Int64
-    var u64: UInt64
-    var f32: Float32
-    var f64: Double
-    var v8: [Int8]
-    var vf64: [Double]
+    public var i8: Int8
+    public var u8: UInt8
+    public var i16: Int16
+    public var u16: UInt16
+    public var i32: Int32
+    public var u32: UInt32
+    public var i64: Int64
+    public var u64: UInt64
+    public var f32: Float32
+    public var f64: Double
+    public var v8: [Int8]
+    public var vf64: [Double]
 
-    init(_ _t: inout MyGame_Example_TypeAliases) {
+    public init(_ _t: inout MyGame_Example_TypeAliases) {
         i8 = _t.i8
         u8 = _t.u8
         i16 = _t.i16
@@ -1544,7 +1544,7 @@ public class MyGame_Example_TypeAliasesT: NativeTable {
         }
     }
 
-    init() {
+    public init() {
         i8 = 0
         u8 = 0
         i16 = 0
@@ -1559,6 +1559,6 @@ public class MyGame_Example_TypeAliasesT: NativeTable {
         vf64 = []
     }
 
-    func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_TypeAliases.self) }
+    public func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_TypeAliases.self) }
 
 }

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/optional_scalars_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/optional_scalars_generated.swift
@@ -14,7 +14,7 @@ public struct optional_scalars_ScalarStuff: FlatBufferObject {
     private init(_ t: Table) { _accessor = t }
     public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-    enum VTOFFSET: VOffset {
+    private enum VTOFFSET: VOffset {
         case justI8 = 4
         case maybeI8 = 6
         case defaultI8 = 8

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
@@ -20,14 +20,14 @@ public enum Character: UInt8, Enum {
     public static var min: Character { return .none_ }
 }
 
-struct CharacterUnion {
-    var type: Character
-    var value: NativeTable?
-    init(_ v: NativeTable?, type: Character) {
+public struct CharacterUnion {
+    public var type: Character
+    public var value: NativeTable?
+    public init(_ v: NativeTable?, type: Character) {
         self.type = type
         self.value = v
     }
-    func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
+    public func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
         switch type {
         case .mulan:
             var __obj = value as? AttackerT
@@ -74,13 +74,13 @@ public struct Rapunzel: Readable {
 
 public class RapunzelT: NativeTable {
 
-    var hairLength: Int32
+    public var hairLength: Int32
 
-    init(_ _t: inout Rapunzel) {
+    public init(_ _t: inout Rapunzel) {
         hairLength = _t.hairLength
     }
 
-    init() {
+    public init() {
         hairLength = 0
     }
 
@@ -114,13 +114,13 @@ public struct BookReader: Readable {
 
 public class BookReaderT: NativeTable {
 
-    var booksRead: Int32
+    public var booksRead: Int32
 
-    init(_ _t: inout BookReader) {
+    public init(_ _t: inout BookReader) {
         booksRead = _t.booksRead
     }
 
-    init() {
+    public init() {
         booksRead = 0
     }
 
@@ -157,7 +157,7 @@ public struct Attacker: FlatBufferObject, ObjectAPI {
     private init(_ t: Table) { _accessor = t }
     public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-    enum VTOFFSET: VOffset {
+    private enum VTOFFSET: VOffset {
         case swordAttackDamage = 4
         var v: Int32 { Int32(self.rawValue) }
         var p: VOffset { self.rawValue }
@@ -195,17 +195,17 @@ public struct Attacker: FlatBufferObject, ObjectAPI {
 
 public class AttackerT: NativeTable {
 
-    var swordAttackDamage: Int32
+    public var swordAttackDamage: Int32
 
-    init(_ _t: inout Attacker) {
+    public init(_ _t: inout Attacker) {
         swordAttackDamage = _t.swordAttackDamage
     }
 
-    init() {
+    public init() {
         swordAttackDamage = 0
     }
 
-    func serialize() -> ByteBuffer { return serialize(type: Attacker.self) }
+    public func serialize() -> ByteBuffer { return serialize(type: Attacker.self) }
 
 }
 public struct Movie: FlatBufferObject, ObjectAPI {
@@ -220,7 +220,7 @@ public struct Movie: FlatBufferObject, ObjectAPI {
     private init(_ t: Table) { _accessor = t }
     public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-    enum VTOFFSET: VOffset {
+    private enum VTOFFSET: VOffset {
         case mainCharacterType = 4
         case mainCharacter = 6
         case charactersType = 8
@@ -288,10 +288,10 @@ public struct Movie: FlatBufferObject, ObjectAPI {
 
 public class MovieT: NativeTable {
 
-    var mainCharacter: CharacterUnion?
-    var characters: [CharacterUnion?]
+    public var mainCharacter: CharacterUnion?
+    public var characters: [CharacterUnion?]
 
-    init(_ _t: inout Movie) {
+    public init(_ _t: inout Movie) {
         switch _t.mainCharacterType {
         case .mulan:
             var _v = _t.mainCharacter(type: Attacker.self)
@@ -327,10 +327,10 @@ public class MovieT: NativeTable {
         }
     }
 
-    init() {
+    public init() {
         characters = []
     }
 
-    func serialize() -> ByteBuffer { return serialize(type: Movie.self) }
+    public func serialize() -> ByteBuffer { return serialize(type: Movie.self) }
 
 }


### PR DESCRIPTION
The following PR includes simple changes to how the access modifiers work. we now adhere to the private keyword in the attributes.
Changes:

- Adds (internal) to FlatBuffers

- Adds access modifiers to Object Apis (public and internal)

- Adds access modifiers to grpc since we added them in FlatBuffers

Closes #6079 