### PR TITLE
[JS] Add getFullyQualifiedName()

### DIFF
--- a/src/idl_gen_js_ts.cpp
+++ b/src/idl_gen_js_ts.cpp
@@ -1783,6 +1783,18 @@ class JsTsGenerator : public BaseGenerator {
       }
     }
 
+    // Emit the fully qualified name
+    if (parser_.opts.generate_name_strings) {
+      GenDocComment(code_ptr, GenTypeAnnotation(kReturns, "string", "", false));
+      if (lang_.language == IDLOptions::kTs) {
+        code += "static getFullyQualifiedName():string {\n";
+      } else {
+        code += object_name + ".getFullyQualifiedName = function() {\n";
+      }
+      code += "  return '" + WrapInNameSpace(struct_def) + "';\n";
+      code += "}\n\n";
+    }
+
     // Emit a factory constructor
     if (struct_def.fixed) {
       std::string annotations =

--- a/tests/JavaScriptTest.sh
+++ b/tests/JavaScriptTest.sh
@@ -16,9 +16,9 @@
 
 pushd "$(dirname $0)" >/dev/null
 ../flatc -b -I include_test monster_test.fbs unicode_test.json
-../flatc --js -o js --gen-mutable --no-fb-import -I include_test monster_test.fbs
+../flatc --js -o js --gen-name-strings --gen-mutable --no-fb-import -I include_test monster_test.fbs
 node JavaScriptTest ./js/monster_test_generated
 
-../flatc --js -o js --no-fb-import union_vector/union_vector.fbs
+../flatc --js --gen-name-strings -o js --no-fb-import union_vector/union_vector.fbs
 node JavaScriptUnionVectorTest ./js/union_vector_generated
 node JavaScriptFlexBuffersTest

--- a/tests/TypeScriptTest.sh
+++ b/tests/TypeScriptTest.sh
@@ -20,12 +20,12 @@ npm install @types/flatbuffers
 
 export FB_TS_TEST="TRUE"
 
-../flatc --ts --no-fb-import --gen-mutable --gen-object-api -o ts -I include_test monster_test.fbs
+../flatc --ts --no-fb-import --gen-name-strings --gen-mutable --gen-object-api -o ts -I include_test monster_test.fbs
 ../flatc --gen-object-api -b -I include_test monster_test.fbs unicode_test.json
 tsc --strict --noUnusedParameters --noUnusedLocals --noImplicitReturns --strictNullChecks ts/monster_test_generated.ts
 node JavaScriptTest ./ts/monster_test_generated
 
-../flatc --ts --no-fb-import --gen-object-api -o ts union_vector/union_vector.fbs
+../flatc --ts --gen-name-strings --no-fb-import --gen-object-api -o ts union_vector/union_vector.fbs
 tsc --strict --noUnusedParameters --noUnusedLocals --noImplicitReturns --strictNullChecks ts/union_vector_generated.ts
 node JavaScriptUnionVectorTest ./ts/union_vector_generated
 

--- a/tests/generate_code.bat
+++ b/tests/generate_code.bat
@@ -29,6 +29,7 @@ if NOT "%commandline%"=="%commandline:--cpp-std c++0x=%" (
 
 set TEST_CPP_FLAGS=--gen-compare --cpp-ptr-type flatbuffers::unique_ptr %TEST_CPP_FLAGS%
 set TEST_CS_FLAGS=--cs-gen-json-serializer
+set TEST_JS_TS_FLAGS=--gen-name-strings
 set TEST_RUST_FLAGS=--gen-name-strings
 set TEST_BASE_FLAGS=--reflect-names --gen-mutable --gen-object-api
 set TEST_NOINCL_FLAGS=%TEST_BASE_FLAGS% --no-includes --no-fb-import
@@ -40,9 +41,9 @@ set TEST_NOINCL_FLAGS=%TEST_BASE_FLAGS% --no-includes --no-fb-import
 ..\%buildtype%\flatc.exe --python %TEST_BASE_FLAGS% --no-fb-import -I include_test monster_test.fbs monsterdata_test.json || goto FAIL
 
 ..\%buildtype%\flatc.exe --binary --cpp --java --csharp --dart --go --lobster --lua --js --ts --php --python --rust ^
-%TEST_NOINCL_FLAGS% %TEST_CPP_FLAGS% %TEST_CS_FLAGS% -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs || goto FAIL
+%TEST_NOINCL_FLAGS% %TEST_CPP_FLAGS% %TEST_CS_FLAGS% %TEST_JS_TS_FLAGS% -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs || goto FAIL
 
-..\%buildtype%\flatc.exe --cpp --java --csharp --js --ts --php %TEST_BASE_FLAGS% %TEST_CPP_FLAGS% %TEST_CS_FLAGS% -o union_vector ./union_vector/union_vector.fbs || goto FAIL
+..\%buildtype%\flatc.exe --cpp --java --csharp --js --ts --php %TEST_BASE_FLAGS% %TEST_CPP_FLAGS% %TEST_CS_FLAGS% %TEST_JS_TS_FLAGS% -o union_vector ./union_vector/union_vector.fbs || goto FAIL
 ..\%buildtype%\flatc.exe --rust -I include_test -o include_test include_test/include_test1.fbs || goto FAIL
 ..\%buildtype%\flatc.exe --rust -I include_test -o include_test/sub include_test/sub/include_test2.fbs || goto FAIL
 ..\%buildtype%\flatc.exe -b --schema --bfbs-comments --bfbs-builtins -I include_test monster_test.fbs || goto FAIL

--- a/tests/generate_code.sh
+++ b/tests/generate_code.sh
@@ -26,6 +26,7 @@ fi
 
 TEST_CPP_FLAGS="--gen-compare --cpp-ptr-type flatbuffers::unique_ptr $TEST_CPP_FLAGS"
 TEST_CS_FLAGS="--cs-gen-json-serializer"
+TEST_JS_TS_FLAGS="--gen-name-strings"
 TEST_BASE_FLAGS="--reflect-names --gen-mutable --gen-object-api"
 TEST_RUST_FLAGS="$TEST_BASE_FLAGS --gen-name-strings"
 TEST_NOINCL_FLAGS="$TEST_BASE_FLAGS --no-includes --no-fb-import"
@@ -37,9 +38,9 @@ $TEST_NOINCL_FLAGS $TEST_CPP_FLAGS $TEST_CS_FLAGS -I include_test monster_test.f
 ../flatc --python $TEST_BASE_FLAGS -I include_test monster_test.fbs monsterdata_test.json
 
 ../flatc --cpp --java --kotlin --csharp --dart --go --binary --lobster --lua --js --ts --php --python --rust \
-$TEST_NOINCL_FLAGS $TEST_CPP_FLAGS $TEST_CS_FLAGS -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs
+$TEST_NOINCL_FLAGS $TEST_CPP_FLAGS $TEST_CS_FLAGS $TEST_JS_TS_FLAGS -o namespace_test namespace_test/namespace_test1.fbs namespace_test/namespace_test2.fbs
 
-../flatc --cpp --java --kotlin --csharp --js --ts --php $TEST_BASE_FLAGS $TEST_CPP_FLAGS $TEST_CS_FLAGS -o union_vector ./union_vector/union_vector.fbs
+../flatc --cpp --java --kotlin --csharp --js --ts --php $TEST_BASE_FLAGS $TEST_CPP_FLAGS $TEST_CS_FLAGS $TEST_JS_TS_FLAGS -o union_vector ./union_vector/union_vector.fbs
 ../flatc --rust -I include_test -o include_test include_test/include_test1.fbs
 ../flatc --rust -I include_test -o include_test/sub include_test/sub/include_test2.fbs
 ../flatc -b --schema --bfbs-comments --bfbs-builtins -I include_test monster_test.fbs

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -66,6 +66,9 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) StructInNestedNS FLATBUFFERS_FINAL_CLASS 
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return StructInNestedNSTypeTable();
   }
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "NamespaceA.NamespaceB.StructInNestedNS";
+  }
   StructInNestedNS()
       : a_(0),
         b_(0) {
@@ -102,6 +105,9 @@ inline bool operator!=(const StructInNestedNS &lhs, const StructInNestedNS &rhs)
 
 struct TableInNestedNST : public flatbuffers::NativeTable {
   typedef TableInNestedNS TableType;
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "NamespaceA.NamespaceB.TableInNestedNST";
+  }
   int32_t foo;
   TableInNestedNST()
       : foo(0) {
@@ -123,6 +129,9 @@ struct TableInNestedNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TableInNestedNSBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInNestedNSTypeTable();
+  }
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "NamespaceA.NamespaceB.TableInNestedNS";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_FOO = 4

--- a/tests/namespace_test/namespace_test1_generated.js
+++ b/tests/namespace_test/namespace_test1_generated.js
@@ -99,6 +99,13 @@ NamespaceA.NamespaceB.TableInNestedNS.prototype.mutate_foo = function(value) {
 };
 
 /**
+ * @returns {string}
+ */
+NamespaceA.NamespaceB.TableInNestedNS.getFullyQualifiedName = function() {
+  return 'NamespaceA.NamespaceB.TableInNestedNS';
+}
+
+/**
  * @param {flatbuffers.Builder} builder
  */
 NamespaceA.NamespaceB.TableInNestedNS.startTableInNestedNS = function(builder) {
@@ -190,6 +197,13 @@ NamespaceA.NamespaceB.StructInNestedNS.prototype.mutate_b = function(value) {
   this.bb.writeInt32(this.bb_pos + 4, value);
   return true;
 };
+
+/**
+ * @returns {string}
+ */
+NamespaceA.NamespaceB.StructInNestedNS.getFullyQualifiedName = function() {
+  return 'NamespaceA.NamespaceB.StructInNestedNS';
+}
 
 /**
  * @param {flatbuffers.Builder} builder

--- a/tests/namespace_test/namespace_test1_generated.rs
+++ b/tests/namespace_test/namespace_test1_generated.rs
@@ -141,6 +141,10 @@ impl StructInNestedNS {
 
     }
   }
+    pub const fn get_fully_qualified_name() -> &'static str {
+        "NamespaceA.NamespaceB.StructInNestedNS"
+    }
+
   pub fn a(&self) -> i32 {
     self.a_.from_little_endian()
   }
@@ -165,6 +169,10 @@ impl<'a> flatbuffers::Follow<'a> for TableInNestedNS<'a> {
 }
 
 impl<'a> TableInNestedNS<'a> {
+    pub const fn get_fully_qualified_name() -> &'static str {
+        "NamespaceA.NamespaceB.TableInNestedNS"
+    }
+
     #[inline]
     pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
         TableInNestedNS {

--- a/tests/namespace_test/namespace_test1_generated.ts
+++ b/tests/namespace_test/namespace_test1_generated.ts
@@ -73,6 +73,13 @@ mutate_foo(value:number):boolean {
 };
 
 /**
+ * @returns string
+ */
+static getFullyQualifiedName():string {
+  return 'NamespaceA.NamespaceB.TableInNestedNS';
+}
+
+/**
  * @param flatbuffers.Builder builder
  */
 static startTableInNestedNS(builder:flatbuffers.Builder) {
@@ -189,6 +196,13 @@ mutate_b(value:number):boolean {
   this.bb!.writeInt32(this.bb_pos + 4, value);
   return true;
 };
+
+/**
+ * @returns string
+ */
+static getFullyQualifiedName():string {
+  return 'NamespaceA.NamespaceB.StructInNestedNS';
+}
 
 /**
  * @param flatbuffers.Builder builder

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -59,6 +59,9 @@ inline const flatbuffers::TypeTable *SecondTableInATypeTable();
 
 struct TableInFirstNST : public flatbuffers::NativeTable {
   typedef TableInFirstNS TableType;
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "NamespaceA.TableInFirstNST";
+  }
   flatbuffers::unique_ptr<NamespaceA::NamespaceB::TableInNestedNST> foo_table;
   NamespaceA::NamespaceB::EnumInNestedNS foo_enum;
   flatbuffers::unique_ptr<NamespaceA::NamespaceB::StructInNestedNS> foo_struct;
@@ -84,6 +87,9 @@ struct TableInFirstNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TableInFirstNSBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInFirstNSTypeTable();
+  }
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "NamespaceA.TableInFirstNS";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_FOO_TABLE = 4,
@@ -165,6 +171,9 @@ namespace NamespaceC {
 
 struct TableInCT : public flatbuffers::NativeTable {
   typedef TableInC TableType;
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "NamespaceC.TableInCT";
+  }
   flatbuffers::unique_ptr<NamespaceA::TableInFirstNST> refer_to_a1;
   flatbuffers::unique_ptr<NamespaceA::SecondTableInAT> refer_to_a2;
   TableInCT() {
@@ -187,6 +196,9 @@ struct TableInC FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TableInCBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInCTypeTable();
+  }
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "NamespaceC.TableInC";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_REFER_TO_A1 = 4,
@@ -256,6 +268,9 @@ namespace NamespaceA {
 
 struct SecondTableInAT : public flatbuffers::NativeTable {
   typedef SecondTableInA TableType;
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "NamespaceA.SecondTableInAT";
+  }
   flatbuffers::unique_ptr<NamespaceC::TableInCT> refer_to_c;
   SecondTableInAT() {
   }
@@ -276,6 +291,9 @@ struct SecondTableInA FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef SecondTableInABuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return SecondTableInATypeTable();
+  }
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "NamespaceA.SecondTableInA";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_REFER_TO_C = 4

--- a/tests/namespace_test/namespace_test2_generated.js
+++ b/tests/namespace_test/namespace_test2_generated.js
@@ -105,6 +105,13 @@ NamespaceA.TableInFirstNS.prototype.fooStruct = function(obj) {
 };
 
 /**
+ * @returns {string}
+ */
+NamespaceA.TableInFirstNS.getFullyQualifiedName = function() {
+  return 'NamespaceA.TableInFirstNS';
+}
+
+/**
  * @param {flatbuffers.Builder} builder
  */
 NamespaceA.TableInFirstNS.startTableInFirstNS = function(builder) {
@@ -208,6 +215,13 @@ NamespaceC.TableInC.prototype.referToA2 = function(obj) {
 };
 
 /**
+ * @returns {string}
+ */
+NamespaceC.TableInC.getFullyQualifiedName = function() {
+  return 'NamespaceC.TableInC';
+}
+
+/**
  * @param {flatbuffers.Builder} builder
  */
 NamespaceC.TableInC.startTableInC = function(builder) {
@@ -292,6 +306,13 @@ NamespaceA.SecondTableInA.prototype.referToC = function(obj) {
   var offset = this.bb.__offset(this.bb_pos, 4);
   return offset ? (obj || new NamespaceC.TableInC).__init(this.bb.__indirect(this.bb_pos + offset), this.bb) : null;
 };
+
+/**
+ * @returns {string}
+ */
+NamespaceA.SecondTableInA.getFullyQualifiedName = function() {
+  return 'NamespaceA.SecondTableInA';
+}
 
 /**
  * @param {flatbuffers.Builder} builder

--- a/tests/namespace_test/namespace_test2_generated.rs
+++ b/tests/namespace_test/namespace_test2_generated.rs
@@ -35,6 +35,10 @@ impl<'a> flatbuffers::Follow<'a> for TableInFirstNS<'a> {
 }
 
 impl<'a> TableInFirstNS<'a> {
+    pub const fn get_fully_qualified_name() -> &'static str {
+        "NamespaceA.TableInFirstNS"
+    }
+
     #[inline]
     pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
         TableInFirstNS {
@@ -133,6 +137,10 @@ impl<'a> flatbuffers::Follow<'a> for SecondTableInA<'a> {
 }
 
 impl<'a> SecondTableInA<'a> {
+    pub const fn get_fully_qualified_name() -> &'static str {
+        "NamespaceA.SecondTableInA"
+    }
+
     #[inline]
     pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
         SecondTableInA {
@@ -219,6 +227,10 @@ impl<'a> flatbuffers::Follow<'a> for TableInC<'a> {
 }
 
 impl<'a> TableInC<'a> {
+    pub const fn get_fully_qualified_name() -> &'static str {
+        "NamespaceC.TableInC"
+    }
+
     #[inline]
     pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
         TableInC {

--- a/tests/namespace_test/namespace_test2_generated.ts
+++ b/tests/namespace_test/namespace_test2_generated.ts
@@ -81,6 +81,13 @@ fooStruct(obj?:NS8755221360535654258.NamespaceA.NamespaceB.StructInNestedNS):NS8
 };
 
 /**
+ * @returns string
+ */
+static getFullyQualifiedName():string {
+  return 'NamespaceA.TableInFirstNS';
+}
+
+/**
  * @param flatbuffers.Builder builder
  */
 static startTableInFirstNS(builder:flatbuffers.Builder) {
@@ -226,6 +233,13 @@ referToA2(obj?:NamespaceA.SecondTableInA):NamespaceA.SecondTableInA|null {
 };
 
 /**
+ * @returns string
+ */
+static getFullyQualifiedName():string {
+  return 'NamespaceC.TableInC';
+}
+
+/**
  * @param flatbuffers.Builder builder
  */
 static startTableInC(builder:flatbuffers.Builder) {
@@ -347,6 +361,13 @@ referToC(obj?:NamespaceC.TableInC):NamespaceC.TableInC|null {
   var offset = this.bb!.__offset(this.bb_pos, 4);
   return offset ? (obj || new NamespaceC.TableInC()).__init(this.bb!.__indirect(this.bb_pos + offset), this.bb!) : null;
 };
+
+/**
+ * @returns string
+ */
+static getFullyQualifiedName():string {
+  return 'NamespaceA.SecondTableInA';
+}
 
 /**
  * @param flatbuffers.Builder builder

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -202,6 +202,9 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Rapunzel FLATBUFFERS_FINAL_CLASS {
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return RapunzelTypeTable();
   }
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "Rapunzel";
+  }
   Rapunzel()
       : hair_length_(0) {
   }
@@ -235,6 +238,9 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) BookReader FLATBUFFERS_FINAL_CLASS {
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return BookReaderTypeTable();
   }
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "BookReader";
+  }
   BookReader()
       : books_read_(0) {
   }
@@ -262,6 +268,9 @@ inline bool operator!=(const BookReader &lhs, const BookReader &rhs) {
 
 struct AttackerT : public flatbuffers::NativeTable {
   typedef Attacker TableType;
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "AttackerT";
+  }
   int32_t sword_attack_damage;
   AttackerT()
       : sword_attack_damage(0) {
@@ -283,6 +292,9 @@ struct Attacker FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef AttackerBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return AttackerTypeTable();
+  }
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "Attacker";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_SWORD_ATTACK_DAMAGE = 4
@@ -333,6 +345,9 @@ flatbuffers::Offset<Attacker> CreateAttacker(flatbuffers::FlatBufferBuilder &_fb
 
 struct MovieT : public flatbuffers::NativeTable {
   typedef Movie TableType;
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "MovieT";
+  }
   CharacterUnion main_character;
   std::vector<CharacterUnion> characters;
   MovieT() {
@@ -355,6 +370,9 @@ struct Movie FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MovieBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return MovieTypeTable();
+  }
+  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
+    return "Movie";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_MAIN_CHARACTER_TYPE = 4,

--- a/tests/union_vector/union_vector_generated.js
+++ b/tests/union_vector/union_vector_generated.js
@@ -95,6 +95,13 @@ Attacker.prototype.mutate_sword_attack_damage = function(value) {
 };
 
 /**
+ * @returns {string}
+ */
+Attacker.getFullyQualifiedName = function() {
+  return 'Attacker';
+}
+
+/**
  * @param {flatbuffers.Builder} builder
  */
 Attacker.startAttacker = function(builder) {
@@ -172,6 +179,13 @@ Rapunzel.prototype.mutate_hair_length = function(value) {
 };
 
 /**
+ * @returns {string}
+ */
+Rapunzel.getFullyQualifiedName = function() {
+  return 'Rapunzel';
+}
+
+/**
  * @param {flatbuffers.Builder} builder
  * @param {number} hair_length
  * @returns {flatbuffers.Offset}
@@ -223,6 +237,13 @@ BookReader.prototype.mutate_books_read = function(value) {
   this.bb.writeInt32(this.bb_pos + 0, value);
   return true;
 };
+
+/**
+ * @returns {string}
+ */
+BookReader.getFullyQualifiedName = function() {
+  return 'BookReader';
+}
 
 /**
  * @param {flatbuffers.Builder} builder
@@ -347,6 +368,13 @@ Movie.prototype.charactersLength = function() {
   var offset = this.bb.__offset(this.bb_pos, 10);
   return offset ? this.bb.__vector_len(this.bb_pos + offset) : 0;
 };
+
+/**
+ * @returns {string}
+ */
+Movie.getFullyQualifiedName = function() {
+  return 'Movie';
+}
 
 /**
  * @param {flatbuffers.Builder} builder

--- a/tests/union_vector/union_vector_generated.ts
+++ b/tests/union_vector/union_vector_generated.ts
@@ -108,6 +108,13 @@ mutate_sword_attack_damage(value:number):boolean {
 };
 
 /**
+ * @returns string
+ */
+static getFullyQualifiedName():string {
+  return 'Attacker';
+}
+
+/**
  * @param flatbuffers.Builder builder
  */
 static startAttacker(builder:flatbuffers.Builder) {
@@ -208,6 +215,13 @@ mutate_hair_length(value:number):boolean {
 };
 
 /**
+ * @returns string
+ */
+static getFullyQualifiedName():string {
+  return 'Rapunzel';
+}
+
+/**
  * @param flatbuffers.Builder builder
  * @param number hair_length
  * @returns flatbuffers.Offset
@@ -288,6 +302,13 @@ mutate_books_read(value:number):boolean {
   this.bb!.writeInt32(this.bb_pos + 0, value);
   return true;
 };
+
+/**
+ * @returns string
+ */
+static getFullyQualifiedName():string {
+  return 'BookReader';
+}
 
 /**
  * @param flatbuffers.Builder builder
@@ -441,6 +462,13 @@ charactersLength():number {
   var offset = this.bb!.__offset(this.bb_pos, 10);
   return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
 };
+
+/**
+ * @returns string
+ */
+static getFullyQualifiedName():string {
+  return 'Movie';
+}
 
 /**
  * @param flatbuffers.Builder builder


### PR DESCRIPTION
This optionally generates a static `getFullyQualifiedName()` function to get the fully-qualified name of a type in JavaScript and TypeScript in a similar fashion to the C++ codegen. Without this change, there is no way to get this information in JavaScript since the constructor functions are all anonymous and hence have empty names.