### PR TITLE
[C++] Add option to not generate direct copy methods.

### DIFF
--- a/docs/source/Compiler.md
+++ b/docs/source/Compiler.md
@@ -137,6 +137,9 @@ Additional options:
     std::string from Flatbuffers, but (char* + length). This allows efficient
 	construction of custom string types, including zero-copy construction.
 
+-   `--no-cpp-direct-copy` : Don't generate direct copy methods for C++
+    object-based API.
+
 -   `--cpp-std CPP_STD` : Generate a C++ code using features of selected C++ standard.
      Supported `CPP_STD` values:
     * `c++0x` - generate code compatible with old compilers (VS2010).

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -538,6 +538,7 @@ struct IDLOptions {
   std::string cpp_object_api_pointer_type;
   std::string cpp_object_api_string_type;
   bool cpp_object_api_string_flexible_constructor;
+  bool cpp_direct_copy;
   bool gen_nullable;
   bool java_checkerframework;
   bool gen_generated;
@@ -632,6 +633,7 @@ struct IDLOptions {
         gen_compare(false),
         cpp_object_api_pointer_type("std::unique_ptr"),
         cpp_object_api_string_flexible_constructor(false),
+        cpp_direct_copy(true),
         gen_nullable(false),
         java_checkerframework(false),
         gen_generated(false),

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -282,6 +282,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.cpp_object_api_string_type = argv[argi];
       } else if (arg == "--cpp-str-flex-ctor") {
         opts.cpp_object_api_string_flexible_constructor = true;
+      } else if (arg == "--no-cpp-direct-copy") {
+        opts.cpp_direct_copy = false;
       } else if (arg == "--gen-nullable") {
         opts.gen_nullable = true;
       } else if (arg == "--java-checkerframework") {

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2360,7 +2360,7 @@ class CppGenerator : public BaseGenerator {
     }
 
     // Generate a CreateXDirect function with vector types as parameters
-    if (has_string_or_vector_fields) {
+    if (opts_.cpp_direct_copy && has_string_or_vector_fields) {
       code_ +=
           "inline flatbuffers::Offset<{{STRUCT_NAME}}> "
           "Create{{STRUCT_NAME}}Direct(";


### PR DESCRIPTION
The direct copy methods generated by flatc utilize std::vector which isn't allowed on some embedded systems. Permit users of the compiler to not generate these methods so they don't have to be stubbed out.