### PR TITLE
[Multiple] Empties the sharedString map

### DIFF
--- a/go/builder.go
+++ b/go/builder.go
@@ -53,6 +53,12 @@ func (b *Builder) Reset() {
 		b.vtable = b.vtable[:0]
 	}
 
+	if b.sharedStrings != nil {
+		for key := range b.sharedStrings {
+			delete(b.sharedStrings, key)
+		}
+	}
+
 	b.head = UOffsetT(len(b.Bytes))
 	b.minalign = 1
 	b.nested = false

--- a/net/FlatBuffers/FlatBufferBuilder.cs
+++ b/net/FlatBuffers/FlatBufferBuilder.cs
@@ -90,6 +90,10 @@ namespace FlatBuffers
             _objectStart = 0;
             _numVtables = 0;
             _vectorNumElems = 0;
+            if (_sharedStringMap != null)
+            {
+                _sharedStringMap.Clear();
+            }
         }
 
         /// <summary>

--- a/tests/FlatBuffers.Test/FlatBufferBuilderTests.cs
+++ b/tests/FlatBuffers.Test/FlatBufferBuilderTests.cs
@@ -359,5 +359,20 @@ namespace FlatBuffers.Test
             Assert.AreEqual(fbb.CreateSharedString(s).Value, 0);
             Assert.AreEqual(fbb.CreateString(s).Value, 0);
         }
+
+        [FlatBuffersTestMethod]
+        public void FlatBufferBuilder_Empty_Builder()
+        {
+            var fbb = new FlatBufferBuilder(16);
+            var str = "Hello";
+            var flatbuffer = "Flatbuffers!";
+            var strOffset = fbb.CreateSharedString(str);
+            var flatbufferOffset = fbb.CreateSharedString(flatbuffer);
+            fbb.Clear();
+            var flatbufferOffset2 = fbb.CreateSharedString(flatbuffer);
+            var strOffset2 = fbb.CreateSharedString(str);
+            Assert.IsFalse(strOffset.Value == strOffset2.Value);
+            Assert.IsFalse(flatbufferOffset.Value == flatbufferOffset2.Value);
+        }
     }
 }

--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -79,7 +79,8 @@ func TestAll(t *testing.T) {
 	CheckStructIsNotInlineError(t.Fatalf)
 	CheckFinishedBytesError(t.Fatalf)
 	CheckSharedStrings(t.Fatalf)
-	
+	CheckEmptiedBuilder(t.Fatalf)
+
 	// Verify that GetRootAs works for non-root tables
 	CheckGetRootAsForNonRootTable(t.Fatalf)
 	CheckTableAccessors(t.Fatalf)
@@ -1375,6 +1376,27 @@ func CheckStringIsNestedError(fail func(string, ...interface{})) {
 		}
 	}()
 	b.CreateString("foo")
+}
+
+func CheckEmptiedBuilder(fail func(string, ...interface{})) {
+	f := func(a, b string) bool {
+		if a == b {
+			return true
+		}
+
+		builder := flatbuffers.NewBuilder(0)
+
+		a1 := builder.CreateSharedString(a)
+		b1 := builder.CreateSharedString(b)
+		builder.Reset()
+		b2 := builder.CreateSharedString(b)
+		a2 := builder.CreateSharedString(a)
+
+		return !(a1 == a2 || b1 == b2)
+	}
+	if err := quick.Check(f, nil); err != nil {
+		fail("expected different offset")
+	}
 }
 
 func CheckSharedStrings(fail func(string, ...interface{})) {


### PR DESCRIPTION
The following PR includes the following:

- Checks if the sharedString is allocated and clears it on reseting/clearing the builder on both Go and C#

Closes #6186 