### PR TITLE
[Swift] Renaming protocols

### DIFF
--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -187,7 +187,7 @@ class SwiftGenerator : public BaseGenerator {
     GenComment(struct_def.doc_comment);
     code_.SetValue("STRUCTNAME", NameWrappedInNameSpace(struct_def));
     code_ += "{{ACCESS_TYPE}} struct {{STRUCTNAME}}: NativeStruct\\";
-    if (parser_.opts.generate_object_based_api) code_ += ", UnionObject\\";
+    if (parser_.opts.generate_object_based_api) code_ += ", NativeObject\\";
     code_ += " {";
     code_ += "";
     Indent();
@@ -410,7 +410,7 @@ class SwiftGenerator : public BaseGenerator {
     code_ +=
         "{{ACCESS_TYPE}} struct {{STRUCTNAME}}{{MUTABLE}}: FlatBufferObject\\";
     if (!struct_def.fixed && parser_.opts.generate_object_based_api)
-      code_ += ", ObjectAPI\\";
+      code_ += ", ObjectAPIPacker\\";
     code_ += " {\n";
     Indent();
     code_ += ValidateFunc();
@@ -871,8 +871,8 @@ class SwiftGenerator : public BaseGenerator {
       code_ += "{{ACCESS_TYPE}} struct {{ENUM_NAME}}Union {";
       Indent();
       code_ += "{{ACCESS_TYPE}} var type: {{ENUM_NAME}}";
-      code_ += "{{ACCESS_TYPE}} var value: UnionObject?";
-      code_ += "{{ACCESS_TYPE}} init(_ v: UnionObject?, type: {{ENUM_NAME}}) {";
+      code_ += "{{ACCESS_TYPE}} var value: NativeObject?";
+      code_ += "{{ACCESS_TYPE}} init(_ v: NativeObject?, type: {{ENUM_NAME}}) {";
       Indent();
       code_ += "self.type = type";
       code_ += "self.value = v";
@@ -944,7 +944,7 @@ class SwiftGenerator : public BaseGenerator {
 
   void GenObjectAPI(const StructDef &struct_def) {
     code_ += "{{ACCESS_TYPE}} class " + ObjectAPIName("{{STRUCTNAME}}") +
-             ": UnionObject {\n";
+             ": NativeObject {\n";
     std::vector<std::string> buffer_constructor;
     std::vector<std::string> base_constructor;
     Indent();

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -872,7 +872,8 @@ class SwiftGenerator : public BaseGenerator {
       Indent();
       code_ += "{{ACCESS_TYPE}} var type: {{ENUM_NAME}}";
       code_ += "{{ACCESS_TYPE}} var value: NativeObject?";
-      code_ += "{{ACCESS_TYPE}} init(_ v: NativeObject?, type: {{ENUM_NAME}}) {";
+      code_ +=
+          "{{ACCESS_TYPE}} init(_ v: NativeObject?, type: {{ENUM_NAME}}) {";
       Indent();
       code_ += "self.type = type";
       code_ += "self.value = v";

--- a/swift/Sources/FlatBuffers/FlatBufferObject.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferObject.swift
@@ -26,7 +26,7 @@ public protocol FlatBufferObject {
   init(_ bb: ByteBuffer, o: Int32)
 }
 
-public protocol ObjectAPI {
+public protocol ObjectAPIPacker {
   associatedtype T
   static func pack(_ builder: inout FlatBufferBuilder, obj: inout T) -> Offset<UOffset>
   mutating func unpack() -> T

--- a/swift/Sources/FlatBuffers/NativeObject.swift
+++ b/swift/Sources/FlatBuffers/NativeObject.swift
@@ -16,14 +16,14 @@
 
 import Foundation
 
-public protocol UnionObject {}
+public protocol NativeObject {}
 
-extension UnionObject {
+extension NativeObject {
 
   /// Serialize is a helper function that serailizes the data from the Object API to a bytebuffer directly th
   /// - Parameter type: Type of the Flatbuffer object
   /// - Returns: returns the encoded sized ByteBuffer
-  public func serialize<T: ObjectAPI>(type: T.Type) -> ByteBuffer where T.T == Self {
+  public func serialize<T: ObjectAPIPacker>(type: T.Type) -> ByteBuffer where T.T == Self {
     var builder = FlatBufferBuilder(initialSize: 1024)
     return serialize(builder: &builder, type: type.self)
   }
@@ -36,7 +36,7 @@ extension UnionObject {
   /// - Returns: returns the encoded sized ByteBuffer
   /// - Note: The `serialize(builder:type)` can be considered as a function that allows you to create smaller builder instead of the default `1024`.
   ///  It can be considered less expensive in terms of memory allocation
-  public func serialize<T: ObjectAPI>(builder: inout FlatBufferBuilder, type: T.Type) -> ByteBuffer where T.T == Self {
+  public func serialize<T: ObjectAPIPacker>(builder: inout FlatBufferBuilder, type: T.Type) -> ByteBuffer where T.T == Self {
     var s = self
     let root = type.pack(&builder, obj: &s)
     builder.finish(offset: root)

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
@@ -51,8 +51,8 @@ public enum MyGame_Example_Any_: UInt8, Enum {
 
 public struct MyGame_Example_Any_Union {
   public var type: MyGame_Example_Any_
-  public var value: UnionObject?
-  public init(_ v: UnionObject?, type: MyGame_Example_Any_) {
+  public var value: NativeObject?
+  public init(_ v: NativeObject?, type: MyGame_Example_Any_) {
     self.type = type
     self.value = v
   }
@@ -87,8 +87,8 @@ public enum MyGame_Example_AnyUniqueAliases: UInt8, Enum {
 
 public struct MyGame_Example_AnyUniqueAliasesUnion {
   public var type: MyGame_Example_AnyUniqueAliases
-  public var value: UnionObject?
-  public init(_ v: UnionObject?, type: MyGame_Example_AnyUniqueAliases) {
+  public var value: NativeObject?
+  public init(_ v: NativeObject?, type: MyGame_Example_AnyUniqueAliases) {
     self.type = type
     self.value = v
   }
@@ -123,8 +123,8 @@ public enum MyGame_Example_AnyAmbiguousAliases: UInt8, Enum {
 
 public struct MyGame_Example_AnyAmbiguousAliasesUnion {
   public var type: MyGame_Example_AnyAmbiguousAliases
-  public var value: UnionObject?
-  public init(_ v: UnionObject?, type: MyGame_Example_AnyAmbiguousAliases) {
+  public var value: NativeObject?
+  public init(_ v: NativeObject?, type: MyGame_Example_AnyAmbiguousAliases) {
     self.type = type
     self.value = v
   }
@@ -143,7 +143,7 @@ public struct MyGame_Example_AnyAmbiguousAliasesUnion {
     }
   }
 }
-public struct MyGame_Example_Test: NativeStruct, UnionObject {
+public struct MyGame_Example_Test: NativeStruct, NativeObject {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
 
@@ -197,7 +197,7 @@ public struct MyGame_Example_Test_Mutable: FlatBufferObject {
   }
 }
 
-public struct MyGame_Example_Vec3: NativeStruct, UnionObject {
+public struct MyGame_Example_Vec3: NativeStruct, NativeObject {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
 
@@ -281,7 +281,7 @@ public struct MyGame_Example_Vec3_Mutable: FlatBufferObject {
   }
 }
 
-public struct MyGame_Example_Ability: NativeStruct, UnionObject {
+public struct MyGame_Example_Ability: NativeStruct, NativeObject {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
 
@@ -334,7 +334,7 @@ public struct MyGame_Example_Ability_Mutable: FlatBufferObject {
   }
 }
 
-public struct MyGame_InParentNamespace: FlatBufferObject, ObjectAPI {
+public struct MyGame_InParentNamespace: FlatBufferObject, ObjectAPIPacker {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -364,7 +364,7 @@ public struct MyGame_InParentNamespace: FlatBufferObject, ObjectAPI {
   }
 }
 
-public class MyGame_InParentNamespaceT: UnionObject {
+public class MyGame_InParentNamespaceT: NativeObject {
 
 
   public init(_ _t: inout MyGame_InParentNamespace) {
@@ -376,7 +376,7 @@ public class MyGame_InParentNamespaceT: UnionObject {
   public func serialize() -> ByteBuffer { return serialize(type: MyGame_InParentNamespace.self) }
 
 }
-public struct MyGame_Example2_Monster: FlatBufferObject, ObjectAPI {
+public struct MyGame_Example2_Monster: FlatBufferObject, ObjectAPIPacker {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -406,7 +406,7 @@ public struct MyGame_Example2_Monster: FlatBufferObject, ObjectAPI {
   }
 }
 
-public class MyGame_Example2_MonsterT: UnionObject {
+public class MyGame_Example2_MonsterT: NativeObject {
 
 
   public init(_ _t: inout MyGame_Example2_Monster) {
@@ -418,7 +418,7 @@ public class MyGame_Example2_MonsterT: UnionObject {
   public func serialize() -> ByteBuffer { return serialize(type: MyGame_Example2_Monster.self) }
 
 }
-internal struct MyGame_Example_TestSimpleTableWithEnum: FlatBufferObject, ObjectAPI {
+internal struct MyGame_Example_TestSimpleTableWithEnum: FlatBufferObject, ObjectAPIPacker {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
   internal var __buffer: ByteBuffer! { return _accessor.bb }
@@ -466,7 +466,7 @@ internal struct MyGame_Example_TestSimpleTableWithEnum: FlatBufferObject, Object
   }
 }
 
-internal class MyGame_Example_TestSimpleTableWithEnumT: UnionObject {
+internal class MyGame_Example_TestSimpleTableWithEnumT: NativeObject {
 
   internal var color: MyGame_Example_Color
 
@@ -481,7 +481,7 @@ internal class MyGame_Example_TestSimpleTableWithEnumT: UnionObject {
   internal func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_TestSimpleTableWithEnum.self) }
 
 }
-public struct MyGame_Example_Stat: FlatBufferObject, ObjectAPI {
+public struct MyGame_Example_Stat: FlatBufferObject, ObjectAPIPacker {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -574,7 +574,7 @@ public struct MyGame_Example_Stat: FlatBufferObject, ObjectAPI {
   }
 }
 
-public class MyGame_Example_StatT: UnionObject {
+public class MyGame_Example_StatT: NativeObject {
 
   public var id: String?
   public var val: Int64
@@ -594,7 +594,7 @@ public class MyGame_Example_StatT: UnionObject {
   public func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_Stat.self) }
 
 }
-public struct MyGame_Example_Referrable: FlatBufferObject, ObjectAPI {
+public struct MyGame_Example_Referrable: FlatBufferObject, ObjectAPIPacker {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -666,7 +666,7 @@ public struct MyGame_Example_Referrable: FlatBufferObject, ObjectAPI {
   }
 }
 
-public class MyGame_Example_ReferrableT: UnionObject {
+public class MyGame_Example_ReferrableT: NativeObject {
 
   public var id: UInt64
 
@@ -682,7 +682,7 @@ public class MyGame_Example_ReferrableT: UnionObject {
 
 }
 ///  an example documentation comment: "monster object"
-public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPI {
+public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1195,7 +1195,7 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPI {
   }
 }
 
-public class MyGame_Example_MonsterT: UnionObject {
+public class MyGame_Example_MonsterT: NativeObject {
 
   public var pos: MyGame_Example_Vec3?
   public var mana: Int16
@@ -1445,7 +1445,7 @@ public class MyGame_Example_MonsterT: UnionObject {
   public func serialize() -> ByteBuffer { return serialize(type: MyGame_Example_Monster.self) }
 
 }
-public struct MyGame_Example_TypeAliases: FlatBufferObject, ObjectAPI {
+public struct MyGame_Example_TypeAliases: FlatBufferObject, ObjectAPIPacker {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1576,7 +1576,7 @@ public struct MyGame_Example_TypeAliases: FlatBufferObject, ObjectAPI {
   }
 }
 
-public class MyGame_Example_TypeAliasesT: UnionObject {
+public class MyGame_Example_TypeAliasesT: NativeObject {
 
   public var i8: Int8
   public var u8: UInt8

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
@@ -23,8 +23,8 @@ public enum Character: UInt8, Enum {
 
 public struct CharacterUnion {
   public var type: Character
-  public var value: UnionObject?
-  public init(_ v: UnionObject?, type: Character) {
+  public var value: NativeObject?
+  public init(_ v: NativeObject?, type: Character) {
     self.type = type
     self.value = v
   }
@@ -46,7 +46,7 @@ public struct CharacterUnion {
     }
   }
 }
-public struct Rapunzel: NativeStruct, UnionObject {
+public struct Rapunzel: NativeStruct, NativeObject {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
 
@@ -92,7 +92,7 @@ public struct Rapunzel_Mutable: FlatBufferObject {
   }
 }
 
-public struct BookReader: NativeStruct, UnionObject {
+public struct BookReader: NativeStruct, NativeObject {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
 
@@ -138,7 +138,7 @@ public struct BookReader_Mutable: FlatBufferObject {
   }
 }
 
-public struct Attacker: FlatBufferObject, ObjectAPI {
+public struct Attacker: FlatBufferObject, ObjectAPIPacker {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -186,7 +186,7 @@ public struct Attacker: FlatBufferObject, ObjectAPI {
   }
 }
 
-public class AttackerT: UnionObject {
+public class AttackerT: NativeObject {
 
   public var swordAttackDamage: Int32
 
@@ -201,7 +201,7 @@ public class AttackerT: UnionObject {
   public func serialize() -> ByteBuffer { return serialize(type: Attacker.self) }
 
 }
-public struct Movie: FlatBufferObject, ObjectAPI {
+public struct Movie: FlatBufferObject, ObjectAPIPacker {
 
   static func validateVersion() { FlatBuffersVersion_1_12_0() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -279,7 +279,7 @@ public struct Movie: FlatBufferObject, ObjectAPI {
   }
 }
 
-public class MovieT: UnionObject {
+public class MovieT: NativeObject {
 
   public var mainCharacter: CharacterUnion?
   public var characters: [CharacterUnion?]


### PR DESCRIPTION
This Pr changes the names of some protocols to reflect what they currently do: 
- `ObjectAPI` -> `ObjectAPIPacker`: packs and unpacks ObjectApi
- `UnionObject` -> `NativeObject`: Since unions are being treated separately now, we can change it to be called NativeObject