### PR TITLE
[C#] Add Union Constructor Utility for ObjectAPI.

### DIFF
--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -1322,7 +1322,7 @@ class CSharpGenerator : public BaseGenerator {
       std::string lower_ev_name;
       for (auto name_it = ev.name.begin(); name_it != ev.name.end();
            ++name_it) {
-        lower_ev_name += static_cast<char>(std::tolower(*name_it));
+        lower_ev_name += CharToLower(*name_it);
       }
       code += "  " + accessibility + " static " + union_name + " From" +
               ev.name + "(" + type_name + " _" + lower_ev_name +

--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -1319,11 +1319,9 @@ class CSharpGenerator : public BaseGenerator {
       code += "  " + accessibility + " " + type_name + " As" + ev.name +
               "() { return this.As<" + type_name + ">(); }\n";
       // From
-      std::string lower_ev_name;
-      for (auto name_it = ev.name.begin(); name_it != ev.name.end();
-           ++name_it) {
-        lower_ev_name += CharToLower(*name_it);
-      }
+      auto lower_ev_name = ev.name;
+      std::transform(lower_ev_name.begin(), lower_ev_name.end(),
+                     lower_ev_name.begin(), CharToLower);
       code += "  " + accessibility + " static " + union_name + " From" +
               ev.name + "(" + type_name + " _" + lower_ev_name +
               ") { return new " + union_name + "{ Type = " + enum_def.name +

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -488,6 +488,26 @@ namespace FlatBuffers.Test
             TestObjectAPI(movie);
         }
 
+        [FlatBuffersTestMethod]
+        public void TestUnionUtility()
+        {
+            var movie = new MovieT
+            {
+                MainCharacter = CharacterUnion.FromRapunzel(new RapunzelT { HairLength = 40 }),
+                Characters = new System.Collections.Generic.List<CharacterUnion>
+                {
+                    CharacterUnion.FromMuLan(new AttackerT { SwordAttackDamage = 10 }),
+                    CharacterUnion.FromBelle(new BookReaderT { BooksRead = 20 }),
+                    CharacterUnion.FromOther("Chip"),
+                },
+            };
+
+            var fbb = new FlatBufferBuilder(100);
+            Movie.FinishMovieBuffer(fbb, Movie.Pack(fbb, movie));
+
+            TestObjectAPI(Movie.GetRootAsMovie(fbb.DataBuffer));
+        }
+
         private void AreEqual(Monster a, MonsterT b)
         {
             Assert.AreEqual(a.Hp, b.Hp);

--- a/tests/MyGame/Example/Any.cs
+++ b/tests/MyGame/Example/Any.cs
@@ -25,8 +25,11 @@ public class AnyUnion {
 
   public T As<T>() where T : class { return this.Value as T; }
   public MyGame.Example.MonsterT AsMonster() { return this.As<MyGame.Example.MonsterT>(); }
+  public static AnyUnion FromMonster(MyGame.Example.MonsterT _monster) { return new AnyUnion{ Type = Any.Monster, Value = _monster }; }
   internal MyGame.Example.TestSimpleTableWithEnumT AsTestSimpleTableWithEnum() { return this.As<MyGame.Example.TestSimpleTableWithEnumT>(); }
+  internal static AnyUnion FromTestSimpleTableWithEnum(MyGame.Example.TestSimpleTableWithEnumT _testsimpletablewithenum) { return new AnyUnion{ Type = Any.TestSimpleTableWithEnum, Value = _testsimpletablewithenum }; }
   public MyGame.Example2.MonsterT AsMyGame_Example2_Monster() { return this.As<MyGame.Example2.MonsterT>(); }
+  public static AnyUnion FromMyGame_Example2_Monster(MyGame.Example2.MonsterT _mygame_example2_monster) { return new AnyUnion{ Type = Any.MyGame_Example2_Monster, Value = _mygame_example2_monster }; }
 
   public static int Pack(FlatBuffers.FlatBufferBuilder builder, AnyUnion _o) {
     switch (_o.Type) {

--- a/tests/MyGame/Example/AnyAmbiguousAliases.cs
+++ b/tests/MyGame/Example/AnyAmbiguousAliases.cs
@@ -25,8 +25,11 @@ public class AnyAmbiguousAliasesUnion {
 
   public T As<T>() where T : class { return this.Value as T; }
   public MyGame.Example.MonsterT AsM1() { return this.As<MyGame.Example.MonsterT>(); }
+  public static AnyAmbiguousAliasesUnion FromM1(MyGame.Example.MonsterT _m1) { return new AnyAmbiguousAliasesUnion{ Type = AnyAmbiguousAliases.M1, Value = _m1 }; }
   public MyGame.Example.MonsterT AsM2() { return this.As<MyGame.Example.MonsterT>(); }
+  public static AnyAmbiguousAliasesUnion FromM2(MyGame.Example.MonsterT _m2) { return new AnyAmbiguousAliasesUnion{ Type = AnyAmbiguousAliases.M2, Value = _m2 }; }
   public MyGame.Example.MonsterT AsM3() { return this.As<MyGame.Example.MonsterT>(); }
+  public static AnyAmbiguousAliasesUnion FromM3(MyGame.Example.MonsterT _m3) { return new AnyAmbiguousAliasesUnion{ Type = AnyAmbiguousAliases.M3, Value = _m3 }; }
 
   public static int Pack(FlatBuffers.FlatBufferBuilder builder, AnyAmbiguousAliasesUnion _o) {
     switch (_o.Type) {

--- a/tests/MyGame/Example/AnyUniqueAliases.cs
+++ b/tests/MyGame/Example/AnyUniqueAliases.cs
@@ -25,8 +25,11 @@ public class AnyUniqueAliasesUnion {
 
   public T As<T>() where T : class { return this.Value as T; }
   public MyGame.Example.MonsterT AsM() { return this.As<MyGame.Example.MonsterT>(); }
+  public static AnyUniqueAliasesUnion FromM(MyGame.Example.MonsterT _m) { return new AnyUniqueAliasesUnion{ Type = AnyUniqueAliases.M, Value = _m }; }
   internal MyGame.Example.TestSimpleTableWithEnumT AsTS() { return this.As<MyGame.Example.TestSimpleTableWithEnumT>(); }
+  internal static AnyUniqueAliasesUnion FromTS(MyGame.Example.TestSimpleTableWithEnumT _ts) { return new AnyUniqueAliasesUnion{ Type = AnyUniqueAliases.TS, Value = _ts }; }
   public MyGame.Example2.MonsterT AsM2() { return this.As<MyGame.Example2.MonsterT>(); }
+  public static AnyUniqueAliasesUnion FromM2(MyGame.Example2.MonsterT _m2) { return new AnyUniqueAliasesUnion{ Type = AnyUniqueAliases.M2, Value = _m2 }; }
 
   public static int Pack(FlatBuffers.FlatBufferBuilder builder, AnyUniqueAliasesUnion _o) {
     switch (_o.Type) {

--- a/tests/namespace_test/NamespaceA/NamespaceB/UnionInNestedNS.cs
+++ b/tests/namespace_test/NamespaceA/NamespaceB/UnionInNestedNS.cs
@@ -23,6 +23,7 @@ public class UnionInNestedNSUnion {
 
   public T As<T>() where T : class { return this.Value as T; }
   public NamespaceA.NamespaceB.TableInNestedNST AsTableInNestedNS() { return this.As<NamespaceA.NamespaceB.TableInNestedNST>(); }
+  public static UnionInNestedNSUnion FromTableInNestedNS(NamespaceA.NamespaceB.TableInNestedNST _tableinnestedns) { return new UnionInNestedNSUnion{ Type = UnionInNestedNS.TableInNestedNS, Value = _tableinnestedns }; }
 
   public static int Pack(FlatBuffers.FlatBufferBuilder builder, UnionInNestedNSUnion _o) {
     switch (_o.Type) {

--- a/tests/union_vector/Character.cs
+++ b/tests/union_vector/Character.cs
@@ -25,11 +25,17 @@ public class CharacterUnion {
 
   public T As<T>() where T : class { return this.Value as T; }
   public AttackerT AsMuLan() { return this.As<AttackerT>(); }
+  public static CharacterUnion FromMuLan(AttackerT _mulan) { return new CharacterUnion{ Type = Character.MuLan, Value = _mulan }; }
   public RapunzelT AsRapunzel() { return this.As<RapunzelT>(); }
+  public static CharacterUnion FromRapunzel(RapunzelT _rapunzel) { return new CharacterUnion{ Type = Character.Rapunzel, Value = _rapunzel }; }
   public BookReaderT AsBelle() { return this.As<BookReaderT>(); }
+  public static CharacterUnion FromBelle(BookReaderT _belle) { return new CharacterUnion{ Type = Character.Belle, Value = _belle }; }
   public BookReaderT AsBookFan() { return this.As<BookReaderT>(); }
+  public static CharacterUnion FromBookFan(BookReaderT _bookfan) { return new CharacterUnion{ Type = Character.BookFan, Value = _bookfan }; }
   public string AsOther() { return this.As<string>(); }
+  public static CharacterUnion FromOther(string _other) { return new CharacterUnion{ Type = Character.Other, Value = _other }; }
   public string AsUnused() { return this.As<string>(); }
+  public static CharacterUnion FromUnused(string _unused) { return new CharacterUnion{ Type = Character.Unused, Value = _unused }; }
 
   public static int Pack(FlatBuffers.FlatBufferBuilder builder, CharacterUnion _o) {
     switch (_o.Type) {


### PR DESCRIPTION
This PR adds a convenience feature to the ObjectAPI to avoid mistakes in union generation.

### Before
The union tag may not match the value type.

```cs
var movie = new MovieT
{
    MainCharacter = new CharacterUnion { Type = Character.Rapunzel, Value = new RapunzelT { HairLength = 40 } },
    Characters = new System.Collections.Generic.List<CharacterUnion>
    {
        new CharacterUnion { Type = Character.MuLan, Value = new AttackerT { SwordAttackDamage = 10 }},
        new CharacterUnion { Type = Character.Belle, Value = new BookReaderT { BooksRead = 20 }},
        new CharacterUnion { Type = Character.Other, Value = "Chip" },
    },
};
```

### This PR
The union tag will always match the value type.

```cs
var movie = new MovieT
{
    MainCharacter = CharacterUnion.FromRapunzel(new RapunzelT { HairLength = 40 }),
    Characters = new System.Collections.Generic.List<CharacterUnion>
    {
        CharacterUnion.FromMuLan(new AttackerT { SwordAttackDamage = 10 }),
        CharacterUnion.FromBelle(new BookReaderT { BooksRead = 20 }),
        CharacterUnion.FromOther("Chip"),
    },
};

```
