### PR TITLE
[TS/JS] Add support for creating vectors from typed arrays

### DIFF
--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -1489,7 +1489,7 @@ class TsGenerator : public BaseGenerator {
            it != struct_def.fields.vec.end(); ++it) {
         auto &field = **it;
         if (!field.deprecated && field.IsRequired()) {
-          code += "  builder.IsRequired()Field(offset, ";
+          code += "  builder.requiredField(offset, ";
           code += NumToString(field.value.offset);
           code += ") // " + field.name + "\n";
         }

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -170,9 +170,6 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) StructInNestedNS FLATBUFFERS_FINAL_CLASS 
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return StructInNestedNSTypeTable();
   }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.NamespaceB.StructInNestedNS";
-  }
   StructInNestedNS()
       : a_(0),
         b_(0) {
@@ -209,9 +206,6 @@ inline bool operator!=(const StructInNestedNS &lhs, const StructInNestedNS &rhs)
 
 struct TableInNestedNST : public flatbuffers::NativeTable {
   typedef TableInNestedNS TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.NamespaceB.TableInNestedNST";
-  }
   int32_t foo = 0;
 };
 
@@ -230,9 +224,6 @@ struct TableInNestedNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TableInNestedNSBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInNestedNSTypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.NamespaceB.TableInNestedNS";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_FOO = 4

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -59,9 +59,6 @@ inline const flatbuffers::TypeTable *SecondTableInATypeTable();
 
 struct TableInFirstNST : public flatbuffers::NativeTable {
   typedef TableInFirstNS TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.TableInFirstNST";
-  }
   flatbuffers::unique_ptr<NamespaceA::NamespaceB::TableInNestedNST> foo_table{};
   NamespaceA::NamespaceB::EnumInNestedNS foo_enum = NamespaceA::NamespaceB::EnumInNestedNS_A;
   NamespaceA::NamespaceB::UnionInNestedNSUnion foo_union{};
@@ -86,9 +83,6 @@ struct TableInFirstNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TableInFirstNSBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInFirstNSTypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.TableInFirstNS";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_FOO_TABLE = 4,
@@ -202,9 +196,6 @@ namespace NamespaceC {
 
 struct TableInCT : public flatbuffers::NativeTable {
   typedef TableInC TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceC.TableInCT";
-  }
   flatbuffers::unique_ptr<NamespaceA::TableInFirstNST> refer_to_a1{};
   flatbuffers::unique_ptr<NamespaceA::SecondTableInAT> refer_to_a2{};
 };
@@ -225,9 +216,6 @@ struct TableInC FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef TableInCBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return TableInCTypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceC.TableInC";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_REFER_TO_A1 = 4,
@@ -297,9 +285,6 @@ namespace NamespaceA {
 
 struct SecondTableInAT : public flatbuffers::NativeTable {
   typedef SecondTableInA TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.SecondTableInAT";
-  }
   flatbuffers::unique_ptr<NamespaceC::TableInCT> refer_to_c{};
 };
 
@@ -318,9 +303,6 @@ struct SecondTableInA FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef SecondTableInABuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return SecondTableInATypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "NamespaceA.SecondTableInA";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_REFER_TO_C = 4

