### PR TITLE
[TS/JS] Fix TS code gen after #6420

### DIFF
--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -1489,7 +1489,7 @@ class TsGenerator : public BaseGenerator {
            it != struct_def.fields.vec.end(); ++it) {
         auto &field = **it;
         if (!field.deprecated && field.IsRequired()) {
-          code += "  builder.IsRequired()Field(offset, ";
+          code += "  builder.requiredField(offset, ";
           code += NumToString(field.value.offset);
           code += ") // " + field.name + "\n";
         }

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -170,9 +170,6 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) StructInNestedNS FLATBUFFERS_FINAL_CLASS 
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return StructInNestedNSTypeTable();
   }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.NamespaceB.StructInNestedNS";
-  }
   StructInNestedNS()
       : a_(0),
         b_(0) {
@@ -209,9 +206,6 @@ inline bool operator!=(const StructInNestedNS &lhs, const StructInNestedNS &rhs)
 
 struct TableInNestedNST : public flatbuffers::NativeTable {
   typedef TableInNestedNS TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.NamespaceB.TableInNestedNST";
-  }
   int32_t foo = 0;
 };
 
@@ -230,9 +224,6 @@ struct TableInNestedNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TableInNestedNSBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInNestedNSTypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.NamespaceB.TableInNestedNS";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_FOO = 4

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -59,9 +59,6 @@ inline const flatbuffers::TypeTable *SecondTableInATypeTable();
 
 struct TableInFirstNST : public flatbuffers::NativeTable {
   typedef TableInFirstNS TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.TableInFirstNST";
-  }
   flatbuffers::unique_ptr<NamespaceA::NamespaceB::TableInNestedNST> foo_table{};
   NamespaceA::NamespaceB::EnumInNestedNS foo_enum = NamespaceA::NamespaceB::EnumInNestedNS_A;
   NamespaceA::NamespaceB::UnionInNestedNSUnion foo_union{};
@@ -86,9 +83,6 @@ struct TableInFirstNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TableInFirstNSBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInFirstNSTypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.TableInFirstNS";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_FOO_TABLE = 4,
@@ -202,9 +196,6 @@ namespace NamespaceC {
 
 struct TableInCT : public flatbuffers::NativeTable {
   typedef TableInC TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceC.TableInCT";
-  }
   flatbuffers::unique_ptr<NamespaceA::TableInFirstNST> refer_to_a1{};
   flatbuffers::unique_ptr<NamespaceA::SecondTableInAT> refer_to_a2{};
 };
@@ -225,9 +216,6 @@ struct TableInC FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TableInCBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInCTypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceC.TableInC";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_REFER_TO_A1 = 4,
@@ -297,9 +285,6 @@ namespace NamespaceA {
 
 struct SecondTableInAT : public flatbuffers::NativeTable {
   typedef SecondTableInA TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.SecondTableInAT";
-  }
   flatbuffers::unique_ptr<NamespaceC::TableInCT> refer_to_c{};
 };
 
@@ -318,9 +303,6 @@ struct SecondTableInA FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef SecondTableInABuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return SecondTableInATypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.SecondTableInA";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_REFER_TO_C = 4

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -202,9 +202,6 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Rapunzel FLATBUFFERS_FINAL_CLASS {
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return RapunzelTypeTable();
   }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "Rapunzel";
-  }
   Rapunzel()
       : hair_length_(0) {
   }
@@ -238,9 +235,6 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) BookReader FLATBUFFERS_FINAL_CLASS {
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return BookReaderTypeTable();
   }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "BookReader";
-  }
   BookReader()
       : books_read_(0) {
   }
@@ -268,9 +262,6 @@ inline bool operator!=(const BookReader &lhs, const BookReader &rhs) {
 
 struct AttackerT : public flatbuffers::NativeTable {
   typedef Attacker TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "AttackerT";
-  }
   int32_t sword_attack_damage = 0;
 };
 
@@ -289,9 +280,6 @@ struct Attacker FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef AttackerBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return AttackerTypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "Attacker";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_SWORD_ATTACK_DAMAGE = 4
@@ -342,9 +330,6 @@ flatbuffers::Offset<Attacker> CreateAttacker(flatbuffers::FlatBufferBuilder &_fb
 
 struct MovieT : public flatbuffers::NativeTable {
   typedef Movie TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "MovieT";
-  }
   CharacterUnion main_character{};
   std::vector<CharacterUnion> characters{};
 };
@@ -365,9 +350,6 @@ struct Movie FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MovieBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return MovieTypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "Movie";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_MAIN_CHARACTER_TYPE = 4,


### PR DESCRIPTION
This PR fixes a code gen problem introduced in #6420. The generated code for "endXXStruct()" doesn't compile. I assume that there was a regexp used to replace `.required` by `.IsRequired`. It was also applied incorrectly to `builder.requiredField`.

To test it I did:
```
make
npm install
npm run test
```

It seem the `make` run did modifications to some generated `.h` files that are totally unrelated to my fix. I suspect that these were not correctly regenerated by a previous PR. I included those changes as a separate commit. Tell me if you want to drop this commit.

Also when I do `cd test, sh generate_code.sh` the changes on the `.h` are reverted and a whole lot of new `.js|.ts|.d.ts` files are created at the root of the `tests` directory and not in the `tests/ts` directory (which already contains the same files). Is that supposed to happen ? Please tell me what to do.