### PR TITLE
[Kotlin] Bump kotlinx.benchmark dependency to 0.3.0

### DIFF
--- a/kotlin/benchmark/build.gradle.kts
+++ b/kotlin/benchmark/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.ir.backend.js.compile
 plugins {
   kotlin("multiplatform") version "1.4.20"
   id("org.jetbrains.kotlin.plugin.allopen") version "1.4.20"
-  id("kotlinx.benchmark") version "0.2.0-dev-20"
+  id("org.jetbrains.kotlinx.benchmark") version "0.3.0"
   id("io.morethan.jmhreport") version "0.9.0"
   id("de.undercouch.download") version "4.1.1"
 }
@@ -72,10 +72,9 @@ kotlin {
     }
     val jvmMain by getting {
       dependencies {
-        implementation("org.jetbrains.kotlinx:kotlinx.benchmark.runtime:0.2.0-dev-20")
+        implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.3.0")
         implementation(kotlin("stdlib-common"))
         implementation(project(":flatbuffers-kotlin"))
-        implementation("org.jetbrains.kotlinx:kotlinx.benchmark.runtime-jvm:0.2.0-dev-20")
         implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.1")
 

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -8,8 +8,6 @@ version = "1.12.0-SNAPSHOT"
 subprojects {
 
   repositories {
-    maven { setUrl("https://dl.bintray.com/kotlin/kotlinx") }
-    maven { setUrl("https://dl.bintray.com/kotlin/kotlin-dev") }
     maven { setUrl("https://plugins.gradle.org/m2/") }
     mavenCentral()
   }
@@ -17,7 +15,6 @@ subprojects {
 
 buildscript {
   repositories {
-    maven { setUrl("https://dl.bintray.com/kotlin/kotlin-dev") }
     maven { setUrl("https://plugins.gradle.org/m2/") }
     gradlePluginPortal()
     mavenCentral()

--- a/kotlin/settings.gradle
+++ b/kotlin/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
   repositories {
-    maven { url 'https://dl.bintray.com/kotlin/kotlinx' }
+    mavenCentral()
     gradlePluginPortal()
   }
 }


### PR DESCRIPTION
Kotlinx.benchmark project just abandoned bintray and moving to maven central,
removing the artifacts from bintray and causing missing dependencies in our build.
So we are updating the dependency to point to the new version on maven central.

More information in:

https://github.com/Kotlin/kotlinx-benchmark/commit/53ee45d0d914ceff111d3581ba3f5897fa897adc#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5
