### PR TITLE
[docs] fix c# json serializer commandline argument docs

### DIFF
--- a/docs/source/CsharpUsage.md
+++ b/docs/source/CsharpUsage.md
@@ -155,7 +155,7 @@ To use:
 
 An additional feature of the object API is the ability to allow you to
 serialize & deserialize a JSON text. 
-To use Json Serialization, add `--gen-json-serializer` option to `flatc` and
+To use Json Serialization, add `--cs-gen-json-serializer` option to `flatc` and
 add `Newtonsoft.Json` nuget package to csproj.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cs}


### PR DESCRIPTION
 Fixed a mistake in the documentation of C# command line arguments :sweat_smile:  #6078

* `--gen-json-serializer` -> `--cs-gen-json-serializer`
