### PR TITLE
Experimental fix for failing oss-fuzz coverage build

### DIFF
--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -52,7 +52,7 @@ add_library(fuzzer_config INTERFACE)
 target_compile_options(
   fuzzer_config
   INTERFACE
-    -fsanitize-coverage=edge,trace-cmp
+    #-fsanitize-coverage=edge,trace-cmp
     $<$<BOOL:${USE_ASAN}>:
       -fsanitize=fuzzer,undefined,address
     >


### PR DESCRIPTION
With the current coverage build failing on the oss-fuzz side, this PR provides an experimental fix.

If this PR solves the coverage build, I will be happy to bring back the -fsanitize-coverage flag into the cmake file in a way that does not interfere with the oss-fuzz coverage build.