### PR TITLE
Set default initialSize for Builder to 0

### DIFF
--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -113,7 +113,7 @@ class Builder(object):
     MAX_BUFFER_SIZE = 2**31
     ## @endcond
 
-    def __init__(self, initialSize):
+    def __init__(self, initialSize=0):
         """Initializes a Builder of size `initial_size`.
 
         The internal buffer is grown as needed.

--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -113,7 +113,7 @@ class Builder(object):
     MAX_BUFFER_SIZE = 2**31
     ## @endcond
 
-    def __init__(self, initialSize=0):
+    def __init__(self, initialSize=1024):
         """Initializes a Builder of size `initial_size`.
 
         The internal buffer is grown as needed.


### PR DESCRIPTION
This seems like a reasonable default for when users don't know or care what the default is. I see the Python tests already have several builders started with this size. It's a minor change, but it makes things marginally easier for new users.