### PR TITLE
Add flatc option to inhibit all warnings #6005

### DIFF
--- a/docs/source/Compiler.md
+++ b/docs/source/Compiler.md
@@ -228,5 +228,10 @@ Additional options:
 -   `--force-empty-vectors` : When serializing from object API representation, force
      vectors to empty rather than null.
 
+-   `--flexbuffers` : Used with "binary" and "json" options, it generates
+     data using schema-less FlexBuffers.
+
+-    `--no-warnings` : Inhibit all warning messages.
+
 NOTE: short-form options for generators are deprecated, use the long form
 whenever possible.

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -663,13 +663,13 @@ struct IDLOptions {
         cs_gen_json_serializer(false),
         filename_suffix("_generated"),
         filename_extension(),
+        no_warnings(false),
         lang(IDLOptions::kJava),
         mini_reflect(IDLOptions::kNone),
         require_explicit_ids(false),
         lang_to_generate(0),
         set_empty_strings_to_null(true),
-        set_empty_vectors_to_null(true), 
-        no_warnings(false) {}
+        set_empty_vectors_to_null(true) {}
 };
 
 // This encapsulates where the parser is in the current source file.

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -572,6 +572,7 @@ struct IDLOptions {
   std::string proto_namespace_suffix;
   std::string filename_suffix;
   std::string filename_extension;
+  bool no_warnings;
 
   // Possible options for the more general generator below.
   enum Language {
@@ -667,7 +668,8 @@ struct IDLOptions {
         require_explicit_ids(false),
         lang_to_generate(0),
         set_empty_strings_to_null(true),
-        set_empty_vectors_to_null(true) {}
+        set_empty_vectors_to_null(true), 
+        no_warnings(false) {}
 };
 
 // This encapsulates where the parser is in the current source file.

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -171,7 +171,7 @@ std::string FlatCompiler::GetUsageString(const char *program_name) const {
     "                         force vectors to empty rather than null.\n"
     "  --flexbuffers          Used with \"binary\" and \"json\" options, it generates\n"
     "                         data using schema-less FlexBuffers.\n"
-    "  --no-warnings          Inhibit all warning messages."
+    "  --no-warnings          Inhibit all warning messages.\n"
     "FILEs may be schemas (must end in .fbs), binary schemas (must end in .bfbs),\n"
     "or JSON files (conforming to preceding schema). FILEs after the -- must be\n"
     "binary flatbuffer format files.\n"

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -171,6 +171,7 @@ std::string FlatCompiler::GetUsageString(const char *program_name) const {
     "                         force vectors to empty rather than null.\n"
     "  --flexbuffers          Used with \"binary\" and \"json\" options, it generates\n"
     "                         data using schema-less FlexBuffers.\n"
+    "  --no-warnings          Inhibit all warning messages."
     "FILEs may be schemas (must end in .fbs), binary schemas (must end in .bfbs),\n"
     "or JSON files (conforming to preceding schema). FILEs after the -- must be\n"
     "binary flatbuffer format files.\n"
@@ -372,6 +373,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.use_flexbuffers = true;
       } else if (arg == "--gen-jvmstatic") {
         opts.gen_jvmstatic = true;
+      } else if (arg == "--no-warnings") {
+        opts.no_warnings = true;
       } else if (arg == "--cpp-std") {
         if (++argi >= argc)
           Error("missing C++ standard specification" + arg, true);

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -142,7 +142,10 @@ void Parser::Message(const std::string &msg) {
   error_ += ": " + msg;
 }
 
-void Parser::Warning(const std::string &msg) { Message("warning: " + msg); }
+void Parser::Warning(const std::string &msg) {
+  if (!opts.no_warnings)
+    Message("warning: " + msg);
+}
 
 CheckedError Parser::Error(const std::string &msg) {
   Message("error: " + msg);


### PR DESCRIPTION
Add option to inhibit all warnings with --no-warnings.
Default all warnings are enabled (no change to previous behaviour).