### PR TITLE
Disable x64-specific optimizations for ARM64EC ReadInt64

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -155,7 +155,7 @@ inline uint64_t ReadUInt64(const uint8_t *data, uint8_t byte_width) {
   // constant, which here it isn't. Test if memcpy is still faster than
   // the conditionals in ReadSizedScalar. Can also use inline asm.
   // clang-format off
-  #if defined(_MSC_VER) && (defined(_M_X64) || defined _M_IX86)
+  #if defined(_MSC_VER) && ((defined(_M_X64) && !defined(_M_ARM64EC)) || defined _M_IX86)
     uint64_t u = 0;
     __movsb(reinterpret_cast<uint8_t *>(&u),
             reinterpret_cast<const uint8_t *>(data), byte_width);


### PR DESCRIPTION
ARM64EC is a new ARM64 ABI designed by Microsoft to support x64 application emulation on ARM64 CPUs. When compiling for ARM64EC, both the _M_X64 and _M_ARM64EC macros are defined. However, that causes problem in compiling this file, because the __movsb intrinsic, which is lowered to rep movsb, is not supported on ARM64, so the optimization for native x64 should be disabled for ARM64EC.