### PR TITLE
rust naming conventions

### DIFF
--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1130,7 +1130,7 @@ class RustGenerator : public BaseGenerator {
   // Generates a fully-qualified name getter for use with --gen-name-strings
   void GenFullyQualifiedNameGetter(const StructDef &struct_def,
                                    const std::string &name) {
-    code_ += "    pub const fn get_fully_qualified_name() -> &'static str {";
+    code_ += "    pub const fn fully_qualified_name() -> &'static str {";
     code_ += "        \"" +
              struct_def.defined_namespace->GetFullyQualifiedName(name) + "\"";
     code_ += "    }";
@@ -1492,7 +1492,7 @@ class RustGenerator : public BaseGenerator {
     // The root datatype accessors:
     code_ += "#[inline]";
     code_ +=
-        "pub fn get_root_as_{{STRUCT_NAME_SNAKECASE}}<'a>(buf: &'a [u8])"
+        "pub fn root_as_{{STRUCT_NAME_SNAKECASE}}<'a>(buf: &'a [u8])"
         " -> {{STRUCT_NAME}}<'a> {";
     code_ += "  flatbuffers::get_root::<{{STRUCT_NAME}}<'a>>(buf)";
     code_ += "}";
@@ -1500,7 +1500,7 @@ class RustGenerator : public BaseGenerator {
 
     code_ += "#[inline]";
     code_ +=
-        "pub fn get_size_prefixed_root_as_{{STRUCT_NAME_SNAKECASE}}"
+        "pub fn size_prefixed_root_as_{{STRUCT_NAME_SNAKECASE}}"
         "<'a>(buf: &'a [u8]) -> {{STRUCT_NAME}}<'a> {";
     code_ +=
         "  flatbuffers::get_size_prefixed_root::<{{STRUCT_NAME}}<'a>>"

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1498,6 +1498,17 @@ class RustGenerator : public BaseGenerator {
     code_ += "}";
     code_ += "";
 
+    // legacy accessor
+
+    code_ += "#[inline]";
+    code_ += "#[deprecated = \"getters starting with get_ are deprecated\"]";
+    code_ +=
+        "pub fn get_root_as_{{STRUCT_NAME_SNAKECASE}}<'a>(buf: &'a [u8])"
+        " -> {{STRUCT_NAME}}<'a> {";
+    code_ += "  flatbuffers::get_root::<{{STRUCT_NAME}}<'a>>(buf)";
+    code_ += "}";
+    code_ += "";
+
     code_ += "#[inline]";
     code_ +=
         "pub fn size_prefixed_root_as_{{STRUCT_NAME_SNAKECASE}}"

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1501,7 +1501,7 @@ class RustGenerator : public BaseGenerator {
     // legacy accessor
 
     code_ += "#[inline]";
-    code_ += "#[deprecated(since = \"1.13.0\", note = \"getters starting with get_ are deprecated\")]";
+    code_ += "#[deprecated(since = \"1.13.0\", note = \"getters starting with get_ are deprecated and will be removed in 1.14\")]";
     code_ +=
         "pub fn get_root_as_{{STRUCT_NAME_SNAKECASE}}<'a>(buf: &'a [u8])"
         " -> {{STRUCT_NAME}}<'a> {";
@@ -1520,7 +1520,7 @@ class RustGenerator : public BaseGenerator {
     code_ += "";
 
     code_ += "#[inline]";
-    code_ += "#[deprecated(since = \"1.13.0\", note = \"getters starting with get_ are deprecated\")]";
+    code_ += "#[deprecated(since = \"1.13.0\", note = \"getters starting with get_ are deprecated and will be removed in 1.14\")]";
     code_ +=
         "pub fn get_size_prefixed_root_as_{{STRUCT_NAME_SNAKECASE}}"
         "<'a>(buf: &'a [u8]) -> {{STRUCT_NAME}}<'a> {";

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1501,7 +1501,7 @@ class RustGenerator : public BaseGenerator {
     // legacy accessor
 
     code_ += "#[inline]";
-    code_ += "#[deprecated = \"getters starting with get_ are deprecated\"]";
+    code_ += "#[deprecated(since = \"1.13.0\", note = \"getters starting with get_ are deprecated\")]";
     code_ +=
         "pub fn get_root_as_{{STRUCT_NAME_SNAKECASE}}<'a>(buf: &'a [u8])"
         " -> {{STRUCT_NAME}}<'a> {";
@@ -1520,7 +1520,7 @@ class RustGenerator : public BaseGenerator {
     code_ += "";
 
     code_ += "#[inline]";
-    code_ += "#[deprecated = \"getters starting with get_ are deprecated\"]";
+    code_ += "#[deprecated(since = \"1.13.0\", note = \"getters starting with get_ are deprecated\")]";
     code_ +=
         "pub fn get_size_prefixed_root_as_{{STRUCT_NAME_SNAKECASE}}"
         "<'a>(buf: &'a [u8]) -> {{STRUCT_NAME}}<'a> {";

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1519,6 +1519,17 @@ class RustGenerator : public BaseGenerator {
     code_ += "}";
     code_ += "";
 
+    code_ += "#[inline]";
+    code_ += "#[deprecated = \"getters starting with get_ are deprecated\"]";
+    code_ +=
+        "pub fn get_size_prefixed_root_as_{{STRUCT_NAME_SNAKECASE}}"
+        "<'a>(buf: &'a [u8]) -> {{STRUCT_NAME}}<'a> {";
+    code_ +=
+        "  flatbuffers::get_size_prefixed_root::<{{STRUCT_NAME}}<'a>>"
+        "(buf)";
+    code_ += "}";
+    code_ += "";
+
     if (parser_.file_identifier_.length()) {
       // Declare the identifier
       // (no lifetime needed as constants have static lifetimes by default)

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -38,7 +38,7 @@ impl<'a> flatbuffers::Follow<'a> for InParentNamespace<'a> {
 }
 
 impl<'a> InParentNamespace<'a> {
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "MyGame.InParentNamespace"
     }
 
@@ -114,7 +114,7 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
 }
 
 impl<'a> Monster<'a> {
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "MyGame.Example2.Monster"
     }
 
@@ -592,7 +592,7 @@ impl Test {
       padding0__: 0,
     }
   }
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "MyGame.Example.Test"
     }
 
@@ -671,7 +671,7 @@ impl Vec3 {
       padding2__: 0,
     }
   }
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "MyGame.Example.Vec3"
     }
 
@@ -748,7 +748,7 @@ impl Ability {
 
     }
   }
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "MyGame.Example.Ability"
     }
 
@@ -786,7 +786,7 @@ impl<'a> flatbuffers::Follow<'a> for TestSimpleTableWithEnum<'a> {
 }
 
 impl<'a> TestSimpleTableWithEnum<'a> {
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "MyGame.Example.TestSimpleTableWithEnum"
     }
 
@@ -864,7 +864,7 @@ impl<'a> flatbuffers::Follow<'a> for Stat<'a> {
 }
 
 impl<'a> Stat<'a> {
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "MyGame.Example.Stat"
     }
 
@@ -966,7 +966,7 @@ impl<'a> flatbuffers::Follow<'a> for Referrable<'a> {
 }
 
 impl<'a> Referrable<'a> {
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "MyGame.Example.Referrable"
     }
 
