### PR TITLE
Add generated Python methods for handling nested flatbuffers

### DIFF
--- a/python/flatbuffers/table.py
+++ b/python/flatbuffers/table.py
@@ -116,11 +116,11 @@ class Table(object):
     def GetVectorAsBytes(self, flags, off):
         """
         GetVectorAsBytes returns the vector that starts at `Vector(off)`
-        as a memoryview.
+        as a bytearray.
         """
         offset = self.Vector(off)
         length = self.VectorLen(off)
-        return memoryview(self.Bytes)[offset : offset + (length * flags.bytewidth)]
+        return self.Bytes[offset : offset + (length * flags.bytewidth)]
 
     def GetVOffsetTSlot(self, slot, d):
         """

--- a/python/flatbuffers/table.py
+++ b/python/flatbuffers/table.py
@@ -112,6 +112,15 @@ class Table(object):
         length = self.VectorLen(off) # TODO: length accounts for bytewidth, right?
         numpy_dtype = N.to_numpy_type(flags)
         return encode.GetVectorAsNumpy(numpy_dtype, self.Bytes, length, offset)
+    
+    def GetVectorAsBytes(self, flags, off):
+        """
+        GetVectorAsBytes returns the vector that starts at `Vector(off)`
+        as a bytearray.
+        """
+        offset = self.Vector(off)
+        length = self.VectorLen(off)
+        return self.Bytes[offset : offset + (length * flags.bytewidth)]
 
     def GetVOffsetTSlot(self, slot, d):
         """

--- a/python/flatbuffers/table.py
+++ b/python/flatbuffers/table.py
@@ -116,11 +116,11 @@ class Table(object):
     def GetVectorAsBytes(self, flags, off):
         """
         GetVectorAsBytes returns the vector that starts at `Vector(off)`
-        as a bytearray.
+        as a memoryview.
         """
         offset = self.Vector(off)
         length = self.VectorLen(off)
