### PR TITLE
Avoid memcpy call for empty vectors

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1607,6 +1607,9 @@ class FlatBufferBuilder {
     // causing the wrong overload to be selected, remove it.
     AssertScalarT<T>();
     StartVector(len, sizeof(T));
+    if (len == 0) {
+      return Offset<Vector<T>>(EndVector(len));
+    }
     // clang-format off
     #if FLATBUFFERS_LITTLEENDIAN
       PushBytes(reinterpret_cast<const uint8_t *>(v), len * sizeof(T));


### PR DESCRIPTION
Undefined behavior sanitizer crashes  when `fbb.CreateVector` is called with empty vector `std::vector<uint16_t>` (any scalar type can be placed here) [C++, clang version 9.0.0-2~ubuntu18.04.2r].

The issue comes from this method call
https://github.com/google/flatbuffers/blob/master/include/flatbuffers/flatbuffers.h#L1612

```
  template<typename T> Offset<Vector<T>> CreateVector(const T *v, size_t len) {
    // If this assert hits, you're specifying a template argument that is
    // causing the wrong overload to be selected, remove it.
    AssertScalarT<T>();
    StartVector(len, sizeof(T));
    // clang-format off
    #if FLATBUFFERS_LITTLEENDIAN
      PushBytes(reinterpret_cast<const uint8_t *>(v), len * sizeof(T));
    #else
      if (sizeof(T) == 1) {
        PushBytes(reinterpret_cast<const uint8_t *>(v), len);
      } else {
        for (auto i = len; i > 0; ) {
          PushElement(v[--i]);
        }
      }
    #endif
    // clang-format on
    return Offset<Vector<T>>(EndVector(len));
  }
```

Here `v` would be a `nullptr` and `PushBytes` eventually calls `memcpy` and it can't be called with `nullptr` which causes the crash.


Following advice from the [issue:6096](https://github.com/google/flatbuffers/issues/6096), I just remove calls to the `PushBytes` for an empty vectors.