### PR TITLE
[Rust] Upgrade flatbuffers library to 2018 edition

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatbuffers"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2018"
 authors = ["Robert Winslow <hello@rwinslow.com>", "FlatBuffers Maintainers"]
 license = "Apache-2.0"

--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "flatbuffers"
 version = "0.6.2"
+edition = "2018"
 authors = ["Robert Winslow <hello@rwinslow.com>", "FlatBuffers Maintainers"]
 license = "Apache-2.0"
 description = "Official FlatBuffers Rust runtime library."

--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -17,18 +17,18 @@
 extern crate smallvec;
 
 use std::cmp::max;
+use std::iter::{DoubleEndedIterator, ExactSizeIterator};
 use std::marker::PhantomData;
 use std::ptr::write_bytes;
 use std::slice::from_raw_parts;
-use std::iter::{DoubleEndedIterator, ExactSizeIterator};
 
-use endian_scalar::{emplace_scalar, read_scalar_at};
-use primitives::*;
-use push::{Push, PushAlignment};
-use table::Table;
-use vector::{SafeSliceAccess, Vector};
-use vtable::{field_index_to_field_offset, VTable};
-use vtable_writer::VTableWriter;
+use crate::endian_scalar::{emplace_scalar, read_scalar_at};
+use crate::primitives::*;
+use crate::push::{Push, PushAlignment};
+use crate::table::Table;
+use crate::vector::{SafeSliceAccess, Vector};
+use crate::vtable::{field_index_to_field_offset, VTable};
+use crate::vtable_writer::VTableWriter;
 
 pub const N_SMALLVEC_STRING_VECTOR_CAPACITY: usize = 16;
 

--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -38,16 +38,16 @@ mod vector;
 mod vtable;
 mod vtable_writer;
 
-pub use builder::FlatBufferBuilder;
-pub use endian_scalar::{
+pub use crate::builder::FlatBufferBuilder;
+pub use crate::endian_scalar::{
     byte_swap_f32, byte_swap_f64, emplace_scalar, read_scalar, read_scalar_at, EndianScalar,
 };
-pub use follow::{Follow, FollowStart};
-pub use primitives::*;
-pub use push::Push;
-pub use table::{buffer_has_identifier, get_root, get_size_prefixed_root, Table};
-pub use vector::{follow_cast_ref, SafeSliceAccess, Vector, VectorIter};
-pub use vtable::field_index_to_field_offset;
+pub use crate::follow::{Follow, FollowStart};
+pub use crate::primitives::*;
+pub use crate::push::Push;
+pub use crate::table::{buffer_has_identifier, get_root, get_size_prefixed_root, Table};
+pub use crate::vector::{follow_cast_ref, SafeSliceAccess, Vector, VectorIter};
+pub use crate::vtable::field_index_to_field_offset;
 
 // TODO(rw): Unify `create_vector` and `create_vector_direct` by using
 //           `Into<Vector<...>>`.

--- a/rust/flatbuffers/src/primitives.rs
+++ b/rust/flatbuffers/src/primitives.rs
@@ -18,9 +18,9 @@ use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ops::Deref;
 
-use endian_scalar::{emplace_scalar, read_scalar, read_scalar_at};
-use follow::Follow;
-use push::Push;
+use crate::endian_scalar::{emplace_scalar, read_scalar, read_scalar_at};
+use crate::follow::Follow;
+use crate::push::Push;
 
 pub const FLATBUFFERS_MAX_BUFFER_SIZE: usize = (1u64 << 31) as usize;
 

--- a/rust/flatbuffers/src/push.rs
+++ b/rust/flatbuffers/src/push.rs
@@ -17,7 +17,7 @@
 use std::cmp::max;
 use std::mem::{align_of, size_of};
 
-use endian_scalar::emplace_scalar;
+use crate::endian_scalar::emplace_scalar;
 
 /// Trait to abstract over functionality needed to write values (either owned
 /// or referenced). Used in FlatBufferBuilder and implemented for generated

--- a/rust/flatbuffers/src/table.rs
+++ b/rust/flatbuffers/src/table.rs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-use follow::Follow;
-use primitives::*;
-use vtable::VTable;
+use crate::follow::Follow;
+use crate::primitives::*;
+use crate::vtable::VTable;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Table<'a> {

--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -20,11 +20,11 @@ use std::mem::size_of;
 use std::slice::from_raw_parts;
 use std::str::from_utf8_unchecked;
 
-use endian_scalar::read_scalar_at;
+use crate::endian_scalar::read_scalar_at;
 #[cfg(target_endian = "little")]
-use endian_scalar::EndianScalar;
-use follow::Follow;
-use primitives::*;
+use crate::endian_scalar::EndianScalar;
+use crate::follow::Follow;
+use crate::primitives::*;
 
 #[derive(Debug)]
 pub struct Vector<'a, T: 'a>(&'a [u8], usize, PhantomData<T>);

--- a/rust/flatbuffers/src/vtable.rs
+++ b/rust/flatbuffers/src/vtable.rs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-use endian_scalar::read_scalar_at;
-use follow::Follow;
-use primitives::*;
+use crate::endian_scalar::read_scalar_at;
+use crate::follow::Follow;
+use crate::primitives::*;
 
 /// VTable encapsulates read-only usage of a vtable. It is only to be used
 /// by generated code.

--- a/rust/flatbuffers/src/vtable_writer.rs
+++ b/rust/flatbuffers/src/vtable_writer.rs
@@ -16,8 +16,8 @@
 
 use std::ptr::write_bytes;
 
-use endian_scalar::{emplace_scalar, read_scalar_at};
-use primitives::*;
+use crate::endian_scalar::{emplace_scalar, read_scalar_at};
+use crate::primitives::*;
 
 /// VTableWriter compartmentalizes actions needed to create a vtable.
 #[derive(Debug)]


### PR DESCRIPTION
What title says, plus `cargo fmt`. Should not be a breaking change.