### PR TITLE
[fuzzer] Limit parser_fuzzer execution time

### DIFF
--- a/tests/fuzzer/flatbuffers_monster_fuzzer.cc
+++ b/tests/fuzzer/flatbuffers_monster_fuzzer.cc
@@ -35,7 +35,7 @@ static fs::path exe_path_;
 namespace {
 
 static constexpr size_t kMinInputLength = 1;
-static constexpr size_t kMaxInputLength = 99000;
+static constexpr size_t kMaxInputLength = 16384;
 
 static constexpr uint8_t flags_strict_json = 0x80;
 static constexpr uint8_t flags_skip_unexpected_fields_in_json = 0x40;

--- a/tests/fuzzer/flatbuffers_parser_fuzzer.cc
+++ b/tests/fuzzer/flatbuffers_parser_fuzzer.cc
@@ -10,7 +10,7 @@
 #include "test_init.h"
 
 static constexpr size_t kMinInputLength = 1;
-static constexpr size_t kMaxInputLength = 33000;
+static constexpr size_t kMaxInputLength = 16384;
 
 static constexpr uint8_t flags_strict_json = 0x80;
 static constexpr uint8_t flags_skip_unexpected_fields_in_json = 0x40;


### PR DESCRIPTION
Limit the length of the fuzzer input to 16384 characters to prevent timeout
in JSON parser (Vector of tables with key).

Related oss-fuzz issue: 5742497110294528
