### PR TITLE
[C++] Add FLATBUFFERS_NO_STL macro.

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -38,13 +38,16 @@
   #include <utility>
 #endif
 
-#include <string>
 #include <type_traits>
+#include <algorithm>
+
+#ifndef FLATBUFFERS_NO_STL
+#include <string>
 #include <vector>
 #include <set>
-#include <algorithm>
 #include <iterator>
 #include <memory>
+#endif
 
 #if defined(__unix__) && !defined(FLATBUFFERS_LOCALE_INDEPENDENT)
   #include <unistd.h>


### PR DESCRIPTION
Certain embedded platforms don't permit usage of most STL features
including std::string or std::vector. Exclude code that uses these
from the header if the macro FLATBUFFERS_NO_STL is defined.
