### PR TITLE
Add `removable-media` plug to the snapcraft config

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,3 +32,4 @@ apps:
     command: flatc
     plugs:
       - home
+      - removable-media


### PR DESCRIPTION
Adds the [removable-media](https://snapcraft.io/docs/removable-media-interface) plug to the snap.

This will allow the snap to access USB drives, but also extra internal drives, where people might have their projects stored (like I do).

@om26er do you know if there are any objections / issues with adding this?