### PR TITLE
Add `CharToLower` and `CharToUpper` into `util.s`

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -73,6 +73,14 @@ inline bool is_xdigit(char c) {
 // Case-insensitive isalnum
 inline bool is_alnum(char c) { return is_alpha(c) || is_digit(c); }
 
+inline char CharToUpper(char c) {
+  return static_cast<char>(::toupper(static_cast<unsigned char>(c)));
+}
+
+inline char CharToLower(char c) {
+  return static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+}
+
 // @end-locale-independent functions for ASCII character set
 
 #ifdef FLATBUFFERS_PREFER_PRINTF

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -26,11 +26,6 @@
 
 namespace flatbuffers {
 
-// Pedantic warning free version of toupper().
-inline char ToUpper(char c) {
-  return static_cast<char>(::toupper(static_cast<unsigned char>(c)));
-}
-
 // Make numerical literal with type-suffix.
 // This function is only needed for C++! Other languages do not need it.
 static inline std::string NumToStringCpp(std::string val, BaseType type) {
@@ -69,7 +64,7 @@ static std::string GenIncludeGuard(const std::string &file_name,
   // Anything extra to add to the guard?
   if (!postfix.empty()) { guard += postfix + "_"; }
   guard += "H_";
-  std::transform(guard.begin(), guard.end(), guard.begin(), ToUpper);
+  std::transform(guard.begin(), guard.end(), guard.begin(), CharToUpper);
   return guard;
 }
 
@@ -1565,7 +1560,7 @@ class CppGenerator : public BaseGenerator {
 
   std::string GenFieldOffsetName(const FieldDef &field) {
     std::string uname = Name(field);
-    std::transform(uname.begin(), uname.end(), uname.begin(), ToUpper);
+    std::transform(uname.begin(), uname.end(), uname.begin(), CharToUpper);
     return "VT_" + uname;
   }
 
@@ -3224,7 +3219,7 @@ bool GenerateCPP(const Parser &parser, const std::string &path,
   // The '--cpp_std' argument could be extended (like ASAN):
   // Example: "flatc --cpp_std c++17:option1:option2".
   auto cpp_std = !opts.cpp_std.empty() ? opts.cpp_std : "C++0X";
-  std::transform(cpp_std.begin(), cpp_std.end(), cpp_std.begin(), ToUpper);
+  std::transform(cpp_std.begin(), cpp_std.end(), cpp_std.begin(), CharToUpper);
   if (cpp_std == "C++0X") {
     opts.g_cpp_std = cpp::CPP_STD_X0;
     opts.g_only_fixed_enums = false;

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -121,16 +121,16 @@ class DartGenerator : public BaseGenerator {
 
     auto ret = sstream.str() + ns.components.back();
     for (size_t i = 0; i < ret.size(); i++) {
-      auto lower = tolower(ret[i]);
+      auto lower = CharToLower(ret[i]);
       if (lower != ret[i]) {
-        ret[i] = static_cast<char>(lower);
+        ret[i] = lower;
         if (i != 0 && ret[i - 1] != '.') {
           ret.insert(i, "_");
           i++;
         }
       }
     }
-    // std::transform(ret.begin(), ret.end(), ret.begin(), ::tolower);
+    // std::transform(ret.begin(), ret.end(), ret.begin(), CharToLower);
     return ret;
   }
 
@@ -487,11 +487,11 @@ class DartGenerator : public BaseGenerator {
 
       for (size_t i = 0; i < part.length(); i++) {
         if (i && !isdigit(part[i]) &&
-            part[i] == static_cast<char>(toupper(part[i]))) {
+            part[i] == CharToUpper(part[i])) {
           ns += "_";
-          ns += static_cast<char>(tolower(part[i]));
+          ns += CharToLower(part[i]);
         } else {
-          ns += static_cast<char>(tolower(part[i]));
+          ns += CharToLower(part[i]);
         }
       }
       if (it != qualified_name_parts.end() - 1) { ns += "_"; }

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -94,7 +94,7 @@ class PythonGenerator : public BaseGenerator {
   // Converts the name of a definition into lower Camel format.
   std::string MakeLowerCamel(const Definition &definition) const {
     auto name = MakeCamel(NormalizedName(definition), false);
-    name[0] = char(tolower(name[0]));
+    name[0] = CharToLower(name[0]);
     return name;
   }
 
@@ -1000,7 +1000,7 @@ class PythonGenerator : public BaseGenerator {
 
     auto field_type_name = TypeName(field);
     auto one_instance = field_type_name + "_";
-    one_instance[0] = char(tolower(one_instance[0]));
+    one_instance[0] = CharToLower(one_instance[0]);
 
     if (parser_.opts.include_dependence_headers) {
       auto package_reference = GenPackageReference(field.value.type);

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -29,14 +29,14 @@ std::string MakeSnakeCase(const std::string &in) {
   std::string s;
   for (size_t i = 0; i < in.length(); i++) {
     if (i == 0) {
-      s += static_cast<char>(tolower(in[0]));
+      s += CharToLower(in[0]);
     } else if (in[i] == '_') {
       s += '_';
     } else if (!islower(in[i])) {
       // Prevent duplicate underscores for Upper_Snake_Case strings
       // and UPPERCASE strings.
       if (islower(in[i - 1])) { s += '_'; }
-      s += static_cast<char>(tolower(in[i]));
+      s += CharToLower(in[i]);
     } else {
       s += in[i];
     }
@@ -48,7 +48,7 @@ std::string MakeSnakeCase(const std::string &in) {
 std::string MakeUpper(const std::string &in) {
   std::string s;
   for (size_t i = 0; i < in.length(); i++) {
-    s += static_cast<char>(toupper(in[i]));
+    s += CharToUpper(in[i]);
   }
   return s;
 }

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -36,10 +36,6 @@ inline std::string GenArrayMainBody(const std::string &optional) {
          optional + " { ";
 }
 
-inline char LowerCase(char c) {
-  return static_cast<char>(::tolower(static_cast<unsigned char>(c)));
-}
-
 class SwiftGenerator : public BaseGenerator {
  private:
   CodeWriter code_;
@@ -1383,7 +1379,7 @@ class SwiftGenerator : public BaseGenerator {
       const auto &ev = **enum_def.Vals().begin();
       name = Name(ev);
     }
-    std::transform(name.begin(), name.end(), name.begin(), LowerCase);
+    std::transform(name.begin(), name.end(), name.begin(), CharToLower);
     return "." + name;
   }
 
@@ -1465,7 +1461,7 @@ class SwiftGenerator : public BaseGenerator {
   std::string Name(const EnumVal &ev) const {
     auto name = ev.name;
     if (isupper(name.front())) {
-      std::transform(name.begin(), name.end(), name.begin(), LowerCase);
+      std::transform(name.begin(), name.end(), name.begin(), CharToLower);
     }
     return EscapeKeyword(MakeCamel(name, false));
   }

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -98,9 +98,9 @@ std::string MakeCamel(const std::string &in, bool first) {
   std::string s;
   for (size_t i = 0; i < in.length(); i++) {
     if (!i && first)
-      s += static_cast<char>(toupper(in[0]));
+      s += CharToUpper(in[0]);
     else if (in[i] == '_' && i + 1 < in.length())
-      s += static_cast<char>(toupper(in[++i]));
+      s += CharToUpper(in[++i]);
     else
       s += in[i];
   }
@@ -112,7 +112,7 @@ std::string MakeScreamingCamel(const std::string &in) {
   std::string s;
   for (size_t i = 0; i < in.length(); i++) {
     if (in[i] != '_')
-      s += static_cast<char>(toupper(in[i]));
+      s += CharToUpper(in[i]);
     else
       s += in[i];
   }


### PR DESCRIPTION
This commit adds replacement of `::tolower` and `::toupper`.
Added CharToLower and CharToUpper routines reduce the number of cast operators
that required for correct usage of standard C/C++ `::tolower/toupper` routines.
