### PR TITLE
Rename Nullable scalars to Optional scalars

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -296,7 +296,7 @@ struct FieldDef : public Definition {
         shared(false),
         native_inline(false),
         flexbuffer(false),
-        nullable(false),
+        optional(false),
         nested_flatbuffer(NULL),
         padding(0) {}
 
@@ -315,7 +315,7 @@ struct FieldDef : public Definition {
   bool native_inline;  // Field will be defined inline (instead of as a pointer)
                        // for native tables if field is a struct.
   bool flexbuffer;     // This field contains FlexBuffer data.
-  bool nullable;       // If True, this field is Null (as opposed to default
+  bool optional;       // If True, this field is Null (as opposed to default
                        // valued).
   StructDef *nested_flatbuffer;  // This field contains nested FlatBuffer data.
   size_t padding;                // Bytes to always pad after this field.
@@ -932,7 +932,7 @@ class Parser : public ParserState {
 
   bool SupportsAdvancedUnionFeatures() const;
   bool SupportsAdvancedArrayFeatures() const;
-  bool SupportsNullableScalars() const;
+  bool SupportsOptionalScalars() const;
   Namespace *UniqueNamespace(Namespace *ns);
 
   FLATBUFFERS_CHECKED_ERROR RecurseError();

--- a/src/idl_gen_lobster.cpp
+++ b/src/idl_gen_lobster.cpp
@@ -110,13 +110,13 @@ class LobsterGenerator : public BaseGenerator {
               offsets + ")";
 
       } else {
-        auto defval = field.nullable ? "0" : field.value.constant;
+        auto defval = field.optional ? "0" : field.value.constant;
         acc = "buf_.flatbuffers_field_" + GenTypeName(field.value.type) +
               "(pos_, " + offsets + ", " + defval + ")";
       }
       if (field.value.type.enum_def)
         acc = NormalizedName(*field.value.type.enum_def) + "(" + acc + ")";
-      if (field.nullable)
+      if (field.optional)
         acc += ", buf_.flatbuffers_field_present(pos_, " + offsets + ")";
       code += def + "():\n        return " + acc + "\n";
       return;
@@ -201,7 +201,7 @@ class LobsterGenerator : public BaseGenerator {
               NormalizedName(field) + ":" + LobsterType(field.value.type) +
               "):\n        b_.Prepend" + GenMethod(field.value.type) + "Slot(" +
               NumToString(offset) + ", " + NormalizedName(field);
-      if (IsScalar(field.value.type.base_type) && !field.nullable)
+      if (IsScalar(field.value.type.base_type) && !field.optional)
         code += ", " + field.value.constant;
       code += ")\n        return this\n";
     }

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -665,10 +665,10 @@ class RustGenerator : public BaseGenerator {
     switch (GetFullType(field.value.type)) {
       case ftInteger:
       case ftFloat: {
-        return field.nullable ? "None" : field.value.constant;
+        return field.optional ? "None" : field.value.constant;
       }
       case ftBool: {
-        return field.nullable ? "None" :
+        return field.optional ? "None" :
           field.value.constant == "0" ? "false" : "true";
       }
       case ftUnionKey:
@@ -707,7 +707,7 @@ class RustGenerator : public BaseGenerator {
       case ftFloat:
       case ftBool: {
         const auto typname = GetTypeBasic(type);
-        return field.nullable ? "Option<" + typname + ">" : typname;
+        return field.optional ? "Option<" + typname + ">" : typname;
       }
       case ftStruct: {
         const auto typname = WrapInNameSpace(*type.struct_def);
@@ -865,7 +865,7 @@ class RustGenerator : public BaseGenerator {
       case ftBool:
       case ftFloat: {
         const auto typname = GetTypeBasic(field.value.type);
-        return (field.nullable ?
+        return (field.optional ?
                    "self.fbb_.push_slot_always::<" :
                    "self.fbb_.push_slot::<") + typname + ">";
       }
@@ -910,7 +910,7 @@ class RustGenerator : public BaseGenerator {
       case ftFloat:
       case ftBool: {
         const auto typname = GetTypeBasic(type);
-        return field.nullable ? "Option<" + typname + ">" : typname;
+        return field.optional ? "Option<" + typname + ">" : typname;
       }
       case ftStruct: {
         const auto typname = WrapInNameSpace(*type.struct_def);
@@ -994,7 +994,7 @@ class RustGenerator : public BaseGenerator {
       case ftFloat:
       case ftBool: {
         const auto typname = GetTypeBasic(type);
-        if (field.nullable) {
+        if (field.optional) {
           return "self._tab.get::<" + typname + ">(" + offset_name + ", None)";
         } else {
           const auto default_value = GetDefaultScalarValue(field);
@@ -1092,7 +1092,7 @@ class RustGenerator : public BaseGenerator {
   }
 
   bool TableFieldReturnsOption(const FieldDef &field) {
-    if (field.nullable) return true;
+    if (field.optional) return true;
     switch (GetFullType(field.value.type)) {
       case ftInteger:
       case ftFloat:
@@ -1416,7 +1416,7 @@ class RustGenerator : public BaseGenerator {
         code_ +=
             "  pub fn add_{{FIELD_NAME}}(&mut self, {{FIELD_NAME}}: "
             "{{FIELD_TYPE}}) {";
-        if (is_scalar && !field.nullable) {
+        if (is_scalar && !field.optional) {
           code_.SetValue("FIELD_DEFAULT_VALUE",
                          TableBuilderAddFuncDefaultValue(field));
           code_ +=

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -744,13 +744,13 @@ CheckedError Parser::ParseField(StructDef &struct_def) {
           "default values currently only supported for scalars in tables");
   }
 
-  // Mark the nullable scalars. Note that a side effect of ParseSingleValue is
+  // Mark the optional scalars. Note that a side effect of ParseSingleValue is
   // fixing field->value.constant to null.
   if (IsScalar(type.base_type)) {
-    field->nullable = (field->value.constant == "null");
-    if (field->nullable && !SupportsNullableScalars()) {
+    field->optional = (field->value.constant == "null");
+    if (field->optional && !SupportsOptionalScalars()) {
       return Error(
-        "Nullable scalars are not yet supported in at least one the of "
+        "Optional scalars are not yet supported in at least one the of "
         "the specified programming languages."
       );
     }
@@ -2257,7 +2257,7 @@ CheckedError Parser::CheckClash(std::vector<FieldDef *> &fields,
 }
 
 
-bool Parser::SupportsNullableScalars() const {
+bool Parser::SupportsOptionalScalars() const {
   return !(opts.lang_to_generate &
     ~(IDLOptions::kRust | IDLOptions::kSwift | IDLOptions::kLobster));
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -3427,8 +3427,8 @@ void TestEmbeddedBinarySchema() {
           0);
 }
 
-void NullableScalarsTest() {
-  // Simple schemas and a "has nullable scalar" sentinal.
+void OptionalScalarsTest() {
+  // Simple schemas and a "has optional scalar" sentinal.
   std::vector<std::string> schemas;
   schemas.push_back("table Monster { mana : int; }");
   schemas.push_back("table Monster { mana : int = 42; }");
@@ -3452,10 +3452,10 @@ void NullableScalarsTest() {
     flatbuffers::Parser parser;
     TEST_ASSERT(parser.Parse(schema->c_str()));
     const auto *mana = parser.structs_.Lookup("Monster")->fields.Lookup("mana");
-    TEST_EQ(mana->nullable, has_null);
+    TEST_EQ(mana->optional, has_null);
   }
 
-  // Test if nullable scalars are allowed for each language.
+  // Test if optional scalars are allowed for each language.
   const int kNumLanguages = 17;
   const auto supported = (flatbuffers::IDLOptions::kRust |
                           flatbuffers::IDLOptions::kSwift |
@@ -3475,9 +3475,9 @@ void NullableScalarsTest() {
 
 void ParseFlexbuffersFromJsonWithNullTest() {
   // Test nulls are handled appropriately through flexbuffers to exercise other
-  // code paths of ParseSingleValue in the nullable scalars change.
+  // code paths of ParseSingleValue in the optional scalars change.
   // TODO(cneo): Json -> Flatbuffers test once some language can generate code
-  // with nullable scalars.
+  // with optional scalars.
   {
     char json[] = "{\"opt_field\": 123 }";
     flatbuffers::Parser parser;
@@ -3593,7 +3593,7 @@ int FlatBufferTests() {
   TestMonsterExtraFloats();
   FixedLengthArrayTest();
   NativeTypeTest();
-  NullableScalarsTest();
+  OptionalScalarsTest();
   ParseFlexbuffersFromJsonWithNullTest();
   return 0;
 }


### PR DESCRIPTION
This standardizes the variable names around optional scalars #6014, using the term "optional" instead of "nullable". This should be submitted before the reflection support in #6097.