### PR TITLE
Add default to offset param of Python generated GetRootAs

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -127,7 +127,7 @@ class PythonGenerator : public BaseGenerator {
     code += Indent + "@classmethod\n";
     code += Indent + "def GetRootAs";
     code += NormalizedName(struct_def);
-    code += "(cls, buf, offset):";
+    code += "(cls, buf, offset=0):";
     code += "\n";
     code += Indent + Indent;
     code += "n = flatbuffers.encode.Get";


### PR DESCRIPTION
This seems like the most common case for this parameter so why not make it even easier.