### PR TITLE
[C#] Adds NetTest.bat to run .NET Core tests on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ mjs/**/*.js
 mjs/**/*.d.ts
 yarn-error.log
 .cache/
+.cmake/

--- a/tests/FlatBuffers.Test/NetTest.bat
+++ b/tests/FlatBuffers.Test/NetTest.bat
@@ -1,0 +1,20 @@
+@echo off
+@REM Builds a .NET solution file, adds the project, builds it
+@REM and executes it. Cleans up all generated files and directories.
+
+set TEMP_BIN=.tmp
+
+@REM Run the .NET Core tests
+set CORE_FILE=FlatBuffers.Core.Test
+set CORE_PROJ_FILE=%CORE_FILE%.csproj
+set CORE_SLN_FILE=%CORE_FILE%.sln
+dotnet new sln --force --name %CORE_FILE%
+dotnet sln %CORE_SLN_FILE% add %CORE_PROJ_FILE%
+dotnet build -c Release -o %TEMP_BIN% -v quiet %CORE_PROJ_FILE%
+%TEMP_BIN%\%CORE_FILE%.exe
+del /f %CORE_SLN_FILE%
+
+@REM TODO(dbaileychess): Support the other configurations in NetTest.sh
+
+@REM remove the temp bin directory, with files (/S) and quietly (/Q)
+RD /S /Q %TEMP_BIN%


### PR DESCRIPTION
Adds a windows batch script (NetTest.bat) that creates a solution, adds the FlatBuffers.Core.Test.csproj to it, restores dependencies, builds, and executes the test binary.

It appears we only do test with Mono in the NetTest.sh script, this adds the basic support for running the tests on a Windows machine. This assumes that the Windows machine has .NET Core installed. I had .NET Core 3.1 installed (via https://dotnet.microsoft.com/download).

Other test configurations (unsafe, SpanT, etc..) will be added in later PRs.

Running:
```
cd tests\FlatBuffers.Test
NetTest.bat
```

Produced the following:
```
The template "Solution File" was created successfully.
Project `FlatBuffers.Core.Test.csproj` added to the solution.
Microsoft (R) Build Engine version 16.7.0+7fb82e5b2 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.


Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:00.93
110 tests run, 0 failed
```
