### PR TITLE
Dart Builder - add optional Allocator

### DIFF
--- a/dart/lib/flat_buffers.dart
+++ b/dart/lib/flat_buffers.dart
@@ -145,8 +145,10 @@ class Builder {
   /// true, will cause [writeString] to pool strings in the buffer so that
   /// identical strings will always use the same offset in tables.
   Builder(
-      {this.initialSize: 1024, bool internStrings = false, Allocator allocator})
-      : _allocator = allocator ?? DefaultAllocator() {
+      {this.initialSize: 1024,
+      bool internStrings = false,
+      Allocator allocator = _defaultAllocator})
+      : _allocator = allocator {
     if (internStrings == true) {
       _strings = new Map<String, int>();
     }
@@ -1249,6 +1251,8 @@ class _VTable {
 
 /// The interface that [Builder] uses to allocate buffers for encoding.
 abstract class Allocator {
+  const Allocator();
+
   /// Allocate a [ByteData] buffer of a given size.
   ByteData allocate(int size);
 
@@ -1300,6 +1304,8 @@ abstract class Allocator {
 }
 
 class DefaultAllocator extends Allocator {
+  const DefaultAllocator();
+
   @override
   ByteData allocate(int size) => ByteData(size);
 
@@ -1317,3 +1323,5 @@ class DefaultAllocator extends Allocator {
     }
   }
 }
+
+const _defaultAllocator = DefaultAllocator();


### PR DESCRIPTION
As [discussed previously](https://github.com/google/flatbuffers/pull/6390#issuecomment-756661215), here's the allocator for Builder in Dart, allowing some custom buffer allocation, e.g. using [C-backed memory](https://github.com/objectbox/objectbox-dart/blob/690b524e2759b4162c08dace790cdf0535dea686/lib/src/bindings/flatbuffers.dart) to be able to pass it directly to FFI.

The Allocator is largely based on the C++ `Allocator` interface. Additionally, I've noticed `size` isn't exposed in the builder at the moment though it is in other languages so I've included it here as well (cause I've needed it :D). If you don't like mixing concerns in PRs I can extract a separate PR exposing `Builder.size`.