### PR TITLE
[Rust] Shared String

### DIFF
--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -54,7 +54,7 @@ pub struct FlatBufferBuilder<'fbb> {
 
     min_align: usize,
     force_defaults: bool,
-    strings_map: Option<Vec<WIPOffset<&'fbb str>>>,
+    strings_pool: Vec<WIPOffset<&'fbb str>>,
 
     _phantom: PhantomData<&'fbb ()>,
 }
@@ -89,7 +89,7 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
 
             min_align: 0,
             force_defaults: false,
-            strings_map: None,
+            strings_pool: Vec::new(),
 
             _phantom: PhantomData,
         }
@@ -123,10 +123,7 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
         self.finished = false;
 
         self.min_align = 0;
-
-        if let Some(pool) = self.strings_map.as_mut() {
-            pool.clear();
-        }
+        self.strings_pool.clear();
     }
 
     /// Destroy the FlatBufferBuilder, returning its internal byte vector
@@ -246,48 +243,40 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
         self.assert_not_nested(
             "create_shared_string can not be called when a table or vector is under construction",
         );
-        // Checks if strings_map is None to allocate it
-        if self.strings_map == None {
-            self.strings_map = Some(Vec::new())
-        }
 
         // Saves a ref to owned_buf since rust doesnt like us refrencing it
         // in the binary_search_by code.
         let buf = &self.owned_buf;
 
-        let found = self.strings_map.as_ref().map(|pool| {
-
-            pool.binary_search_by(|offset| {
-                let ptr = offset.value() as usize;
-                // Gets The pointer to the size of the string
-                let str_memory = &buf[buf.len() - ptr..];
-                // Gets the size of the written string from buffer
-                let size = u32::from_le_bytes([
-                    str_memory[0],
-                    str_memory[1],
-                    str_memory[2],
-                    str_memory[3],
-                ]) as usize;
-                // Size of the string size
-                let string_size: usize = 4;
-                // Fetches actual string bytes from index of string after string size
-                // to the size of string plus string size
-                let iter = str_memory[string_size..size + string_size].iter();
-                // Compares bytes of fetched string and current writable string
-                iter.cloned().cmp(s.bytes())
-            })
+        let found = self.strings_pool.binary_search_by(|offset| {
+            let ptr = offset.value() as usize;
+            // Gets The pointer to the size of the string
+            let str_memory = &buf[buf.len() - ptr..];
+            // Gets the size of the written string from buffer
+            let size = u32::from_le_bytes([
+                str_memory[0],
+                str_memory[1],
+                str_memory[2],
+                str_memory[3],
+            ]) as usize;
+            // Size of the string size
+            let string_size: usize = 4;
+            // Fetches actual string bytes from index of string after string size
+            // to the size of string plus string size
+            let iter = str_memory[string_size..size + string_size].iter();
+            // Compares bytes of fetched string and current writable string
+            iter.cloned().cmp(s.bytes())
         });
 
-        let address = if let Some(Ok(index)) = found {
-            self.strings_map.as_ref().unwrap()[index]
+        let address = if let Ok(index) = found {
+            self.strings_pool[index]
         } else {
             let _address = WIPOffset::new(self.create_byte_string(s.as_bytes()).value());
             _address
         };
 
-        if let Some(Err(index)) = found {
-            let pool = self.strings_map.as_mut().unwrap();
-            pool.insert(index, address);
+        if let Err(index) = found {
+            self.strings_pool.insert(index, address);
         }
         return address
     }

--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -124,6 +124,8 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
         self.finished = false;
 
         self.min_align = 0;
+
+        self.strings_map.clear();
     }
 
     /// Destroy the FlatBufferBuilder, returning its internal byte vector

--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -268,17 +268,14 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
             iter.cloned().cmp(s.bytes())
         });
 
-        let address = if let Ok(index) = found {
-            self.strings_pool[index]
-        } else {
-            let _address = WIPOffset::new(self.create_byte_string(s.as_bytes()).value());
-            _address
-        };
-
-        if let Err(index) = found {
-            self.strings_pool.insert(index, address);
+        match found {
+            Ok(index) => self.strings_pool[index],
+            Err(index) => {
+                let address = WIPOffset::new(self.create_byte_string(s.as_bytes()).value());
+                self.strings_pool.insert(index, address);
+                address
+            }
         }
-        return address
     }
 
     /// Create a utf8 string.

--- a/rust/flatbuffers/src/primitives.rs
+++ b/rust/flatbuffers/src/primitives.rs
@@ -93,6 +93,8 @@ impl<T> Clone for WIPOffset<T> {
     }
 }
 
