### PR TITLE
Rust flexbuffers serde human readable set to false (BREAKING)

### DIFF
--- a/rust/flexbuffers/Cargo.toml
+++ b/rust/flexbuffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flexbuffers"
-version = "0.1.1"
+version = "0.2.1"
 authors = ["Casper Neo <cneo@google.com>", "FlatBuffers Maintainers"]
 edition = "2018"
 license = "Apache-2.0"
@@ -9,6 +9,17 @@ homepage = "https://google.github.io/flatbuffers/flexbuffers"
 repository = "https://github.com/google/flatbuffers"
 keywords = ["flatbuffers", "flexbuffers", "serialization", "zero-copy"]
 categories = ["encoding", "data-structures", "memory-management"]
+
+[features]
+# Sets serde::Serializer::is_human_readable() to true.
+# The default was changed from true to false in version "0.2.1".
+# You basically never need this to be true unless writing data for old binaries.
+serialize_human_readable = []
+# Sets serde::Deserializer::is_human_readable() to true.
+# The default was changed from true to false in version "0.2.1".
+# You basically never need this to be true unless reading data from old binaries.
+deserialize_human_readable = []
+
 
 [dependencies]
 serde = "1.0"

--- a/rust/flexbuffers/src/builder/ser.rs
+++ b/rust/flexbuffers/src/builder/ser.rs
@@ -217,6 +217,9 @@ impl<'a> ser::Serializer for &'a mut FlexbufferSerializer {
     type SerializeStructVariant = &'a mut FlexbufferSerializer;
     type Ok = ();
     type Error = Error;
+    fn is_human_readable(&self) -> bool {
+        cfg!(serialize_human_readable)
+    }
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
         self.builder.push(v);
         self.finish_if_not_nested()

--- a/rust/flexbuffers/src/reader/de.rs
+++ b/rust/flexbuffers/src/reader/de.rs
@@ -151,6 +151,10 @@ impl<'de> VariantAccess<'de> for Reader<'de> {
 
 impl<'de> Deserializer<'de> for crate::Reader<'de> {
     type Error = DeserializationError;
+    fn is_human_readable(&self) -> bool {
+        cfg!(deserialize_human_readable)
+    }
+
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,


### PR DESCRIPTION
This should fix #6255. @damip @aardappel 

Instead of flags, which would probably require additional dependencies, I used cargo features. Existing users will have to read and rewrite their old data if they saved any, so serialize_human_readable and deserialize_human_readable are decoupled.