### PR TITLE
[Rust] Fix small mistyping in a sample

### DIFF
--- a/samples/sample_binary.rs
+++ b/samples/sample_binary.rs
@@ -72,7 +72,7 @@ fn main() {
   // Create the monster using the `Monster::create` helper function. This
   // function accepts a `MonsterArgs` struct, which supplies all of the data
   // needed to build a `Monster`. To supply empty/default fields, just use the
-  // Rust built-in `Default::default()` function, as demononstrated below.
+  // Rust built-in `Default::default()` function, as demonstrated below.
   let orc = Monster::create(&mut builder, &MonsterArgs{
       pos: Some(&Vec3::new(1.0f32, 2.0f32, 3.0f32)),
       mana: 150,


### PR DESCRIPTION
Hi!

Just a veeeeeery small fix in the Rust sample. No functionality is affected.

That's not important at all but annoying for my eyes :)