@@ -1055,7 +1055,7 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
 }
 
 impl<'a> Monster<'a> {
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "MyGame.Example.Monster"
     }
 
@@ -1806,7 +1806,7 @@ impl<'a> flatbuffers::Follow<'a> for TypeAliases<'a> {
 }
 
 impl<'a> TypeAliases<'a> {
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "MyGame.Example.TypeAliases"
     }
 
@@ -2001,12 +2001,12 @@ impl<'a: 'b, 'b> TypeAliasesBuilder<'a, 'b> {
 }
 
 #[inline]
-pub fn get_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
+pub fn root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
   flatbuffers::get_root::<Monster<'a>>(buf)
 }
 
 #[inline]
-pub fn get_size_prefixed_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
+pub fn size_prefixed_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
   flatbuffers::get_size_prefixed_root::<Monster<'a>>(buf)
 }
 

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -2006,7 +2006,7 @@ pub fn root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
 }
 
 #[inline]
-#[deprecated = "getters starting with get_ are deprecated"]
+#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated")]
 pub fn get_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
   flatbuffers::get_root::<Monster<'a>>(buf)
 }
@@ -2017,7 +2017,7 @@ pub fn size_prefixed_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
 }
 
 #[inline]
-#[deprecated = "getters starting with get_ are deprecated"]
+#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated")]
 pub fn get_size_prefixed_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
   flatbuffers::get_size_prefixed_root::<Monster<'a>>(buf)
 }

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -2006,6 +2006,12 @@ pub fn root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
 }
 
 #[inline]
