### PR TITLE
enum refactoring

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -11,3 +11,4 @@ categories = ["encoding", "data-structures", "memory-management"]
 
 [dependencies]
 smallvec = "1.0"
+thiserror = "1.0"

--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -11,4 +11,3 @@ categories = ["encoding", "data-structures", "memory-management"]
 
 [dependencies]
 smallvec = "1.0"
-thiserror = "1.0"

--- a/rust/flatbuffers/src/error.rs
+++ b/rust/flatbuffers/src/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+pub enum ConvertError {
+    #[error("invalid value in buffer")]
+    InvalidValue,
+}

--- a/rust/flatbuffers/src/error.rs
+++ b/rust/flatbuffers/src/error.rs
@@ -4,6 +4,6 @@ use thiserror::Error;
 
 #[derive(Error, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 pub enum ConvertError<T: Debug + Display> {
-    #[error("invalid value in buffer: {0}")]
-    InvalidValue(T),
+    #[error("unknown variant in buffer: {0}")]
+    UnknownVariant(T),
 }

--- a/rust/flatbuffers/src/error.rs
+++ b/rust/flatbuffers/src/error.rs
@@ -1,17 +1,9 @@
-use std::error::Error;
-use std::fmt;
+use std::fmt::{Debug, Display};
 
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
-pub enum ConvertError {
-    InvalidValue,
+use thiserror::Error;
+
+#[derive(Error, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+pub enum ConvertError<T: Debug + Display> {
+    #[error("invalid value in buffer: {0}")]
+    InvalidValue(T),
 }
-
-impl fmt::Display for ConvertError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            ConvertError::InvalidValue => write!(f, "invalid value in buffer"),
-        }
-    }
-}
-
-impl Error for ConvertError {}

--- a/rust/flatbuffers/src/error.rs
+++ b/rust/flatbuffers/src/error.rs
@@ -1,7 +1,17 @@
-use thiserror::Error;
+use std::error::Error;
+use std::fmt;
 
-#[derive(Error, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 pub enum ConvertError {
-    #[error("invalid value in buffer")]
     InvalidValue,
 }
+
+impl fmt::Display for ConvertError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            ConvertError::InvalidValue => write!(f, "invalid value in buffer"),
+        }
+    }
+}
+
+impl Error for ConvertError {}

--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -28,8 +28,11 @@
 //! At this time, to generate Rust code, you will need the latest `master` version of `flatc`, available from here: https://github.com/google/flatbuffers
 //! (On OSX, you can install FlatBuffers from `HEAD` with the Homebrew package manager.)
 
+extern crate thiserror;
+
 mod builder;
 mod endian_scalar;
+mod error;
 mod follow;
 mod primitives;
 mod push;
@@ -42,6 +45,7 @@ pub use builder::FlatBufferBuilder;
 pub use endian_scalar::{
     byte_swap_f32, byte_swap_f64, emplace_scalar, read_scalar, read_scalar_at, EndianScalar,
 };
+pub use error::ConvertError;
 pub use follow::{Follow, FollowStart};
 pub use primitives::*;
 pub use push::Push;

--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -27,6 +27,7 @@
 //!
 //! At this time, to generate Rust code, you will need the latest `master` version of `flatc`, available from here: https://github.com/google/flatbuffers
 //! (On OSX, you can install FlatBuffers from `HEAD` with the Homebrew package manager.)
+extern crate thiserror;
 
 mod builder;
 mod endian_scalar;

--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -28,8 +28,6 @@
 //! At this time, to generate Rust code, you will need the latest `master` version of `flatc`, available from here: https://github.com/google/flatbuffers
 //! (On OSX, you can install FlatBuffers from `HEAD` with the Homebrew package manager.)
 
-extern crate thiserror;
-
 mod builder;
 mod endian_scalar;
 mod error;

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -612,7 +612,7 @@ class RustGenerator : public BaseGenerator {
         code_ += "          {{VALUE}} => Ok({{ENUM_NAME}}::{{KEY}}),";
       }
 
