### PR TITLE
[Swift] Adds a fix for enum generation

### DIFF
--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -1384,7 +1384,6 @@ class SwiftGenerator : public BaseGenerator {
       const auto &ev = **enum_def.Vals().begin();
       name = Name(ev);
     }
-    std::transform(name.begin(), name.end(), name.begin(), CharToLower);
     return "." + name;
   }
 


### PR DESCRIPTION
The following PR fixes accessors for enums where default values are always fully lowercased in swift.

issue:
```
enum Action {
  case fetchRecords
}
...
public var action: Action { ... ?? .fetchrecords }
```

Solution:
```
enum Action {
  case fetchRecords
}
...
public var action: Action { ... ?? .fetchRecords }
```
    

Closes #6262 