+#[deprecated = "getters starting with get_ are deprecated"]
+pub fn get_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
+  flatbuffers::get_root::<Monster<'a>>(buf)
+}
+
+#[inline]
 pub fn size_prefixed_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
   flatbuffers::get_size_prefixed_root::<Monster<'a>>(buf)
 }

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -2016,6 +2016,12 @@ pub fn size_prefixed_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
   flatbuffers::get_size_prefixed_root::<Monster<'a>>(buf)
 }
 
+#[inline]
+#[deprecated = "getters starting with get_ are deprecated"]
+pub fn get_size_prefixed_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
+  flatbuffers::get_size_prefixed_root::<Monster<'a>>(buf)
+}
+
 pub const MONSTER_IDENTIFIER: &str = "MONS";
 
 #[inline]

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -2006,7 +2006,7 @@ pub fn root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
 }
 
 #[inline]
-#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated")]
+#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated and will be removed in 1.14")]
 pub fn get_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
   flatbuffers::get_root::<Monster<'a>>(buf)
 }
@@ -2017,7 +2017,7 @@ pub fn size_prefixed_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
 }
 
 #[inline]
-#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated")]
+#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated and will be removed in 1.14")]
 pub fn get_size_prefixed_root_as_monster<'a>(buf: &'a [u8]) -> Monster<'a> {
   flatbuffers::get_size_prefixed_root::<Monster<'a>>(buf)
 }

--- a/tests/namespace_test/namespace_test1_generated.rs
+++ b/tests/namespace_test/namespace_test1_generated.rs
@@ -153,7 +153,7 @@ impl StructInNestedNS {
 
     }
   }
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "NamespaceA.NamespaceB.StructInNestedNS"
     }
 
@@ -181,7 +181,7 @@ impl<'a> flatbuffers::Follow<'a> for TableInNestedNS<'a> {
 }
 
 impl<'a> TableInNestedNS<'a> {
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "NamespaceA.NamespaceB.TableInNestedNS"
     }
 

--- a/tests/namespace_test/namespace_test2_generated.rs
+++ b/tests/namespace_test/namespace_test2_generated.rs
@@ -36,7 +36,7 @@ impl<'a> flatbuffers::Follow<'a> for TableInFirstNS<'a> {
 }
 
 impl<'a> TableInFirstNS<'a> {
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "NamespaceA.TableInFirstNS"
     }
 
@@ -138,7 +138,7 @@ impl<'a> flatbuffers::Follow<'a> for SecondTableInA<'a> {
 }
 
 impl<'a> SecondTableInA<'a> {
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "NamespaceA.SecondTableInA"
     }
 
@@ -228,7 +228,7 @@ impl<'a> flatbuffers::Follow<'a> for TableInC<'a> {
 }
 
 impl<'a> TableInC<'a> {
-    pub const fn get_fully_qualified_name() -> &'static str {
+    pub const fn fully_qualified_name() -> &'static str {
         "NamespaceC.TableInC"
     }
 

--- a/tests/optional_scalars_generated.rs
+++ b/tests/optional_scalars_generated.rs
@@ -592,7 +592,7 @@ pub fn root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
 }
 
 #[inline]
-#[deprecated = "getters starting with get_ are deprecated"]
+#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated")]
 pub fn get_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
   flatbuffers::get_root::<ScalarStuff<'a>>(buf)
 }
@@ -603,7 +603,7 @@ pub fn size_prefixed_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> 
 }
 
 #[inline]
-#[deprecated = "getters starting with get_ are deprecated"]
+#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated")]
 pub fn get_size_prefixed_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
   flatbuffers::get_size_prefixed_root::<ScalarStuff<'a>>(buf)
 }

