### PR TITLE
[CMake] Version message should be a "STATUS" to avoid going to stderr.

### DIFF
--- a/CMake/Version.cmake
+++ b/CMake/Version.cmake
@@ -25,4 +25,4 @@ else()
   message(WARNING "git is not found")
 endif()
 
-message("Proceeding with version: ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.${VERSION_COMMIT}")
+message(STATUS "Proceeding with version: ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.${VERSION_COMMIT}")


### PR DESCRIPTION
In modern versions of CMake, the `message(...)` function requires an explicit `STATUS` as the first argument otherwise it will default to `NOTICE` which then causes it to go to stderr as explained on this page:

https://cmake.org/cmake/help/latest/command/message.html

(might be a change from older versions of CMake where it was `STATUS` by default, but not sure).  But it seems that stderr is probably not the right place for this particular message, so I have marked it explicitly as `STATUS` so that it goes to stdout and doesn't get included in error logs.