-      code_ += "          _ => Err(Self::Error::InvalidValue(value))",
+      code_ += "          _ => Err(Self::Error::UnknownVariant(value))",
           code_ += "        }";
       code_ += "    }";
       code_ += "}";

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -598,7 +598,7 @@ class RustGenerator : public BaseGenerator {
 
     if (!IsBitFlags(enum_def)) {
       code_ += "impl TryFrom<{{BASE_TYPE}}> for {{ENUM_NAME}} {";
-      code_ += "    type Error = flatbuffers::ConvertError;";
+      code_ += "    type Error = flatbuffers::ConvertError<{{BASE_TYPE}}>;";
       code_ += "";
       code_ += "    #[inline]";
       code_ += "    fn try_from(value: {{BASE_TYPE}}) -> Result<Self, Self::Error> {";
@@ -612,7 +612,7 @@ class RustGenerator : public BaseGenerator {
         code_ += "          {{VALUE}} => Ok({{ENUM_NAME}}::{{KEY}}),";
       }
 
-      code_ += "          _ => Err(Self::Error::InvalidValue)",
+      code_ += "          _ => Err(Self::Error::InvalidValue(value))",
           code_ += "        }";
       code_ += "    }";
       code_ += "}";
@@ -962,7 +962,8 @@ class RustGenerator : public BaseGenerator {
       case ftEnumKey: {
         auto typname = WrapInNameSpace(*type.enum_def);
         if (!unchecked) {
-          typname = "Result<" + typname + ", flatbuffers::ConvertError>";
+          const auto underlying_typname = GetEnumTypeForDecl(type.enum_def->underlying_type);
+          typname = "Result<" + typname + ", flatbuffers::ConvertError<" + underlying_typname + ">>";
         }
 
         return field.optional ? "Option<" + typname + ">" : typname;

--- a/tests/include_test/include_test1_generated.rs
+++ b/tests/include_test/include_test1_generated.rs
@@ -5,6 +5,8 @@
 use crate::include_test2_generated::*;
 use std::mem;
 use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::convert::TryInto;
 
 extern crate flatbuffers;
 use self::flatbuffers::EndianScalar;

--- a/tests/include_test/sub/include_test2_generated.rs
+++ b/tests/include_test/sub/include_test2_generated.rs
@@ -83,7 +83,7 @@ impl TryFrom<i64> for FromInclude {
     fn try_from(value: i64) -> Result<Self, Self::Error> {
         match value {
           0 => Ok(FromInclude::IncludeVal),
-          _ => Err(Self::Error::InvalidValue(value))
+          _ => Err(Self::Error::UnknownVariant(value))
         }
     }
 }

--- a/tests/include_test/sub/include_test2_generated.rs
+++ b/tests/include_test/sub/include_test2_generated.rs
@@ -5,6 +5,8 @@
 use crate::include_test1_generated::*;
 use std::mem;
 use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::convert::TryInto;
 
 extern crate flatbuffers;
 use self::flatbuffers::EndianScalar;
@@ -15,6 +17,8 @@ pub mod my_game {
   use crate::include_test1_generated::*;
   use std::mem;
   use std::cmp::Ordering;
+  use std::convert::TryFrom;
+  use std::convert::TryInto;
 
   extern crate flatbuffers;
   use self::flatbuffers::EndianScalar;
@@ -24,6 +28,8 @@ pub mod other_name_space {
   use crate::include_test1_generated::*;
   use std::mem;
   use std::cmp::Ordering;
+  use std::convert::TryFrom;
+  use std::convert::TryInto;
 
   extern crate flatbuffers;
   use self::flatbuffers::EndianScalar;
@@ -67,6 +73,18 @@ impl flatbuffers::Push for FromInclude {
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
         flatbuffers::emplace_scalar::<FromInclude>(dst, *self);
+    }
+}
+
+impl TryFrom<i64> for FromInclude {
+    type Error = flatbuffers::ConvertError;
+
+    #[inline]
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        match value {
+          0 => Ok(FromInclude::IncludeVal),
+          _ => Err(Self::Error::InvalidValue)
+        }
     }
 }
 

--- a/tests/include_test/sub/include_test2_generated.rs
+++ b/tests/include_test/sub/include_test2_generated.rs
@@ -77,13 +77,13 @@ impl flatbuffers::Push for FromInclude {
 }
 
 impl TryFrom<i64> for FromInclude {
-    type Error = flatbuffers::ConvertError;
+    type Error = flatbuffers::ConvertError<i64>;
 
     #[inline]
     fn try_from(value: i64) -> Result<Self, Self::Error> {
         match value {
           0 => Ok(FromInclude::IncludeVal),
-          _ => Err(Self::Error::InvalidValue)
+          _ => Err(Self::Error::InvalidValue(value))
         }
     }
 }

--- a/tests/include_test/sub/include_test2_generated.rs
+++ b/tests/include_test/sub/include_test2_generated.rs
@@ -42,8 +42,15 @@ pub enum FromInclude {
 
 }
 
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MIN_FROM_INCLUDE: i64 = 0;
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MAX_FROM_INCLUDE: i64 = 0;
+
+impl FromInclude {
+    pub const MIN: i64 = 0;
+    pub const MAX: i64 = 0;
+}
 
 impl<'a> flatbuffers::Follow<'a> for FromInclude {
   type Inner = Self;
@@ -89,18 +96,26 @@ impl TryFrom<i64> for FromInclude {
 }
 
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_VALUES_FROM_INCLUDE: [FromInclude; 1] = [
   FromInclude::IncludeVal
 ];
 
+impl FromInclude {
+    pub const NAMES: [&'static str; 1] = [
+    "IncludeVal"
+    ];
+}
+
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_NAMES_FROM_INCLUDE: [&str; 1] = [
     "IncludeVal"
 ];
 
 pub fn enum_name_from_include(e: FromInclude) -> &'static str {
   let index = e as i64;
-  ENUM_NAMES_FROM_INCLUDE[index as usize]
+  FromInclude::NAMES[index as usize]
 }
 
 // struct Unused, aligned to 4

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -301,7 +301,7 @@ impl flatbuffers::Push for Race {
 }
 
 impl TryFrom<i8> for Race {
-    type Error = flatbuffers::ConvertError;
+    type Error = flatbuffers::ConvertError<i8>;
 
     #[inline]
     fn try_from(value: i8) -> Result<Self, Self::Error> {
@@ -310,7 +310,7 @@ impl TryFrom<i8> for Race {
           0 => Ok(Race::Human),
           1 => Ok(Race::Dwarf),
           2 => Ok(Race::Elf),
-          _ => Err(Self::Error::InvalidValue)
+          _ => Err(Self::Error::InvalidValue(value))
         }
     }
 }
@@ -382,7 +382,7 @@ impl flatbuffers::Push for Any {
 }
 
 impl TryFrom<u8> for Any {
-    type Error = flatbuffers::ConvertError;
+    type Error = flatbuffers::ConvertError<u8>;
 
     #[inline]
     fn try_from(value: u8) -> Result<Self, Self::Error> {
@@ -391,7 +391,7 @@ impl TryFrom<u8> for Any {
           1 => Ok(Any::Monster),
           2 => Ok(Any::TestSimpleTableWithEnum),
           3 => Ok(Any::MyGame_Example2_Monster),
-          _ => Err(Self::Error::InvalidValue)
+          _ => Err(Self::Error::InvalidValue(value))
         }
     }
 }
@@ -464,7 +464,7 @@ impl flatbuffers::Push for AnyUniqueAliases {
 }
 
 impl TryFrom<u8> for AnyUniqueAliases {
-    type Error = flatbuffers::ConvertError;
+    type Error = flatbuffers::ConvertError<u8>;
 
     #[inline]
     fn try_from(value: u8) -> Result<Self, Self::Error> {
@@ -473,7 +473,7 @@ impl TryFrom<u8> for AnyUniqueAliases {
           1 => Ok(AnyUniqueAliases::M),
           2 => Ok(AnyUniqueAliases::TS),
           3 => Ok(AnyUniqueAliases::M2),
-          _ => Err(Self::Error::InvalidValue)
+          _ => Err(Self::Error::InvalidValue(value))
         }
     }
 }
@@ -546,7 +546,7 @@ impl flatbuffers::Push for AnyAmbiguousAliases {
 }
 
 impl TryFrom<u8> for AnyAmbiguousAliases {
-    type Error = flatbuffers::ConvertError;
+    type Error = flatbuffers::ConvertError<u8>;
 
     #[inline]
     fn try_from(value: u8) -> Result<Self, Self::Error> {
@@ -555,7 +555,7 @@ impl TryFrom<u8> for AnyAmbiguousAliases {
           1 => Ok(AnyAmbiguousAliases::M1),
           2 => Ok(AnyAmbiguousAliases::M2),
           3 => Ok(AnyAmbiguousAliases::M3),
-          _ => Err(Self::Error::InvalidValue)
+          _ => Err(Self::Error::InvalidValue(value))
         }
     }
 }
@@ -1425,7 +1425,7 @@ impl<'a> Monster<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, Color>>>(Monster::VT_VECTOR_OF_ENUMS, None)
   }
   #[inline]
-  pub fn signed_enum(&self) -> Result<Race, flatbuffers::ConvertError> {
+  pub fn signed_enum(&self) -> Result<Race, flatbuffers::ConvertError<i8>> {
     self._tab.get::<i8>(Monster::VT_SIGNED_ENUM, Some(-1)).map(|value| value.try_into()).unwrap()
   }
   #[inline]

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -197,8 +197,15 @@ pub enum Color {
 
 }
 
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MIN_COLOR: u8 = 1;
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MAX_COLOR: u8 = 8;
+
+impl Color {
+    pub const MIN: u8 = 1;
+    pub const MAX: u8 = 8;
+}
 
 impl<'a> flatbuffers::Follow<'a> for Color {
   type Inner = Self;
@@ -232,13 +239,28 @@ impl flatbuffers::Push for Color {
 }
 
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_VALUES_COLOR: [Color; 3] = [
   Color::Red,
   Color::Green,
   Color::Blue
 ];
 
+impl Color {
+    pub const NAMES: [&'static str; 8] = [
+    "Red",
+    "Green",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "Blue"
+    ];
+}
+
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_NAMES_COLOR: [&str; 8] = [
     "Red",
     "Green",
@@ -252,7 +274,7 @@ pub const ENUM_NAMES_COLOR: [&str; 8] = [
 
 pub fn enum_name_color(e: Color) -> &'static str {
   let index = e as u8 - Color::Red as u8;
-  ENUM_NAMES_COLOR[index as usize]
+  Color::NAMES[index as usize]
 }
 
 #[allow(non_camel_case_types)]
@@ -266,8 +288,15 @@ pub enum Race {
 
 }
 
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MIN_RACE: i8 = -1;
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MAX_RACE: i8 = 2;
+
+impl Race {
+    pub const MIN: i8 = -1;
+    pub const MAX: i8 = 2;
+}
 
 impl<'a> flatbuffers::Follow<'a> for Race {
   type Inner = Self;
@@ -316,6 +345,7 @@ impl TryFrom<i8> for Race {
 }
 
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_VALUES_RACE: [Race; 4] = [
   Race::None,
   Race::Human,
@@ -323,7 +353,17 @@ pub const ENUM_VALUES_RACE: [Race; 4] = [
   Race::Elf
 ];
 
+impl Race {
+    pub const NAMES: [&'static str; 4] = [
+    "None",
+    "Human",
+    "Dwarf",
+    "Elf"
+    ];
+}
+
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_NAMES_RACE: [&str; 4] = [
     "None",
     "Human",
@@ -333,7 +373,7 @@ pub const ENUM_NAMES_RACE: [&str; 4] = [
 
 pub fn enum_name_race(e: Race) -> &'static str {
   let index = e as i8 - Race::None as i8;
-  ENUM_NAMES_RACE[index as usize]
+  Race::NAMES[index as usize]
 }
 
 #[allow(non_camel_case_types)]
@@ -347,8 +387,15 @@ pub enum Any {
 
 }
 
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MIN_ANY: u8 = 0;
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MAX_ANY: u8 = 3;
+
+impl Any {
+    pub const MIN: u8 = 0;
+    pub const MAX: u8 = 3;
+}
 
 impl<'a> flatbuffers::Follow<'a> for Any {
   type Inner = Self;
@@ -397,6 +444,7 @@ impl TryFrom<u8> for Any {
 }
 
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_VALUES_ANY: [Any; 4] = [
   Any::NONE,
   Any::Monster,
@@ -404,7 +452,17 @@ pub const ENUM_VALUES_ANY: [Any; 4] = [
   Any::MyGame_Example2_Monster
 ];
 
+impl Any {
+    pub const NAMES: [&'static str; 4] = [
+    "NONE",
+    "Monster",
+    "TestSimpleTableWithEnum",
+    "MyGame_Example2_Monster"
+    ];
+}
+
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_NAMES_ANY: [&str; 4] = [
     "NONE",
     "Monster",
@@ -414,7 +472,7 @@ pub const ENUM_NAMES_ANY: [&str; 4] = [
 
 pub fn enum_name_any(e: Any) -> &'static str {
   let index = e as u8;
-  ENUM_NAMES_ANY[index as usize]
+  Any::NAMES[index as usize]
 }
 
 pub struct AnyUnionTableOffset {}
@@ -429,8 +487,15 @@ pub enum AnyUniqueAliases {
 
 }
 
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MIN_ANY_UNIQUE_ALIASES: u8 = 0;
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MAX_ANY_UNIQUE_ALIASES: u8 = 3;
+
+impl AnyUniqueAliases {
+    pub const MIN: u8 = 0;
+    pub const MAX: u8 = 3;
+}
 
 impl<'a> flatbuffers::Follow<'a> for AnyUniqueAliases {
   type Inner = Self;
@@ -479,6 +544,7 @@ impl TryFrom<u8> for AnyUniqueAliases {
 }
 
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_VALUES_ANY_UNIQUE_ALIASES: [AnyUniqueAliases; 4] = [
   AnyUniqueAliases::NONE,
   AnyUniqueAliases::M,
@@ -486,7 +552,17 @@ pub const ENUM_VALUES_ANY_UNIQUE_ALIASES: [AnyUniqueAliases; 4] = [
   AnyUniqueAliases::M2
 ];
 
+impl AnyUniqueAliases {
+    pub const NAMES: [&'static str; 4] = [
+    "NONE",
+    "M",
+    "TS",
+    "M2"
+    ];
+}
+
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_NAMES_ANY_UNIQUE_ALIASES: [&str; 4] = [
     "NONE",
     "M",
@@ -496,7 +572,7 @@ pub const ENUM_NAMES_ANY_UNIQUE_ALIASES: [&str; 4] = [
 
 pub fn enum_name_any_unique_aliases(e: AnyUniqueAliases) -> &'static str {
   let index = e as u8;
-  ENUM_NAMES_ANY_UNIQUE_ALIASES[index as usize]
+  AnyUniqueAliases::NAMES[index as usize]
 }
 
 pub struct AnyUniqueAliasesUnionTableOffset {}
@@ -511,8 +587,15 @@ pub enum AnyAmbiguousAliases {
 
 }
 
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MIN_ANY_AMBIGUOUS_ALIASES: u8 = 0;
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MAX_ANY_AMBIGUOUS_ALIASES: u8 = 3;
+
+impl AnyAmbiguousAliases {
+    pub const MIN: u8 = 0;
+    pub const MAX: u8 = 3;
+}
 
 impl<'a> flatbuffers::Follow<'a> for AnyAmbiguousAliases {
   type Inner = Self;
@@ -561,6 +644,7 @@ impl TryFrom<u8> for AnyAmbiguousAliases {
 }
 
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_VALUES_ANY_AMBIGUOUS_ALIASES: [AnyAmbiguousAliases; 4] = [
   AnyAmbiguousAliases::NONE,
   AnyAmbiguousAliases::M1,
@@ -568,7 +652,17 @@ pub const ENUM_VALUES_ANY_AMBIGUOUS_ALIASES: [AnyAmbiguousAliases; 4] = [
   AnyAmbiguousAliases::M3
 ];
 
+impl AnyAmbiguousAliases {
+    pub const NAMES: [&'static str; 4] = [
+    "NONE",
+    "M1",
+    "M2",
+    "M3"
+    ];
+}
+
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_NAMES_ANY_AMBIGUOUS_ALIASES: [&str; 4] = [
     "NONE",
     "M1",
@@ -578,7 +672,7 @@ pub const ENUM_NAMES_ANY_AMBIGUOUS_ALIASES: [&str; 4] = [
 
 pub fn enum_name_any_ambiguous_aliases(e: AnyAmbiguousAliases) -> &'static str {
   let index = e as u8;
-  ENUM_NAMES_ANY_AMBIGUOUS_ALIASES[index as usize]
+  AnyAmbiguousAliases::NAMES[index as usize]
 }
 
 pub struct AnyAmbiguousAliasesUnionTableOffset {}

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -6,6 +6,8 @@ use crate::include_test1_generated::*;
 use crate::include_test2_generated::*;
 use std::mem;
 use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::convert::TryInto;
 
 extern crate flatbuffers;
 use self::flatbuffers::EndianScalar;
@@ -17,6 +19,8 @@ pub mod my_game {
   use crate::include_test2_generated::*;
   use std::mem;
   use std::cmp::Ordering;
+  use std::convert::TryFrom;
+  use std::convert::TryInto;
 
   extern crate flatbuffers;
   use self::flatbuffers::EndianScalar;
@@ -93,6 +97,8 @@ pub mod example_2 {
   use crate::include_test2_generated::*;
   use std::mem;
   use std::cmp::Ordering;
+  use std::convert::TryFrom;
+  use std::convert::TryInto;
 
   extern crate flatbuffers;
   use self::flatbuffers::EndianScalar;
@@ -171,6 +177,8 @@ pub mod example {
   use crate::include_test2_generated::*;
   use std::mem;
   use std::cmp::Ordering;
+  use std::convert::TryFrom;
+  use std::convert::TryInto;
 
   extern crate flatbuffers;
   use self::flatbuffers::EndianScalar;
@@ -292,6 +300,21 @@ impl flatbuffers::Push for Race {
     }
 }
 
+impl TryFrom<i8> for Race {
+    type Error = flatbuffers::ConvertError;
+
+    #[inline]
+    fn try_from(value: i8) -> Result<Self, Self::Error> {
+        match value {
+          -1 => Ok(Race::None),
+          0 => Ok(Race::Human),
+          1 => Ok(Race::Dwarf),
+          2 => Ok(Race::Elf),
+          _ => Err(Self::Error::InvalidValue)
+        }
+    }
+}
+
 #[allow(non_camel_case_types)]
 pub const ENUM_VALUES_RACE: [Race; 4] = [
   Race::None,
@@ -355,6 +378,21 @@ impl flatbuffers::Push for Any {
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
         flatbuffers::emplace_scalar::<Any>(dst, *self);
+    }
+}
+
+impl TryFrom<u8> for Any {
+    type Error = flatbuffers::ConvertError;
+
+    #[inline]
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+          0 => Ok(Any::NONE),
+          1 => Ok(Any::Monster),
+          2 => Ok(Any::TestSimpleTableWithEnum),
+          3 => Ok(Any::MyGame_Example2_Monster),
+          _ => Err(Self::Error::InvalidValue)
+        }
     }
 }
 
@@ -425,6 +463,21 @@ impl flatbuffers::Push for AnyUniqueAliases {
     }
 }
 
+impl TryFrom<u8> for AnyUniqueAliases {
+    type Error = flatbuffers::ConvertError;
+
+    #[inline]
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+          0 => Ok(AnyUniqueAliases::NONE),
+          1 => Ok(AnyUniqueAliases::M),
+          2 => Ok(AnyUniqueAliases::TS),
+          3 => Ok(AnyUniqueAliases::M2),
+          _ => Err(Self::Error::InvalidValue)
+        }
+    }
+}
+
 #[allow(non_camel_case_types)]
 pub const ENUM_VALUES_ANY_UNIQUE_ALIASES: [AnyUniqueAliases; 4] = [
   AnyUniqueAliases::NONE,
@@ -489,6 +542,21 @@ impl flatbuffers::Push for AnyAmbiguousAliases {
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
         flatbuffers::emplace_scalar::<AnyAmbiguousAliases>(dst, *self);
+    }
+}
+
+impl TryFrom<u8> for AnyAmbiguousAliases {
+    type Error = flatbuffers::ConvertError;
+
+    #[inline]
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+          0 => Ok(AnyAmbiguousAliases::NONE),
+          1 => Ok(AnyAmbiguousAliases::M1),
+          2 => Ok(AnyAmbiguousAliases::M2),
+          3 => Ok(AnyAmbiguousAliases::M3),
+          _ => Err(Self::Error::InvalidValue)
+        }
     }
 }
 
@@ -1357,8 +1425,12 @@ impl<'a> Monster<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, Color>>>(Monster::VT_VECTOR_OF_ENUMS, None)
   }
   #[inline]
-  pub fn signed_enum(&self) -> Race {
-    self._tab.get::<Race>(Monster::VT_SIGNED_ENUM, Some(Race::None)).unwrap()
+  pub fn signed_enum(&self) -> Result<Race, flatbuffers::ConvertError> {
+    self._tab.get::<i8>(Monster::VT_SIGNED_ENUM, Some(-1)).map(|value| value.try_into()).unwrap()
+  }
+  #[inline]
+  pub unsafe fn signed_enum_unchecked(&self) -> Race {
+    self._tab.get::<i8>(Monster::VT_SIGNED_ENUM, Some(-1)).map(|value| std::mem::transmute(value)).unwrap()
   }
   #[inline]
   #[allow(non_snake_case)]

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -1433,6 +1433,10 @@ impl<'a> Monster<'a> {
     self._tab.get::<i8>(Monster::VT_SIGNED_ENUM, Some(-1)).map(|value| std::mem::transmute(value)).unwrap()
   }
   #[inline]
+  pub fn signed_enum_raw(&self) -> i8 {
+    self._tab.get::<i8>(Monster::VT_SIGNED_ENUM, Some(-1)).unwrap()
+  }
+  #[inline]
   #[allow(non_snake_case)]
   pub fn test_as_monster(&self) -> Option<Monster<'a>> {
     if self.test_type() == Any::Monster {

--- a/tests/monster_test_generated.rs
+++ b/tests/monster_test_generated.rs
@@ -310,7 +310,7 @@ impl TryFrom<i8> for Race {
           0 => Ok(Race::Human),
           1 => Ok(Race::Dwarf),
           2 => Ok(Race::Elf),
-          _ => Err(Self::Error::InvalidValue(value))
+          _ => Err(Self::Error::UnknownVariant(value))
         }
     }
 }
@@ -391,7 +391,7 @@ impl TryFrom<u8> for Any {
           1 => Ok(Any::Monster),
           2 => Ok(Any::TestSimpleTableWithEnum),
           3 => Ok(Any::MyGame_Example2_Monster),
-          _ => Err(Self::Error::InvalidValue(value))
+          _ => Err(Self::Error::UnknownVariant(value))
         }
     }
 }
@@ -473,7 +473,7 @@ impl TryFrom<u8> for AnyUniqueAliases {
           1 => Ok(AnyUniqueAliases::M),
           2 => Ok(AnyUniqueAliases::TS),
           3 => Ok(AnyUniqueAliases::M2),
-          _ => Err(Self::Error::InvalidValue(value))
+          _ => Err(Self::Error::UnknownVariant(value))
         }
     }
 }
@@ -555,7 +555,7 @@ impl TryFrom<u8> for AnyAmbiguousAliases {
           1 => Ok(AnyAmbiguousAliases::M1),
           2 => Ok(AnyAmbiguousAliases::M2),
           3 => Ok(AnyAmbiguousAliases::M3),
-          _ => Err(Self::Error::InvalidValue(value))
+          _ => Err(Self::Error::UnknownVariant(value))
         }
     }
 }

--- a/tests/namespace_test/namespace_test1_generated.rs
+++ b/tests/namespace_test/namespace_test1_generated.rs
@@ -4,6 +4,8 @@
 
 use std::mem;
 use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::convert::TryInto;
 
 extern crate flatbuffers;
 use self::flatbuffers::EndianScalar;
@@ -13,6 +15,8 @@ pub mod namespace_a {
 
   use std::mem;
   use std::cmp::Ordering;
+  use std::convert::TryFrom;
+  use std::convert::TryInto;
 
   extern crate flatbuffers;
   use self::flatbuffers::EndianScalar;
@@ -21,6 +25,8 @@ pub mod namespace_b {
 
   use std::mem;
   use std::cmp::Ordering;
+  use std::convert::TryFrom;
+  use std::convert::TryInto;
 
   extern crate flatbuffers;
   use self::flatbuffers::EndianScalar;
@@ -66,6 +72,20 @@ impl flatbuffers::Push for EnumInNestedNS {
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
         flatbuffers::emplace_scalar::<EnumInNestedNS>(dst, *self);
+    }
+}
+
+impl TryFrom<i8> for EnumInNestedNS {
+    type Error = flatbuffers::ConvertError;
+
+    #[inline]
+    fn try_from(value: i8) -> Result<Self, Self::Error> {
+        match value {
+          0 => Ok(EnumInNestedNS::A),
+          1 => Ok(EnumInNestedNS::B),
+          2 => Ok(EnumInNestedNS::C),
+          _ => Err(Self::Error::InvalidValue)
+        }
     }
 }
 

--- a/tests/namespace_test/namespace_test1_generated.rs
+++ b/tests/namespace_test/namespace_test1_generated.rs
@@ -84,7 +84,7 @@ impl TryFrom<i8> for EnumInNestedNS {
           0 => Ok(EnumInNestedNS::A),
           1 => Ok(EnumInNestedNS::B),
           2 => Ok(EnumInNestedNS::C),
-          _ => Err(Self::Error::InvalidValue(value))
+          _ => Err(Self::Error::UnknownVariant(value))
         }
     }
 }

--- a/tests/namespace_test/namespace_test1_generated.rs
+++ b/tests/namespace_test/namespace_test1_generated.rs
@@ -41,8 +41,15 @@ pub enum EnumInNestedNS {
 
 }
 
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MIN_ENUM_IN_NESTED_NS: i8 = 0;
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MAX_ENUM_IN_NESTED_NS: i8 = 2;
+
+impl EnumInNestedNS {
+    pub const MIN: i8 = 0;
+    pub const MAX: i8 = 2;
+}
 
 impl<'a> flatbuffers::Follow<'a> for EnumInNestedNS {
   type Inner = Self;
@@ -90,13 +97,23 @@ impl TryFrom<i8> for EnumInNestedNS {
 }
 
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_VALUES_ENUM_IN_NESTED_NS: [EnumInNestedNS; 3] = [
   EnumInNestedNS::A,
   EnumInNestedNS::B,
   EnumInNestedNS::C
 ];
 
+impl EnumInNestedNS {
+    pub const NAMES: [&'static str; 3] = [
+    "A",
+    "B",
+    "C"
+    ];
+}
+
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_NAMES_ENUM_IN_NESTED_NS: [&str; 3] = [
     "A",
     "B",
@@ -105,7 +122,7 @@ pub const ENUM_NAMES_ENUM_IN_NESTED_NS: [&str; 3] = [
 
 pub fn enum_name_enum_in_nested_ns(e: EnumInNestedNS) -> &'static str {
   let index = e as i8;
-  ENUM_NAMES_ENUM_IN_NESTED_NS[index as usize]
+  EnumInNestedNS::NAMES[index as usize]
 }
 
 // struct StructInNestedNS, aligned to 4

--- a/tests/namespace_test/namespace_test1_generated.rs
+++ b/tests/namespace_test/namespace_test1_generated.rs
@@ -76,7 +76,7 @@ impl flatbuffers::Push for EnumInNestedNS {
 }
 
 impl TryFrom<i8> for EnumInNestedNS {
-    type Error = flatbuffers::ConvertError;
+    type Error = flatbuffers::ConvertError<i8>;
 
     #[inline]
     fn try_from(value: i8) -> Result<Self, Self::Error> {
@@ -84,7 +84,7 @@ impl TryFrom<i8> for EnumInNestedNS {
           0 => Ok(EnumInNestedNS::A),
           1 => Ok(EnumInNestedNS::B),
           2 => Ok(EnumInNestedNS::C),
-          _ => Err(Self::Error::InvalidValue)
+          _ => Err(Self::Error::InvalidValue(value))
         }
     }
 }

--- a/tests/namespace_test/namespace_test2_generated.rs
+++ b/tests/namespace_test/namespace_test2_generated.rs
@@ -5,6 +5,8 @@
 use crate::namespace_test1_generated::*;
 use std::mem;
 use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::convert::TryInto;
 
 extern crate flatbuffers;
 use self::flatbuffers::EndianScalar;
@@ -15,6 +17,8 @@ pub mod namespace_a {
   use crate::namespace_test1_generated::*;
   use std::mem;
   use std::cmp::Ordering;
+  use std::convert::TryFrom;
+  use std::convert::TryInto;
 
   extern crate flatbuffers;
   use self::flatbuffers::EndianScalar;
@@ -65,8 +69,12 @@ impl<'a> TableInFirstNS<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<namespace_b::TableInNestedNS<'a>>>(TableInFirstNS::VT_FOO_TABLE, None)
   }
   #[inline]
-  pub fn foo_enum(&self) -> namespace_b::EnumInNestedNS {
-    self._tab.get::<namespace_b::EnumInNestedNS>(TableInFirstNS::VT_FOO_ENUM, Some(namespace_b::EnumInNestedNS::A)).unwrap()
+  pub fn foo_enum(&self) -> Result<namespace_b::EnumInNestedNS, flatbuffers::ConvertError> {
+    self._tab.get::<i8>(TableInFirstNS::VT_FOO_ENUM, Some(0)).map(|value| value.try_into()).unwrap()
+  }
+  #[inline]
+  pub unsafe fn foo_enum_unchecked(&self) -> namespace_b::EnumInNestedNS {
+    self._tab.get::<i8>(TableInFirstNS::VT_FOO_ENUM, Some(0)).map(|value| std::mem::transmute(value)).unwrap()
   }
   #[inline]
   pub fn foo_struct(&self) -> Option<&'a namespace_b::StructInNestedNS> {
@@ -207,6 +215,8 @@ pub mod namespace_c {
   use crate::namespace_test1_generated::*;
   use std::mem;
   use std::cmp::Ordering;
+  use std::convert::TryFrom;
+  use std::convert::TryInto;
 
   extern crate flatbuffers;
   use self::flatbuffers::EndianScalar;

--- a/tests/namespace_test/namespace_test2_generated.rs
+++ b/tests/namespace_test/namespace_test2_generated.rs
@@ -77,6 +77,10 @@ impl<'a> TableInFirstNS<'a> {
     self._tab.get::<i8>(TableInFirstNS::VT_FOO_ENUM, Some(0)).map(|value| std::mem::transmute(value)).unwrap()
   }
   #[inline]
+  pub fn foo_enum_raw(&self) -> i8 {
+    self._tab.get::<i8>(TableInFirstNS::VT_FOO_ENUM, Some(0)).unwrap()
+  }
+  #[inline]
   pub fn foo_struct(&self) -> Option<&'a namespace_b::StructInNestedNS> {
     self._tab.get::<namespace_b::StructInNestedNS>(TableInFirstNS::VT_FOO_STRUCT, None)
   }

--- a/tests/namespace_test/namespace_test2_generated.rs
+++ b/tests/namespace_test/namespace_test2_generated.rs
@@ -69,7 +69,7 @@ impl<'a> TableInFirstNS<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<namespace_b::TableInNestedNS<'a>>>(TableInFirstNS::VT_FOO_TABLE, None)
   }
   #[inline]
-  pub fn foo_enum(&self) -> Result<namespace_b::EnumInNestedNS, flatbuffers::ConvertError> {
+  pub fn foo_enum(&self) -> Result<namespace_b::EnumInNestedNS, flatbuffers::ConvertError<i8>> {
     self._tab.get::<i8>(TableInFirstNS::VT_FOO_ENUM, Some(0)).map(|value| value.try_into()).unwrap()
   }
   #[inline]

--- a/tests/optional_scalars2_generated.rs
+++ b/tests/optional_scalars2_generated.rs
@@ -74,7 +74,7 @@ impl TryFrom<i8> for OptionalByte {
           0 => Ok(OptionalByte::None),
           1 => Ok(OptionalByte::One),
           2 => Ok(OptionalByte::Two),
-          _ => Err(Self::Error::InvalidValue(value))
+          _ => Err(Self::Error::UnknownVariant(value))
         }
     }
 }

--- a/tests/optional_scalars2_generated.rs
+++ b/tests/optional_scalars2_generated.rs
@@ -342,6 +342,10 @@ impl<'a> ScalarStuff<'a> {
     self._tab.get::<i8>(ScalarStuff::VT_JUST_ENUM, Some(0)).map(|value| std::mem::transmute(value)).unwrap()
   }
   #[inline]
+  pub fn just_enum_raw(&self) -> i8 {
+    self._tab.get::<i8>(ScalarStuff::VT_JUST_ENUM, Some(0)).unwrap()
+  }
+  #[inline]
   pub fn maybe_enum(&self) -> Option<Result<OptionalByte, flatbuffers::ConvertError<i8>>> {
     self._tab.get::<i8>(ScalarStuff::VT_MAYBE_ENUM, None).map(|value| value.try_into())
   }
@@ -350,12 +354,20 @@ impl<'a> ScalarStuff<'a> {
     self._tab.get::<i8>(ScalarStuff::VT_MAYBE_ENUM, None).map(|value| std::mem::transmute(value))
   }
   #[inline]
+  pub fn maybe_enum_raw(&self) -> Option<i8> {
+    self._tab.get::<i8>(ScalarStuff::VT_MAYBE_ENUM, None)
+  }
+  #[inline]
   pub fn default_enum(&self) -> Result<OptionalByte, flatbuffers::ConvertError<i8>> {
     self._tab.get::<i8>(ScalarStuff::VT_DEFAULT_ENUM, Some(1)).map(|value| value.try_into()).unwrap()
   }
   #[inline]
   pub unsafe fn default_enum_unchecked(&self) -> OptionalByte {
     self._tab.get::<i8>(ScalarStuff::VT_DEFAULT_ENUM, Some(1)).map(|value| std::mem::transmute(value)).unwrap()
+  }
+  #[inline]
+  pub fn default_enum_raw(&self) -> i8 {
+    self._tab.get::<i8>(ScalarStuff::VT_DEFAULT_ENUM, Some(1)).unwrap()
   }
 }
 

--- a/tests/optional_scalars2_generated.rs
+++ b/tests/optional_scalars2_generated.rs
@@ -66,7 +66,7 @@ impl flatbuffers::Push for OptionalByte {
 }
 
 impl TryFrom<i8> for OptionalByte {
-    type Error = flatbuffers::ConvertError;
+    type Error = flatbuffers::ConvertError<i8>;
 
     #[inline]
     fn try_from(value: i8) -> Result<Self, Self::Error> {
@@ -74,7 +74,7 @@ impl TryFrom<i8> for OptionalByte {
           0 => Ok(OptionalByte::None),
           1 => Ok(OptionalByte::One),
           2 => Ok(OptionalByte::Two),
-          _ => Err(Self::Error::InvalidValue)
+          _ => Err(Self::Error::InvalidValue(value))
         }
     }
 }
@@ -334,7 +334,7 @@ impl<'a> ScalarStuff<'a> {
     self._tab.get::<bool>(ScalarStuff::VT_DEFAULT_BOOL, Some(true)).unwrap()
   }
   #[inline]
-  pub fn just_enum(&self) -> Result<OptionalByte, flatbuffers::ConvertError> {
+  pub fn just_enum(&self) -> Result<OptionalByte, flatbuffers::ConvertError<i8>> {
     self._tab.get::<i8>(ScalarStuff::VT_JUST_ENUM, Some(0)).map(|value| value.try_into()).unwrap()
   }
   #[inline]
@@ -342,7 +342,7 @@ impl<'a> ScalarStuff<'a> {
     self._tab.get::<i8>(ScalarStuff::VT_JUST_ENUM, Some(0)).map(|value| std::mem::transmute(value)).unwrap()
   }
   #[inline]
-  pub fn maybe_enum(&self) -> Option<Result<OptionalByte, flatbuffers::ConvertError>> {
+  pub fn maybe_enum(&self) -> Option<Result<OptionalByte, flatbuffers::ConvertError<i8>>> {
     self._tab.get::<i8>(ScalarStuff::VT_MAYBE_ENUM, None).map(|value| value.try_into())
   }
   #[inline]
@@ -350,7 +350,7 @@ impl<'a> ScalarStuff<'a> {
     self._tab.get::<i8>(ScalarStuff::VT_MAYBE_ENUM, None).map(|value| std::mem::transmute(value))
   }
   #[inline]
-  pub fn default_enum(&self) -> Result<OptionalByte, flatbuffers::ConvertError> {
+  pub fn default_enum(&self) -> Result<OptionalByte, flatbuffers::ConvertError<i8>> {
     self._tab.get::<i8>(ScalarStuff::VT_DEFAULT_ENUM, Some(1)).map(|value| value.try_into()).unwrap()
   }
   #[inline]

--- a/tests/optional_scalars2_generated.rs
+++ b/tests/optional_scalars2_generated.rs
@@ -31,8 +31,15 @@ pub enum OptionalByte {
 
 }
 
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MIN_OPTIONAL_BYTE: i8 = 0;
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_MAX_OPTIONAL_BYTE: i8 = 2;
+
+impl OptionalByte {
+    pub const MIN: i8 = 0;
+    pub const MAX: i8 = 2;
+}
 
 impl<'a> flatbuffers::Follow<'a> for OptionalByte {
   type Inner = Self;
@@ -80,13 +87,23 @@ impl TryFrom<i8> for OptionalByte {
 }
 
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_VALUES_OPTIONAL_BYTE: [OptionalByte; 3] = [
   OptionalByte::None,
   OptionalByte::One,
   OptionalByte::Two
 ];
 
+impl OptionalByte {
+    pub const NAMES: [&'static str; 3] = [
+    "None",
+    "One",
+    "Two"
+    ];
+}
+
 #[allow(non_camel_case_types)]
+#[deprecated(since = "1.13", note = "Use associated constants instead.")]
 pub const ENUM_NAMES_OPTIONAL_BYTE: [&str; 3] = [
     "None",
     "One",
@@ -95,7 +112,7 @@ pub const ENUM_NAMES_OPTIONAL_BYTE: [&str; 3] = [
 
 pub fn enum_name_optional_byte(e: OptionalByte) -> &'static str {
   let index = e as i8;
-  ENUM_NAMES_OPTIONAL_BYTE[index as usize]
+  OptionalByte::NAMES[index as usize]
 }
 
 pub enum ScalarStuffOffset {}

--- a/tests/rust_usage_test/tests/optional_scalars_test.rs
+++ b/tests/rust_usage_test/tests/optional_scalars_test.rs
@@ -41,6 +41,41 @@ macro_rules! make_test {
     };
 }
 
+macro_rules! make_enum_test {
+    (
+        $test_name: ident,
+        $just: ident, $default: ident, $maybe: ident,
+        $five: expr, $zero: expr, $fortytwo: expr
+    ) => {
+        #[test]
+        fn $test_name() {
+            let mut builder = flatbuffers::FlatBufferBuilder::new();
+            // Test five makes sense when specified.
+            let ss = ScalarStuff::create(
+                &mut builder,
+                &ScalarStuffArgs {
+                    $just: $five,
+                    $default: $five,
+                    $maybe: Some($five),
+                    ..Default::default()
+                },
+            );
+            builder.finish(ss, None);
+
+            let s = flatbuffers::get_root::<ScalarStuff>(builder.finished_data());
+            assert_eq!(s.$just(), Ok($five));
+            assert_eq!(s.$default(), Ok($five));
+            assert_eq!(s.$maybe(), Some(Ok($five)));
+
+            // Test defaults are used when not specified.
+            let s = flatbuffers::get_root::<ScalarStuff>(&[0; 8]);
+            assert_eq!(s.$just(), Ok($zero));
+            assert_eq!(s.$default(), Ok($fortytwo));
+            assert_eq!(s.$maybe(), None);
+        }
+    };
+}
+
 make_test!(optional_i8, just_i8, default_i8, maybe_i8, 5, 0, 42);
 make_test!(optional_u8, just_u8, default_u8, maybe_u8, 5, 0, 42);
 make_test!(optional_i16, just_i16, default_i16, maybe_i16, 5, 0, 42);
@@ -76,7 +111,7 @@ make_test!(
     false,
     true
 );
-make_test!(
+make_enum_test!(
      optional_enum,
      just_enum,
      default_enum,


### PR DESCRIPTION
This PR is an alternative solution to unsoundess in #5581. The benefits over https://github.com/google/flatbuffers/pull/6098 are:

1. Enums are kept as proper enum types.
1. Untrusted buffers now have fallible enum accessors for safe and future-compatible access.
1. Trusted buffers have `unsafe` accessor which doesn't incur any performance penalty due to transmutation. The user is responsible for ensuring the buffer is trusted.

This solution is also compatible with potential future verifier returning trusted buffer types.

@rw @aardappel r?