### PR TITLE
[Rust] fix Miri flag passing

### DIFF
--- a/tests/RustTest.sh
+++ b/tests/RustTest.sh
@@ -63,5 +63,5 @@ fi
 # RUST_NIGHTLY environment variable set in dockerfile.
 if [[ $RUST_NIGHTLY == 1 ]]; then
   rustup +nightly component add miri
-  cargo +nightly miri test -- -Zmiri-disable-isolation
+  MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test
 fi


### PR DESCRIPTION
Miri flag passing changed a while ago and the compatibility code is [scheduled to be removed soon](https://github.com/rust-lang/miri/pull/1769). This ports the test suite to the new way of passing flags to Miri.

Cc @CasperN