### PR TITLE
[C#]SpanT is available in .Net Standard 2.0.

### DIFF
--- a/net/FlatBuffers/FlatBufferBuilder.cs
+++ b/net/FlatBuffers/FlatBufferBuilder.cs
@@ -206,7 +206,7 @@ namespace FlatBuffers
             _space = _bb.Put(_space, x);
         }
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && (UNSAFE_BYTEBUFFER || NETSTANDARD2_1)
         /// <summary>
         /// Puts a span of type T into this builder at the
         /// current offset
@@ -317,7 +317,7 @@ namespace FlatBuffers
             Put(x);
         }
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && (UNSAFE_BYTEBUFFER || NETSTANDARD2_1)
         /// <summary>
         /// Add a span of type T to the buffer (aligns the data and grows if necessary).
         /// </summary>
@@ -567,7 +567,7 @@ namespace FlatBuffers
         }
 
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && (UNSAFE_BYTEBUFFER || NETSTANDARD2_1)
         /// <summary>
         /// Creates a string in the buffer from a Span containing
         /// a UTF8 string.

--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -86,7 +86,7 @@ namespace FlatBuffers
             return offset + bb.GetInt(offset) + sizeof(int);  // data starts after the length
         }
 
-#if ENABLE_SPAN_T
+#if ENABLE_SPAN_T && (UNSAFE_BYTEBUFFER || NETSTANDARD2_1)
         // Get the data of a vector whoses offset is stored at "offset" in this object as an
         // Spant&lt;byte&gt;. If the vector is not present in the ByteBuffer,
         // then an empty span will be returned.


### PR DESCRIPTION
Restored the use of SpanT in .NetStandard 2.0 as pointed out in the following link.

[https://github.com/google/flatbuffers/pull/6073#issuecomment-698609656](https://github.com/google/flatbuffers/pull/6073#issuecomment-698609656)


A warning is added for compiling if the flags are inconsistent.