### PR TITLE
Fixed missing ending quotes in labeller

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -85,9 +85,9 @@ documentation:
 
 CI:
   - '.github/**/*'
-  - '.appveyor/**/*
+  - '.appveyor/**/*'
   - '.travis/**/*'
-  - '.bazelci/**/*
+  - '.bazelci/**/*'
   - .travis.yml
   - appveyor.yml
 


### PR DESCRIPTION
Didn't close the quoted text correctly.