### PR TITLE
fix Dart Builder._writeString() - always write trailing zero byte

### DIFF
--- a/dart/lib/flat_buffers.dart
+++ b/dart/lib/flat_buffers.dart
@@ -669,6 +669,7 @@ class Builder {
     for (int i = 0; i < length; i++) {
       _buf.setUint8(offset++, bytes[i]);
     }
+    _buf.setUint8(offset, 0); // trailing zero
     return result;
   }
 


### PR DESCRIPTION
Looks like `_writeString()` allocates the string including the trailing zero but doesn't explicitly write it to the buffer. This currently works only because `ByteData _buf` is zero-initialized. 