### PR TITLE
[CMake] generate pkg-config flatbuffers.pc file

### DIFF
--- a/CMake/flatbuffers.pc.in
+++ b/CMake/flatbuffers.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: FlatBuffers
+Description: Memory Efficient Serialization Library
+Version: @VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@
+
+Libs: -L${libdir} -lflatbuffers
+Cflags: -I${includedir}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -629,6 +629,14 @@ if(FLATBUFFERS_INSTALL)
       DESTINATION ${FB_CMAKE_DIR}
     )
   endif()
+
+  if(FLATBUFFERS_BUILD_SHAREDLIB OR FLATBUFFERS_BUILD_FLATLIB)
+      configure_file(CMake/flatbuffers.pc.in flatbuffers.pc @ONLY)
+      install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers.pc"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+      )
+  endif()
 endif()
 
 if(FLATBUFFERS_BUILD_TESTS)


### PR DESCRIPTION
This PR enables CMake to generate a `flatbuffers.pc` file on install, so end users can find the flatbuffers library.

[pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) eases the utilization of software libraries by enabling the developers of a library to define how the library should be used.

It can be used as a tool by build systems to find and manage dependencies, this is notably the default [Meson](https://mesonbuild.com/) behavior and optionally used by CMake.

---

I Tested that the generated `flatbuffers.pc` was valid:
- On the supplied commit 322a90d0
  - By manually building/installing flatbuffers via Cmake, in a shell with `cmake-3.14.5`, then inspecting `flatbuffers.pc` manually.
  - In a Nix setup where flatbuffers is used by my external library — flatbuffers is found by Meson via pkg-config. Everything builds/runs correctly.
- On top of last release v1.12.0, applying only 7e4124d6 and 322a90d0 as patches
  - In a Nix setup where flatbuffers is used by my external library — flatbuffers is found by Meson via pkg-config. Everything builds/runs correctly.
