### PR TITLE
[C#] Implement class generation option on csharp

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -779,6 +779,7 @@ class Parser : public ParserState {
     known_attributes_["original_order"] = true;
     known_attributes_["nested_flatbuffer"] = true;
     known_attributes_["csharp_partial"] = true;
+    known_attributes_["csharp_class"] = true;
     known_attributes_["streaming"] = true;
     known_attributes_["idempotent"] = true;
     known_attributes_["cpp_type"] = true;

--- a/net/FlatBuffers/FlatBufferBuilder.cs
+++ b/net/FlatBuffers/FlatBufferBuilder.cs
@@ -387,7 +387,7 @@ namespace FlatBuffers
         /// Creates a vector of tables.
         /// </summary>
         /// <param name="offsets">Offsets of the tables.</param>
-        public VectorOffset CreateVectorOfTables<T>(Offset<T>[] offsets) where T : struct
+        public VectorOffset CreateVectorOfTables<T>(Offset<T>[] offsets)
         {
             NotNested();
             StartVector(sizeof(int), offsets.Length, sizeof(int));

--- a/net/FlatBuffers/Offset.cs
+++ b/net/FlatBuffers/Offset.cs
@@ -19,7 +19,7 @@ namespace FlatBuffers
     /// <summary>
     /// Offset class for typesafe assignments.
     /// </summary>
-    public struct Offset<T> where T : struct
+    public struct Offset<T>
     {
         public int Value;
         public Offset(int value)

--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -150,7 +150,7 @@ namespace FlatBuffers
         }
 
         // Initialize any Table-derived type to point to the union at the given offset.
-        public T __union<T>(int offset) where T : struct, IFlatbufferObject
+        public T __union<T>(int offset) where T : IFlatbufferObject, new()
         {
             T t = new T();
             t.__init(__indirect(offset), bb);

--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -535,7 +535,9 @@ class CSharpGenerator : public BaseGenerator {
       // generate a partial class for this C# struct/table
       code += "partial ";
     }
-    code += "struct " + struct_def.name;
+
+    code += struct_def.attributes.Lookup("csharp_class") ? "class " : "struct ";
+    code += struct_def.name;
     code += " : IFlatbufferObject";
     code += "\n{\n";
     code += "  private ";


### PR DESCRIPTION
https://github.com/google/flatbuffers/pull/3998

OK, so FlatBuffers Objects on C# has been changed to struct from class since 1.4,0, and nowadays, I think there's a lot more complicated stories than just using structs on them, such as boxing for performance side, limitations on structs - by modifying field values... (I am using ILookup or Dictionaries as Lazy object on array FlatBuffers object cause flatbuffers native key indexing has limitation on it.) and so on.

plus, migration on projects which is using before 1.4.0 (wow, It's been a long time.) should be fine with this option.

Of course I truly agree that basic usage on FlatBuffers Objects with struct should be fine as non heap allocation, etc..
So, It would be great if I can use both of them! 😅