### PR TITLE
[Swift] Resets buffer without deallocating current pointer

### DIFF
--- a/swift/FlatBuffers.podspec
+++ b/swift/FlatBuffers.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FlatBuffers'
-  s.version          = '0.8.0'
+  s.version          = '0.8.1'
   s.summary          = 'FlatBuffers: Memory Efficient Serialization Library'
 
   s.description      = "FlatBuffers is a cross platform serialization library architected for

--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -283,8 +283,6 @@ public struct ByteBuffer {
     mutating public func clear() {
         _writerSize = 0
         alignment = 1
-        _storage.memory.deallocate()
-        _storage.memory = UnsafeMutableRawPointer.allocate(byteCount: _storage.capacity, alignment: alignment)
         _storage.initialize(for: _storage.capacity)
     }
     


### PR DESCRIPTION
Fixes the clear method to only reset the buffer instead of deallocating it