+impl<T> Eq for WIPOffset<T> {}
+
 impl<T> PartialEq for WIPOffset<T> {
     fn eq(&self, o: &WIPOffset<T>) -> bool {
         self.value() == o.value()

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -3070,24 +3070,24 @@ fn test_shared_strings() {
     // Checks if the shared string function would always work with
     // an object in between the writes
     let name = builder.create_shared_string("foo");
-    let _m = my_game::example::Monster::create(&mut builder, &my_game::example::MonsterArgs {
+    let enemy = my_game::example::Monster::create(&mut builder, &my_game::example::MonsterArgs {
         name: Some(name),
         ..Default::default()
     });
     let secondary_name = builder.create_shared_string("foo");
     assert_eq!(name.value(), secondary_name.value());
 
-    // Builds a new monster object and embeds _m into it so we can verify
+    // Builds a new monster object and embeds enemy into it so we can verify
     // that shared strings are working.
     let args = my_game::example::MonsterArgs {
         name: Some(secondary_name),
-        enemy: Some(_m),
+        enemy: Some(enemy),
         testarrayofstring: Some(builder.create_vector(&[name, secondary_name])),
         ..Default::default()
     };
     // Building secondary monster
-    let _m2 = my_game::example::Monster::create(&mut builder, &args);
-    builder.finish(_m2, None);
+    let main_monster = my_game::example::Monster::create(&mut builder, &args);
+    builder.finish(main_monster, None);
     let monster = my_game::example::root_as_monster(builder.finished_data()).unwrap();
 
     // Checks if the embedded object (Enemy) name is foo

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -3054,7 +3054,7 @@ fn load_file(filename: &str) -> Result<Vec<u8>, std::io::Error> {
 
 #[test]
 fn test_shared_strings() {
-    let builder = &mut flatbuffers::FlatBufferBuilder::new();
+    let mut builder = &mut flatbuffers::FlatBufferBuilder::new();
     let offset1 = builder.create_shared_string("welcome to flatbuffers!!");
     let offset2 = builder.create_shared_string("welcome");
     let offset3 = builder.create_shared_string("welcome to flatbuffers!!");
@@ -3065,6 +3065,17 @@ fn test_shared_strings() {
     let offset5 = builder.create_shared_string("welcome to flatbuffers!!");
     assert_eq!(false, offset2.value() == offset4.value());
     assert_eq!(false, offset5.value() == offset1.value());
+    builder.reset();
+
+    // Checks if the shared string function would always work with
+    // an object in between the writes
+    let name = builder.create_shared_string("foo");
+    let _m = my_game::example::Monster::create(&mut builder, &my_game::example::MonsterArgs {
+        name: Some(name),
+        ..Default::default()
+    });
+    let secondary_name = builder.create_shared_string("foo");
+    assert_eq!(name.value(), secondary_name.value());
 }
 
 }

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -3051,4 +3051,17 @@ fn load_file(filename: &str) -> Result<Vec<u8>, std::io::Error> {
     f.read_to_end(&mut buf)?;
     Ok(buf)
 }
+
+#[test]
+fn test_shared_strings() {
+    let b = &mut flatbuffers::FlatBufferBuilder::new();
+    let offset1 = b.create_shared_string("welcome to flatbuffers!!");
+    let offset2 = b.create_shared_string("welcome");
+    let offset3 = b.create_shared_string("welcome to flatbuffers!!");
+    let offset4 = b.create_shared_string("welcome to flatbuffers!!");
+    assert_eq!(false, offset2.value() == offset3.value());
+    assert_eq!(offset1.value(), offset3.value());
+    assert_eq!(offset4.value(), offset3.value());
+}
+
 }

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -3054,14 +3054,17 @@ fn load_file(filename: &str) -> Result<Vec<u8>, std::io::Error> {
 
 #[test]
 fn test_shared_strings() {
-    let b = &mut flatbuffers::FlatBufferBuilder::new();
-    let offset1 = b.create_shared_string("welcome to flatbuffers!!");
-    let offset2 = b.create_shared_string("welcome");
-    let offset3 = b.create_shared_string("welcome to flatbuffers!!");
-    let offset4 = b.create_shared_string("welcome to flatbuffers!!");
+    let builder = &mut flatbuffers::FlatBufferBuilder::new();
+    let offset1 = builder.create_shared_string("welcome to flatbuffers!!");
+    let offset2 = builder.create_shared_string("welcome");
+    let offset3 = builder.create_shared_string("welcome to flatbuffers!!");
     assert_eq!(false, offset2.value() == offset3.value());
     assert_eq!(offset1.value(), offset3.value());
-    assert_eq!(offset4.value(), offset3.value());
+    builder.reset();
+    let offset4 = builder.create_shared_string("welcome");
+    let offset5 = builder.create_shared_string("welcome to flatbuffers!!");
+    assert_eq!(false, offset2.value() == offset4.value());
+    assert_eq!(false, offset5.value() == offset1.value());
 }
 
 }


### PR DESCRIPTION
The following PR implements shared strings for rust. The following function is implemented in C++, C#, swift, and many others. I've been trying to implement it for rust for a while, however I didnt fully understand why a str cant be saved normally into a HashMap. However, I used a `String::from` to save it as a string, since rust is a bit picky when it comes to refrences. I've added test cases too for this