--- a/tests/ts/movie.ts
+++ b/tests/ts/movie.ts
@@ -87,7 +87,7 @@ static addCharactersType(builder:flatbuffers.Builder, charactersTypeOffset:flatb
 
 static createCharactersTypeVector(builder:flatbuffers.Builder, data:Character[]):flatbuffers.Offset {
   builder.startVector(1, data.length, 1);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addInt8(data[i]);
   }
   return builder.endVector();
@@ -103,7 +103,7 @@ static addCharacters(builder:flatbuffers.Builder, charactersOffset:flatbuffers.O
 
 static createCharactersVector(builder:flatbuffers.Builder, data:flatbuffers.Offset[]):flatbuffers.Offset {
   builder.startVector(4, data.length, 4);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addOffset(data[i]);
   }
   return builder.endVector();

--- a/tests/ts/my-game/example/monster.ts
+++ b/tests/ts/my-game/example/monster.ts
@@ -675,11 +675,7 @@ static addInventory(builder:flatbuffers.Builder, inventoryOffset:flatbuffers.Off
 }
 
 static createInventoryVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
-  builder.startVector(1, data.length, 1);
-  for (let i = data.length - 1; i >= 0; i--) {
-    builder.addInt8(data[i]);
-  }
-  return builder.endVector();
+  return builder.createUint8Vector(data);
 }
 
 static startInventoryVector(builder:flatbuffers.Builder, numElems:number) {
@@ -712,7 +708,7 @@ static addTestarrayofstring(builder:flatbuffers.Builder, testarrayofstringOffset
 
 static createTestarrayofstringVector(builder:flatbuffers.Builder, data:flatbuffers.Offset[]):flatbuffers.Offset {
   builder.startVector(4, data.length, 4);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addOffset(data[i]);
   }
   return builder.endVector();
@@ -728,7 +724,7 @@ static addTestarrayoftables(builder:flatbuffers.Builder, testarrayoftablesOffset
 
 static createTestarrayoftablesVector(builder:flatbuffers.Builder, data:flatbuffers.Offset[]):flatbuffers.Offset {
   builder.startVector(4, data.length, 4);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addOffset(data[i]);
   }
   return builder.endVector();
@@ -747,11 +743,7 @@ static addTestnestedflatbuffer(builder:flatbuffers.Builder, testnestedflatbuffer
 }
 
 static createTestnestedflatbufferVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
-  builder.startVector(1, data.length, 1);
-  for (let i = data.length - 1; i >= 0; i--) {
-    builder.addInt8(data[i]);
-  }
-  return builder.endVector();
+  return builder.createUint8Vector(data);
 }
 
 static startTestnestedflatbufferVector(builder:flatbuffers.Builder, numElems:number) {
@@ -804,7 +796,7 @@ static addTestarrayofbools(builder:flatbuffers.Builder, testarrayofboolsOffset:f
 
 static createTestarrayofboolsVector(builder:flatbuffers.Builder, data:boolean[]):flatbuffers.Offset {
   builder.startVector(1, data.length, 1);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addInt8(+data[i]);
   }
   return builder.endVector();
@@ -832,7 +824,7 @@ static addTestarrayofstring2(builder:flatbuffers.Builder, testarrayofstring2Offs
 
 static createTestarrayofstring2Vector(builder:flatbuffers.Builder, data:flatbuffers.Offset[]):flatbuffers.Offset {
   builder.startVector(4, data.length, 4);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addOffset(data[i]);
   }
   return builder.endVector();
@@ -855,11 +847,7 @@ static addFlex(builder:flatbuffers.Builder, flexOffset:flatbuffers.Offset) {
 }
 
 static createFlexVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
-  builder.startVector(1, data.length, 1);
-  for (let i = data.length - 1; i >= 0; i--) {
-    builder.addInt8(data[i]);
-  }
-  return builder.endVector();
+  return builder.createUint8Vector(data);
 }
 
 static startFlexVector(builder:flatbuffers.Builder, numElems:number) {
@@ -880,7 +868,7 @@ static addVectorOfLongs(builder:flatbuffers.Builder, vectorOfLongsOffset:flatbuf
 
 static createVectorOfLongsVector(builder:flatbuffers.Builder, data:flatbuffers.Long[]):flatbuffers.Offset {
   builder.startVector(8, data.length, 8);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addInt64(data[i]);
   }
   return builder.endVector();
@@ -894,17 +882,8 @@ static addVectorOfDoubles(builder:flatbuffers.Builder, vectorOfDoublesOffset:fla
   builder.addFieldOffset(33, vectorOfDoublesOffset, 0);
 }
 
-static createVectorOfDoublesVector(builder:flatbuffers.Builder, data:number[]|Float64Array):flatbuffers.Offset;
-/**
- * @deprecated This Uint8Array overload will be removed in the future.
- */
-static createVectorOfDoublesVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset;
-static createVectorOfDoublesVector(builder:flatbuffers.Builder, data:number[]|Float64Array|Uint8Array):flatbuffers.Offset {
-  builder.startVector(8, data.length, 8);
-  for (let i = data.length - 1; i >= 0; i--) {
-    builder.addFloat64(data[i]);
-  }
-  return builder.endVector();
+static createVectorOfDoublesVector(builder:flatbuffers.Builder, data:number[]|Float64Array):flatbuffers.Offset {
+  return builder.createFloat64Vector(data);
 }
 
 static startVectorOfDoublesVector(builder:flatbuffers.Builder, numElems:number) {
@@ -921,7 +900,7 @@ static addVectorOfReferrables(builder:flatbuffers.Builder, vectorOfReferrablesOf
 
 static createVectorOfReferrablesVector(builder:flatbuffers.Builder, data:flatbuffers.Offset[]):flatbuffers.Offset {
   builder.startVector(4, data.length, 4);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addOffset(data[i]);
   }
   return builder.endVector();
@@ -941,7 +920,7 @@ static addVectorOfWeakReferences(builder:flatbuffers.Builder, vectorOfWeakRefere
 
 static createVectorOfWeakReferencesVector(builder:flatbuffers.Builder, data:flatbuffers.Long[]):flatbuffers.Offset {
   builder.startVector(8, data.length, 8);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addInt64(data[i]);
   }
   return builder.endVector();
@@ -957,7 +936,7 @@ static addVectorOfStrongReferrables(builder:flatbuffers.Builder, vectorOfStrongR
 
 static createVectorOfStrongReferrablesVector(builder:flatbuffers.Builder, data:flatbuffers.Offset[]):flatbuffers.Offset {
   builder.startVector(4, data.length, 4);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addOffset(data[i]);
   }
   return builder.endVector();
@@ -977,7 +956,7 @@ static addVectorOfCoOwningReferences(builder:flatbuffers.Builder, vectorOfCoOwni
 
 static createVectorOfCoOwningReferencesVector(builder:flatbuffers.Builder, data:flatbuffers.Long[]):flatbuffers.Offset {
   builder.startVector(8, data.length, 8);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addInt64(data[i]);
   }
   return builder.endVector();
@@ -997,7 +976,7 @@ static addVectorOfNonOwningReferences(builder:flatbuffers.Builder, vectorOfNonOw
 
 static createVectorOfNonOwningReferencesVector(builder:flatbuffers.Builder, data:flatbuffers.Long[]):flatbuffers.Offset {
   builder.startVector(8, data.length, 8);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addInt64(data[i]);
   }
   return builder.endVector();
@@ -1028,11 +1007,7 @@ static addVectorOfEnums(builder:flatbuffers.Builder, vectorOfEnumsOffset:flatbuf
 }
 
 static createVectorOfEnumsVector(builder:flatbuffers.Builder, data:Color[]):flatbuffers.Offset {
-  builder.startVector(1, data.length, 1);
-  for (let i = data.length - 1; i >= 0; i--) {
-    builder.addInt8(data[i]);
-  }
-  return builder.endVector();
+  return builder.createUint8Vector(data);
 }
 
 static startVectorOfEnumsVector(builder:flatbuffers.Builder, numElems:number) {
@@ -1048,11 +1023,7 @@ static addTestrequirednestedflatbuffer(builder:flatbuffers.Builder, testrequired
 }
 
 static createTestrequirednestedflatbufferVector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset {
-  builder.startVector(1, data.length, 1);
-  for (let i = data.length - 1; i >= 0; i--) {
-    builder.addInt8(data[i]);
-  }
-  return builder.endVector();
+  return builder.createUint8Vector(data);
 }
 
 static startTestrequirednestedflatbufferVector(builder:flatbuffers.Builder, numElems:number) {
@@ -1065,7 +1036,7 @@ static addScalarKeySortedTables(builder:flatbuffers.Builder, scalarKeySortedTabl
 
 static createScalarKeySortedTablesVector(builder:flatbuffers.Builder, data:flatbuffers.Offset[]):flatbuffers.Offset {
   builder.startVector(4, data.length, 4);
-  for (let i = data.length - 1; i >= 0; i--) {
+  for (var i = data.length - 1; i >= 0; i--) {
     builder.addOffset(data[i]);
   }
   return builder.endVector();

--- a/tests/ts/my-game/example/type-aliases.ts
+++ b/tests/ts/my-game/example/type-aliases.ts
@@ -264,17 +264,8 @@ static addV8(builder:flatbuffers.Builder, v8Offset:flatbuffers.Offset) {
   builder.addFieldOffset(10, v8Offset, 0);
 }
 
-static createV8Vector(builder:flatbuffers.Builder, data:number[]|Int8Array):flatbuffers.Offset;
-/**
- * @deprecated This Uint8Array overload will be removed in the future.
- */
-static createV8Vector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset;
-static createV8Vector(builder:flatbuffers.Builder, data:number[]|Int8Array|Uint8Array):flatbuffers.Offset {
-  builder.startVector(1, data.length, 1);
-  for (let i = data.length - 1; i >= 0; i--) {
-    builder.addInt8(data[i]);
-  }
-  return builder.endVector();
+static createV8Vector(builder:flatbuffers.Builder, data:number[]|Int8Array):flatbuffers.Offset {
+  return builder.createInt8Vector(data);
 }
 
 static startV8Vector(builder:flatbuffers.Builder, numElems:number) {
@@ -285,17 +276,8 @@ static addVf64(builder:flatbuffers.Builder, vf64Offset:flatbuffers.Offset) {
   builder.addFieldOffset(11, vf64Offset, 0);
 }
 
-static createVf64Vector(builder:flatbuffers.Builder, data:number[]|Float64Array):flatbuffers.Offset;
-/**
- * @deprecated This Uint8Array overload will be removed in the future.
- */
-static createVf64Vector(builder:flatbuffers.Builder, data:number[]|Uint8Array):flatbuffers.Offset;
-static createVf64Vector(builder:flatbuffers.Builder, data:number[]|Float64Array|Uint8Array):flatbuffers.Offset {
-  builder.startVector(8, data.length, 8);
-  for (let i = data.length - 1; i >= 0; i--) {
-    builder.addFloat64(data[i]);
-  }
-  return builder.endVector();
+static createVf64Vector(builder:flatbuffers.Builder, data:number[]|Float64Array):flatbuffers.Offset {
+  return builder.createFloat64Vector(data);
 }
 
 static startVf64Vector(builder:flatbuffers.Builder, numElems:number) {

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -202,9 +202,6 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Rapunzel FLATBUFFERS_FINAL_CLASS {
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return RapunzelTypeTable();
   }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "Rapunzel";
-  }
   Rapunzel()
       : hair_length_(0) {
   }
@@ -238,9 +235,6 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) BookReader FLATBUFFERS_FINAL_CLASS {
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return BookReaderTypeTable();
   }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "BookReader";
-  }
   BookReader()
       : books_read_(0) {
   }
@@ -268,9 +262,6 @@ inline bool operator!=(const BookReader &lhs, const BookReader &rhs) {
 
 struct AttackerT : public flatbuffers::NativeTable {
   typedef Attacker TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "AttackerT";
-  }
   int32_t sword_attack_damage = 0;
 };
 
@@ -289,9 +280,6 @@ struct Attacker FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef AttackerBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return AttackerTypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "Attacker";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_SWORD_ATTACK_DAMAGE = 4
@@ -342,9 +330,6 @@ flatbuffers::Offset<Attacker> CreateAttacker(flatbuffers::FlatBufferBuilder &_fb
 
 struct MovieT : public flatbuffers::NativeTable {
   typedef Movie TableType;
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "MovieT";
-  }
   CharacterUnion main_character{};
   std::vector<CharacterUnion> characters{};
 };
@@ -365,9 +350,6 @@ struct Movie FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef MovieBuilder Builder;
   static const flatbuffers::TypeTable *MiniReflectTypeTable() {
     return MovieTypeTable();
-  }
-  static FLATBUFFERS_CONSTEXPR const char *GetFullyQualifiedName() {
-    return "Movie";
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_MAIN_CHARACTER_TYPE = 4,

--- a/ts/byte-buffer.ts
+++ b/ts/byte-buffer.ts
@@ -146,7 +146,11 @@ export class ByteBuffer {
       this.writeInt32(offset, int32[isLittleEndian ? 0 : 1]);
       this.writeInt32(offset + 4, int32[isLittleEndian ? 1 : 0]);
     }
-  
+
+    writeBytes(offset: number, bytes: ArrayBuffer, length: number) {
+      this.bytes_.set(new Uint8Array(bytes, 0, length), offset)
+    }
+
     /**
      * Return the file identifier.   Behavior is undefined for FlatBuffers whose
      * schema does not include a file_identifier (likely points at padding or the


### PR DESCRIPTION
This commit add support for creating vectors directly from in-memory JavaScript typed arrays (`Int8Array`, `Uint8Array`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float32Array` and `Float64Array`).

There was already support for reading directly to typed arrays. This brings the counterpart for writing.

This commit also removes the invalid `Uint8Array` overloads. These overloads were invalid as they enabled a TypeScript user to pass a `Uint8Array` to the generated methods which were in turn iterating on the array content as if they were normal numbers.

Summary of changes:
* add support for typed array factory methods in `builder.ts`
* add corresponding support in `idl_gen_ts.cpp`
* remove invalid `Uint8Array` overloads in `idl_gen_ts.cpp`

This PR is based on #6445 which fixed a code gen bug after #6420.