### PR TITLE
[Java] Removed C# references from java generator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ js/**/*.d.ts
 mjs/**/*.js
 mjs/**/*.d.ts
 yarn-error.log
+.cache/

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -60,7 +60,7 @@ class JavaGenerator : public BaseGenerator {
         one_file_code += enumcode;
       } else {
         if (!SaveType(enum_def.name, *enum_def.defined_namespace, enumcode,
-                      false))
+                      /* needs_includes= */ false))
           return false;
       }
     }
@@ -76,14 +76,14 @@ class JavaGenerator : public BaseGenerator {
         one_file_code += declcode;
       } else {
         if (!SaveType(struct_def.name, *struct_def.defined_namespace, declcode,
-                      true))
+                      /* needs_includes= */ true))
           return false;
       }
     }
 
     if (parser_.opts.one_file) {
       return SaveType(file_name_, *parser_.current_namespace_, one_file_code,
-                      true);
+                      /* needs_includes= */ true);
     }
     return true;
   }
@@ -112,11 +112,9 @@ class JavaGenerator : public BaseGenerator {
       if (parser_.opts.java_checkerframework) {
         code += "\nimport org.checkerframework.dataflow.qual.Pure;\n";
       }
-      code += "\n@SuppressWarnings(\"unused\")\n";
+      code += "\n";
     }
-    if (parser_.opts.gen_generated) {
-      code += "\n@javax.annotation.Generated(value=\"flatc\")\n";
-    }
+
     code += classcode;
     if (!namespace_name.empty()) code += "";
     auto filename = NamespaceDir(ns) + defname + ".java";
@@ -226,9 +224,7 @@ class JavaGenerator : public BaseGenerator {
   // Cast statements for mutator method parameters.
   // In Java, parameters representing unsigned numbers need to be cast down to
   // their respective type. For example, a long holding an unsigned int value
-  // would be cast down to int before being put onto the buffer. In C#, one cast
-  // directly cast an Enum to its underlying type, which is essential before
-  // putting it onto the buffer.
+  // would be cast down to int before being put onto the buffer.
   std::string SourceCast(const Type &type, bool castFromDest) const {
     if (IsSeries(type)) {
       return SourceCast(type.VectorType(), castFromDest);
@@ -305,7 +301,6 @@ class JavaGenerator : public BaseGenerator {
 
     if (enum_def.attributes.Lookup("private")) {
       // For Java, we leave the enum unmarked to indicate package-private
-      // For C# we mark the enum as internal
     } else {
       code += "public ";
     }
@@ -324,7 +319,6 @@ class JavaGenerator : public BaseGenerator {
     }
 
     // Generate a generate string table for enum values.
-    // We do not do that for C# where this functionality is native.
     // Problem is, if values are very sparse that could generate really big
     // tables. Ideally in that case we generate a map lookup instead, but for
     // the moment we simply don't output a table at all.
@@ -354,10 +348,7 @@ class JavaGenerator : public BaseGenerator {
     }
 
     // Close the class
-    code += "}";
-    // Java does not need the closing semi-colon on class definitions.
-    code += "";
-    code += "\n\n";
+    code += "}\n\n";
   }
 
   // Returns the function name that is able to read a value of the given type.
@@ -575,14 +566,17 @@ class JavaGenerator : public BaseGenerator {
     //   int o = __offset(offset); return o != 0 ? bb.getType(o + i) : default;
     // }
     GenComment(struct_def.doc_comment, code_ptr, &comment_config);
+
+    if (parser_.opts.gen_generated) {
+      code += "@javax.annotation.Generated(value=\"flatc\")\n";
+    }
+    code += "@SuppressWarnings(\"unused\")\n";
     if (struct_def.attributes.Lookup("private")) {
       // For Java, we leave the struct unmarked to indicate package-private
-      // For C# we mark the struct as internal
     } else {
       code += "public ";
     }
-    code += "final ";
-    code += "class " + struct_def.name;
+    code += "final class " + struct_def.name;
     code += " extends ";
     code += struct_def.fixed ? "Struct" : "Table";
     code += " {\n";

--- a/tests/MyGame/Example/Monster.java
+++ b/tests/MyGame/Example/Monster.java
@@ -7,10 +7,10 @@ import java.lang.*;
 import java.util.*;
 import com.google.flatbuffers.*;
 
-@SuppressWarnings("unused")
 /**
  * an example documentation comment: "monster object"
  */
+@SuppressWarnings("unused")
 public final class Monster extends Table {
   public static void ValidateVersion() { Constants.FLATBUFFERS_1_12_0(); }
   public static Monster getRootAsMonster(ByteBuffer _bb) { return getRootAsMonster(_bb, new Monster()); }


### PR DESCRIPTION
 There were still some left over C# references in the java generator from when I split the two apart, removed those.

Also moved the java annotations closer to the definitions to address #6194

Fixes: #6194
