### PR TITLE
[idl_parser] Add kTokenNumericConstant token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ yarn-error.log
 **/vendor
 **/go.sum
 /tests/**/*.js
+flatbuffers.pc

--- a/flatbuffers.pc
+++ b/flatbuffers.pc
@@ -1,9 +1,0 @@
-libdir=/usr/local/lib
-includedir=/usr/local/include
-
-Name: FlatBuffers
-Description: Memory Efficient Serialization Library
-Version: 1.12.0
-
-Libs: -L${libdir} -lflatbuffers
-Cflags: -I${includedir}

--- a/tests/generate_code.bat
+++ b/tests/generate_code.bat
@@ -74,7 +74,7 @@ if NOT "%MONSTER_EXTRA%"=="skip" (
   @echo monster_extra.fbs skipped (the strtod function from MSVC2013 or older doesn't support NaN/Inf arguments)
 )
 
-set TEST_CPP17_FLAGS=--cpp --cpp-std c++17 -o ./cpp17/generated_cpp17 %TEST_NOINCL_FLAGS%
+set TEST_CPP17_FLAGS=--cpp --cpp-std c++17 --cpp-static-reflection -o ./cpp17/generated_cpp17 %TEST_NOINCL_FLAGS%
 if NOT "%MONSTER_EXTRA%"=="skip" (
   @rem Flag c++17 requires Clang6, GCC7, MSVC2017 (_MSC_VER >= 1914)  or higher.
   ..\%buildtype%\flatc.exe %TEST_CPP17_FLAGS% -I include_test monster_test.fbs  || goto FAIL

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1694,6 +1694,9 @@ void ErrorTest() {
   TestError("table X { y: [int] = [1]; }", "Expected `]`");
   TestError("table X { y: [int] = [; }", "Expected `]`");
   TestError("table X { y: [int] = \"\"; }", "type mismatch");
+  // An identifier can't start from sign (+|-)
+  TestError("table X { -Y: int; } root_type Y: {Y:1.0}", "identifier");
+  TestError("table X { +Y: int; } root_type Y: {Y:1.0}", "identifier");
 }
 
 template<typename T>
@@ -2028,6 +2031,8 @@ void ValidFloatTest() {
   TEST_EQ(std::isnan(TestValue<double>("{ y:nan }", "double")), true);
   TEST_EQ(std::isnan(TestValue<float>("{ y:nan }", "float")), true);
   TEST_EQ(std::isnan(TestValue<float>("{ y:\"nan\" }", "float")), true);
+  TEST_EQ(std::isnan(TestValue<float>("{ y:\"+nan\" }", "float")), true);
+  TEST_EQ(std::isnan(TestValue<float>("{ y:\"-nan\" }", "float")), true);
   TEST_EQ(std::isnan(TestValue<float>("{ y:+nan }", "float")), true);
   TEST_EQ(std::isnan(TestValue<float>("{ y:-nan }", "float")), true);
   TEST_EQ(std::isnan(TestValue<float>(nullptr, "float=nan")), true);
@@ -2035,6 +2040,8 @@ void ValidFloatTest() {
   // check inf
   TEST_EQ(TestValue<float>("{ y:inf }", "float"), infinity_f);
   TEST_EQ(TestValue<float>("{ y:\"inf\" }", "float"), infinity_f);
+  TEST_EQ(TestValue<float>("{ y:\"-inf\" }", "float"), -infinity_f);
+  TEST_EQ(TestValue<float>("{ y:\"+inf\" }", "float"), infinity_f);
   TEST_EQ(TestValue<float>("{ y:+inf }", "float"), infinity_f);
   TEST_EQ(TestValue<float>("{ y:-inf }", "float"), -infinity_f);
   TEST_EQ(TestValue<float>(nullptr, "float=inf"), infinity_f);
@@ -3779,6 +3786,26 @@ void FieldIdentifierTest() {
   TEST_EQ(true, Parser().Parse("union X{} table T{ u: X; }"));
 }
 
+void ParseIncorrectMonsterJsonTest() {
+  std::string schemafile;
+  TEST_EQ(flatbuffers::LoadFile((test_data_path + "monster_test.bfbs").c_str(),
+                                true, &schemafile),
+          true);
+  // parse schema first, so we can use it to parse the data after
+  flatbuffers::Parser parser;
+  flatbuffers::Verifier verifier(
+      reinterpret_cast<const uint8_t *>(schemafile.c_str()), schemafile.size());
+  TEST_EQ(reflection::VerifySchemaBuffer(verifier), true);
+  // auto schema = reflection::GetSchema(schemafile.c_str());
+  TEST_EQ(parser.Deserialize((const uint8_t *)schemafile.c_str(),
+                             schemafile.size()),
+          true);
+
+  TEST_EQ(parser.ParseJson(""), false);
+  TEST_EQ(parser.ParseJson("{name:-f}"), false);
+  TEST_EQ(parser.ParseJson("{name:+f}"), false);
+}
+
 int FlatBufferTests() {
   // clang-format off
 
@@ -3873,6 +3900,7 @@ int FlatBufferTests() {
   FixedLengthArrayConstructorTest();
   FieldIdentifierTest();
   StringVectorDefaultsTest();
+  ParseIncorrectMonsterJsonTest();
   return 0;
 }
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -3796,17 +3796,18 @@ void ParseIncorrectMonsterJsonTest() {
   TEST_EQ(flatbuffers::LoadFile((test_data_path + "monster_test.bfbs").c_str(),
                                 true, &schemafile),
           true);
-  // parse schema first, so we can use it to parse the data after
   flatbuffers::Parser parser;
   flatbuffers::Verifier verifier(
       reinterpret_cast<const uint8_t *>(schemafile.c_str()), schemafile.size());
   TEST_EQ(reflection::VerifySchemaBuffer(verifier), true);
-  // auto schema = reflection::GetSchema(schemafile.c_str());
   TEST_EQ(parser.Deserialize((const uint8_t *)schemafile.c_str(),
                              schemafile.size()),
           true);
-
+  TEST_EQ(parser.ParseJson("{name:\"monster\"}"), true);
   TEST_EQ(parser.ParseJson(""), false);
+  TEST_EQ(parser.ParseJson("{name: 1}"), false);
+  TEST_EQ(parser.ParseJson("{name:+1}"), false);
+  TEST_EQ(parser.ParseJson("{name:-1}"), false);
   TEST_EQ(parser.ParseJson("{name:-f}"), false);
   TEST_EQ(parser.ParseJson("{name:+f}"), false);
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -3784,6 +3784,11 @@ void FieldIdentifierTest() {
   // Positive tests for unions
   TEST_EQ(true, Parser().Parse("union X{} table T{ u: X (id:1); }"));
   TEST_EQ(true, Parser().Parse("union X{} table T{ u: X; }"));
+  // Test using 'inf' and 'nan' words both as identifiers and as default values.
+  TEST_EQ(true, Parser().Parse("table T{ inf: float = inf; }"));
+  TEST_EQ(true, Parser().Parse("table T{ nan: float = inf; }"));
+  TEST_EQ(true, Parser().Parse("table T{ nan: string; }"));
+  TEST_EQ(true, Parser().Parse("table T{ inf: string; }"));
 }
 
 void ParseIncorrectMonsterJsonTest() {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -3785,10 +3785,12 @@ void FieldIdentifierTest() {
   TEST_EQ(true, Parser().Parse("union X{} table T{ u: X (id:1); }"));
   TEST_EQ(true, Parser().Parse("union X{} table T{ u: X; }"));
   // Test using 'inf' and 'nan' words both as identifiers and as default values.
-  TEST_EQ(true, Parser().Parse("table T{ inf: float = inf; }"));
-  TEST_EQ(true, Parser().Parse("table T{ nan: float = inf; }"));
   TEST_EQ(true, Parser().Parse("table T{ nan: string; }"));
   TEST_EQ(true, Parser().Parse("table T{ inf: string; }"));
+#if defined(FLATBUFFERS_HAS_NEW_STRTOD) && (FLATBUFFERS_HAS_NEW_STRTOD > 0)
+  TEST_EQ(true, Parser().Parse("table T{ inf: float = inf; }"));
+  TEST_EQ(true, Parser().Parse("table T{ nan: float = inf; }"));
+#endif
 }
 
 void ParseIncorrectMonsterJsonTest() {


### PR DESCRIPTION
This commit adds the new token for correct parsing of signed numeric constants.
Before this expressions `-nan` or `-inf` were treated as `kTokenStringConstant`. This was ambiguous if a real string field parsed.
For example, `{ "text_field" : -name }` was accepted by the parser as valid JSON object.

Related oss-fuzz issue: 6200301176619008