-        return self.Bytes[offset : offset + (length * flags.bytewidth)]
+        return memoryview(self.Bytes)[offset : offset + (length * flags.bytewidth)]
 
     def GetVOffsetTSlot(self, slot, d):
         """

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -429,15 +429,18 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
     code += MakeCamel(NormalizedName(field)) + "NestedRoot(self):";
+
     code += OffsetPrefix(field);
 
+    code += Indent + Indent + Indent;
+    code += "from " + qualified_name + " import " + unqualified_name + "\n";
     code += Indent + Indent + Indent;
     code += "nestedBytes = ";
     code += "self._tab.GetVectorAsBytes(flatbuffers.number_types.";
     code += MakeCamel(GenTypeGet(field.value.type));
     code += "Flags, o)\n";
     code += Indent + Indent + Indent;
-    code += "return " + qualified_name + "." + unqualified_name;
+    code += "return " + unqualified_name;
     code += ".GetRootAs" + unqualified_name + "(nestedBytes, 0)\n";
     code += Indent + Indent + "return 0\n";
     code += "\n";

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -599,17 +599,18 @@ class PythonGenerator : public BaseGenerator {
   // Set the value of one of the members of a table's vector and fills in the
   // elements from a bytearray. This is for simplifying the use of nested
   // flatbuffers.
-  void BuildVectorOfTableFromBytes(const StructDef &struct_def, const FieldDef &field,
-                          std::string *code_ptr) {
+  void BuildVectorOfTableFromBytes(const StructDef &struct_def,
+                                   const FieldDef &field,
+                                   std::string *code_ptr) {
     auto nested = field.attributes.Lookup("nested_flatbuffer");
-    if (!nested) { return; } // There is no nested flatbuffer.
+    if (!nested) { return; }  // There is no nested flatbuffer.
 
     std::string unqualified_name = nested->constant;
     std::string qualified_name = nested->constant;
     auto nested_root = parser_.LookupStruct(nested->constant);
     if (nested_root == nullptr) {
-      qualified_name = parser_.current_namespace_->GetFullyQualifiedName(
-          nested->constant);
+      qualified_name =
+          parser_.current_namespace_->GetFullyQualifiedName(nested->constant);
       nested_root = parser_.LookupStruct(qualified_name);
     }
     FLATBUFFERS_ASSERT(nested_root);  // Guaranteed to exist by parser.

--- a/tests/MyGame/Example/Monster.py
+++ b/tests/MyGame/Example/Monster.py
@@ -206,6 +206,14 @@ class Monster(object):
         return 0
 
     # Monster
+    def TestnestedflatbufferNestedRoot(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(30))
+        if o != 0:
+            nestedBytes = self._tab.GetVectorAsBytes(flatbuffers.number_types.Uint8Flags, o)
+            return MyGame.Example.Monster.Monster.GetRootAsMonster(nestedBytes, 0)
+        return 0
+
+    # Monster
     def TestnestedflatbufferLength(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(30))
         if o != 0:
@@ -732,6 +740,14 @@ class Monster(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(102))
         if o != 0:
             return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Uint8Flags, o)
+        return 0
+
+    # Monster
+    def TestrequirednestedflatbufferNestedRoot(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(102))
+        if o != 0:
+            nestedBytes = self._tab.GetVectorAsBytes(flatbuffers.number_types.Uint8Flags, o)
+            return MyGame.Example.Monster.Monster.GetRootAsMonster(nestedBytes, 0)
         return 0
 
     # Monster

--- a/tests/MyGame/Example/Monster.py
+++ b/tests/MyGame/Example/Monster.py
@@ -209,8 +209,9 @@ class Monster(object):
     def TestnestedflatbufferNestedRoot(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(30))
         if o != 0:
+            from MyGame.Example.Monster import Monster
             nestedBytes = self._tab.GetVectorAsBytes(flatbuffers.number_types.Uint8Flags, o)
-            return MyGame.Example.Monster.Monster.GetRootAsMonster(nestedBytes, 0)
+            return Monster.GetRootAsMonster(nestedBytes, 0)
         return 0
 
     # Monster
@@ -746,8 +747,9 @@ class Monster(object):
     def TestrequirednestedflatbufferNestedRoot(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(102))
         if o != 0:
+            from MyGame.Example.Monster import Monster
             nestedBytes = self._tab.GetVectorAsBytes(flatbuffers.number_types.Uint8Flags, o)
-            return MyGame.Example.Monster.Monster.GetRootAsMonster(nestedBytes, 0)
+            return Monster.GetRootAsMonster(nestedBytes, 0)
         return 0
 
     # Monster

--- a/tests/MyGame/Example/Monster.py
+++ b/tests/MyGame/Example/Monster.py
@@ -781,6 +781,11 @@ def MonsterStartTestarrayoftablesVector(builder, numElems): return builder.Start
 def MonsterAddEnemy(builder, enemy): builder.PrependUOffsetTRelativeSlot(12, flatbuffers.number_types.UOffsetTFlags.py_type(enemy), 0)
 def MonsterAddTestnestedflatbuffer(builder, testnestedflatbuffer): builder.PrependUOffsetTRelativeSlot(13, flatbuffers.number_types.UOffsetTFlags.py_type(testnestedflatbuffer), 0)
 def MonsterStartTestnestedflatbufferVector(builder, numElems): return builder.StartVector(1, numElems, 1)
+def MonsterMakeTestnestedflatbufferVectorFromBytes(builder, bytes):
+    builder.StartVector(1, len(bytes), 1)
+    builder.head = builder.head - len(bytes)
+    builder.Bytes[builder.head : builder.head + len(bytes)] = bytes
+    return builder.EndVector(len(bytes))
 def MonsterAddTestempty(builder, testempty): builder.PrependUOffsetTRelativeSlot(14, flatbuffers.number_types.UOffsetTFlags.py_type(testempty), 0)
 def MonsterAddTestbool(builder, testbool): builder.PrependBoolSlot(15, testbool, 0)
 def MonsterAddTesthashs32Fnv1(builder, testhashs32Fnv1): builder.PrependInt32Slot(16, testhashs32Fnv1, 0)
@@ -831,6 +836,11 @@ def MonsterStartVectorOfEnumsVector(builder, numElems): return builder.StartVect
 def MonsterAddSignedEnum(builder, signedEnum): builder.PrependInt8Slot(48, signedEnum, -1)
 def MonsterAddTestrequirednestedflatbuffer(builder, testrequirednestedflatbuffer): builder.PrependUOffsetTRelativeSlot(49, flatbuffers.number_types.UOffsetTFlags.py_type(testrequirednestedflatbuffer), 0)
 def MonsterStartTestrequirednestedflatbufferVector(builder, numElems): return builder.StartVector(1, numElems, 1)
+def MonsterMakeTestrequirednestedflatbufferVectorFromBytes(builder, bytes):
+    builder.StartVector(1, len(bytes), 1)
+    builder.head = builder.head - len(bytes)
+    builder.Bytes[builder.head : builder.head + len(bytes)] = bytes
+    return builder.EndVector(len(bytes))
 def MonsterEnd(builder): return builder.EndObject()
 
 import MyGame.Example.Ability

--- a/tests/py_test.py
+++ b/tests/py_test.py
@@ -1886,13 +1886,11 @@ class TestAllCodePathsOfExampleSchema(unittest.TestCase):
         nestedMon = MyGame.Example.Monster.MonsterEnd(nestedB)
         nestedB.Finish(nestedMon)
 
-        # write the nested FB bytes directly to b.Bytes
-        MyGame.Example.Monster.MonsterStartTestnestedflatbufferVector(b, len(nestedB.Output()))
-        b.head = b.head - len(nestedB.Output())
-        b.Bytes[b.head : b.head + len(nestedB.Output())] = nestedB.Output()
-        sub_buf = b.EndVector(len(nestedB.Output()))
+        # write the nested FB bytes
+        sub_buf = MyGame.Example.Monster.MonsterMakeTestnestedflatbufferVectorFromBytes(
+            b, nestedB.Output())
 
-        # make the parent monster and include the vector of Monster:
+        # make the parent monster and include the bytes of the nested monster
         MyGame.Example.Monster.MonsterStart(b)
         MyGame.Example.Monster.MonsterAddTestnestedflatbuffer(b, sub_buf)
         mon = MyGame.Example.Monster.MonsterEnd(b)


### PR DESCRIPTION
This adds two new generated Python methods for nested_flatbuffers.

<Class>Make<Field>VectorFromBytes creates a vector from a bytearray
<Class>.Get<Field>NestedRoot decodes a nested_flatbuffer

Both are shown in a new test case I added. This closes #6298 and makes it much easier to work with nested_flatbuffers in Python.

This is my first time touching any of this code so there's a good chance I missed something. If there are more cases I should be testing let me know.