--- a/tests/optional_scalars_generated.rs
+++ b/tests/optional_scalars_generated.rs
@@ -602,6 +602,12 @@ pub fn size_prefixed_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> 
   flatbuffers::get_size_prefixed_root::<ScalarStuff<'a>>(buf)
 }
 
+#[inline]
+#[deprecated = "getters starting with get_ are deprecated"]
+pub fn get_size_prefixed_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
+  flatbuffers::get_size_prefixed_root::<ScalarStuff<'a>>(buf)
+}
+
 pub const SCALAR_STUFF_IDENTIFIER: &str = "NULL";
 
 #[inline]

--- a/tests/optional_scalars_generated.rs
+++ b/tests/optional_scalars_generated.rs
@@ -587,12 +587,12 @@ impl<'a: 'b, 'b> ScalarStuffBuilder<'a, 'b> {
 }
 
 #[inline]
-pub fn get_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
+pub fn root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
   flatbuffers::get_root::<ScalarStuff<'a>>(buf)
 }
 
 #[inline]
-pub fn get_size_prefixed_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
+pub fn size_prefixed_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
   flatbuffers::get_size_prefixed_root::<ScalarStuff<'a>>(buf)
 }
 

--- a/tests/optional_scalars_generated.rs
+++ b/tests/optional_scalars_generated.rs
@@ -592,7 +592,7 @@ pub fn root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
 }
 
 #[inline]
-#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated")]
+#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated and will be removed in 1.14")]
 pub fn get_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
   flatbuffers::get_root::<ScalarStuff<'a>>(buf)
 }
@@ -603,7 +603,7 @@ pub fn size_prefixed_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> 
 }
 
 #[inline]
-#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated")]
+#[deprecated(since = "1.13.0", note = "getters starting with get_ are deprecated and will be removed in 1.14")]
 pub fn get_size_prefixed_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
   flatbuffers::get_size_prefixed_root::<ScalarStuff<'a>>(buf)
 }

--- a/tests/optional_scalars_generated.rs
+++ b/tests/optional_scalars_generated.rs
@@ -592,6 +592,12 @@ pub fn root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
 }
 
 #[inline]
+#[deprecated = "getters starting with get_ are deprecated"]
+pub fn get_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
+  flatbuffers::get_root::<ScalarStuff<'a>>(buf)
+}
+
+#[inline]
 pub fn size_prefixed_root_as_scalar_stuff<'a>(buf: &'a [u8]) -> ScalarStuff<'a> {
   flatbuffers::get_size_prefixed_root::<ScalarStuff<'a>>(buf)
 }

