### PR TITLE
Refactor FieldDef to model presense as an enum rather than 2 bools.

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -308,6 +308,15 @@ struct FieldDef : public Definition {
   bool IsScalarOptional() const {
     return IsScalar(value.type.base_type) && optional;
   }
+  bool IsOptional() const {
+    return presence == kOptional;
+  }
+  bool IsRequired() const {
+    return presence == kRequired;
+  }
+  bool IsDefault() const {
+    return presence == kDefault;
+  }
 
   Value value;
   bool deprecated;  // Field is allowed to be present in old data, but can't be.
@@ -321,6 +330,19 @@ struct FieldDef : public Definition {
   bool flexbuffer;     // This field contains FlexBuffer data.
   bool optional;       // If True, this field is Null (as opposed to default
                        // valued).
+
+  enum Presence {
+    // Field must always be present.
+    kRequired,
+    // Non-presence should be signalled to and controlled by users.
+    kOptional,
+    // Non-presence is hidden from users.
+    // Implementations may omit writing default values.
+    kDefault,
+  };
+  Presence presence;
+
+
   StructDef *nested_flatbuffer;  // This field contains nested FlatBuffer data.
   size_t padding;                // Bytes to always pad after this field.
 };

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -335,6 +335,13 @@ struct FieldDef : public Definition {
     // Implementations may omit writing default values.
     kDefault,
   };
+  Presence static MakeFieldPresence(bool optional, bool required) {
+    // clang-format off
+    return required ? FieldDef::kRequired
+                    : optional ? FieldDef::kOptional
+                               : FieldDef::kDefault;
+    // clang-format on
+  }
   Presence presence = kDefault;
 
 

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -291,12 +291,10 @@ struct Definition {
 struct FieldDef : public Definition {
   FieldDef()
       : deprecated(false),
-        required(false),
         key(false),
         shared(false),
         native_inline(false),
         flexbuffer(false),
-        optional(false),
         nested_flatbuffer(NULL),
         padding(0) {}
 
@@ -306,7 +304,7 @@ struct FieldDef : public Definition {
   bool Deserialize(Parser &parser, const reflection::Field *field);
 
   bool IsScalarOptional() const {
-    return IsScalar(value.type.base_type) && optional;
+    return IsScalar(value.type.base_type) && IsOptional();
   }
   bool IsOptional() const {
     return presence == kOptional;
@@ -321,15 +319,12 @@ struct FieldDef : public Definition {
   Value value;
   bool deprecated;  // Field is allowed to be present in old data, but can't be.
                     // written in new data nor accessed in new code.
-  bool required;    // Field must always be present.
   bool key;         // Field functions as a key for creating sorted vectors.
   bool shared;  // Field will be using string pooling (i.e. CreateSharedString)
                 // as default serialization behavior if field is a string.
   bool native_inline;  // Field will be defined inline (instead of as a pointer)
                        // for native tables if field is a struct.
   bool flexbuffer;     // This field contains FlexBuffer data.
-  bool optional;       // If True, this field is Null (as opposed to default
-                       // valued).
 
   enum Presence {
     // Field must always be present.

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -295,6 +295,7 @@ struct FieldDef : public Definition {
         shared(false),
         native_inline(false),
         flexbuffer(false),
+        presence(kDefault),
         nested_flatbuffer(NULL),
         padding(0) {}
 
@@ -342,7 +343,7 @@ struct FieldDef : public Definition {
                     : FieldDef::kDefault;
     // clang-format on
   }
-  Presence presence = kDefault;
+  Presence presence;
 
   StructDef *nested_flatbuffer;  // This field contains nested FlatBuffer data.
   size_t padding;                // Bytes to always pad after this field.

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -340,7 +340,7 @@ struct FieldDef : public Definition {
     // Implementations may omit writing default values.
     kDefault,
   };
-  Presence presence;
+  Presence presence = kDefault;
 
 
   StructDef *nested_flatbuffer;  // This field contains nested FlatBuffer data.

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -338,12 +338,11 @@ struct FieldDef : public Definition {
   Presence static MakeFieldPresence(bool optional, bool required) {
     // clang-format off
     return required ? FieldDef::kRequired
-                    : optional ? FieldDef::kOptional
-                               : FieldDef::kDefault;
+         : optional ? FieldDef::kOptional
+                    : FieldDef::kDefault;
     // clang-format on
   }
   Presence presence = kDefault;
-
 
   StructDef *nested_flatbuffer;  // This field contains nested FlatBuffer data.
   size_t padding;                // Bytes to always pad after this field.

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -1871,7 +1871,7 @@ class CppGenerator : public BaseGenerator {
   void GenVerifyCall(const FieldDef &field, const char *prefix) {
     code_.SetValue("PRE", prefix);
     code_.SetValue("NAME", Name(field));
-    code_.SetValue("REQUIRED", field.required ? "Required" : "");
+    code_.SetValue("REQUIRED", field.IsRequired() ? "Required" : "");
     code_.SetValue("SIZE", GenTypeSize(field.value.type));
     code_.SetValue("OFFSET", GenFieldOffsetName(field));
     if (IsScalar(field.value.type.base_type) || IsStruct(field.value.type)) {
@@ -2340,7 +2340,7 @@ class CppGenerator : public BaseGenerator {
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
       const auto &field = **it;
-      if (!field.deprecated && field.required) {
+      if (!field.deprecated && field.IsRequired()) {
         code_.SetValue("FIELD_NAME", Name(field));
         code_.SetValue("OFFSET_NAME", GenFieldOffsetName(field));
         code_ += "    fbb_.Required(o, {{STRUCT_NAME}}::{{OFFSET_NAME}});";
@@ -2684,7 +2684,7 @@ class CppGenerator : public BaseGenerator {
         // in _o->field before attempting to access it. If there isn't,
         // depending on set_empty_strings_to_null either set it to 0 or an empty
         // string.
-        if (!field.required) {
+        if (!field.IsRequired()) {
           auto empty_value = opts_.set_empty_strings_to_null
                                  ? "0"
                                  : "_fbb.CreateSharedString(\"\")";
@@ -2793,7 +2793,7 @@ class CppGenerator : public BaseGenerator {
         // If set_empty_vectors_to_null option is enabled, for optional fields,
         // check to see if there actually is any data in _o->field before
         // attempting to access it.
-        if (opts_.set_empty_vectors_to_null && !field.required) {
+        if (opts_.set_empty_vectors_to_null && !field.IsRequired()) {
           code = value + ".size() ? " + code + " : 0";
         }
         break;

--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -1142,7 +1142,7 @@ class CSharpGenerator : public BaseGenerator {
       for (auto it = struct_def.fields.vec.begin();
            it != struct_def.fields.vec.end(); ++it) {
         auto &field = **it;
-        if (!field.deprecated && field.required) {
+        if (!field.deprecated && field.IsRequired()) {
           code += "    builder.Required(o, ";
           code += NumToString(field.value.offset);
           code += ");  // " + field.name + "\n";

--- a/src/idl_gen_fbs.cpp
+++ b/src/idl_gen_fbs.cpp
@@ -136,7 +136,7 @@ std::string GenerateFBS(const Parser &parser, const std::string &file_name) {
         GenComment(field.doc_comment, &schema, nullptr, "  ");
         schema += "  " + field.name + ":" + GenType(field.value.type);
         if (field.value.constant != "0") schema += " = " + field.value.constant;
-        if (field.required) schema += " (required)";
+        if (field.IsRequired()) schema += " (required)";
         schema += ";\n";
       }
     }

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -649,7 +649,7 @@ class JavaGenerator : public BaseGenerator {
       std::string src_cast = SourceCast(field.value.type);
       std::string method_start =
           "  public " +
-          (field.required ? "" : GenNullableAnnotation(field.value.type)) +
+          (field.IsRequired() ? "" : GenNullableAnnotation(field.value.type)) +
           GenPureAnnotation(field.value.type) + type_name_dest + optional +
           " " + MakeCamel(field.name, false);
       std::string obj = "obj";
@@ -1095,7 +1095,7 @@ class JavaGenerator : public BaseGenerator {
       for (auto it = struct_def.fields.vec.begin();
            it != struct_def.fields.vec.end(); ++it) {
         auto &field = **it;
-        if (!field.deprecated && field.required) {
+        if (!field.deprecated && field.IsRequired()) {
           code += "    builder.required(o, ";
           code += NumToString(field.value.offset);
           code += ");  // " + field.name + "\n";

--- a/src/idl_gen_json_schema.cpp
+++ b/src/idl_gen_json_schema.cpp
@@ -239,7 +239,7 @@ class JsonSchemaGenerator : public BaseGenerator {
       std::vector<FieldDef *> requiredProperties;
       std::copy_if(properties.begin(), properties.end(),
                    back_inserter(requiredProperties),
-                   [](FieldDef const *prop) { return prop->required; });
+                   [](FieldDef const *prop) { return prop->IsRequired(); });
       if (!requiredProperties.empty()) {
         auto required_string(Indent(3) + "\"required\" : [");
         for (auto req_prop = requiredProperties.cbegin();

--- a/src/idl_gen_kotlin.cpp
+++ b/src/idl_gen_kotlin.cpp
@@ -646,7 +646,7 @@ class KotlinGenerator : public BaseGenerator {
           writer.IncrementIdentLevel();
           for (auto it = field_vec.begin(); it != field_vec.end(); ++it) {
             auto &field = **it;
-            if (field.deprecated || !field.required) { continue; }
+            if (field.deprecated || !field.IsRequired()) { continue; }
             writer.SetValue("offset", NumToString(field.value.offset));
             writer += "builder.required(o, {{offset}})";
           }

--- a/src/idl_gen_lobster.cpp
+++ b/src/idl_gen_lobster.cpp
@@ -110,13 +110,13 @@ class LobsterGenerator : public BaseGenerator {
               offsets + ")";
 
       } else {
-        auto defval = field.optional ? "0" : field.value.constant;
+        auto defval = field.IsOptional() ? "0" : field.value.constant;
         acc = "buf_.flatbuffers_field_" + GenTypeName(field.value.type) +
               "(pos_, " + offsets + ", " + defval + ")";
       }
       if (field.value.type.enum_def)
         acc = NormalizedName(*field.value.type.enum_def) + "(" + acc + ")";
-      if (field.optional)
+      if (field.IsOptional())
         acc += ", buf_.flatbuffers_field_present(pos_, " + offsets + ")";
       code += def + "():\n        return " + acc + "\n";
       return;
@@ -201,7 +201,7 @@ class LobsterGenerator : public BaseGenerator {
               NormalizedName(field) + ":" + LobsterType(field.value.type) +
               "):\n        b_.Prepend" + GenMethod(field.value.type) + "Slot(" +
               NumToString(offset) + ", " + NormalizedName(field);
-      if (IsScalar(field.value.type.base_type) && !field.optional)
+      if (IsScalar(field.value.type.base_type) && !field.IsOptional())
         code += ", " + field.value.constant;
       code += ")\n        return this\n";
     }

--- a/src/idl_gen_php.cpp
+++ b/src/idl_gen_php.cpp
@@ -536,7 +536,7 @@ class PhpGenerator : public BaseGenerator {
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
       auto &field = **it;
-      if (!field.deprecated && field.required) {
+      if (!field.deprecated && field.IsRequired()) {
         code += Indent + Indent + "$builder->required($o, ";
         code += NumToString(field.value.offset);
         code += ");  // " + field.name + "\n";
@@ -645,7 +645,7 @@ class PhpGenerator : public BaseGenerator {
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
       auto &field = **it;
-      if (!field.deprecated && field.required) {
+      if (!field.deprecated && field.IsRequired()) {
         code += Indent + Indent + "$builder->required($o, ";
         code += NumToString(field.value.offset);
         code += ");  // " + field.name + "\n";

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -887,15 +887,15 @@ class RustGenerator : public BaseGenerator {
     switch (GetFullType(field.value.type)) {
       case ftInteger:
       case ftFloat: {
-        return field.optional ? "None" : field.value.constant;
+        return field.IsOptional() ? "None" : field.value.constant;
       }
       case ftBool: {
-        return field.optional ? "None"
+        return field.IsOptional() ? "None"
                               : field.value.constant == "0" ? "false" : "true";
       }
       case ftUnionKey:
       case ftEnumKey: {
-        if (field.optional) { return "None"; }
+        if (field.IsOptional()) { return "None"; }
         auto ev = field.value.type.enum_def->FindByValue(field.value.constant);
         if (!ev) return "Default::default()";  // Bitflags enum.
         return WrapInNameSpace(field.value.type.enum_def->defined_namespace,
@@ -930,7 +930,7 @@ class RustGenerator : public BaseGenerator {
       case ftFloat:
       case ftBool: {
         const auto typname = GetTypeBasic(type);
-        return field.optional ? "Option<" + typname + ">" : typname;
+        return field.IsOptional() ? "Option<" + typname + ">" : typname;
       }
       case ftStruct: {
         const auto typname = WrapInNameSpace(*type.struct_def);
@@ -947,7 +947,7 @@ class RustGenerator : public BaseGenerator {
       case ftEnumKey:
       case ftUnionKey: {
         const auto typname = WrapInNameSpace(*type.enum_def);
-        return field.optional ? "Option<" + typname + ">" : typname;
+        return field.IsOptional() ? "Option<" + typname + ">" : typname;
       }
       case ftUnionValue: {
         return "Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>";
@@ -1056,7 +1056,7 @@ class RustGenerator : public BaseGenerator {
       }
     }
     if (in_a_table && !IsUnion(type) &&
-        (IsScalar(type.base_type) ? field.optional : !field.required)) {
+        (IsScalar(type.base_type) ? field.IsOptional() : !field.IsRequired())) {
       return "Option<" + ty + ">";
     } else {
       return ty;
@@ -1137,14 +1137,14 @@ class RustGenerator : public BaseGenerator {
       case ftBool:
       case ftFloat: {
         const auto typname = GetTypeBasic(field.value.type);
-        return (field.optional ? "self.fbb_.push_slot_always::<"
+        return (field.IsOptional() ? "self.fbb_.push_slot_always::<"
                                : "self.fbb_.push_slot::<") +
                typname + ">";
       }
       case ftEnumKey:
       case ftUnionKey: {
         const auto underlying_typname = GetTypeBasic(type);
-        return (field.optional ? "self.fbb_.push_slot_always::<"
+        return (field.IsOptional() ? "self.fbb_.push_slot_always::<"
                                : "self.fbb_.push_slot::<") +
                underlying_typname + ">";
       }
@@ -1184,31 +1184,31 @@ class RustGenerator : public BaseGenerator {
       case ftFloat:
       case ftBool: {
         const auto typname = GetTypeBasic(type);
-        return field.optional ? "Option<" + typname + ">" : typname;
+        return field.IsOptional() ? "Option<" + typname + ">" : typname;
       }
       case ftStruct: {
         const auto typname = WrapInNameSpace(*type.struct_def);
         return WrapInOptionIfNotRequired("&" + lifetime + " " + typname,
-                                         field.required);
+                                         field.IsRequired());
       }
       case ftTable: {
         const auto typname = WrapInNameSpace(*type.struct_def);
         return WrapInOptionIfNotRequired(typname + "<" + lifetime + ">",
-                                         field.required);
+                                         field.IsRequired());
       }
       case ftEnumKey:
       case ftUnionKey: {
         const auto typname = WrapInNameSpace(*type.enum_def);
-        return field.optional ? "Option<" + typname + ">" : typname;
+        return field.IsOptional() ? "Option<" + typname + ">" : typname;
       }
 
       case ftUnionValue: {
         return WrapInOptionIfNotRequired("flatbuffers::Table<" + lifetime + ">",
-                                         field.required);
+                                         field.IsRequired());
       }
       case ftString: {
         return WrapInOptionIfNotRequired("&" + lifetime + " str",
-                                         field.required);
+                                         field.IsRequired());
       }
       case ftVectorOfInteger:
       case ftVectorOfBool:
@@ -1216,35 +1216,35 @@ class RustGenerator : public BaseGenerator {
         const auto typname = GetTypeBasic(type.VectorType());
         if (IsOneByte(type.VectorType().base_type)) {
           return WrapInOptionIfNotRequired(
-              "&" + lifetime + " [" + typname + "]", field.required);
+              "&" + lifetime + " [" + typname + "]", field.IsRequired());
         }
         return WrapInOptionIfNotRequired(
             "flatbuffers::Vector<" + lifetime + ", " + typname + ">",
-            field.required);
+            field.IsRequired());
       }
       case ftVectorOfEnumKey: {
         const auto typname = WrapInNameSpace(*type.enum_def);
         return WrapInOptionIfNotRequired(
             "flatbuffers::Vector<" + lifetime + ", " + typname + ">",
-            field.required);
+            field.IsRequired());
       }
       case ftVectorOfStruct: {
         const auto typname = WrapInNameSpace(*type.struct_def);
         return WrapInOptionIfNotRequired("&" + lifetime + " [" + typname + "]",
-                                         field.required);
+                                         field.IsRequired());
       }
       case ftVectorOfTable: {
         const auto typname = WrapInNameSpace(*type.struct_def);
         return WrapInOptionIfNotRequired("flatbuffers::Vector<" + lifetime +
                                              ", flatbuffers::ForwardsUOffset<" +
                                              typname + "<" + lifetime + ">>>",
-                                         field.required);
+                                         field.IsRequired());
       }
       case ftVectorOfString: {
         return WrapInOptionIfNotRequired(
             "flatbuffers::Vector<" + lifetime +
                 ", flatbuffers::ForwardsUOffset<&" + lifetime + " str>>",
-            field.required);
+            field.IsRequired());
       }
       case ftVectorOfUnionValue: {
         FLATBUFFERS_ASSERT(false && "vectors of unions are not yet supported");
@@ -1324,10 +1324,10 @@ class RustGenerator : public BaseGenerator {
     const std::string typname = FollowType(field.value.type, lifetime);
     // Default-y fields (scalars so far) are neither optional nor required.
     const std::string default_value =
-        !(field.optional || field.required)
+        !(field.IsOptional() || field.IsRequired())
             ? "Some(" + GetDefaultScalarValue(field) + ")"
             : "None";
-    const std::string unwrap = field.optional ? "" : ".unwrap()";
+    const std::string unwrap = field.IsOptional() ? "" : ".unwrap()";
 
     const auto t = GetFullType(field.value.type);
 
@@ -1345,7 +1345,7 @@ class RustGenerator : public BaseGenerator {
   }
 
   bool TableFieldReturnsOption(const FieldDef &field) {
-    if (field.optional) return true;
+    if (field.IsOptional()) return true;
     switch (GetFullType(field.value.type)) {
       case ftInteger:
       case ftFloat:
@@ -1571,7 +1571,7 @@ class RustGenerator : public BaseGenerator {
             return;
           }
         }
-        if (field.optional) {
+        if (field.IsOptional()) {
           code_ += "      let {{FIELD_NAME}} = self.{{FIELD_NAME}}().map(|x| {";
           code_ += "        {{EXPR}}";
           code_ += "      });";
@@ -1638,7 +1638,7 @@ class RustGenerator : public BaseGenerator {
 
         code_.SetValue("NESTED", WrapInNameSpace(*nested_root));
         code_ += "  pub fn {{FIELD_NAME}}_nested_flatbuffer(&'a self) -> \\";
-        if (field.required) {
+        if (field.IsRequired()) {
           code_ += "{{NESTED}}<'a> {";
           code_ += "    let data = self.{{FIELD_NAME}}();";
           code_ += "    use flatbuffers::Follow;";
@@ -1687,7 +1687,7 @@ class RustGenerator : public BaseGenerator {
 
             // The following logic is not tested in the integration test,
             // as of April 10, 2020
-            if (field.required) {
+            if (field.IsRequired()) {
               code_ += "      let u = self.{{FIELD_NAME}}();";
               code_ +=
                   "      Some({{U_ELEMENT_TABLE_TYPE}}::init_from_table(u))";
@@ -1719,7 +1719,7 @@ class RustGenerator : public BaseGenerator {
     ForAllTableFields(struct_def, [&](const FieldDef &field) {
       if (GetFullType(field.value.type) == ftUnionKey) return;
 
-      code_.SetValue("IS_REQ", field.required ? "true" : "false");
+      code_.SetValue("IS_REQ", field.IsRequired() ? "true" : "false");
       if (GetFullType(field.value.type) != ftUnionValue) {
         // All types besides unions.
         code_.SetValue("TY", FollowType(field.value.type, "'_"));
@@ -1770,7 +1770,7 @@ class RustGenerator : public BaseGenerator {
     code_ += "        {{STRUCT_NAME}}Args {";
     ForAllTableFields(struct_def, [&](const FieldDef &field) {
       code_ += "            {{FIELD_NAME}}: {{DEFAULT_VALUE}},\\";
-      code_ += field.required ? " // required field" : "";
+      code_ += field.IsRequired() ? " // required field" : "";
     });
     code_ += "        }";
     code_ += "    }";
@@ -1807,7 +1807,7 @@ class RustGenerator : public BaseGenerator {
       code_ +=
           "  pub fn add_{{FIELD_NAME}}(&mut self, {{FIELD_NAME}}: "
           "{{FIELD_TYPE}}) {";
-      if (is_scalar && !field.optional) {
+      if (is_scalar && !field.IsOptional()) {
         code_ +=
             "    {{FUNC_BODY}}({{FIELD_OFFSET}}, {{FIELD_NAME}}, "
             "{{DEFAULT_VALUE}});";
@@ -1838,7 +1838,7 @@ class RustGenerator : public BaseGenerator {
     code_ += "    let o = self.fbb_.end_table(self.start_);";
 
     ForAllTableFields(struct_def, [&](const FieldDef &field) {
-      if (!field.required) return;
+      if (!field.IsRequired()) return;
       code_ +=
           "    self.fbb_.required(o, {{STRUCT_NAME}}::{{OFFSET_NAME}},"
           "\"{{FIELD_NAME}}\");";
@@ -1948,7 +1948,7 @@ class RustGenerator : public BaseGenerator {
         }
         case ftStruct: {
           // Hold the struct in a variable so we can reference it.
-          if (field.required) {
+          if (field.IsRequired()) {
             code_ +=
                 "    let {{FIELD_NAME}}_tmp = "
                 "Some(self.{{FIELD_NAME}}.pack());";
@@ -2023,7 +2023,7 @@ class RustGenerator : public BaseGenerator {
     }
   }
   void MapNativeTableField(const FieldDef &field, const std::string &expr) {
-    if (field.required) {
+    if (field.IsRequired()) {
       // For some reason Args has optional types for required fields.
       // TODO(cneo): Fix this... but its a breaking change?
       code_ += "    let {{FIELD_NAME}} = Some({";

--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -355,7 +355,7 @@ class TsGenerator : public BaseGenerator {
       } else {
         *arguments +=
             ", " + nameprefix + field.name + ": " +
-            GenTypeName(imports, field, field.value.type, true, field.optional);
+            GenTypeName(imports, field, field.value.type, true, field.IsOptional());
       }
     }
   }
@@ -1141,7 +1141,7 @@ class TsGenerator : public BaseGenerator {
         if (field.value.type.enum_def) {
           code += "):" +
                   GenTypeName(imports, struct_def, field.value.type, false,
-                              field.optional) +
+                              field.IsOptional()) +
                   " {\n";
         } else {
           code += "):" +
@@ -1488,8 +1488,8 @@ class TsGenerator : public BaseGenerator {
       for (auto it = struct_def.fields.vec.begin();
            it != struct_def.fields.vec.end(); ++it) {
         auto &field = **it;
-        if (!field.deprecated && field.required) {
-          code += "  builder.requiredField(offset, ";
+        if (!field.deprecated && field.IsRequired()) {
+          code += "  builder.IsRequired()Field(offset, ";
           code += NumToString(field.value.offset);
           code += ") // " + field.name + "\n";
         }
@@ -1566,13 +1566,13 @@ class TsGenerator : public BaseGenerator {
   }
 
   static bool HasNullDefault(const FieldDef &field) {
-    return field.optional && field.value.constant == "null";
+    return field.IsOptional() && field.value.constant == "null";
   }
 
   std::string GetArgType(import_set &imports, const Definition &owner,
                          const FieldDef &field, bool allowNull) {
     return GenTypeName(imports, owner, field.value.type, true,
-                       allowNull && field.optional);
+                       allowNull && field.IsOptional());
   }
 
   static std::string GetArgName(const FieldDef &field) {

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -858,7 +858,9 @@ CheckedError Parser::ParseField(StructDef &struct_def) {
                         (IsString(type) && field->key);
   const bool optional =
       IsScalar(type.base_type) ? (field->value.constant == "null") : !required;
-  FLATBUFFERS_ASSERT(!(required && optional));
+  if (required && optional) {
+    return Error("Fields cannot be both optional and required.");
+  }
   // clang-format off
   field->presence = required ? FieldDef::kRequired
                   : optional ? FieldDef::kOptional

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -861,11 +861,7 @@ CheckedError Parser::ParseField(StructDef &struct_def) {
   if (required && optional) {
     return Error("Fields cannot be both optional and required.");
   }
-  // clang-format off
-  field->presence = required ? FieldDef::kRequired
-                  : optional ? FieldDef::kOptional
-                             : FieldDef::kDefault;
-  // clang-format on
+  field->presence = FieldDef::MakeFieldPresence(optional, required);
 
   if (required && (struct_def.fixed || IsScalar(type.base_type))) {
     return Error("only non-scalar fields in tables may be 'required'");
@@ -3517,11 +3513,7 @@ bool FieldDef::Deserialize(Parser &parser, const reflection::Field *field) {
   } else if (IsFloat(value.type.base_type)) {
     value.constant = FloatToString(field->default_real(), 16);
   }
-  // clang-format off
-  presence = field->required() ? FieldDef::kRequired
-           : field->optional() ? FieldDef::kOptional
-                               : FieldDef::kDefault;
-  // clang-format on
+  presence = FieldDef::MakeFieldPresence(field->optional(), field->required());
   key = field->key();
   if (!DeserializeAttributes(parser, field->attributes())) return false;
   // TODO: this should probably be handled by a separate attribute

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1297,7 +1297,7 @@ CheckedError Parser::ParseTable(const StructDef &struct_def, std::string *value,
       if (!struct_def.sortbysize ||
           size == SizeOf(field_value.type.base_type)) {
         switch (field_value.type.base_type) {
-// clang-format off
+          // clang-format off
           #define FLATBUFFERS_TD(ENUM, IDLTYPE, CTYPE, ...) \
             case BASE_TYPE_ ## ENUM: \
               builder_.Pad(field->padding); \
@@ -1483,7 +1483,7 @@ CheckedError Parser::ParseVector(const Type &type, uoffset_t *ovalue,
     // start at the back, since we're building the data backwards.
     auto &val = field_stack_.back().first;
     switch (val.type.base_type) {
-// clang-format off
+      // clang-format off
       #define FLATBUFFERS_TD(ENUM, IDLTYPE, CTYPE,...) \
         case BASE_TYPE_ ## ENUM: \
           if (IsStruct(val.type)) SerializeStruct(*val.type.struct_def, val); \

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -934,6 +934,12 @@ CheckedError Parser::ParseField(StructDef &struct_def) {
         return Error("'key' field must be string or scalar type");
     }
   }
+
+  FLATBUFFERS_ASSERT(!(field->required && field->optional));
+  field->presence = field->required ? FieldDef::kRequired
+                  : field->optional ? FieldDef::kOptional
+                                    : FieldDef::kDefault;
+
   field->shared = field->attributes.Lookup("shared") != nullptr;
   if (field->shared && field->value.type.base_type != BASE_TYPE_STRING)
     return Error("shared can only be defined on strings");

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -935,8 +935,8 @@ void ReflectionTest(uint8_t *flatbuf, size_t length) {
 
   // Test nullability of fields: hp is a 0-default scalar, pos is a struct =>
   // optional, and name is a required string => not optional.
-  TEST_EQ(hp_field.optional(), false);
-  TEST_EQ(pos_field_ptr->optional(), true);
+  TEST_EQ(hp_field.IsOptional(), false);
+  TEST_EQ(pos_field_ptr->IsOptional(), true);
   TEST_EQ(fields->LookupByKey("name")->optional(), false);
 
   // Now use it to dynamically access a buffer.

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -935,8 +935,8 @@ void ReflectionTest(uint8_t *flatbuf, size_t length) {
 
   // Test nullability of fields: hp is a 0-default scalar, pos is a struct =>
   // optional, and name is a required string => not optional.
-  TEST_EQ(hp_field.IsOptional(), false);
-  TEST_EQ(pos_field_ptr->IsOptional(), true);
+  TEST_EQ(hp_field.optional(), false);
+  TEST_EQ(pos_field_ptr->optional(), true);
   TEST_EQ(fields->LookupByKey("name")->optional(), false);
 
   // Now use it to dynamically access a buffer.
@@ -3654,7 +3654,7 @@ void OptionalScalarsTest() {
     flatbuffers::Parser parser;
     TEST_ASSERT(parser.Parse(schema->c_str()));
     const auto *mana = parser.structs_.Lookup("Monster")->fields.Lookup("mana");
-    TEST_EQ(mana->optional, has_null);
+    TEST_EQ(mana->IsOptional(), has_null);
   }
 
   // Test if nullable scalars are allowed for each language.


### PR DESCRIPTION
This should be "just a no-op refactoring" where we convert two booleans into an enum with 3 variants. It also centralizes logic around field presence which was previously spread out over many more lines.