### PR TITLE
[C++] Define Vector::value_type for STL compatibility

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -257,6 +257,7 @@ template<typename T> class Vector {
 
   typedef typename IndirectHelper<T>::return_type return_type;
   typedef typename IndirectHelper<T>::mutable_return_type mutable_return_type;
+  typedef return_type value_type;
 
   return_type Get(uoffset_t i) const {
     FLATBUFFERS_ASSERT(i < size());


### PR DESCRIPTION
Specifically, this lets the googlemock container matchers work with a
flatbuffers::Vector.

https://github.com/google/googletest/blob/master/googlemock/docs/cheat_sheet.md#container-matchers