### PR TITLE
Fix for issue #6100: ResizeContext shrinking logic is incorrect

### DIFF
--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -195,7 +195,7 @@ class ResizeContext {
     if (delta_ > 0)
       buf_.insert(buf_.begin() + start, delta_, 0);
     else
-      buf_.erase(buf_.begin() + start, buf_.begin() + start - delta_);
+      buf_.erase(buf_.begin() + start + delta_, buf_.begin() + start);
   }
 
   // Check if the range between first (lower address) and second straddles


### PR DESCRIPTION
This change fixes the issue reported in https://github.com/google/flatbuffers/issues/6100.

ResizeContext logic for shrinking case is incorrect and removes serialization data past the area that should actually be shrinked.