### PR TITLE
[C++] Adds -lm linker flag for FreeBSD/OpenBSD where we're using cmat…

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,6 +10,22 @@ exports_files([
     "LICENSE",
 ])
 
+config_setting(
+    name = "platform_freebsd",
+    constraint_values = [
+        "@platforms//os:freebsd",
+    ],
+    visibility = [":__subpackages__"],
+)
+
+config_setting(
+    name = "platform_openbsd",
+    constraint_values = [
+        "@platforms//os:openbsd",
+    ],
+    visibility = [":__subpackages__"],
+)
+
 # Public flatc library to compile flatbuffer files at runtime.
 cc_library(
     name = "flatbuffers",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,13 @@ workspace(name = "com_github_google_flatbuffers")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+#### Platform detection for Bazel.
+http_archive(
+    name = "platforms",
+    strip_prefix = "platforms-master",
+    urls = ["https://github.com/bazelbuild/platforms/archive/master.zip"],
+)
+
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "e88471aea3a3a4f19ec1310a55ba94772d087e9ce46e41ae38ecebe17935de7b",

--- a/src/BUILD
+++ b/src/BUILD
@@ -23,6 +23,7 @@ cc_library(
     linkopts = select({
         "//:platform_freebsd": BSD_LINKOPTS,
         "//:platform_openbsd": BSD_LINKOPTS,
+        "//conditions:default": [],
     }),
     strip_include_prefix = "/include",
     visibility = ["//:__pkg__"],

--- a/src/BUILD
+++ b/src/BUILD
@@ -4,6 +4,10 @@ package(
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
+BSD_LINKOPTS = [
+    "-lm",
+]
+
 # Public flatc library to compile flatbuffer files at runtime.
 cc_library(
     name = "flatbuffers",
@@ -16,6 +20,10 @@ cc_library(
         "util.cpp",
     ],
     hdrs = ["//:public_headers"],
+    linkopts = select({
+        "//:platform_freebsd": BSD_LINKOPTS,
+        "//:platform_openbsd": BSD_LINKOPTS,
+    }),
     strip_include_prefix = "/include",
     visibility = ["//:__pkg__"],
 )


### PR DESCRIPTION
…h. (#6089)

Fixes #6089 by adding `-lm` to the build linker opts for FreeBSD and OpenBSD.
