### PR TITLE
[C++] Switch `flatc` to `--cpp-std c++11` C++ code generator

### DIFF
--- a/docs/source/Compiler.md
+++ b/docs/source/Compiler.md
@@ -142,8 +142,9 @@ Additional options:
 
 -   `--cpp-std CPP_STD` : Generate a C++ code using features of selected C++ standard.
      Supported `CPP_STD` values:
-    * `c++0x` - generate code compatible with old compilers (VS2010).
-    * `c++11` - use C++11 code generator (default);
+    * `c++0x` - generate code compatible with old compilers (VS2010),
+    * `c++11` - use C++11 code generator (default),
+    * `c++17` - use C++17 features in generated code (experimental).
 
 -   `--object-prefix` : Customise class prefix for C++ object-based API.
 

--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -197,10 +197,15 @@ namespace flatbuffers {
 #if (!defined(_MSC_VER) || _MSC_FULL_VER >= 180020827) && \
     (!defined(__GNUC__) || (__GNUC__ * 100 + __GNUC_MINOR__ >= 404)) || \
     defined(__clang__)
-  #define FLATBUFFERS_DEFAULT_DECLARATION
   #define FLATBUFFERS_DELETE_FUNC(func) func = delete;
 #else
   #define FLATBUFFERS_DELETE_FUNC(func) private: func;
+#endif
+
+#if (!defined(_MSC_VER) || _MSC_VER >= 1900) && \
+    (!defined(__GNUC__) || (__GNUC__ * 100 + __GNUC_MINOR__ >= 409)) || \
+    defined(__clang__)
+  #define FLATBUFFERS_DEFAULT_DECLARATION
 #endif
 
 // Check if we can use template aliases

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -32,7 +32,7 @@ inline const flatbuffers::TypeTable *MonsterTypeTable();
 
 inline const flatbuffers::TypeTable *WeaponTypeTable();
 
-enum Color {
+enum Color : int8_t {
   Color_Red = 0,
   Color_Green = 1,
   Color_Blue = 2,
@@ -65,7 +65,7 @@ inline const char *EnumNameColor(Color e) {
   return EnumNamesColor()[index];
 }
 
-enum Equipment {
+enum Equipment : uint8_t {
   Equipment_NONE = 0,
   Equipment_Weapon = 1,
   Equipment_MIN = Equipment_NONE,
@@ -224,20 +224,15 @@ inline bool operator!=(const Vec3 &lhs, const Vec3 &rhs) {
 
 struct MonsterT : public flatbuffers::NativeTable {
   typedef Monster TableType;
-  flatbuffers::unique_ptr<MyGame::Sample::Vec3> pos;
-  int16_t mana;
-  int16_t hp;
-  std::string name;
-  std::vector<uint8_t> inventory;
-  MyGame::Sample::Color color;
-  std::vector<flatbuffers::unique_ptr<MyGame::Sample::WeaponT>> weapons;
-  MyGame::Sample::EquipmentUnion equipped;
-  std::vector<MyGame::Sample::Vec3> path;
-  MonsterT()
-      : mana(150),
-        hp(100),
-        color(MyGame::Sample::Color_Blue) {
-  }
+  flatbuffers::unique_ptr<MyGame::Sample::Vec3> pos{};
+  int16_t mana = 150;
+  int16_t hp = 100;
+  std::string name{};
+  std::vector<uint8_t> inventory{};
+  MyGame::Sample::Color color = MyGame::Sample::Color_Blue;
+  std::vector<flatbuffers::unique_ptr<MyGame::Sample::WeaponT>> weapons{};
+  MyGame::Sample::EquipmentUnion equipped{};
+  std::vector<MyGame::Sample::Vec3> path{};
 };
 
 inline bool operator==(const MonsterT &lhs, const MonsterT &rhs) {
@@ -471,11 +466,8 @@ flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct WeaponT : public flatbuffers::NativeTable {
   typedef Weapon TableType;
-  std::string name;
-  int16_t damage;
-  WeaponT()
-      : damage(0) {
-  }
+  std::string name{};
+  int16_t damage = 0;
 };
 
 inline bool operator==(const WeaponT &lhs, const WeaponT &rhs) {
@@ -568,7 +560,7 @@ inline flatbuffers::Offset<Weapon> CreateWeaponDirect(
 flatbuffers::Offset<Weapon> CreateWeapon(flatbuffers::FlatBufferBuilder &_fbb, const WeaponT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 inline MonsterT *Monster::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MyGame::Sample::MonsterT> _o = flatbuffers::unique_ptr<MyGame::Sample::MonsterT>(new MonsterT());
+  auto _o = std::unique_ptr<MonsterT>(new MonsterT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
@@ -621,7 +613,7 @@ inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder
 }
 
 inline WeaponT *Weapon::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MyGame::Sample::WeaponT> _o = flatbuffers::unique_ptr<MyGame::Sample::WeaponT>(new WeaponT());
+  auto _o = std::unique_ptr<WeaponT>(new WeaponT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -376,6 +376,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         if (++argi >= argc)
           Error("missing C++ standard specification" + arg, true);
         opts.cpp_std = argv[argi];
+      } else if (arg.rfind("--cpp-std=", 0) == 0) {
+        opts.cpp_std = arg.substr(std::string("--cpp-std=").size());
       } else {
         for (size_t i = 0; i < params_.num_generators; ++i) {
           if (arg == params_.generators[i].generator_opt_long ||

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -3312,7 +3312,7 @@ bool GenerateCPP(const Parser &parser, const std::string &path,
   cpp::IDLOptionsCpp opts(parser.opts);
   // The '--cpp_std' argument could be extended (like ASAN):
   // Example: "flatc --cpp_std c++17:option1:option2".
-  auto cpp_std = !opts.cpp_std.empty() ? opts.cpp_std : "C++0X";
+  auto cpp_std = !opts.cpp_std.empty() ? opts.cpp_std : "C++11";
   std::transform(cpp_std.begin(), cpp_std.end(), cpp_std.begin(), CharToUpper);
   if (cpp_std == "C++0X") {
     opts.g_cpp_std = cpp::CPP_STD_X0;

--- a/tests/arrays_test_generated.h
+++ b/tests/arrays_test_generated.h
@@ -264,9 +264,7 @@ inline bool operator!=(const ArrayStruct &lhs, const ArrayStruct &rhs) {
 
 struct ArrayTableT : public flatbuffers::NativeTable {
   typedef ArrayTable TableType;
-  flatbuffers::unique_ptr<MyGame::Example::ArrayStruct> a;
-  ArrayTableT() {
-  }
+  flatbuffers::unique_ptr<MyGame::Example::ArrayStruct> a{};
 };
 
 inline bool operator==(const ArrayTableT &lhs, const ArrayTableT &rhs) {
@@ -333,7 +331,7 @@ inline flatbuffers::Offset<ArrayTable> CreateArrayTable(
 flatbuffers::Offset<ArrayTable> CreateArrayTable(flatbuffers::FlatBufferBuilder &_fbb, const ArrayTableT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 inline ArrayTableT *ArrayTable::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MyGame::Example::ArrayTableT> _o = flatbuffers::unique_ptr<MyGame::Example::ArrayTableT>(new ArrayTableT());
+  auto _o = std::unique_ptr<ArrayTableT>(new ArrayTableT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }

--- a/tests/monster_extra_generated.h
+++ b/tests/monster_extra_generated.h
@@ -19,26 +19,16 @@ inline const flatbuffers::TypeTable *MonsterExtraTypeTable();
 
 struct MonsterExtraT : public flatbuffers::NativeTable {
   typedef MonsterExtra TableType;
-  double d0;
-  double d1;
-  double d2;
-  double d3;
-  float f0;
-  float f1;
-  float f2;
-  float f3;
-  std::vector<double> dvec;
-  std::vector<float> fvec;
-  MonsterExtraT()
-      : d0(std::numeric_limits<double>::quiet_NaN()),
-        d1(std::numeric_limits<double>::quiet_NaN()),
-        d2(std::numeric_limits<double>::infinity()),
-        d3(-std::numeric_limits<double>::infinity()),
-        f0(std::numeric_limits<float>::quiet_NaN()),
-        f1(std::numeric_limits<float>::quiet_NaN()),
-        f2(std::numeric_limits<float>::infinity()),
-        f3(-std::numeric_limits<float>::infinity()) {
-  }
+  double d0 = std::numeric_limits<double>::quiet_NaN();
+  double d1 = std::numeric_limits<double>::quiet_NaN();
+  double d2 = std::numeric_limits<double>::infinity();
+  double d3 = -std::numeric_limits<double>::infinity();
+  float f0 = std::numeric_limits<float>::quiet_NaN();
+  float f1 = std::numeric_limits<float>::quiet_NaN();
+  float f2 = std::numeric_limits<float>::infinity();
+  float f3 = -std::numeric_limits<float>::infinity();
+  std::vector<double> dvec{};
+  std::vector<float> fvec{};
 };
 
 inline bool operator==(const MonsterExtraT &lhs, const MonsterExtraT &rhs) {
@@ -261,7 +251,7 @@ inline flatbuffers::Offset<MonsterExtra> CreateMonsterExtraDirect(
 flatbuffers::Offset<MonsterExtra> CreateMonsterExtra(flatbuffers::FlatBufferBuilder &_fbb, const MonsterExtraT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 inline MonsterExtraT *MonsterExtra::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MyGame::MonsterExtraT> _o = flatbuffers::unique_ptr<MyGame::MonsterExtraT>(new MonsterExtraT());
+  auto _o = std::unique_ptr<MonsterExtraT>(new MonsterExtraT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -107,7 +107,7 @@ inline const flatbuffers::TypeTable *MonsterTypeTable();
 inline const flatbuffers::TypeTable *TypeAliasesTypeTable();
 
 /// Composite components of Monster color.
-enum Color {
+enum Color : uint8_t {
   Color_Red = 1,
   /// \brief color Green
   /// Green is bit_flag with value (1u << 1)
@@ -148,7 +148,7 @@ inline const char *EnumNameColor(Color e) {
   return EnumNamesColor()[index];
 }
 
-enum Race {
+enum Race : int8_t {
   Race_None = -1,
   Race_Human = 0,
   Race_Dwarf = 1,
@@ -184,7 +184,7 @@ inline const char *EnumNameRace(Race e) {
   return EnumNamesRace()[index];
 }
 
-enum Any {
+enum Any : uint8_t {
   Any_NONE = 0,
   Any_Monster = 1,
   Any_TestSimpleTableWithEnum = 2,
@@ -326,7 +326,7 @@ inline bool operator!=(const AnyUnion &lhs, const AnyUnion &rhs) {
 bool VerifyAny(flatbuffers::Verifier &verifier, const void *obj, Any type);
 bool VerifyAnyVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<uint8_t> *types);
 
-enum AnyUniqueAliases {
+enum AnyUniqueAliases : uint8_t {
   AnyUniqueAliases_NONE = 0,
   AnyUniqueAliases_M = 1,
   AnyUniqueAliases_TS = 2,
@@ -468,7 +468,7 @@ inline bool operator!=(const AnyUniqueAliasesUnion &lhs, const AnyUniqueAliasesU
 bool VerifyAnyUniqueAliases(flatbuffers::Verifier &verifier, const void *obj, AnyUniqueAliases type);
 bool VerifyAnyUniqueAliasesVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<uint8_t> *types);
 
-enum AnyAmbiguousAliases {
+enum AnyAmbiguousAliases : uint8_t {
   AnyAmbiguousAliases_NONE = 0,
   AnyAmbiguousAliases_M1 = 1,
   AnyAmbiguousAliases_M2 = 2,
@@ -781,8 +781,6 @@ inline bool operator!=(const Ability &lhs, const Ability &rhs) {
 
 struct InParentNamespaceT : public flatbuffers::NativeTable {
   typedef InParentNamespace TableType;
-  InParentNamespaceT() {
-  }
 };
 
 inline bool operator==(const InParentNamespaceT &, const InParentNamespaceT &) {
@@ -836,8 +834,6 @@ namespace Example2 {
 
 struct MonsterT : public flatbuffers::NativeTable {
   typedef Monster TableType;
-  MonsterT() {
-  }
 };
 
 inline bool operator==(const MonsterT &, const MonsterT &) {
@@ -893,10 +889,7 @@ namespace Example {
 
 struct TestSimpleTableWithEnumT : public flatbuffers::NativeTable {
   typedef TestSimpleTableWithEnum TableType;
-  MyGame::Example::Color color;
-  TestSimpleTableWithEnumT()
-      : color(MyGame::Example::Color_Green) {
-  }
+  MyGame::Example::Color color = MyGame::Example::Color_Green;
 };
 
 inline bool operator==(const TestSimpleTableWithEnumT &lhs, const TestSimpleTableWithEnumT &rhs) {
@@ -964,13 +957,9 @@ flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnum(flatb
 
 struct StatT : public flatbuffers::NativeTable {
   typedef Stat TableType;
-  std::string id;
-  int64_t val;
-  uint16_t count;
-  StatT()
-      : val(0),
-        count(0) {
-  }
+  std::string id{};
+  int64_t val = 0;
+  uint16_t count = 0;
 };
 
 inline bool operator==(const StatT &lhs, const StatT &rhs) {
@@ -1080,10 +1069,7 @@ flatbuffers::Offset<Stat> CreateStat(flatbuffers::FlatBufferBuilder &_fbb, const
 
 struct ReferrableT : public flatbuffers::NativeTable {
   typedef Referrable TableType;
-  uint64_t id;
-  ReferrableT()
-      : id(0) {
-  }
+  uint64_t id = 0;
 };
 
 inline bool operator==(const ReferrableT &lhs, const ReferrableT &rhs) {
@@ -1157,73 +1143,52 @@ flatbuffers::Offset<Referrable> CreateReferrable(flatbuffers::FlatBufferBuilder 
 
 struct MonsterT : public flatbuffers::NativeTable {
   typedef Monster TableType;
-  flatbuffers::unique_ptr<MyGame::Example::Vec3> pos;
-  int16_t mana;
-  int16_t hp;
-  std::string name;
-  std::vector<uint8_t> inventory;
-  MyGame::Example::Color color;
-  MyGame::Example::AnyUnion test;
-  std::vector<MyGame::Example::Test> test4;
-  std::vector<std::string> testarrayofstring;
-  std::vector<flatbuffers::unique_ptr<MyGame::Example::MonsterT>> testarrayoftables;
-  flatbuffers::unique_ptr<MyGame::Example::MonsterT> enemy;
-  std::vector<uint8_t> testnestedflatbuffer;
-  flatbuffers::unique_ptr<MyGame::Example::StatT> testempty;
-  bool testbool;
-  int32_t testhashs32_fnv1;
-  uint32_t testhashu32_fnv1;
-  int64_t testhashs64_fnv1;
-  uint64_t testhashu64_fnv1;
-  int32_t testhashs32_fnv1a;
-  Stat *testhashu32_fnv1a;
-  int64_t testhashs64_fnv1a;
-  uint64_t testhashu64_fnv1a;
-  std::vector<bool> testarrayofbools;
-  float testf;
-  float testf2;
-  float testf3;
-  std::vector<std::string> testarrayofstring2;
-  std::vector<MyGame::Example::Ability> testarrayofsortedstruct;
-  std::vector<uint8_t> flex;
-  std::vector<MyGame::Example::Test> test5;
-  std::vector<int64_t> vector_of_longs;
-  std::vector<double> vector_of_doubles;
-  flatbuffers::unique_ptr<MyGame::InParentNamespaceT> parent_namespace_test;
-  std::vector<flatbuffers::unique_ptr<MyGame::Example::ReferrableT>> vector_of_referrables;
-  ReferrableT *single_weak_reference;
-  std::vector<ReferrableT *> vector_of_weak_references;
-  std::vector<flatbuffers::unique_ptr<MyGame::Example::ReferrableT>> vector_of_strong_referrables;
-  ReferrableT *co_owning_reference;
-  std::vector<flatbuffers::unique_ptr<ReferrableT>> vector_of_co_owning_references;
-  ReferrableT *non_owning_reference;
-  std::vector<ReferrableT *> vector_of_non_owning_references;
-  MyGame::Example::AnyUniqueAliasesUnion any_unique;
-  MyGame::Example::AnyAmbiguousAliasesUnion any_ambiguous;
-  std::vector<MyGame::Example::Color> vector_of_enums;
-  MyGame::Example::Race signed_enum;
-  std::vector<uint8_t> testrequirednestedflatbuffer;
-  MonsterT()
-      : mana(150),
-        hp(100),
-        color(MyGame::Example::Color_Blue),
-        testbool(false),
-        testhashs32_fnv1(0),
-        testhashu32_fnv1(0),
-        testhashs64_fnv1(0),
-        testhashu64_fnv1(0),
-        testhashs32_fnv1a(0),
-        testhashu32_fnv1a(nullptr),
-        testhashs64_fnv1a(0),
-        testhashu64_fnv1a(0),
-        testf(3.14159f),
-        testf2(3.0f),
-        testf3(0.0f),
-        single_weak_reference(nullptr),
-        co_owning_reference(nullptr),
-        non_owning_reference(nullptr),
-        signed_enum(MyGame::Example::Race_None) {
-  }
+  flatbuffers::unique_ptr<MyGame::Example::Vec3> pos{};
+  int16_t mana = 150;
+  int16_t hp = 100;
+  std::string name{};
+  std::vector<uint8_t> inventory{};
+  MyGame::Example::Color color = MyGame::Example::Color_Blue;
+  MyGame::Example::AnyUnion test{};
+  std::vector<MyGame::Example::Test> test4{};
+  std::vector<std::string> testarrayofstring{};
+  std::vector<flatbuffers::unique_ptr<MyGame::Example::MonsterT>> testarrayoftables{};
+  flatbuffers::unique_ptr<MyGame::Example::MonsterT> enemy{};
+  std::vector<uint8_t> testnestedflatbuffer{};
+  flatbuffers::unique_ptr<MyGame::Example::StatT> testempty{};
+  bool testbool = false;
+  int32_t testhashs32_fnv1 = 0;
+  uint32_t testhashu32_fnv1 = 0;
+  int64_t testhashs64_fnv1 = 0;
+  uint64_t testhashu64_fnv1 = 0;
+  int32_t testhashs32_fnv1a = 0;
+  Stat *testhashu32_fnv1a = nullptr;
+  int64_t testhashs64_fnv1a = 0;
+  uint64_t testhashu64_fnv1a = 0;
+  std::vector<bool> testarrayofbools{};
+  float testf = 3.14159f;
+  float testf2 = 3.0f;
+  float testf3 = 0.0f;
+  std::vector<std::string> testarrayofstring2{};
+  std::vector<MyGame::Example::Ability> testarrayofsortedstruct{};
+  std::vector<uint8_t> flex{};
+  std::vector<MyGame::Example::Test> test5{};
+  std::vector<int64_t> vector_of_longs{};
+  std::vector<double> vector_of_doubles{};
+  flatbuffers::unique_ptr<MyGame::InParentNamespaceT> parent_namespace_test{};
+  std::vector<flatbuffers::unique_ptr<MyGame::Example::ReferrableT>> vector_of_referrables{};
+  ReferrableT *single_weak_reference = nullptr;
+  std::vector<ReferrableT *> vector_of_weak_references{};
+  std::vector<flatbuffers::unique_ptr<MyGame::Example::ReferrableT>> vector_of_strong_referrables{};
+  ReferrableT *co_owning_reference = nullptr;
+  std::vector<flatbuffers::unique_ptr<ReferrableT>> vector_of_co_owning_references{};
+  ReferrableT *non_owning_reference = nullptr;
+  std::vector<ReferrableT *> vector_of_non_owning_references{};
+  MyGame::Example::AnyUniqueAliasesUnion any_unique{};
+  MyGame::Example::AnyAmbiguousAliasesUnion any_ambiguous{};
+  std::vector<MyGame::Example::Color> vector_of_enums{};
+  MyGame::Example::Race signed_enum = MyGame::Example::Race_None;
+  std::vector<uint8_t> testrequirednestedflatbuffer{};
 };
 
 inline bool operator==(const MonsterT &lhs, const MonsterT &rhs) {
@@ -2178,30 +2143,18 @@ flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct TypeAliasesT : public flatbuffers::NativeTable {
   typedef TypeAliases TableType;
-  int8_t i8;
-  uint8_t u8;
-  int16_t i16;
-  uint16_t u16;
-  int32_t i32;
-  uint32_t u32;
-  int64_t i64;
-  uint64_t u64;
-  float f32;
-  double f64;
-  std::vector<int8_t> v8;
-  std::vector<double> vf64;
-  TypeAliasesT()
-      : i8(0),
-        u8(0),
-        i16(0),
-        u16(0),
-        i32(0),
-        u32(0),
-        i64(0),
-        u64(0),
-        f32(0.0f),
-        f64(0.0) {
-  }
+  int8_t i8 = 0;
+  uint8_t u8 = 0;
+  int16_t i16 = 0;
+  uint16_t u16 = 0;
+  int32_t i32 = 0;
+  uint32_t u32 = 0;
+  int64_t i64 = 0;
+  uint64_t u64 = 0;
+  float f32 = 0.0f;
+  double f64 = 0.0;
+  std::vector<int8_t> v8{};
+  std::vector<double> vf64{};
 };
 
 inline bool operator==(const TypeAliasesT &lhs, const TypeAliasesT &rhs) {
@@ -2458,7 +2411,7 @@ flatbuffers::Offset<TypeAliases> CreateTypeAliases(flatbuffers::FlatBufferBuilde
 }  // namespace Example
 
 inline InParentNamespaceT *InParentNamespace::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MyGame::InParentNamespaceT> _o = flatbuffers::unique_ptr<MyGame::InParentNamespaceT>(new InParentNamespaceT());
+  auto _o = std::unique_ptr<InParentNamespaceT>(new InParentNamespaceT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
@@ -2483,7 +2436,7 @@ inline flatbuffers::Offset<InParentNamespace> CreateInParentNamespace(flatbuffer
 namespace Example2 {
 
 inline MonsterT *Monster::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MyGame::Example2::MonsterT> _o = flatbuffers::unique_ptr<MyGame::Example2::MonsterT>(new MonsterT());
+  auto _o = std::unique_ptr<MonsterT>(new MonsterT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
@@ -2510,7 +2463,7 @@ inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder
 namespace Example {
 
 inline TestSimpleTableWithEnumT *TestSimpleTableWithEnum::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MyGame::Example::TestSimpleTableWithEnumT> _o = flatbuffers::unique_ptr<MyGame::Example::TestSimpleTableWithEnumT>(new TestSimpleTableWithEnumT());
+  auto _o = std::unique_ptr<TestSimpleTableWithEnumT>(new TestSimpleTableWithEnumT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
@@ -2536,7 +2489,7 @@ inline flatbuffers::Offset<TestSimpleTableWithEnum> CreateTestSimpleTableWithEnu
 }
 
 inline StatT *Stat::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MyGame::Example::StatT> _o = flatbuffers::unique_ptr<MyGame::Example::StatT>(new StatT());
+  auto _o = std::unique_ptr<StatT>(new StatT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
@@ -2568,7 +2521,7 @@ inline flatbuffers::Offset<Stat> CreateStat(flatbuffers::FlatBufferBuilder &_fbb
 }
 
 inline ReferrableT *Referrable::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MyGame::Example::ReferrableT> _o = flatbuffers::unique_ptr<MyGame::Example::ReferrableT>(new ReferrableT());
+  auto _o = std::unique_ptr<ReferrableT>(new ReferrableT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
@@ -2594,7 +2547,7 @@ inline flatbuffers::Offset<Referrable> CreateReferrable(flatbuffers::FlatBufferB
 }
 
 inline MonsterT *Monster::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MyGame::Example::MonsterT> _o = flatbuffers::unique_ptr<MyGame::Example::MonsterT>(new MonsterT());
+  auto _o = std::unique_ptr<MonsterT>(new MonsterT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
@@ -2771,7 +2724,7 @@ inline flatbuffers::Offset<Monster> CreateMonster(flatbuffers::FlatBufferBuilder
 }
 
 inline TypeAliasesT *TypeAliases::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MyGame::Example::TypeAliasesT> _o = flatbuffers::unique_ptr<MyGame::Example::TypeAliasesT>(new TypeAliasesT());
+  auto _o = std::unique_ptr<TypeAliasesT>(new TypeAliasesT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -24,7 +24,7 @@ inline const flatbuffers::TypeTable *TableInNestedNSTypeTable();
 
 inline const flatbuffers::TypeTable *StructInNestedNSTypeTable();
 
-enum EnumInNestedNS {
+enum EnumInNestedNS : int8_t {
   EnumInNestedNS_A = 0,
   EnumInNestedNS_B = 1,
   EnumInNestedNS_C = 2,
@@ -108,10 +108,7 @@ struct TableInNestedNST : public flatbuffers::NativeTable {
   static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
     return "NamespaceA.NamespaceB.TableInNestedNST";
   }
-  int32_t foo;
-  TableInNestedNST()
-      : foo(0) {
-  }
+  int32_t foo = 0;
 };
 
 inline bool operator==(const TableInNestedNST &lhs, const TableInNestedNST &rhs) {
@@ -181,7 +178,7 @@ inline flatbuffers::Offset<TableInNestedNS> CreateTableInNestedNS(
 flatbuffers::Offset<TableInNestedNS> CreateTableInNestedNS(flatbuffers::FlatBufferBuilder &_fbb, const TableInNestedNST *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 inline TableInNestedNST *TableInNestedNS::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<NamespaceA::NamespaceB::TableInNestedNST> _o = flatbuffers::unique_ptr<NamespaceA::NamespaceB::TableInNestedNST>(new TableInNestedNST());
+  auto _o = std::unique_ptr<TableInNestedNST>(new TableInNestedNST());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -62,12 +62,9 @@ struct TableInFirstNST : public flatbuffers::NativeTable {
   static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
     return "NamespaceA.TableInFirstNST";
   }
-  flatbuffers::unique_ptr<NamespaceA::NamespaceB::TableInNestedNST> foo_table;
-  NamespaceA::NamespaceB::EnumInNestedNS foo_enum;
-  flatbuffers::unique_ptr<NamespaceA::NamespaceB::StructInNestedNS> foo_struct;
-  TableInFirstNST()
-      : foo_enum(NamespaceA::NamespaceB::EnumInNestedNS_A) {
-  }
+  flatbuffers::unique_ptr<NamespaceA::NamespaceB::TableInNestedNST> foo_table{};
+  NamespaceA::NamespaceB::EnumInNestedNS foo_enum = NamespaceA::NamespaceB::EnumInNestedNS_A;
+  flatbuffers::unique_ptr<NamespaceA::NamespaceB::StructInNestedNS> foo_struct{};
 };
 
 inline bool operator==(const TableInFirstNST &lhs, const TableInFirstNST &rhs) {
@@ -174,10 +171,8 @@ struct TableInCT : public flatbuffers::NativeTable {
   static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
     return "NamespaceC.TableInCT";
   }
-  flatbuffers::unique_ptr<NamespaceA::TableInFirstNST> refer_to_a1;
-  flatbuffers::unique_ptr<NamespaceA::SecondTableInAT> refer_to_a2;
-  TableInCT() {
-  }
+  flatbuffers::unique_ptr<NamespaceA::TableInFirstNST> refer_to_a1{};
+  flatbuffers::unique_ptr<NamespaceA::SecondTableInAT> refer_to_a2{};
 };
 
 inline bool operator==(const TableInCT &lhs, const TableInCT &rhs) {
@@ -271,9 +266,7 @@ struct SecondTableInAT : public flatbuffers::NativeTable {
   static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
     return "NamespaceA.SecondTableInAT";
   }
-  flatbuffers::unique_ptr<NamespaceC::TableInCT> refer_to_c;
-  SecondTableInAT() {
-  }
+  flatbuffers::unique_ptr<NamespaceC::TableInCT> refer_to_c{};
 };
 
 inline bool operator==(const SecondTableInAT &lhs, const SecondTableInAT &rhs) {
@@ -344,7 +337,7 @@ inline flatbuffers::Offset<SecondTableInA> CreateSecondTableInA(
 flatbuffers::Offset<SecondTableInA> CreateSecondTableInA(flatbuffers::FlatBufferBuilder &_fbb, const SecondTableInAT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 inline TableInFirstNST *TableInFirstNS::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<NamespaceA::TableInFirstNST> _o = flatbuffers::unique_ptr<NamespaceA::TableInFirstNST>(new TableInFirstNST());
+  auto _o = std::unique_ptr<TableInFirstNST>(new TableInFirstNST());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
@@ -380,7 +373,7 @@ inline flatbuffers::Offset<TableInFirstNS> CreateTableInFirstNS(flatbuffers::Fla
 namespace NamespaceC {
 
 inline TableInCT *TableInC::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<NamespaceC::TableInCT> _o = flatbuffers::unique_ptr<NamespaceC::TableInCT>(new TableInCT());
+  auto _o = std::unique_ptr<TableInCT>(new TableInCT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
@@ -413,7 +406,7 @@ inline flatbuffers::Offset<TableInC> CreateTableInC(flatbuffers::FlatBufferBuild
 namespace NamespaceA {
 
 inline SecondTableInAT *SecondTableInA::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<NamespaceA::SecondTableInAT> _o = flatbuffers::unique_ptr<NamespaceA::SecondTableInAT>(new SecondTableInAT());
+  auto _o = std::unique_ptr<SecondTableInAT>(new SecondTableInAT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }

--- a/tests/native_type_test_generated.h
+++ b/tests/native_type_test_generated.h
@@ -63,9 +63,7 @@ FLATBUFFERS_STRUCT_END(Vector3D, 12);
 
 struct ApplicationDataT : public flatbuffers::NativeTable {
   typedef ApplicationData TableType;
-  std::vector<Native::Vector3D> vectors;
-  ApplicationDataT() {
-  }
+  std::vector<Native::Vector3D> vectors{};
 };
 
 struct ApplicationData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
@@ -132,7 +130,7 @@ inline flatbuffers::Offset<ApplicationData> CreateApplicationDataDirect(
 flatbuffers::Offset<ApplicationData> CreateApplicationData(flatbuffers::FlatBufferBuilder &_fbb, const ApplicationDataT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 inline ApplicationDataT *ApplicationData::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<Geometry::ApplicationDataT> _o = flatbuffers::unique_ptr<Geometry::ApplicationDataT>(new ApplicationDataT());
+  auto _o = std::unique_ptr<ApplicationDataT>(new ApplicationDataT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }

--- a/tests/optional_scalars_generated.h
+++ b/tests/optional_scalars_generated.h
@@ -17,7 +17,7 @@ bool operator!=(const ScalarStuffT &lhs, const ScalarStuffT &rhs);
 
 inline const flatbuffers::TypeTable *ScalarStuffTypeTable();
 
-enum OptionalByte {
+enum OptionalByte : int8_t {
   OptionalByte_None = 0,
   OptionalByte_One = 1,
   OptionalByte_Two = 2,
@@ -52,80 +52,42 @@ inline const char *EnumNameOptionalByte(OptionalByte e) {
 
 struct ScalarStuffT : public flatbuffers::NativeTable {
   typedef ScalarStuff TableType;
-  int8_t just_i8;
-  flatbuffers::Optional<int8_t> maybe_i8;
-  int8_t default_i8;
-  uint8_t just_u8;
-  flatbuffers::Optional<uint8_t> maybe_u8;
-  uint8_t default_u8;
-  int16_t just_i16;
-  flatbuffers::Optional<int16_t> maybe_i16;
-  int16_t default_i16;
-  uint16_t just_u16;
-  flatbuffers::Optional<uint16_t> maybe_u16;
-  uint16_t default_u16;
-  int32_t just_i32;
-  flatbuffers::Optional<int32_t> maybe_i32;
-  int32_t default_i32;
-  uint32_t just_u32;
-  flatbuffers::Optional<uint32_t> maybe_u32;
-  uint32_t default_u32;
-  int64_t just_i64;
-  flatbuffers::Optional<int64_t> maybe_i64;
-  int64_t default_i64;
-  uint64_t just_u64;
-  flatbuffers::Optional<uint64_t> maybe_u64;
-  uint64_t default_u64;
-  float just_f32;
-  flatbuffers::Optional<float> maybe_f32;
-  float default_f32;
-  double just_f64;
-  flatbuffers::Optional<double> maybe_f64;
-  double default_f64;
-  bool just_bool;
-  flatbuffers::Optional<bool> maybe_bool;
-  bool default_bool;
-  optional_scalars::OptionalByte just_enum;
-  flatbuffers::Optional<optional_scalars::OptionalByte> maybe_enum;
-  optional_scalars::OptionalByte default_enum;
-  ScalarStuffT()
-      : just_i8(0),
-        maybe_i8(flatbuffers::nullopt),
-        default_i8(42),
-        just_u8(0),
-        maybe_u8(flatbuffers::nullopt),
-        default_u8(42),
-        just_i16(0),
-        maybe_i16(flatbuffers::nullopt),
-        default_i16(42),
-        just_u16(0),
-        maybe_u16(flatbuffers::nullopt),
-        default_u16(42),
-        just_i32(0),
-        maybe_i32(flatbuffers::nullopt),
-        default_i32(42),
-        just_u32(0),
-        maybe_u32(flatbuffers::nullopt),
-        default_u32(42),
-        just_i64(0),
-        maybe_i64(flatbuffers::nullopt),
-        default_i64(42LL),
-        just_u64(0),
-        maybe_u64(flatbuffers::nullopt),
-        default_u64(42ULL),
-        just_f32(0.0f),
-        maybe_f32(flatbuffers::nullopt),
-        default_f32(42.0f),
-        just_f64(0.0),
-        maybe_f64(flatbuffers::nullopt),
-        default_f64(42.0),
-        just_bool(false),
-        maybe_bool(flatbuffers::nullopt),
-        default_bool(true),
-        just_enum(optional_scalars::OptionalByte_None),
-        maybe_enum(flatbuffers::nullopt),
-        default_enum(optional_scalars::OptionalByte_One) {
-  }
+  int8_t just_i8 = 0;
+  flatbuffers::Optional<int8_t> maybe_i8 = flatbuffers::nullopt;
+  int8_t default_i8 = 42;
+  uint8_t just_u8 = 0;
+  flatbuffers::Optional<uint8_t> maybe_u8 = flatbuffers::nullopt;
+  uint8_t default_u8 = 42;
+  int16_t just_i16 = 0;
+  flatbuffers::Optional<int16_t> maybe_i16 = flatbuffers::nullopt;
+  int16_t default_i16 = 42;
+  uint16_t just_u16 = 0;
+  flatbuffers::Optional<uint16_t> maybe_u16 = flatbuffers::nullopt;
+  uint16_t default_u16 = 42;
+  int32_t just_i32 = 0;
+  flatbuffers::Optional<int32_t> maybe_i32 = flatbuffers::nullopt;
+  int32_t default_i32 = 42;
+  uint32_t just_u32 = 0;
+  flatbuffers::Optional<uint32_t> maybe_u32 = flatbuffers::nullopt;
+  uint32_t default_u32 = 42;
+  int64_t just_i64 = 0;
+  flatbuffers::Optional<int64_t> maybe_i64 = flatbuffers::nullopt;
+  int64_t default_i64 = 42LL;
+  uint64_t just_u64 = 0;
+  flatbuffers::Optional<uint64_t> maybe_u64 = flatbuffers::nullopt;
+  uint64_t default_u64 = 42ULL;
+  float just_f32 = 0.0f;
+  flatbuffers::Optional<float> maybe_f32 = flatbuffers::nullopt;
+  float default_f32 = 42.0f;
+  double just_f64 = 0.0;
+  flatbuffers::Optional<double> maybe_f64 = flatbuffers::nullopt;
+  double default_f64 = 42.0;
+  bool just_bool = false;
+  flatbuffers::Optional<bool> maybe_bool = flatbuffers::nullopt;
+  bool default_bool = true;
+  optional_scalars::OptionalByte just_enum = optional_scalars::OptionalByte_None;
+  flatbuffers::Optional<optional_scalars::OptionalByte> maybe_enum = flatbuffers::nullopt;
+  optional_scalars::OptionalByte default_enum = optional_scalars::OptionalByte_One;
 };
 
 inline bool operator==(const ScalarStuffT &lhs, const ScalarStuffT &rhs) {
@@ -682,7 +644,7 @@ inline flatbuffers::Offset<ScalarStuff> CreateScalarStuff(
 flatbuffers::Offset<ScalarStuff> CreateScalarStuff(flatbuffers::FlatBufferBuilder &_fbb, const ScalarStuffT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 inline ScalarStuffT *ScalarStuff::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<optional_scalars::ScalarStuffT> _o = flatbuffers::unique_ptr<optional_scalars::ScalarStuffT>(new ScalarStuffT());
+  auto _o = std::unique_ptr<ScalarStuffT>(new ScalarStuffT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -33,9 +33,9 @@
 #include "namespace_test/namespace_test1_generated.h"
 #include "namespace_test/namespace_test2_generated.h"
 #include "union_vector/union_vector_generated.h"
-#include "monster_extra_generated.h"
 #include "optional_scalars_generated.h"
 #if !defined(_MSC_VER) || _MSC_VER >= 1700
+#  include "monster_extra_generated.h"
 #  include "arrays_test_generated.h"
 #  include "evolution_test/evolution_v1_generated.h"
 #  include "evolution_test/evolution_v2_generated.h"

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -35,7 +35,7 @@ inline const flatbuffers::TypeTable *BookReaderTypeTable();
 
 inline const flatbuffers::TypeTable *MovieTypeTable();
 
-enum Character {
+enum Character : uint8_t {
   Character_NONE = 0,
   Character_MuLan = 1,
   Character_Rapunzel = 2,
@@ -271,10 +271,7 @@ struct AttackerT : public flatbuffers::NativeTable {
   static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
     return "AttackerT";
   }
-  int32_t sword_attack_damage;
-  AttackerT()
-      : sword_attack_damage(0) {
-  }
+  int32_t sword_attack_damage = 0;
 };
 
 inline bool operator==(const AttackerT &lhs, const AttackerT &rhs) {
@@ -348,10 +345,8 @@ struct MovieT : public flatbuffers::NativeTable {
   static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
     return "MovieT";
   }
-  CharacterUnion main_character;
-  std::vector<CharacterUnion> characters;
-  MovieT() {
-  }
+  CharacterUnion main_character{};
+  std::vector<CharacterUnion> characters{};
 };
 
 inline bool operator==(const MovieT &lhs, const MovieT &rhs) {
@@ -496,7 +491,7 @@ inline flatbuffers::Offset<Movie> CreateMovieDirect(
 flatbuffers::Offset<Movie> CreateMovie(flatbuffers::FlatBufferBuilder &_fbb, const MovieT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 inline AttackerT *Attacker::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<AttackerT> _o = flatbuffers::unique_ptr<AttackerT>(new AttackerT());
+  auto _o = std::unique_ptr<AttackerT>(new AttackerT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }
@@ -522,7 +517,7 @@ inline flatbuffers::Offset<Attacker> CreateAttacker(flatbuffers::FlatBufferBuild
 }
 
 inline MovieT *Movie::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  flatbuffers::unique_ptr<MovieT> _o = flatbuffers::unique_ptr<MovieT>(new MovieT());
+  auto _o = std::unique_ptr<MovieT>(new MovieT());
   UnPackTo(_o.get(), _resolver);
   return _o.release();
 }


### PR DESCRIPTION
Prior to this PR the default C++ code generator was `c++0x`.
A code generated with `c++0x` code-gen might have a vulnerability (undefined behavior) connected evolution of enums in a schema. This UB could break the backward compatibility if previously generated code casts an unknown enumerator to enum type that knows nothing about future enumerators added to the schema.

The main differences between `c++0x` and `c++11`:
- generated enums use explicitly declared underlying type;
- generated object-API tables don't declare default ctor() explicitly, instead of it default data member initializers are generated.

Related issues: #6267, #5611, #5656. 
