### PR TITLE
Update to flags in fuzzing cmake file

### DIFF
--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -18,7 +18,9 @@ message(STATUS "FLATBUFFERS_MAX_PARSING_DEPTH: ${FLATBUFFERS_MAX_PARSING_DEPTH}"
 # MemorySanitizer will not work out-of-the-box, and will instead report false
 # positives coming from uninstrumented code. Need to re-build both C++ standard
 # library: https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo
-option(USE_MSAN "Use MSAN instead of ASASN" OFF)
+option(USE_ASAN "Use fuzzers with ASASN" OFF)
+option(USE_MSAN "Use fuzzers with MSASN" OFF)
+option(OSS_FUZZ "Set this option to use flags by oss-fuzz" OFF)
 
 # Use Clang linker.
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
@@ -51,23 +53,30 @@ target_compile_options(
   fuzzer_config
   INTERFACE
     -fsanitize-coverage=edge,trace-cmp
-    $<$<BOOL:NOT ${USE_MSAN}>:
+    $<$<BOOL:${USE_ASAN}>:
       -fsanitize=fuzzer,undefined,address
     >
     $<$<BOOL:${USE_MSAN}>:
       -fsanitize=fuzzer,undefined,memory
       -fsanitize-memory-track-origins=2
     >
+    $<$<BOOL:${OSS_FUZZ}>:
+      ${CXX}
+      ${CXXFLAGS}
+    >
 )
 
 target_link_libraries(
   fuzzer_config
   INTERFACE
-    $<$<BOOL:NOT ${USE_MSAN}>:
+    $<$<BOOL:${USE_ASAN}>:
       -fsanitize=fuzzer,undefined,address
     >
     $<$<BOOL:${USE_MSAN}>:
       -fsanitize=fuzzer,undefined,memory
+    >
+    $<$<BOOL:${OSS_FUZZ}>:
+      $ENV{LIB_FUZZING_ENGINE}
     >
 )
 


### PR DESCRIPTION
This PR adds the possibility for oss-fuzz to pass its environment flags when building the fuzzers.

Furthermore, it adds a "USE_ASAN" flag as a replacement for the case when the "USE_MSAN" flag was not set to "ON". This means that a flag must be specified when building the fuzzers with cmake in contrast to the case prior to this PR, where the "USE_MSAN" could be left out.

I will shortly be submitting a PR to integrate Flatbuffers into OSS-fuzz, and that integration depends on this PR being merged in. I will link the PR on the oss-fuzz side and this PR once the PR on the oss-fuzz side has been submitted.