--- a/tests/rust_usage_test/benches/flatbuffers_benchmarks.rs
+++ b/tests/rust_usage_test/benches/flatbuffers_benchmarks.rs
@@ -148,7 +148,7 @@ fn blackbox<T>(t: T) -> T {
 
 #[inline(always)]
 fn traverse_serialized_example_with_generated_code(bytes: &[u8]) {
-    let m = my_game::example::get_root_as_monster(bytes);
+    let m = my_game::example::root_as_monster(bytes);
     blackbox(m.hp());
     blackbox(m.mana());
     blackbox(m.name());

--- a/tests/rust_usage_test/bin/flatbuffers_alloc_check.rs
+++ b/tests/rust_usage_test/bin/flatbuffers_alloc_check.rs
@@ -131,7 +131,7 @@ fn main() {
 
         // do many reads, forcing them to execute by using assert_eq:
         {
-            let m = my_game::example::get_root_as_monster(buf);
+            let m = my_game::example::root_as_monster(buf);
             assert_eq!(80, m.hp());
             assert_eq!(150, m.mana());
             assert_eq!("MyMonster", m.name());

--- a/tests/rust_usage_test/bin/monster_example.rs
+++ b/tests/rust_usage_test/bin/monster_example.rs
@@ -20,7 +20,7 @@ fn main() {
     let mut buf = Vec::new();
     f.read_to_end(&mut buf).expect("file reading failed");
 
-    let monster = my_game::example::get_root_as_monster(&buf[..]);
+    let monster = my_game::example::root_as_monster(&buf[..]);
     println!("{}", monster.hp()); // `80`
     println!("{}", monster.mana()); // default value of `150`
     println!("{:?}", monster.name()); // Some("MyMonster")

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -177,9 +177,9 @@ fn serialized_example_is_accessible_and_correct(bytes: &[u8], identifier_require
     }
 
     let m = if size_prefixed {
-        my_game::example::get_size_prefixed_root_as_monster(bytes)
+        my_game::example::size_prefixed_root_as_monster(bytes)
     } else {
-        my_game::example::get_root_as_monster(bytes)
+        my_game::example::root_as_monster(bytes)
     };
 
     check_eq!(m.hp(), 80)?;
@@ -310,20 +310,20 @@ mod lifetime_correctness {
     use super::load_file;
 
     #[test]
-    fn table_get_field_from_static_buffer_1() {
+    fn table_field_from_static_buffer_1() {
         let buf = load_file("../monsterdata_test.mon").expect("missing monsterdata_test.mon");
         // create 'static slice
         let slice: &[u8] = &buf;
         let slice: &'static [u8] = unsafe { mem::transmute(slice) };
         // make sure values retrieved from the 'static buffer are themselves 'static
-        let monster: my_game::example::Monster<'static> = my_game::example::get_root_as_monster(slice);
+        let monster: my_game::example::Monster<'static> = my_game::example::root_as_monster(slice);
         // this line should compile:
         let name: Option<&'static str> = monster._tab.get::<flatbuffers::ForwardsUOffset<&str>>(my_game::example::Monster::VT_NAME, None);
         assert_eq!(name, Some("MyMonster"));
     }
 
     #[test]
-    fn table_get_field_from_static_buffer_2() {
+    fn table_field_from_static_buffer_2() {
         static DATA: [u8; 4] = [0, 0, 0, 0]; // some binary data
         let table: flatbuffers::Table<'static> = flatbuffers::Table::new(&DATA, 0);
         // this line should compile:
@@ -334,7 +334,7 @@ mod lifetime_correctness {
     fn table_object_self_lifetime_in_closure() {
         // This test is designed to ensure that lifetimes for temporary intermediate tables aren't inflated beyond where the need to be.
         let buf = load_file("../monsterdata_test.mon").expect("missing monsterdata_test.mon");
-        let monster = my_game::example::get_root_as_monster(&buf);
+        let monster = my_game::example::root_as_monster(&buf);
         let enemy: Option<my_game::example::Monster> = monster.enemy();
         // This line won't compile if "self" is required to live for the lifetime of buf above as the borrow disappears at the end of the closure.
         let enemy_of_my_enemy = enemy.map(|e| {
@@ -357,7 +357,7 @@ mod roundtrip_generated_code {
     fn build_mon<'a, 'b>(builder: &'a mut flatbuffers::FlatBufferBuilder, args: &'b my_game::example::MonsterArgs) -> my_game::example::Monster<'a> {
         let mon = my_game::example::Monster::create(builder, &args);
         my_game::example::finish_monster_buffer(builder, mon);
-        my_game::example::get_root_as_monster(builder.finished_data())
+        my_game::example::root_as_monster(builder.finished_data())
     }
 
     #[test]
@@ -437,7 +437,7 @@ mod roundtrip_generated_code {
             my_game::example::finish_monster_buffer(b, outer);
         }
 
-        let mon = my_game::example::get_root_as_monster(b.finished_data());
+        let mon = my_game::example::root_as_monster(b.finished_data());
         assert_eq!(mon.name(), "bar");
         assert_eq!(mon.test_type(), my_game::example::Any::Monster);
         assert_eq!(my_game::example::Monster::init_from_table(mon.test().unwrap()).name(),
@@ -473,7 +473,7 @@ mod roundtrip_generated_code {
             my_game::example::finish_monster_buffer(b, outer);
         }
 
-        let mon = my_game::example::get_root_as_monster(b.finished_data());
+        let mon = my_game::example::root_as_monster(b.finished_data());
         assert_eq!(mon.name(), "bar");
         assert_eq!(mon.enemy().unwrap().name(), "foo");
     }
@@ -503,7 +503,7 @@ mod roundtrip_generated_code {
             my_game::example::finish_monster_buffer(b, outer);
         }
 
-        let mon = my_game::example::get_root_as_monster(b.finished_data());
+        let mon = my_game::example::root_as_monster(b.finished_data());
         assert_eq!(mon.name(), "bar");
         assert_eq!(mon.testempty().unwrap().id(), Some("foo"));
     }
@@ -540,12 +540,12 @@ mod roundtrip_generated_code {
             b1
         };
 
-        let m = my_game::example::get_root_as_monster(b1.finished_data());
+        let m = my_game::example::root_as_monster(b1.finished_data());
 
         assert!(m.testnestedflatbuffer().is_some());
         assert_eq!(m.testnestedflatbuffer().unwrap(), b0.finished_data());
 
-        let m2_a = my_game::example::get_root_as_monster(m.testnestedflatbuffer().unwrap());
+        let m2_a = my_game::example::root_as_monster(m.testnestedflatbuffer().unwrap());
         assert_eq!(m2_a.hp(), 123);
         assert_eq!(m2_a.name(), "foobar");
 
@@ -799,7 +799,7 @@ mod generated_code_alignment_and_padding {
             my_game::example::finish_monster_buffer(b, mon);
         }
         let buf = b.finished_data();
-        let mon = my_game::example::get_root_as_monster(buf);
+        let mon = my_game::example::root_as_monster(buf);
         let vec3 = mon.pos().unwrap();
 
         let start_ptr = buf.as_ptr() as usize;
@@ -835,7 +835,7 @@ mod generated_code_alignment_and_padding {
             my_game::example::finish_monster_buffer(b, mon);
         }
         let buf = b.finished_data();
-        let mon = my_game::example::get_root_as_monster(buf);
+        let mon = my_game::example::root_as_monster(buf);
         let abilities = mon.testarrayofsortedstruct().unwrap();
 
         let start_ptr = buf.as_ptr() as usize;
@@ -1011,7 +1011,7 @@ mod roundtrip_vectors {
         impl_prop!(test_i8, prop_i8, i8);
 
         #[cfg(test)]
-        #[cfg(target_endian = "little")]
+        #[cfg(tarendian = "little")]
         mod host_is_le {
             const N: u64 = 20;
             use super::flatbuffers;
@@ -1676,7 +1676,7 @@ mod generated_key_comparisons {
         let builder = &mut flatbuffers::FlatBufferBuilder::new();
         super::create_serialized_example_with_library_code(builder);
         let buf = builder.finished_data();
-        let a = my_game::example::get_root_as_monster(buf);
+        let a = my_game::example::root_as_monster(buf);
 
         // preconditions
         assert_eq!(a.name(), "MyMonster");
@@ -1692,7 +1692,7 @@ mod generated_key_comparisons {
         let builder = &mut flatbuffers::FlatBufferBuilder::new();
         super::create_serialized_example_with_library_code(builder);
         let buf = builder.finished_data();
-        let a = my_game::example::get_root_as_monster(buf);
+        let a = my_game::example::root_as_monster(buf);
         let b = a.test_as_monster().unwrap();
 
         // preconditions
@@ -1879,7 +1879,7 @@ mod follow_impls {
         assert_eq!(off.self_follow(&vec[..], 4).safe_slice(), &[1, 2, 3][..]);
     }
 
-    #[cfg(target_endian = "little")]
+    #[cfg(tarendian = "little")]
     #[test]
     fn to_slice_of_u16() {
         let vec: Vec<u8> = vec![255, 255, 255, 255, 2, 0, 0, 0, 1, 2, 3, 4];
@@ -1942,7 +1942,7 @@ mod follow_impls {
     }
 
     #[test]
-    fn to_root_table_get_slot_scalar_u8() {
+    fn to_root_table_slot_scalar_u8() {
         let buf: Vec<u8> = vec![
             14, 0, 0, 0, // offset to root table
             // enter vtable
@@ -1960,7 +1960,7 @@ mod follow_impls {
     }
 
     #[test]
-    fn to_root_to_table_get_slot_scalar_u8_default_via_vtable_len() {
+    fn to_root_to_table_slot_scalar_u8_default_via_vtable_len() {
         let buf: Vec<u8> = vec![
             12, 0, 0, 0, // offset to root table
             // enter vtable
@@ -1976,7 +1976,7 @@ mod follow_impls {
     }
 
     #[test]
-    fn to_root_to_table_get_slot_scalar_u8_default_via_vtable_zero() {
+    fn to_root_to_table_slot_scalar_u8_default_via_vtable_zero() {
         let buf: Vec<u8> = vec![
             14, 0, 0, 0, // offset to root table
             // enter vtable
@@ -1993,7 +1993,7 @@ mod follow_impls {
     }
 
     #[test]
-    fn to_root_to_table_get_slot_string_multiple_types() {
+    fn to_root_to_table_slot_string_multiple_types() {
         let buf: Vec<u8> = vec![
             14, 0, 0, 0, // offset to root table
             // enter vtable
@@ -2021,7 +2021,7 @@ mod follow_impls {
     }
 
     #[test]
-    fn to_root_to_table_get_slot_string_multiple_types_default_via_vtable_len() {
+    fn to_root_to_table_slot_string_multiple_types_default_via_vtable_len() {
         let buf: Vec<u8> = vec![
             12, 0, 0, 0, // offset to root table
             // enter vtable
@@ -2033,7 +2033,7 @@ mod follow_impls {
         ];
         let tab = <flatbuffers::ForwardsUOffset<flatbuffers::Table>>::follow(&buf[..], 0);
         assert_eq!(tab.get::<flatbuffers::ForwardsUOffset<&str>>(fi2fo(0), Some("abc")), Some("abc"));
-        #[cfg(target_endian = "little")]
+        #[cfg(tarendian = "little")]
         {
             assert_eq!(tab.get::<flatbuffers::ForwardsUOffset<&[u8]>>(fi2fo(0), Some(&vec![70, 71, 72][..])), Some(&vec![70, 71, 72][..]));
         }
@@ -2048,7 +2048,7 @@ mod follow_impls {
     }
 
     #[test]
-    fn to_root_to_table_get_slot_string_multiple_types_default_via_vtable_zero() {
+    fn to_root_to_table_slot_string_multiple_types_default_via_vtable_zero() {
         let buf: Vec<u8> = vec![
             14, 0, 0, 0, // offset to root table
             // enter vtable
@@ -2061,7 +2061,7 @@ mod follow_impls {
         ];
         let tab = <flatbuffers::ForwardsUOffset<flatbuffers::Table>>::follow(&buf[..], 0);
         assert_eq!(tab.get::<flatbuffers::ForwardsUOffset<&str>>(fi2fo(0), Some("abc")), Some("abc"));
-        #[cfg(target_endian = "little")]
+        #[cfg(tarendian = "little")]
         {
             assert_eq!(tab.get::<flatbuffers::ForwardsUOffset<&[u8]>>(fi2fo(0), Some(&vec![70, 71, 72][..])), Some(&vec![70, 71, 72][..]));
         }
@@ -2871,11 +2871,11 @@ mod copy_clone_traits {
 mod fully_qualified_name {
     #[test]
     fn fully_qualified_name_generated() {
-        assert!(check_eq!(::my_game::example::Monster::get_fully_qualified_name(), "MyGame.Example.Monster").is_ok());
-        assert!(check_eq!(::my_game::example_2::Monster::get_fully_qualified_name(), "MyGame.Example2.Monster").is_ok());
+        assert!(check_eq!(::my_game::example::Monster::fully_qualified_name(), "MyGame.Example.Monster").is_ok());
+        assert!(check_eq!(::my_game::example_2::Monster::fully_qualified_name(), "MyGame.Example2.Monster").is_ok());
 
-        assert!(check_eq!(::my_game::example::Vec3::get_fully_qualified_name(), "MyGame.Example.Vec3").is_ok());
-        assert!(check_eq!(::my_game::example::Ability::get_fully_qualified_name(), "MyGame.Example.Ability").is_ok());
+        assert!(check_eq!(::my_game::example::Vec3::fully_qualified_name(), "MyGame.Example.Vec3").is_ok());
+        assert!(check_eq!(::my_game::example::Ability::fully_qualified_name(), "MyGame.Example.Ability").is_ok());
     }
 }
 


### PR DESCRIPTION
This is a backwards-incompatible change but follows Rust naming conventions.

@rw @aardappel r?