### PR TITLE
Search for includes in the directory containg the current file

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -3175,11 +3175,19 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
       if (opts.proto_mode && attribute_ == "public") NEXT();
       auto name = flatbuffers::PosixPath(attribute_.c_str());
       EXPECT(kTokenStringConstant);
-      // Look for the file in include_paths.
+      // Look for the file relative to the directory of the current file
       std::string filepath;
-      for (auto paths = include_paths; paths && *paths; paths++) {
-        filepath = flatbuffers::ConCatPathFileName(*paths, name);
-        if (FileExists(filepath.c_str())) break;
+      if (source_filename) {
+        auto source_file_directory =
+            flatbuffers::StripFileName(source_filename);
+        filepath = flatbuffers::ConCatPathFileName(source_file_directory, name);
+      }
+      if (!FileExists(filepath.c_str())) {
+        // Look for the file in include_paths.
+        for (auto paths = include_paths; paths && *paths; paths++) {
+          filepath = flatbuffers::ConCatPathFileName(*paths, name);
+          if (FileExists(filepath.c_str())) break;
+        }
       }
       if (filepath.empty())
         return Error("unable to locate include file: " + name);

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -3182,7 +3182,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
             flatbuffers::StripFileName(source_filename);
         filepath = flatbuffers::ConCatPathFileName(source_file_directory, name);
       }
-      if (!FileExists(filepath.c_str())) {
+      if (filepath.empty() || !FileExists(filepath.c_str())) {
         // Look for the file in include_paths.
         for (auto paths = include_paths; paths && *paths; paths++) {
           filepath = flatbuffers::ConCatPathFileName(*paths, name);

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -3175,7 +3175,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
       if (opts.proto_mode && attribute_ == "public") NEXT();
       auto name = flatbuffers::PosixPath(attribute_.c_str());
       EXPECT(kTokenStringConstant);
-      // Look for the file relative to the directory of the current file
+      // Look for the file relative to the directory of the current file.
       std::string filepath;
       if (source_filename) {
         auto source_file_directory =


### PR DESCRIPTION
This matches the behavior of a C preprocessor, see:
https://gcc.gnu.org/onlinedocs/cpp/Search-Path.html

fixes #6370

For the top level file (the one passed to flatc), this is redundant to the push/pop of the directory containing the top level file to the include paths in `FlatCompiler::ParseFile`:
https://github.com/google/flatbuffers/blob/85d5c9fd58193715e37736afea603601c9d04583/src/flatc.cpp#L25-L39
That extra include path, however, has an additional effect: if you're compiling `/foo.fbs` and it includes `/some/dir/tree/bar.fbs`, currently `bar.fbs` is able to include `/baz.fbs`. This seems very odd to me and imo the push/pop should be removed, but perhaps that's desirable for some reason.