### PR TITLE
[Python/JS/TS] Codegen SizeOf method for structs

### DIFF
--- a/src/idl_gen_js_ts.cpp
+++ b/src/idl_gen_js_ts.cpp
@@ -1795,6 +1795,18 @@ class JsTsGenerator : public BaseGenerator {
       code += "}\n\n";
     }
 
+    // Emit the size of the struct.
+    if (struct_def.fixed) {
+      GenDocComment(code_ptr, GenTypeAnnotation(kReturns, "number", "", false));
+      if (lang_.language == IDLOptions::kTs) {
+        code += "static sizeOf():number {\n";
+      } else {
+        code += object_name + ".sizeOf = function() {\n";
+      }
+      code += "  return " + NumToString(struct_def.bytesize) + ";\n";
+      code += "}\n\n";
+    }
+
     // Emit a factory constructor
     if (struct_def.fixed) {
       std::string annotations =

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -621,6 +621,16 @@ class PythonGenerator : public BaseGenerator {
     }
   }
 
+  // Generate struct sizeof.
+  void GenStructSizeOf(const StructDef &struct_def, std::string *code_ptr) {
+    auto &code = *code_ptr;
+    code += Indent + "@classmethod\n";
+    code += Indent + "def SizeOf(cls):\n";
+    code +=
+        Indent + Indent + "return " + NumToString(struct_def.bytesize) + "\n";
+    code += "\n";
+  }
+
   // Generate table constructors, conditioned on its members' types.
   void GenTableBuilders(const StructDef &struct_def, std::string *code_ptr) {
     GetStartOfTable(struct_def, code_ptr);
@@ -678,6 +688,9 @@ class PythonGenerator : public BaseGenerator {
         // Generate a special function to test file_identifier
         GenHasFileIdentifier(struct_def, code_ptr);
       }
+    } else {
+      // Generates the SizeOf method for all structs.
+      GenStructSizeOf(struct_def, code_ptr);
     }
     // Generates the Init method that sets the field in a pre-existing
     // accessor object. This is to allow object reuse.

--- a/tests/MyGame/Example/Ability.py
+++ b/tests/MyGame/Example/Ability.py
@@ -9,6 +9,10 @@ np = import_numpy()
 class Ability(object):
     __slots__ = ['_tab']
 
+    @classmethod
+    def SizeOf(cls):
+        return 8
+
     # Ability
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/MyGame/Example/ArrayStruct.py
+++ b/tests/MyGame/Example/ArrayStruct.py
@@ -9,6 +9,10 @@ np = import_numpy()
 class ArrayStruct(object):
     __slots__ = ['_tab']
 
+    @classmethod
+    def SizeOf(cls):
+        return 160
+
     # ArrayStruct
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/MyGame/Example/NestedStruct.py
+++ b/tests/MyGame/Example/NestedStruct.py
@@ -9,6 +9,10 @@ np = import_numpy()
 class NestedStruct(object):
     __slots__ = ['_tab']
 
+    @classmethod
+    def SizeOf(cls):
+        return 32
+
     # NestedStruct
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/MyGame/Example/Test.py
+++ b/tests/MyGame/Example/Test.py
@@ -9,6 +9,10 @@ np = import_numpy()
 class Test(object):
     __slots__ = ['_tab']
 
+    @classmethod
+    def SizeOf(cls):
+        return 4
+
     # Test
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/MyGame/Example/Vec3.py
+++ b/tests/MyGame/Example/Vec3.py
@@ -9,6 +9,10 @@ np = import_numpy()
 class Vec3(object):
     __slots__ = ['_tab']
 
