### PR TITLE
[idl_parser] Validate `force_align` on all possible paths

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -330,6 +330,11 @@ typedef uintmax_t largest_scalar_t;
 // We support aligning the contents of buffers up to this size.
 #define FLATBUFFERS_MAX_ALIGNMENT 16
 
+inline bool VerifyAlignmentRequirements(size_t align, size_t min_align = 1) {
+  return (min_align <= align) && (align <= (FLATBUFFERS_MAX_ALIGNMENT)) &&
+         (align & (align - 1)) == 0;  // must be power of 2
+}
+
 #if defined(_MSC_VER)
   #pragma warning(disable: 4351) // C4351: new behavior: elements of array ... will be default initialized
   #pragma warning(push)

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1518,7 +1518,6 @@ class FlatBufferBuilder {
   // Aligns such that when "len" bytes are written, an object can be written
   // after it with "alignment" without padding.
   void PreAlign(size_t len, size_t alignment) {
-    FLATBUFFERS_ASSERT(VerifyAlignmentRequirements(alignment));
     TrackMinAlign(alignment);
     buf_.fill(PaddingBytes(GetSize() + len, alignment));
   }
@@ -1671,11 +1670,13 @@ class FlatBufferBuilder {
   // This is useful when storing a nested_flatbuffer in a vector of bytes,
   // or when storing SIMD floats, etc.
   void ForceVectorAlignment(size_t len, size_t elemsize, size_t alignment) {
+    FLATBUFFERS_ASSERT(VerifyAlignmentRequirements(alignment));
     PreAlign(len * elemsize, alignment);
   }
 
   // Similar to ForceVectorAlignment but for String fields.
   void ForceStringAlignment(size_t len, size_t alignment) {
+    FLATBUFFERS_ASSERT(VerifyAlignmentRequirements(alignment));
     PreAlign((len + 1) * sizeof(char), alignment);
   }
 

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1518,6 +1518,7 @@ class FlatBufferBuilder {
   // Aligns such that when "len" bytes are written, an object can be written
   // after it with "alignment" without padding.
   void PreAlign(size_t len, size_t alignment) {
+    FLATBUFFERS_ASSERT(VerifyAlignmentRequirements(alignment));
     TrackMinAlign(alignment);
     buf_.fill(PaddingBytes(GetSize() + len, alignment));
   }

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -967,6 +967,8 @@ class Parser : public ParserState {
   FLATBUFFERS_CHECKED_ERROR CheckClash(std::vector<FieldDef *> &fields,
                                        StructDef *struct_def,
                                        const char *suffix, BaseType baseType);
+  FLATBUFFERS_CHECKED_ERROR ParseAlignAttribute(
+      const std::string &align_constant, size_t min_align, size_t *align);
 
   bool SupportsAdvancedUnionFeatures() const;
   bool SupportsAdvancedArrayFeatures() const;

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -335,7 +335,8 @@ inline bool StringToFloatImpl(T *val, const char *const str) {
 // - If the converted value falls out of range of corresponding return type, a
 // range error occurs. In this case value MAX(T)/MIN(T) is returned.
 template<typename T> inline bool StringToNumber(const char *s, T *val) {
-  // Assert with size_t that is a distinguish unsigned 64-bit type on Mac.
+  // Assert on `unsigned long` and `signed long` on LP64.
+  // If it is necessary, it could be solved with flatbuffers::enable_if<B,T>.
   static_assert(sizeof(T) < sizeof(int64_t), "unexpected type T");
   FLATBUFFERS_ASSERT(s && val);
   int64_t i64;

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -335,6 +335,8 @@ inline bool StringToFloatImpl(T *val, const char *const str) {
 // - If the converted value falls out of range of corresponding return type, a
 // range error occurs. In this case value MAX(T)/MIN(T) is returned.
 template<typename T> inline bool StringToNumber(const char *s, T *val) {
+  // Assert with size_t that is a distinguish unsigned 64-bit type on Mac.
+  static_assert(sizeof(T) < sizeof(int64_t), "unexpected type T");
   FLATBUFFERS_ASSERT(s && val);
   int64_t i64;
   // The errno check isn't needed, will return MAX/MIN on overflow.

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1460,8 +1460,8 @@ void SimpleQsort(T *begin, T *end, size_t width, F comparator, S swapper) {
 
 CheckedError Parser::ParseAlignAttribute(const std::string &align_constant,
                                          size_t min_align, size_t *align) {
-  // Use small temporary to avoid possible problems with size_t on Mac.
-  size_t align_value;
+  // Use uint8_t to avoid problems with size_t==`unsigned long` on LP64.
+  uint8_t align_value;
   if (StringToNumber(align_constant.c_str(), &align_value) &&
       VerifyAlignmentRequirements(static_cast<size_t>(align_value),
                                   min_align)) {

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1461,7 +1461,7 @@ void SimpleQsort(T *begin, T *end, size_t width, F comparator, S swapper) {
 CheckedError Parser::ParseAlignAttribute(const std::string &align_constant,
                                          size_t min_align, size_t *align) {
   // Use small temporary to avoid possible problems with size_t on Mac.
-  uint8_t align_value;
+  size_t align_value;
   if (StringToNumber(align_constant.c_str(), &align_value) &&
       VerifyAlignmentRequirements(static_cast<size_t>(align_value),
                                   min_align)) {


### PR DESCRIPTION
- added validation of `force_align` for `Vector`.
- added assertion to `flatbuffers::PreAlign` method

These changes should resolve following oss-fuzz issues:
- 6275816289861632
- 5713529908887552
- 4761242994606080