### PR TITLE
Explain how FlatBuffers encodes unions

### DIFF
--- a/docs/source/Internals.md
+++ b/docs/source/Internals.md
@@ -111,6 +111,13 @@ is 0, that means the field is not present in this object, and the
 default value is return. Otherwise, the entry is used as offset to the
 field to be read.
 
+### Unions
+
+Unions are encoded as the combination of two fields: an enum representing the
+union choice and the offset to the actual element. FlatBuffers reserves the
+enumeration constant `NONE` (encoded as 0) to mean that the union field is not
+set.
+
 ### Strings and Vectors
 
 Strings are simply a vector of bytes, and are always


### PR DESCRIPTION
This is an attempt to explain how FlatBuffers encodes union types as an
extra section in the "FlatBuffers internals" document.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

***

This description is based on observations from running my own experiments. Please let me know if something is off and I'll clarify it!