+    @classmethod
+    def SizeOf(cls):
+        return 32
+
     # Vec3
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/monster_test_generated.js
+++ b/tests/monster_test_generated.js
@@ -343,6 +343,13 @@ MyGame.Example.Test.prototype.mutate_b = function(value) {
 };
 
 /**
+ * @returns {number}
+ */
+MyGame.Example.Test.sizeOf = function() {
+  return 4;
+}
+
+/**
  * @param {flatbuffers.Builder} builder
  * @param {number} a
  * @param {number} b
@@ -574,6 +581,13 @@ MyGame.Example.Vec3.prototype.test3 = function(obj) {
 };
 
 /**
+ * @returns {number}
+ */
+MyGame.Example.Vec3.sizeOf = function() {
+  return 32;
+}
+
+/**
  * @param {flatbuffers.Builder} builder
  * @param {number} x
  * @param {number} y
@@ -658,6 +672,13 @@ MyGame.Example.Ability.prototype.mutate_distance = function(value) {
   this.bb.writeUint32(this.bb_pos + 4, value);
   return true;
 };
+
+/**
+ * @returns {number}
+ */
+MyGame.Example.Ability.sizeOf = function() {
+  return 8;
+}
 
 /**
  * @param {flatbuffers.Builder} builder

--- a/tests/monster_test_generated.ts
+++ b/tests/monster_test_generated.ts
@@ -377,6 +377,13 @@ mutate_b(value:number):boolean {
 };
 
 /**
+ * @returns number
+ */
+static sizeOf():number {
+  return 4;
+}
+
+/**
  * @param flatbuffers.Builder builder
  * @param number a
  * @param number b
@@ -669,6 +676,13 @@ test3(obj?:MyGame.Example.Test):MyGame.Example.Test|null {
 };
 
 /**
+ * @returns number
+ */
+static sizeOf():number {
+  return 32;
+}
+
+/**
  * @param flatbuffers.Builder builder
  * @param number x
  * @param number y
@@ -810,6 +824,13 @@ mutate_distance(value:number):boolean {
   this.bb!.writeUint32(this.bb_pos + 4, value);
   return true;
 };
+
+/**
+ * @returns number
+ */
+static sizeOf():number {
+  return 8;
+}
 
 /**
  * @param flatbuffers.Builder builder

--- a/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.py
+++ b/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.py
@@ -9,6 +9,10 @@ np = import_numpy()
 class StructInNestedNS(object):
     __slots__ = ['_tab']
 
+    @classmethod
+    def SizeOf(cls):
+        return 8
+
     # StructInNestedNS
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)

--- a/tests/namespace_test/namespace_test1_generated.js
+++ b/tests/namespace_test/namespace_test1_generated.js
@@ -206,6 +206,13 @@ NamespaceA.NamespaceB.StructInNestedNS.getFullyQualifiedName = function() {
 }
 
 /**
+ * @returns {number}
+ */
+NamespaceA.NamespaceB.StructInNestedNS.sizeOf = function() {
+  return 8;
+}
+
+/**
  * @param {flatbuffers.Builder} builder
  * @param {number} a
  * @param {number} b

--- a/tests/namespace_test/namespace_test1_generated.ts
+++ b/tests/namespace_test/namespace_test1_generated.ts
@@ -205,6 +205,13 @@ static getFullyQualifiedName():string {
 }
 
 /**
+ * @returns number
+ */
+static sizeOf():number {
+  return 8;
+}
+
+/**
  * @param flatbuffers.Builder builder
  * @param number a
  * @param number b

--- a/tests/union_vector/union_vector_generated.js
+++ b/tests/union_vector/union_vector_generated.js
@@ -186,6 +186,13 @@ Rapunzel.getFullyQualifiedName = function() {
 }
 
 /**
+ * @returns {number}
+ */
+Rapunzel.sizeOf = function() {
+  return 4;
+}
+
+/**
  * @param {flatbuffers.Builder} builder
  * @param {number} hair_length
  * @returns {flatbuffers.Offset}
@@ -243,6 +250,13 @@ BookReader.prototype.mutate_books_read = function(value) {
  */
 BookReader.getFullyQualifiedName = function() {
   return 'BookReader';
+}
+
+/**
+ * @returns {number}
+ */
+BookReader.sizeOf = function() {
+  return 4;
 }
 
 /**

--- a/tests/union_vector/union_vector_generated.ts
+++ b/tests/union_vector/union_vector_generated.ts
@@ -222,6 +222,13 @@ static getFullyQualifiedName():string {
 }
 
 /**
+ * @returns number
+ */
+static sizeOf():number {
+  return 4;
+}
+
+/**
  * @param flatbuffers.Builder builder
  * @param number hair_length
  * @returns flatbuffers.Offset
@@ -308,6 +315,13 @@ mutate_books_read(value:number):boolean {
  */
 static getFullyQualifiedName():string {
   return 'BookReader';
+}
+
+/**
+ * @returns number
+ */
+static sizeOf():number {
+  return 4;
 }
 
 /**


### PR DESCRIPTION
This codegens a `SizeOf()` classmethod in Python and a `sizeOf()` static method in JavaScript/TypeScript for all structs since we can't determine the size of a FlatBuffer generated struct from Python, JavaScript or TypeScript otherwise.

cc: @rw, @evanw, @evolutional, @krojew 