### PR TITLE
[idl_parser] Check the range of explicitly set field's id value

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -3710,6 +3710,22 @@ void ParseFlexbuffersFromJsonWithNullTest() {
   }
 }
 
+void FieldIdentifierTest() {
+  TEST_EQ(true, flatbuffers::Parser().Parse("table T{ f: int (id:0); }"));
+  // non-integer `id` should be rejected 
+  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:text); }"));
+  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:\"text\"); }"));
+  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:0text); }"));
+  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:1.0); }"));
+  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:-1); g: int (id:0); }"));
+  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:129496726); }"));
+  // A unuion filed occupys two ids: enumerator + pointer (offset).
+  TEST_EQ(false, flatbuffers::Parser().Parse("union X{}\ntable T{ u: X(id:0);\ntable F{x:int;\n}"));
+  // Positive tests for unions
+  TEST_EQ(true, flatbuffers::Parser().Parse("union X{} table T{ u: X (id:1); }"));
+  TEST_EQ(true, flatbuffers::Parser().Parse("union X{} table T{ u: X; }"));
+}
+
 int FlatBufferTests() {
   // clang-format off
 
@@ -3802,6 +3818,7 @@ int FlatBufferTests() {
   ParseFlexbuffersFromJsonWithNullTest();
   FlatbuffersSpanTest();
   FixedLengthArrayConstructorTest();
+  FieldIdentifierTest();
   return 0;
 }
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -3711,19 +3711,21 @@ void ParseFlexbuffersFromJsonWithNullTest() {
 }
 
 void FieldIdentifierTest() {
-  TEST_EQ(true, flatbuffers::Parser().Parse("table T{ f: int (id:0); }"));
-  // non-integer `id` should be rejected 
-  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:text); }"));
-  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:\"text\"); }"));
-  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:0text); }"));
-  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:1.0); }"));
-  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:-1); g: int (id:0); }"));
-  TEST_EQ(false, flatbuffers::Parser().Parse("table T{ f: int (id:129496726); }"));
+  using flatbuffers::Parser;
+  TEST_EQ(true, Parser().Parse("table T{ f: int (id:0); }"));
+  // non-integer `id` should be rejected
+  TEST_EQ(false, Parser().Parse("table T{ f: int (id:text); }"));
+  TEST_EQ(false, Parser().Parse("table T{ f: int (id:\"text\"); }"));
+  TEST_EQ(false, Parser().Parse("table T{ f: int (id:0text); }"));
+  TEST_EQ(false, Parser().Parse("table T{ f: int (id:1.0); }"));
+  TEST_EQ(false, Parser().Parse("table T{ f: int (id:-1); g: int (id:0); }"));
+  TEST_EQ(false, Parser().Parse("table T{ f: int (id:129496726); }"));
   // A unuion filed occupys two ids: enumerator + pointer (offset).
-  TEST_EQ(false, flatbuffers::Parser().Parse("union X{}\ntable T{ u: X(id:0);\ntable F{x:int;\n}"));
+  TEST_EQ(false,
+          Parser().Parse("union X{} table T{ u: X(id:0); table F{x:int;\n}"));
   // Positive tests for unions
-  TEST_EQ(true, flatbuffers::Parser().Parse("union X{} table T{ u: X (id:1); }"));
-  TEST_EQ(true, flatbuffers::Parser().Parse("union X{} table T{ u: X; }"));
+  TEST_EQ(true, Parser().Parse("union X{} table T{ u: X (id:1); }"));
+  TEST_EQ(true, Parser().Parse("union X{} table T{ u: X; }"));
 }
 
 int FlatBufferTests() {


### PR DESCRIPTION
The explicitly set `id` attribute should be a non-negative value of the `voffset_t` type.
This commit must fix UB (integer overflow) in https://oss-fuzz.com/testcase-detail/5201775321808896.