### PR TITLE
[Swift] Enables optional enums

### DIFF
--- a/tests/FlatBuffers.Test.Swift/SwiftTest.sh
+++ b/tests/FlatBuffers.Test.Swift/SwiftTest.sh
@@ -4,7 +4,7 @@ test_dir=`pwd`
 
 cd ${swift_dir}/Tests/FlatBuffers.Test.SwiftTests
 ${test_dir}/../flatc --swift --gen-mutable --grpc --gen-object-api -I ${test_dir}/include_test ${test_dir}/monster_test.fbs ${test_dir}/union_vector/union_vector.fbs
-${test_dir}/../flatc --swift ${test_dir}/optional_scalars.fbs
+${test_dir}/../flatc --swift ${test_dir}/optional_scalars2.fbs
 cd ${swift_dir}
 swift build --build-tests
 swift test

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersTests.swift
@@ -72,14 +72,20 @@ final class FlatBuffersTests: XCTestCase {
                                                                   justI8: 80,
                                                                   maybeI8: nil,
                                                                   justU8: 100,
-                                                                  maybeU8: 10)
+                                                                  maybeU8: 10,
+                                                                  maybeBool: true,
+                                                                  justEnum: .one,
+                                                                  maybeEnum: nil)
         b.finish(offset: root)
         let scalarTable = optional_scalars_ScalarStuff.getRootAsScalarStuff(bb: b.sizedBuffer)
         XCTAssertEqual(scalarTable.justI8, 80)
         XCTAssertNil(scalarTable.maybeI8)
+        XCTAssertEqual(scalarTable.maybeBool, true)
         XCTAssertEqual(scalarTable.defaultI8, 42)
         XCTAssertEqual(scalarTable.justU8, 100)
         XCTAssertEqual(scalarTable.maybeU8, 10)
+        XCTAssertEqual(scalarTable.justEnum, .one)
+        XCTAssertNil(scalarTable.maybeEnum)
     }
 }
 

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/optional_scalars2_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/optional_scalars2_generated.swift
@@ -9,9 +9,10 @@ public enum optional_scalars_OptionalByte: Int8, Enum {
     public var value: Int8 { return self.rawValue }
     case none_ = 0
     case one = 1
+    case two = 2
     
 
-    public static var max: optional_scalars_OptionalByte { return .one }
+    public static var max: optional_scalars_OptionalByte { return .two }
     public static var min: optional_scalars_OptionalByte { return .none_ }
 }
 
@@ -62,7 +63,8 @@ public struct optional_scalars_ScalarStuff: FlatBufferObject {
         case maybeBool = 66
         case defaultBool = 68
         case justEnum = 70
-        case defaultEnum = 72
+        case maybeEnum = 72
+        case defaultEnum = 74
         var v: Int32 { Int32(self.rawValue) }
         var p: VOffset { self.rawValue }
     }
