### PR TITLE
Unified rust version with current release

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatbuffers"
-version = "0.6.3"
+version = "1.12.0"
 edition = "2018"
 authors = ["Robert Winslow <hello@rwinslow.com>", "FlatBuffers Maintainers"]
 license = "Apache-2.0"


### PR DESCRIPTION
For some reason, Rust FB has different versioning scheme than FB proper.

@rw @aardappel r?