### PR TITLE
[idl_parser, JSON] Disable parsing of JSON for incomplete schemes

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -3189,6 +3189,9 @@ CheckedError Parser::ParseRoot(const char *source, const char **include_paths,
       }
     }
   }
+  // Parse JSON object only if the scheme has been parsed.
+  if (token_ == '{') { ECHECK(DoParseJson()); }
+  EXPECT(kTokenEof);
   return NoError();
 }
 
@@ -3287,7 +3290,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
     } else if (IsIdent("namespace")) {
       ECHECK(ParseNamespace());
     } else if (token_ == '{') {
-      ECHECK(DoParseJson());
+      return NoError();
     } else if (IsIdent("enum")) {
       ECHECK(ParseEnum(false, nullptr));
     } else if (IsIdent("union")) {


### PR DESCRIPTION
This commit disable JSON parsing for an incomplete scheme if JSON object is embedded into one file with the scheme.
This should improve the quality of OSS-Fuzz inputs for the `parser_fuzzer` target.