@@ -101,8 +103,9 @@ public struct optional_scalars_ScalarStuff: FlatBufferObject {
     public var maybeBool: Bool? { let o = _accessor.offset(VTOFFSET.maybeBool.v); return o == 0 ? true : 0 != _accessor.readBuffer(of: Byte.self, at: o) }
     public var defaultBool: Bool { let o = _accessor.offset(VTOFFSET.defaultBool.v); return o == 0 ? true : 0 != _accessor.readBuffer(of: Byte.self, at: o) }
     public var justEnum: optional_scalars_OptionalByte { let o = _accessor.offset(VTOFFSET.justEnum.v); return o == 0 ? .none_ : optional_scalars_OptionalByte(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .none_ }
+    public var maybeEnum: optional_scalars_OptionalByte? { let o = _accessor.offset(VTOFFSET.maybeEnum.v); return o == 0 ? nil : optional_scalars_OptionalByte(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? nil }
     public var defaultEnum: optional_scalars_OptionalByte { let o = _accessor.offset(VTOFFSET.defaultEnum.v); return o == 0 ? .one : optional_scalars_OptionalByte(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .one }
-    public static func startScalarStuff(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 35) }
+    public static func startScalarStuff(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 36) }
     public static func add(justI8: Int8, _ fbb: inout FlatBufferBuilder) { fbb.add(element: justI8, def: 0, at: VTOFFSET.justI8.p) }
     public static func add(maybeI8: Int8?, _ fbb: inout FlatBufferBuilder) { fbb.add(element: maybeI8, at: VTOFFSET.maybeI8.p) }
     public static func add(defaultI8: Int8, _ fbb: inout FlatBufferBuilder) { fbb.add(element: defaultI8, def: 42, at: VTOFFSET.defaultI8.p) }
@@ -139,6 +142,7 @@ public struct optional_scalars_ScalarStuff: FlatBufferObject {
     public static func add(defaultBool: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: defaultBool, def: true,
      at: VTOFFSET.defaultBool.p) }
     public static func add(justEnum: optional_scalars_OptionalByte, _ fbb: inout FlatBufferBuilder) { fbb.add(element: justEnum.rawValue, def: 0, at: VTOFFSET.justEnum.p) }
+    public static func add(maybeEnum: optional_scalars_OptionalByte?, _ fbb: inout FlatBufferBuilder) { fbb.add(element: maybeEnum?.rawValue, at: VTOFFSET.maybeEnum.p) }
     public static func add(defaultEnum: optional_scalars_OptionalByte, _ fbb: inout FlatBufferBuilder) { fbb.add(element: defaultEnum.rawValue, def: 1, at: VTOFFSET.defaultEnum.p) }
     public static func endScalarStuff(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
     public static func createScalarStuff(
@@ -177,6 +181,7 @@ public struct optional_scalars_ScalarStuff: FlatBufferObject {
         maybeBool: Bool? = nil,
         defaultBool: Bool = true,
         justEnum: optional_scalars_OptionalByte = .none_,
+        maybeEnum: optional_scalars_OptionalByte? = nil,
         defaultEnum: optional_scalars_OptionalByte = .one
     ) -> Offset<UOffset> {
         let __start = optional_scalars_ScalarStuff.startScalarStuff(&fbb)
@@ -214,6 +219,7 @@ public struct optional_scalars_ScalarStuff: FlatBufferObject {
         optional_scalars_ScalarStuff.add(maybeBool: maybeBool, &fbb)
         optional_scalars_ScalarStuff.add(defaultBool: defaultBool, &fbb)
         optional_scalars_ScalarStuff.add(justEnum: justEnum, &fbb)
+        optional_scalars_ScalarStuff.add(maybeEnum: maybeEnum, &fbb)
         optional_scalars_ScalarStuff.add(defaultEnum: defaultEnum, &fbb)
         return optional_scalars_ScalarStuff.endScalarStuff(&fbb, start: __start)
     }

--- a/tests/generate_code.sh
+++ b/tests/generate_code.sh
@@ -64,7 +64,7 @@ working_dir=`pwd`
 cd FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests
 $working_dir/../flatc --swift --grpc $TEST_NOINCL_FLAGS $TEST_CPP_FLAGS $TEST_CS_FLAGS -I ../../../include_test ../../../monster_test.fbs
 $working_dir/../flatc --swift $TEST_BASE_FLAGS $TEST_CPP_FLAGS $TEST_CS_FLAGS ../../../union_vector/union_vector.fbs
-$working_dir/../flatc --swift ../../../optional_scalars.fbs
+$working_dir/../flatc --swift ../../../optional_scalars2.fbs
 cd $working_dir
 
 cd FlatBuffers.GRPC.Swift/Sources/Model


### PR DESCRIPTION
The following PR includes the following:


- [X] Optional enums in swift

- [X] Newly added generated code for optional_scalars2.fbs

- [X] tests for the enums and bools