### PR TITLE
Update Building.md

### DIFF
--- a/docs/source/Building.md
+++ b/docs/source/Building.md
@@ -45,7 +45,7 @@ It is possible to cancel `warnings as errors` flag at `cmake` configuration stag
 appended to the project-level `CMAKE_CXX_FLAGS` variable.
 Examples:
 
-- GCC and Clang: `cmake . -D FLATBUFFERS_CXX_FLAGS="Wno-error"`
+- GCC and Clang: `cmake . -D FLATBUFFERS_CXX_FLAGS="-Wno-error"`
 - MSVC: `cmake . -D FLATBUFFERS_CXX_FLAGS="/WX-"`
 - MSVC: `cmake . -D FLATBUFFERS_CXX_FLAGS="/Wv <compiler.version>"`
 


### PR DESCRIPTION
`cmake . -D FLATBUFFERS_CXX_FLAGS="Wno-error"` returns an error (file 'Wno-error' not found).