### PR TITLE
[fuzzer] Add `monster_debug` target

### DIFF
--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -175,4 +175,16 @@ if(BUILD_DEBUGGER)
     scalar_debug.cpp
   )
   target_link_libraries(scalar_debug PRIVATE flatbuffers_nonfuzz)
+
+  add_executable(monster_debug
+    flatbuffers_monster_fuzzer.cc
+    monster_debug.cpp
+  )
+  target_link_libraries(monster_debug PRIVATE flatbuffers_nonfuzz)
+  add_custom_command(
+    TARGET monster_debug PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_SOURCE_DIR}/../monster_test.bfbs
+    ${CMAKE_CURRENT_BINARY_DIR}/monster_test.bfbs)
+  
 endif(BUILD_DEBUGGER)

--- a/tests/fuzzer/fuzzer_assert.h
+++ b/tests/fuzzer/fuzzer_assert.h
@@ -1,9 +1,14 @@
 #ifndef FUZZER_ASSERT_IMPL_H_
 #define FUZZER_ASSERT_IMPL_H_
 
+#if defined(_MSC_VER)
+extern "C" void __debugbreak();
+#define __builtin_trap __debugbreak
+#else // Clang
+extern "C" void __builtin_trap(void);
+#endif
+
 // Declare Debug/Release independed assert macro.
 #define fuzzer_assert_impl(x) (!!(x) ? static_cast<void>(0) : __builtin_trap())
-
-extern "C" void __builtin_trap(void);
 
 #endif // !FUZZER_ASSERT_IMPL_H_

--- a/tests/fuzzer/monster_debug.cpp
+++ b/tests/fuzzer/monster_debug.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <assert.h>
+
+#include "flatbuffers/util.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    std::cerr << "Usage: monster_debug <path to fuzzer crash file>\n";
+    return 0;
+  }
+  std::string crash_file_name(argv[1]);
+  std::string crash_file_data;
+  auto done =
+      flatbuffers::LoadFile(crash_file_name.c_str(), true, &crash_file_data);
+  if (!done) {
+    std::cerr << "Can not load file: '" << crash_file_name << "'";
+    return -1;
+  }
+  if (crash_file_data.size() < 3) {
+    std::cerr << "Invalid file data: '" << crash_file_data << "'";
+    return -2;
+  }
+  auto rc = LLVMFuzzerTestOneInput(
+      reinterpret_cast<const uint8_t *>(crash_file_data.data()),
+      crash_file_data.size());
+  std::cout << "LLVMFuzzerTestOneInput finished with code " << rc << "\n\n";
+  return rc;
+}


### PR DESCRIPTION
Add the `monster_debug` target for better troubleshooting.
Improve oss-fuzz logs.