### PR TITLE
C++: Fix generation of  Optional<bool> and Optional<Enum>

### DIFF
--- a/tests/cpp17/generated_cpp17/optional_scalars_generated.h
+++ b/tests/cpp17/generated_cpp17/optional_scalars_generated.h
@@ -77,7 +77,7 @@ struct ScalarStuffT : public flatbuffers::NativeTable {
   flatbuffers::Optional<double> maybe_f64 = flatbuffers::nullopt;
   double default_f64 = 42.0;
   bool just_bool = false;
-  flatbuffers::Optional<bool> maybe_bool = true;
+  flatbuffers::Optional<bool> maybe_bool = flatbuffers::nullopt;
   bool default_bool = true;
   optional_scalars::OptionalByte just_enum = optional_scalars::OptionalByte::None;
   optional_scalars::OptionalByte default_enum = optional_scalars::OptionalByte::One;

--- a/tests/optional_scalars_generated.h
+++ b/tests/optional_scalars_generated.h
@@ -116,7 +116,7 @@ struct ScalarStuffT : public flatbuffers::NativeTable {
         maybe_f64(flatbuffers::nullopt),
         default_f64(42.0),
         just_bool(false),
-        maybe_bool(true),
+        maybe_bool(flatbuffers::nullopt),
         default_bool(true),
         just_enum(optional_scalars::OptionalByte_None),
         default_enum(optional_scalars::OptionalByte_One) {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -3516,6 +3516,8 @@ void OptionalScalarsTest() {
   TEST_ASSERT(!opts->mutate_maybe_i16(-10));
 
   optional_scalars::ScalarStuffT obj;
+  TEST_ASSERT(!obj.maybe_bool);
+  TEST_ASSERT(!obj.maybe_f32.has_value());
   opts->UnPackTo(&obj);
   TEST_ASSERT(!obj.maybe_bool);
   TEST_ASSERT(!obj.maybe_f32.has_value());


### PR DESCRIPTION
This PR fixes generation of defaults values for `Optional<bool>` and `Optional<Enum>` in C++ generated code.
Related issue: #6014