### PR TITLE
[Swift] Fixes typo in docs

### DIFF
--- a/docs/source/Tutorial.md
+++ b/docs/source/Tutorial.md
@@ -1434,7 +1434,7 @@ for the `path` field above:
   for i in obj {
     _ = create(struct: i)
   }
-  let points = fbb.endVectorOfStructs(count: size)
+  let points = fbb.endVector(len: size)
 ~~~
 </div>
 


### PR DESCRIPTION
The pr fixing a typo in the PR where we still used `endVectorOfStructs` instead the normal `endVector`