### PR TITLE
[idl_parser] Track include files by absolute path

### DIFF
--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -407,7 +407,7 @@ int FlatCompiler::Compile(int argc, const char **argv) {
 
   for (auto file_it = filenames.begin(); file_it != filenames.end();
        ++file_it) {
-    auto &filename = *file_it;
+    auto filename = flatbuffers::AbsolutePath(*file_it);
     std::string contents;
     if (!flatbuffers::LoadFile(filename.c_str(), true, &contents))
       Error("unable to load file: " + filename);

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -3208,6 +3208,8 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
       }
       if (filepath.empty())
         return Error("unable to locate include file: " + name);
+      if (FileExists(filepath.c_str()))
+        filepath = flatbuffers::AbsolutePath(filepath);
       if (source_filename)
         files_included_per_file_[source_filename].insert(filepath);
       if (included_files_.find(filepath) == included_files_.end()) {


### PR DESCRIPTION
As found in #6425, the paths used as keys in included_files_ can end up
with relative elements inside of them (eg. ../b/../a/a.fbs). If the same
file is included via two path strings that don't compare equal, we try
to parse it twice, leading to errors.

Fix by converting filepath to an absolute path if it points to an actual
on-disk file. Fixes #6425.