### PR TITLE
fix Dart Builder.reset() - clear vTables

### DIFF
--- a/dart/lib/flat_buffers.dart
+++ b/dart/lib/flat_buffers.dart
@@ -443,6 +443,7 @@ class Builder {
     _maxAlign = 1;
     _tail = 0;
     _currentVTable = null;
+    _vTables.clear();
     if (_strings != null) {
       _strings = new Map<String, int>();
     }


### PR DESCRIPTION
Dart version of the FlatBuffers `Builder.reset()` doesn't call `_vTables.clear()`, reducing performance of `endTable()` after each reuse (exponentially, due to the for loop on vTables).