### PR TITLE
Remove `flatbuffers.pc` from the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ yarn-error.log
 **/vendor
 **/go.sum
 /tests/**/*.js
+flatbuffers.pc

--- a/flatbuffers.pc
+++ b/flatbuffers.pc
@@ -1,9 +1,0 @@
-libdir=/usr/local/lib
-includedir=/usr/local/include
-
-Name: FlatBuffers
-Description: Memory Efficient Serialization Library
-Version: 1.12.0
-
-Libs: -L${libdir} -lflatbuffers
-Cflags: -I${includedir}


### PR DESCRIPTION
The file `flatbuffers.pc` was added to the repository by accident  (#6495).
Related issue: #6455
