### PR TITLE
Flex Blobs accept nullptr, resulting in buffer resizing.

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -920,6 +920,12 @@ class Builder FLATBUFFERS_FINAL_CLASS {
     return buf_;
   }
 
+  /// @brief Get the serializing buffer, which is in-progress. This is a footgun.
+  /// @return Returns a vector owned by this class.
+  const std::vector<uint8_t> &GetUnfinishedBuffer() const {
+    return buf_;
+  }
+
   // Size of the buffer. Does not include unfinished values.
   size_t GetSize() const { return buf_.size(); }
 

--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -1335,6 +1335,10 @@ class Builder FLATBUFFERS_FINAL_CLASS {
     finished_ = true;
   }
 
+  void ExtendBuffer(size_t size) {
+    buf_.resize(buf_.size() + size);
+  }
+
  private:
   void Finished() const {
     // If you get this assert, you're attempting to get access a buffer
@@ -1496,7 +1500,11 @@ class Builder FLATBUFFERS_FINAL_CLASS {
     auto byte_width = Align(bit_width);
     Write<uint64_t>(len, byte_width);
     auto sloc = buf_.size();
-    WriteBytes(data, len + trailing);
+    if (data != nullptr) {
+      WriteBytes(data, len + trailing);
+    } else {
+      ExtendBuffer(len + trailing);
+    }
     stack_.push_back(Value(static_cast<uint64_t>(sloc), type, bit_width));
     return sloc;
   }


### PR DESCRIPTION
With this change, Flex Blobs can now be created with nullptr as their first parameter. If that parameter is NOT nullptr, then everything works as before. If it IS nullptr, then the underlying buffer is resized according to the desired length.

This permits an important optimization for 0-copy and working with expression template libraries, such as xtensor: now we can allocate such a Blob without having an intermediate value of the expression template result, and later evaluate the expression template directly into the blob memory. This means that we don't require the allocation of intermediate containers, just so we can then copy the bytes: we instead evaluate expressions directly into the Blob. This can be achieved by simply getting Blob's data, casting away const, and aiming at foot.
