### PR TITLE
Fix multiple fbs Kotlin and cpp code generation failure

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,7 +48,11 @@ android {
 
     standardOutput = new ByteArrayOutputStream()
     errorOutput = new ByteArrayOutputStream()
-    commandLine 'flatc', '-o', outputCppDir, '--cpp', "${fbsFiles.join(" ")}"
+    def commandLineArgs = ['flatc', '-o', outputCppDir, '--cpp']
+    fbsFiles.forEach{
+      commandLineArgs.add(it.path)
+    }
+    commandLine commandLineArgs
 
     doFirst {
       delete "$outputCppDir/"
@@ -70,7 +74,11 @@ android {
 
     standardOutput = new ByteArrayOutputStream()
     errorOutput = new ByteArrayOutputStream()
-    commandLine 'flatc', '-o', outputKotlinDir, '--kotlin', "${fbsFiles.join(" ")}"
+    def commandLineArgs = ['flatc', '-o', outputKotlinDir, '--kotlin']
+    fbsFiles.forEach{
+      commandLineArgs.add(it.path)
+    }
+    commandLine commandLineArgs
 
     doFirst {
       delete "$outputKotlinDir/"


### PR DESCRIPTION
Having multiple `.fbs` files in the input directory in the Android example will fail. Solution: pass the path to each file individually (after being added to a list), instead of having one string made up of joined strings of all paths. 
