### PR TITLE
chore: ensure bash is used to generate code

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Make sure you include the names of the affected language(s) in your PR title.
 This helps us get the correct maintainers to look at your issue.
 
 If you make changes to any of the code generators, be sure to run
-`cd tests && sh generate_code.sh` (or equivalent .bat) and include the generated
+`cd tests && bash generate_code.sh` (or equivalent .bat) and include the generated
 code changes in the PR. This allows us to better see the effect of the PR.
 
 If your PR includes C++ code, please adhere to the Google C++ Style Guide,


### PR DESCRIPTION
In some platforms, like Ubuntu, `sh` is linked to `dash` but not `bash`.
