### PR TITLE
[flatc]: Use float when possible in FlexBuffers

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2987,7 +2987,13 @@ CheckedError Parser::ParseFlexBufferValue(flexbuffers::Builder *builder) {
     case kTokenFloatConstant: {
       double d;
       StringToNumber(attribute_.c_str(), &d);
-      builder->Double(d);
+
+      if (flexbuffers::WidthF(d) == flexbuffers::BIT_WIDTH_32) {
+        builder->Float(static_cast<float>(d));
+      } else {
+        builder->Double(d);
+      }
+
       EXPECT(kTokenFloatConstant);
       break;
     }


### PR DESCRIPTION
When serializing a JSON object with FlexBuffers using `flatc`, the
implementation always defaults to encoding the value as a `double`.
Whenever possible, encoding the value as a `float` would yield a more
space-efficient result.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

--- 

I couldn't find a way to write a unit test for this change. The FlexBuffers C++ API supports an `IsFloat()` method that returns true if the value is a floating-point number independently of its width, and the `byte_width_` member is private to the class and does not have any way to access its value as far as I can see.

If there was a `GetByteWidth()` method, then we could write a unit test that parses JSON files with real numbers of different precision and assert that the results are `BIT_WIDTH_32` or `BIT_WIDTH_64`.
