### PR TITLE
[c++] Apply NativeName before WrapInNameSpace in idl_gen_cpp.cpp

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -883,10 +883,10 @@ class CppGenerator : public BaseGenerator {
   }
 
   std::string GetUnionElement(const EnumVal &ev, bool wrap_namespace,
-                              bool actual_type, bool native_type,
-                              bool wrap_native, const IDLOptions &opts) {
+                              bool native_type, bool wrap_native,
+                              const IDLOptions &opts) {
     if (ev.union_type.base_type == BASE_TYPE_STRUCT) {
-      auto name = actual_type ? ev.union_type.struct_def->name : Name(ev);
+      auto name = ev.union_type.struct_def->name;
       if (wrap_native) {
         name = NativeName(name, ev.union_type.struct_def, opts);
       }
@@ -896,8 +896,7 @@ class CppGenerator : public BaseGenerator {
       }
       return name;
     } else if (IsString(ev.union_type)) {
-      return actual_type ? (native_type ? "std::string" : "flatbuffers::String")
-                         : Name(ev);
+      return native_type ? "std::string" : "flatbuffers::String";
     } else {
       FLATBUFFERS_ASSERT(false);
       return Name(ev);
@@ -1268,7 +1267,7 @@ class CppGenerator : public BaseGenerator {
         if (it == enum_def.Vals().begin()) {
           code_ += "template<typename T> struct {{ENUM_NAME}}Traits {";
         } else {
-          auto name = GetUnionElement(ev, true, true, false, false, opts_);
+          auto name = GetUnionElement(ev, true, false, false, opts_);
           code_ += "template<> struct {{ENUM_NAME}}Traits<" + name + "> {";
         }
 
@@ -1331,8 +1330,7 @@ class CppGenerator : public BaseGenerator {
         const auto &ev = **it;
         if (ev.IsZero()) { continue; }
 
-        const auto native_type =
-            GetUnionElement(ev, true, true, true, true, opts_);
+        const auto native_type = GetUnionElement(ev, true, true, true, opts_);
         code_.SetValue("NATIVE_TYPE", native_type);
         code_.SetValue("NATIVE_NAME", Name(ev));
         code_.SetValue("NATIVE_ID", GetEnumValUse(enum_def, ev));
@@ -1365,7 +1363,7 @@ class CppGenerator : public BaseGenerator {
           code_.SetValue("NATIVE_ID", GetEnumValUse(enum_def, ev));
           if (ev.IsNonZero()) {
             const auto native_type =
-                GetUnionElement(ev, true, true, true, true, opts_);
+                GetUnionElement(ev, true, true, true, opts_);
             code_.SetValue("NATIVE_TYPE", native_type);
             code_ += "    case {{NATIVE_ID}}: {";
             code_ +=
@@ -1419,8 +1417,7 @@ class CppGenerator : public BaseGenerator {
       code_.SetValue("LABEL", GetEnumValUse(enum_def, ev));
 
       if (ev.IsNonZero()) {
-        code_.SetValue("TYPE",
-                       GetUnionElement(ev, true, true, false, false, opts_));
+        code_.SetValue("TYPE", GetUnionElement(ev, true, false, false, opts_));
         code_ += "    case {{LABEL}}: {";
         auto getptr =
             "      auto ptr = reinterpret_cast<const {{TYPE}} *>(obj);";
@@ -1475,8 +1472,7 @@ class CppGenerator : public BaseGenerator {
         if (ev.IsZero()) { continue; }
 
         code_.SetValue("LABEL", GetEnumValUse(enum_def, ev));
-        code_.SetValue("TYPE",
-                       GetUnionElement(ev, true, true, false, false, opts_));
+        code_.SetValue("TYPE", GetUnionElement(ev, true, false, false, opts_));
         code_ += "    case {{LABEL}}: {";
         code_ += "      auto ptr = reinterpret_cast<const {{TYPE}} *>(obj);";
         if (ev.union_type.base_type == BASE_TYPE_STRUCT) {
@@ -1506,10 +1502,8 @@ class CppGenerator : public BaseGenerator {
         if (ev.IsZero()) { continue; }
 
         code_.SetValue("LABEL", GetEnumValUse(enum_def, ev));
-        code_.SetValue("TYPE",
-                       GetUnionElement(ev, true, true, true, true, opts_));
-        code_.SetValue("NAME",
-                       GetUnionElement(ev, false, true, false, false, opts_));
+        code_.SetValue("TYPE", GetUnionElement(ev, true, true, true, opts_));
+        code_.SetValue("NAME", GetUnionElement(ev, false, false, false, opts_));
         code_ += "    case {{LABEL}}: {";
         code_ += "      auto ptr = reinterpret_cast<const {{TYPE}} *>(value);";
         if (ev.union_type.base_type == BASE_TYPE_STRUCT) {
@@ -1541,8 +1535,7 @@ class CppGenerator : public BaseGenerator {
         const auto &ev = **it;
         if (ev.IsZero()) { continue; }
         code_.SetValue("LABEL", GetEnumValUse(enum_def, ev));
-        code_.SetValue("TYPE",
-                       GetUnionElement(ev, true, true, true, true, opts_));
+        code_.SetValue("TYPE", GetUnionElement(ev, true, true, true, opts_));
         code_ += "    case {{LABEL}}: {";
         bool copyable = true;
         if (ev.union_type.base_type == BASE_TYPE_STRUCT) {
@@ -1586,8 +1579,7 @@ class CppGenerator : public BaseGenerator {
         const auto &ev = **it;
         if (ev.IsZero()) { continue; }
         code_.SetValue("LABEL", GetEnumValUse(enum_def, ev));
-        code_.SetValue("TYPE",
-                       GetUnionElement(ev, true, true, true, true, opts_));
+        code_.SetValue("TYPE", GetUnionElement(ev, true, true, true, opts_));
         code_ += "    case {{LABEL}}: {";
         code_ += "      auto ptr = reinterpret_cast<{{TYPE}} *>(value);";
         code_ += "      delete ptr;";
@@ -1989,8 +1981,7 @@ class CppGenerator : public BaseGenerator {
     for (auto u_it = u->Vals().begin(); u_it != u->Vals().end(); ++u_it) {
       auto &ev = **u_it;
       if (ev.union_type.base_type == BASE_TYPE_NONE) { continue; }
-      auto full_struct_name =
-          GetUnionElement(ev, true, true, false, false, opts_);
+      auto full_struct_name = GetUnionElement(ev, true, false, false, opts_);
 
       // @TODO: Mby make this decisions more universal? How?
       code_.SetValue("U_GET_TYPE",
@@ -2235,8 +2226,7 @@ class CppGenerator : public BaseGenerator {
         auto &ev = **u_it;
         if (ev.union_type.base_type == BASE_TYPE_NONE) { continue; }
 
-        auto full_struct_name =
-            GetUnionElement(ev, true, true, false, false, opts_);
+        auto full_struct_name = GetUnionElement(ev, true, false, false, opts_);
 
         code_.SetValue(
             "U_ELEMENT_TYPE",

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -550,9 +550,7 @@ class CppGenerator : public BaseGenerator {
 
       if (opts_.generate_object_based_api) {
         // A convenient root unpack function.
-        auto native_name =
-            WrapInNameSpace(struct_def.defined_namespace,
-                            NativeName(Name(struct_def), &struct_def, opts_));
+        auto native_name = WrapNativeNameInNameSpace(struct_def, opts_);
         code_.SetValue("UNPACK_RETURN",
                        GenTypeNativePtr(native_name, nullptr, false));
         code_.SetValue("UNPACK_TYPE",
@@ -710,6 +708,12 @@ class CppGenerator : public BaseGenerator {
                             : name;
   }
 
+  std::string WrapNativeNameInNameSpace(const StructDef &struct_def,
+                                        const IDLOptions &opts) {
+    return WrapInNameSpace(struct_def.defined_namespace,
+                           NativeName(Name(struct_def), &struct_def, opts));
+  }
+
   const std::string &PtrType(const FieldDef *field) {
     auto attr = field ? field->attributes.Lookup("cpp_ptr_type") : nullptr;
     return attr ? attr->constant : opts_.cpp_object_api_pointer_type;
@@ -788,10 +792,8 @@ class CppGenerator : public BaseGenerator {
           }
         } else {
           return GenTypeNativePtr(
-              WrapInNameSpace(
-                  type.struct_def->defined_namespace,
-                  NativeName(Name(*type.struct_def), type.struct_def, opts_)),
-              &field, false);
+              WrapNativeNameInNameSpace(*type.struct_def, opts_), &field,
+              false);
         }
       }
       case BASE_TYPE_UNION: {
@@ -2508,10 +2510,8 @@ class CppGenerator : public BaseGenerator {
           }
         } else {
           const auto ptype = GenTypeNativePtr(
-              WrapInNameSpace(
-                  type.struct_def->defined_namespace,
-                  NativeName(Name(*type.struct_def), type.struct_def, opts_)),
-              &afield, true);
+              WrapNativeNameInNameSpace(*type.struct_def, opts_), &afield,
+              true);
           return ptype + "(" + val + "->UnPack(_resolver))";
         }
       }
@@ -2847,9 +2847,7 @@ class CppGenerator : public BaseGenerator {
           "inline " + TableUnPackSignature(struct_def, false, opts_) + " {";
 
       if (opts_.g_cpp_std == cpp::CPP_STD_X0) {
-        auto native_name = WrapInNameSpace(
-            struct_def.defined_namespace,
-            NativeName(Name(struct_def), &struct_def, parser_.opts));
+        auto native_name = WrapNativeNameInNameSpace(struct_def, parser_.opts);
         code_.SetValue("POINTER_TYPE",
                        GenTypeNativePtr(native_name, nullptr, false));
         code_ +=

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2493,7 +2493,6 @@ class CppGenerator : public BaseGenerator {
         }
       }
       case BASE_TYPE_STRUCT: {
-        const auto name = WrapInNameSpace(*type.struct_def);
         if (IsStruct(type)) {
           auto native_type = type.struct_def->attributes.Lookup("native_type");
           if (native_type) {
@@ -2501,6 +2500,7 @@ class CppGenerator : public BaseGenerator {
           } else if (invector || afield.native_inline) {
             return "*" + val;
           } else {
+            const auto name = WrapInNameSpace(*type.struct_def);
             const auto ptype = GenTypeNativePtr(name, &afield, true);
             return ptype + "(new " + name + "(*" + val + "))";
           }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -883,11 +883,10 @@ class CppGenerator : public BaseGenerator {
   }
 
   std::string GetUnionElement(const EnumVal &ev, bool wrap_namespace,
-                              bool native_type, bool wrap_native,
-                              const IDLOptions &opts) {
+                              bool native_type, const IDLOptions &opts) {
     if (ev.union_type.base_type == BASE_TYPE_STRUCT) {
       auto name = ev.union_type.struct_def->name;
-      if (wrap_native) {
+      if (native_type) {
         name = NativeName(name, ev.union_type.struct_def, opts);
       }
       if (wrap_namespace) {
@@ -1267,7 +1266,7 @@ class CppGenerator : public BaseGenerator {
         if (it == enum_def.Vals().begin()) {
           code_ += "template<typename T> struct {{ENUM_NAME}}Traits {";
         } else {
-          auto name = GetUnionElement(ev, true, false, false, opts_);
+          auto name = GetUnionElement(ev, true, false, opts_);
           code_ += "template<> struct {{ENUM_NAME}}Traits<" + name + "> {";
         }
 
@@ -1330,7 +1329,7 @@ class CppGenerator : public BaseGenerator {
         const auto &ev = **it;
         if (ev.IsZero()) { continue; }
 
-        const auto native_type = GetUnionElement(ev, true, true, true, opts_);
+        const auto native_type = GetUnionElement(ev, true, true, opts_);
         code_.SetValue("NATIVE_TYPE", native_type);
         code_.SetValue("NATIVE_NAME", Name(ev));
         code_.SetValue("NATIVE_ID", GetEnumValUse(enum_def, ev));
@@ -1362,8 +1361,7 @@ class CppGenerator : public BaseGenerator {
           const auto &ev = **it;
           code_.SetValue("NATIVE_ID", GetEnumValUse(enum_def, ev));
           if (ev.IsNonZero()) {
-            const auto native_type =
-                GetUnionElement(ev, true, true, true, opts_);
+            const auto native_type = GetUnionElement(ev, true, true, opts_);
             code_.SetValue("NATIVE_TYPE", native_type);
             code_ += "    case {{NATIVE_ID}}: {";
             code_ +=
@@ -1417,7 +1415,7 @@ class CppGenerator : public BaseGenerator {
       code_.SetValue("LABEL", GetEnumValUse(enum_def, ev));
 
       if (ev.IsNonZero()) {
-        code_.SetValue("TYPE", GetUnionElement(ev, true, false, false, opts_));
+        code_.SetValue("TYPE", GetUnionElement(ev, true, false, opts_));
         code_ += "    case {{LABEL}}: {";
         auto getptr =
             "      auto ptr = reinterpret_cast<const {{TYPE}} *>(obj);";
@@ -1472,7 +1470,7 @@ class CppGenerator : public BaseGenerator {
         if (ev.IsZero()) { continue; }
 
         code_.SetValue("LABEL", GetEnumValUse(enum_def, ev));
-        code_.SetValue("TYPE", GetUnionElement(ev, true, false, false, opts_));
+        code_.SetValue("TYPE", GetUnionElement(ev, true, false, opts_));
         code_ += "    case {{LABEL}}: {";
         code_ += "      auto ptr = reinterpret_cast<const {{TYPE}} *>(obj);";
         if (ev.union_type.base_type == BASE_TYPE_STRUCT) {
@@ -1502,8 +1500,8 @@ class CppGenerator : public BaseGenerator {
         if (ev.IsZero()) { continue; }
 
         code_.SetValue("LABEL", GetEnumValUse(enum_def, ev));
-        code_.SetValue("TYPE", GetUnionElement(ev, true, true, true, opts_));
-        code_.SetValue("NAME", GetUnionElement(ev, false, false, false, opts_));
+        code_.SetValue("TYPE", GetUnionElement(ev, true, true, opts_));
+        code_.SetValue("NAME", GetUnionElement(ev, false, false, opts_));
         code_ += "    case {{LABEL}}: {";
         code_ += "      auto ptr = reinterpret_cast<const {{TYPE}} *>(value);";
         if (ev.union_type.base_type == BASE_TYPE_STRUCT) {
@@ -1535,7 +1533,7 @@ class CppGenerator : public BaseGenerator {
         const auto &ev = **it;
         if (ev.IsZero()) { continue; }
         code_.SetValue("LABEL", GetEnumValUse(enum_def, ev));
-        code_.SetValue("TYPE", GetUnionElement(ev, true, true, true, opts_));
+        code_.SetValue("TYPE", GetUnionElement(ev, true, true, opts_));
         code_ += "    case {{LABEL}}: {";
         bool copyable = true;
         if (ev.union_type.base_type == BASE_TYPE_STRUCT) {
@@ -1579,7 +1577,7 @@ class CppGenerator : public BaseGenerator {
         const auto &ev = **it;
         if (ev.IsZero()) { continue; }
         code_.SetValue("LABEL", GetEnumValUse(enum_def, ev));
-        code_.SetValue("TYPE", GetUnionElement(ev, true, true, true, opts_));
+        code_.SetValue("TYPE", GetUnionElement(ev, true, true, opts_));
         code_ += "    case {{LABEL}}: {";
         code_ += "      auto ptr = reinterpret_cast<{{TYPE}} *>(value);";
         code_ += "      delete ptr;";
@@ -1981,7 +1979,7 @@ class CppGenerator : public BaseGenerator {
     for (auto u_it = u->Vals().begin(); u_it != u->Vals().end(); ++u_it) {
       auto &ev = **u_it;
       if (ev.union_type.base_type == BASE_TYPE_NONE) { continue; }
-      auto full_struct_name = GetUnionElement(ev, true, false, false, opts_);
+      auto full_struct_name = GetUnionElement(ev, true, false, opts_);
 
       // @TODO: Mby make this decisions more universal? How?
       code_.SetValue("U_GET_TYPE",
@@ -2226,7 +2224,7 @@ class CppGenerator : public BaseGenerator {
         auto &ev = **u_it;
         if (ev.union_type.base_type == BASE_TYPE_NONE) { continue; }
 
-        auto full_struct_name = GetUnionElement(ev, true, false, false, opts_);
+        auto full_struct_name = GetUnionElement(ev, true, false, opts_);
 
         code_.SetValue(
             "U_ELEMENT_TYPE",


### PR DESCRIPTION
This addresses issue #6418 (namespace-qualified names in generated C++ code are ill-formed when --object-prefix flag is non-empty). 

This does not change the output of `tests/generate_code.sh`.

I informally tested this change by generating C++ code for the TFLite schema
```sh
./flatc --cpp --gen-object-api --object-prefix PRE  schema.fbs
```
and verifying that the resulting code now compiles without errors.
