### PR TITLE
[Dart] Improve pub.dev score and bump up version to 1.13.0

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -13,9 +13,7 @@
 
 - Initial release, supports Dart 1.x and many dev versions of Dart 2.x
 
-## 1.13.0
+## 1.12.0+1
 
-- Add FlexBuffer support
-- Fix union type names
-- Generate constant values map for enums
+- Improve `pubspec.yaml` to achieve higher pub.dev score
 - Update documentation

--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -12,3 +12,10 @@
 ## 1.9.0
 
 - Initial release, supports Dart 1.x and many dev versions of Dart 2.x
+
+## 1.13.0
+
+- Add FlexBuffer support
+- Fix union type names
+- Generate constant values map for enums
+- Update documentation

--- a/dart/README.md
+++ b/dart/README.md
@@ -10,4 +10,12 @@ or write binary files that are interoperable with other languages and platforms
 supported by FlatBuffers, as illustrated in the `example.dart` in the
 examples folder.
 
-Additional documentation and examples are available [at the FlatBuffers site](https://google.github.io/flatbuffers/index.html)
+Additional documentation and examples are available [at the FlatBuffers site](https://google.github.io/flatbuffers/index.html).
+
+Based on original work by Konstantin Scheglov and Paul Berry of the Dart SDK team.
+
+## Authors
+
+- Dan Field <dfield@gmail.com>
+- Konstantin Scheglov
+- Paul Berry

--- a/dart/lib/flat_buffers.dart
+++ b/dart/lib/flat_buffers.dart
@@ -30,8 +30,8 @@ class BufferContext {
 
   factory BufferContext.fromBytes(List<int> byteList) {
     Uint8List uint8List = _asUint8List(byteList);
-    ByteData buf = new ByteData.view(uint8List.buffer, uint8List.offsetInBytes);
-    return new BufferContext._(buf);
+    ByteData buf = ByteData.view(uint8List.buffer, uint8List.offsetInBytes);
+    return BufferContext._(buf);
   }
 
   BufferContext._(this._buffer);

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flat_buffers
-version: 1.13.0
+version: 1.12.0+1
 description:
   Library for reading and writing FlatBuffers. Use the flatc compiler to
   generate Dart classes from a FlatBuffer schema, and this library read and write the binary format.

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,15 +1,8 @@
 name: flat_buffers
-version: 1.12.0
-description: >
-  FlatBuffers reading and writing library for Dart.  Use the flatc compiler to
-  generate Dart classes for a FlatBuffers schema, and this library to assist with
-  reading and writing the binary format.
-
-  Based on original work by Konstantin Scheglov and Paul Berry of the Dart SDK team.
-authors:
-- Dan Field <dfield@gmail.com>
-- Konstantin Scheglov
-- Paul Berry
+version: 1.13.0
+description:
+  Library for reading and writing FlatBuffers. Use the flatc compiler to
+  generate Dart classes from a FlatBuffer schema, and this library read and write the binary format.
 homepage: https://github.com/google/flatbuffers
 documentation: https://google.github.io/flatbuffers/index.html
 dev_dependencies:
@@ -17,4 +10,4 @@ dev_dependencies:
   test_reflective_loader: ^0.1.4
   path: ^1.5.1
 environment:
-  sdk: '>=2.0.0-dev.28.0 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -11,3 +11,4 @@ dev_dependencies:
   path: ^1.5.1
 environment:
   sdk: '>=2.0.0 <3.0.0'
+  


### PR DESCRIPTION
This PR aims to update the package for pub.dev and increase the pub.dev score.

Changes to the pubspec.yaml file include
- shortening the description to the maximum of 180 characters allowed by pub.dev requirements
- removing the authors from the pubspec.yaml and moving them into the README.md
- Bumping up the version to 1.13.0 to include the FlexBuffer implementation

Changes to the code: Remove unnecessary `new` keywords in order to pass static analysis of pub.dev.

Changes to CHANGELOG.md: Include changelog for version 1.13.0.

`pub publish --dry-run` returns with 0 warnings.