### PR TITLE
Fix a typo in Swift codegen

### DIFF
--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -591,7 +591,8 @@ class SwiftGenerator : public BaseGenerator {
     if (IsStruct(field.value.type)) {
       auto create_struct =
           "guard let {{VALUENAME}} = {{VALUENAME}} else { return };"
-          " fbb.create(struct: {{VALUENAME}}, position: {{TABLEOFFSET}}.{{OFFSET}}.p) }";
+          " fbb.create(struct: {{VALUENAME}}, position: "
+          "{{TABLEOFFSET}}.{{OFFSET}}.p) }";
       code_ += type + "?" + builder_string + create_struct;
       /// Optional hard coded since structs are always optional
       create_func_header.push_back(name + ": " + type + "? = nil");

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -590,8 +590,8 @@ class SwiftGenerator : public BaseGenerator {
 
     if (IsStruct(field.value.type)) {
       auto create_struct =
-          "guard let pos = pos else { return };"
-          " fbb.create(struct: pos, position: {{TABLEOFFSET}}.{{OFFSET}}.p) }";
+          "guard let {{VALUENAME}} = {{VALUENAME}} else { return };"
+          " fbb.create(struct: {{VALUENAME}}, position: {{TABLEOFFSET}}.{{OFFSET}}.p) }";
       code_ += type + "?" + builder_string + create_struct;
       /// Optional hard coded since structs are always optional
       create_func_header.push_back(name + ": " + type + "? = nil");


### PR DESCRIPTION
The Swift codegen introduced a bug since https://github.com/google/flatbuffers/commit/4e79d129cb9018fdf6584cc1fef6a8d2db41715e where it uses a fixed name (pos) rather than the actual VALUENAME. This PR fixed the said issue.
