### PR TITLE
[Swift] Implements union strings

### DIFF
--- a/grpc/examples/swift/Greeter/Sources/Model/greeter_generated.swift
+++ b/grpc/examples/swift/Greeter/Sources/Model/greeter_generated.swift
@@ -24,12 +24,12 @@ public struct models_HelloReply: FlatBufferObject {
   public var message: String? { let o = _accessor.offset(VTOFFSET.message.v); return o == 0 ? nil : _accessor.string(at: o) }
   public var messageSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.message.v) }
   public static func startHelloReply(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
-  public static func add(message: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: message, at: VTOFFSET.message.p) }
-  public static func endHelloReply(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  public static func add(message: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: message, at: VTOFFSET.message.p) }
+  public static func endHelloReply(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createHelloReply(
     _ fbb: inout FlatBufferBuilder,
-    messageOffset message: Offset<String> = Offset()
-  ) -> Offset<UOffset> {
+    messageOffset message: Offset = Offset()
+  ) -> Offset {
     let __start = models_HelloReply.startHelloReply(&fbb)
     models_HelloReply.add(message: message, &fbb)
     return models_HelloReply.endHelloReply(&fbb, start: __start)
@@ -56,12 +56,12 @@ public struct models_HelloRequest: FlatBufferObject {
   public var name: String? { let o = _accessor.offset(VTOFFSET.name.v); return o == 0 ? nil : _accessor.string(at: o) }
   public var nameSegmentArray: [UInt8]? { return _accessor.getVector(at: VTOFFSET.name.v) }
   public static func startHelloRequest(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
-  public static func add(name: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: name, at: VTOFFSET.name.p) }
-  public static func endHelloRequest(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  public static func add(name: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: name, at: VTOFFSET.name.p) }
+  public static func endHelloRequest(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createHelloRequest(
     _ fbb: inout FlatBufferBuilder,
-    nameOffset name: Offset<String> = Offset()
-  ) -> Offset<UOffset> {
+    nameOffset name: Offset = Offset()
+  ) -> Offset {
     let __start = models_HelloRequest.startHelloRequest(&fbb)
     models_HelloRequest.add(name: name, &fbb)
     return models_HelloRequest.endHelloRequest(&fbb, start: __start)

--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -28,7 +28,7 @@ public struct FlatBufferBuilder {
   /// A check if the buffer is being written into by a different table
   private var isNested = false
   /// Dictonary that stores a map of all the strings that were written to the buffer
-  private var stringOffsetMap: [String: Offset<String>] = [:]
+  private var stringOffsetMap: [String: Offset] = [:]
   /// A check to see if finish(::) was ever called to retreive data object
   private var finished = false
   /// A check to see if the buffer should serialize Default values
@@ -107,7 +107,7 @@ public struct FlatBufferBuilder {
   /// - Parameters:
   ///   - table: offset for the table
   ///   - fields: Array of all the important fields to be serialized
-  mutating public func require(table: Offset<UOffset>, fields: [Int32]) {
+  mutating public func require(table: Offset, fields: [Int32]) {
     for field in fields {
       let start = _bb.capacity &- Int(table.o)
       let startTable = start &- Int(_bb.read(def: Int32.self, position: start))
@@ -121,7 +121,7 @@ public struct FlatBufferBuilder {
   ///   - offset: Offset of the table
   ///   - fileId: Takes the fileId
   ///   - prefix: if false it wont add the size of the buffer
-  mutating public func finish<T>(offset: Offset<T>, fileId: String, addPrefix prefix: Bool = false) {
+  mutating public func finish(offset: Offset, fileId: String, addPrefix prefix: Bool = false) {
     let size = MemoryLayout<UOffset>.size
     preAlign(len: size &+ (prefix ? size : 0) &+ FileIdLength, alignment: _minAlignment)
     assert(fileId.count == FileIdLength, "Flatbuffers requires file id to be 4")
@@ -133,7 +133,7 @@ public struct FlatBufferBuilder {
   /// - Parameters:
   ///   - offset: Offset of the table
   ///   - prefix: if false it wont add the size of the buffer
-  mutating public func finish<T>(offset: Offset<T>, addPrefix prefix: Bool = false) {
+  mutating public func finish(offset: Offset, addPrefix prefix: Bool = false) {
     notNested()
     let size = MemoryLayout<UOffset>.size
     preAlign(len: size &+ (prefix ? size : 0), alignment: _minAlignment)
@@ -296,7 +296,7 @@ public struct FlatBufferBuilder {
   ///
   /// The current function will fatalError if startVector is called before serializing the vector
   /// - Parameter len: Length of the buffer
-  mutating public func endVector(len: Int) -> Offset<UOffset> {
+  mutating public func endVector(len: Int) -> Offset {
     assert(isNested, "Calling endVector without calling startVector")
     isNested = false
     return Offset(offset: push(element: Int32(len)))
@@ -305,7 +305,7 @@ public struct FlatBufferBuilder {
   /// Creates a vector of type Scalar in the buffer
   /// - Parameter elements: elements to be written into the buffer
   /// - returns: Offset of the vector
-  mutating public func createVector<T: Scalar>(_ elements: [T]) -> Offset<UOffset> {
+  mutating public func createVector<T: Scalar>(_ elements: [T]) -> Offset {
     createVector(elements, size: elements.count)
   }
 
@@ -313,7 +313,7 @@ public struct FlatBufferBuilder {
   /// - Parameter elements: Elements to be written into the buffer
   /// - Parameter size: Count of elements
   /// - returns: Offset of the vector
-  mutating public func createVector<T: Scalar>(_ elements: [T], size: Int) -> Offset<UOffset> {
+  mutating public func createVector<T: Scalar>(_ elements: [T], size: Int) -> Offset {
     let size = size
     startVector(size, elementSize: MemoryLayout<T>.size)
     _bb.push(elements: elements)
@@ -323,7 +323,7 @@ public struct FlatBufferBuilder {
   /// Creates a vector of type Enums in the buffer
   /// - Parameter elements: elements to be written into the buffer
   /// - returns: Offset of the vector
-  mutating public func createVector<T: Enum>(_ elements: [T]) -> Offset<UOffset> {
+  mutating public func createVector<T: Enum>(_ elements: [T]) -> Offset {
     createVector(elements, size: elements.count)
   }
 
@@ -331,7 +331,7 @@ public struct FlatBufferBuilder {
   /// - Parameter elements: Elements to be written into the buffer
   /// - Parameter size: Count of elements
   /// - returns: Offset of the vector
-  mutating public func createVector<T: Enum>(_ elements: [T], size: Int) -> Offset<UOffset> {
+  mutating public func createVector<T: Enum>(_ elements: [T], size: Int) -> Offset {
     let size = size
     startVector(size, elementSize: T.byteSize)
     for e in elements.reversed() {
@@ -343,7 +343,7 @@ public struct FlatBufferBuilder {
   /// Creates a vector of type Offsets  in the buffer
   /// - Parameter offsets:Array of offsets of type T
   /// - returns: Offset of the vector
-  mutating public func createVector<T>(ofOffsets offsets: [Offset<T>]) -> Offset<UOffset> {
+  mutating public func createVector(ofOffsets offsets: [Offset]) -> Offset {
     createVector(ofOffsets: offsets, len: offsets.count)
   }
 
@@ -351,8 +351,8 @@ public struct FlatBufferBuilder {
   /// - Parameter elements: Array of offsets of type T
   /// - Parameter size: Count of elements
   /// - returns: Offset of the vector
-  mutating public func createVector<T>(ofOffsets offsets: [Offset<T>], len: Int) -> Offset<UOffset> {
-    startVector(len, elementSize: MemoryLayout<Offset<T>>.size)
+  mutating public func createVector(ofOffsets offsets: [Offset], len: Int) -> Offset {
+    startVector(len, elementSize: MemoryLayout<Offset>.size)
     for o in offsets.reversed() {
       push(element: o)
     }
@@ -362,8 +362,8 @@ public struct FlatBufferBuilder {
   /// Creates a vector of Strings
   /// - Parameter str: a vector of strings that will be written into the buffer
   /// - returns: Offset of the vector
-  mutating public func createVector(ofStrings str: [String]) -> Offset<UOffset> {
-    var offsets: [Offset<String>] = []
+  mutating public func createVector(ofStrings str: [String]) -> Offset {
+    var offsets: [Offset] = []
     for s in str {
       offsets.append(create(string: s))
     }
@@ -373,7 +373,7 @@ public struct FlatBufferBuilder {
   /// Creates a vector of `Native swift structs` which were padded to flatbuffers standards
   /// - Parameter structs: A vector of structs
   /// - Returns: offset of the vector
-  mutating public func createVector<T: NativeStruct>(ofStructs structs: [T]) -> Offset<UOffset> {
+  mutating public func createVector<T: NativeStruct>(ofStructs structs: [T]) -> Offset {
     startVector(structs.count * MemoryLayout<T>.size, elementSize: MemoryLayout<T>.alignment)
     for i in structs.reversed() {
       _ = create(struct: i)
@@ -390,7 +390,7 @@ public struct FlatBufferBuilder {
   /// - Returns: offset of written struct
   @discardableResult
   mutating public func create<T: NativeStruct>(
-    struct s: T, position: VOffset) -> Offset<UOffset>
+    struct s: T, position: VOffset) -> Offset
   {
     let offset = create(struct: s)
     _vtableStorage.add(loc: FieldLoc(offset: _bb.size, position: VOffset(position)))
@@ -403,7 +403,7 @@ public struct FlatBufferBuilder {
   /// - Returns: offset of written struct
   @discardableResult
   mutating public func create<T: NativeStruct>(
-    struct s: T) -> Offset<UOffset>
+    struct s: T) -> Offset
   {
     let size = MemoryLayout<T>.size
     preAlign(len: size, alignment: MemoryLayout<T>.alignment)
@@ -416,7 +416,7 @@ public struct FlatBufferBuilder {
   /// Insets a string into the buffer using UTF8
   /// - Parameter str: String to be serialized
   /// - returns: The strings offset in the buffer
-  mutating public func create(string str: String?) -> Offset<String> {
+  mutating public func create(string str: String?) -> Offset {
     guard let str = str else { return Offset() }
     let len = str.utf8.count
     notNested()
@@ -432,7 +432,7 @@ public struct FlatBufferBuilder {
   /// The function checks the stringOffsetmap if it's seen a similar string before
   /// - Parameter str: String to be serialized
   /// - returns: The strings offset in the buffer
-  mutating public func createShared(string str: String?) -> Offset<String> {
+  mutating public func createShared(string str: String?) -> Offset {
     guard let str = str else { return Offset() }
     if let offset = stringOffsetMap[str] {
       return offset
@@ -448,7 +448,7 @@ public struct FlatBufferBuilder {
   /// - Parameters:
   ///   - offset: Offset of another object to be written
   ///   - position: The  predefined position of the object
-  mutating public func add<T>(offset: Offset<T>, at position: VOffset) {
+  mutating public func add(offset: Offset, at position: VOffset) {
     if offset.isEmpty { return }
     add(element: refer(to: offset.o), def: 0, at: position)
   }
@@ -457,7 +457,7 @@ public struct FlatBufferBuilder {
   /// - Parameter o: Offset
   /// - returns: Position of the offset
   @discardableResult
-  mutating public func push<T>(element o: Offset<T>) -> UOffset {
+  mutating public func push(element o: Offset) -> UOffset {
     push(element: refer(to: o.o))
   }
 

--- a/swift/Sources/FlatBuffers/FlatBufferObject.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferObject.swift
@@ -20,15 +20,21 @@ import Foundation
 /// since now we will be serializing native structs into the buffer.
 public protocol NativeStruct {}
 
-/// FlatbufferObject structures all the Flatbuffers objects
-public protocol FlatBufferObject {
-  var __buffer: ByteBuffer! { get }
+/// FlatbuffersInitializable is a protocol that allows any object to be
+/// Initialized from a ByteBuffer
+public protocol FlatbuffersInitializable {
   init(_ bb: ByteBuffer, o: Int32)
+}
+
+/// FlatbufferObject structures all the Flatbuffers objects
+public protocol FlatBufferObject: FlatbuffersInitializable {
+  var __buffer: ByteBuffer! { get }
 }
 
 public protocol ObjectAPIPacker {
   associatedtype T
-  static func pack(_ builder: inout FlatBufferBuilder, obj: inout T) -> Offset<UOffset>
+  static func pack(_ builder: inout FlatBufferBuilder, obj: inout T?) -> Offset
+  static func pack(_ builder: inout FlatBufferBuilder, obj: inout T) -> Offset
   mutating func unpack() -> T
 }
 

--- a/swift/Sources/FlatBuffers/Offset.swift
+++ b/swift/Sources/FlatBuffers/Offset.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// Offset object for all the Objects that are written into the buffer
-public struct Offset<T> {
+public struct Offset {
   /// Offset of the object in the buffer
   public var o: UOffset
   /// Returns false if the offset is equal to zero

--- a/swift/Sources/FlatBuffers/String+extension.swift
+++ b/swift/Sources/FlatBuffers/String+extension.swift
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+extension String: FlatbuffersInitializable {
+
+  /// Initailizes a string from a Flatbuffers ByteBuffer
+  /// - Parameters:
+  ///   - bb: ByteBuffer containing the readable string
+  ///   - o: Current position
+  public init(_ bb: ByteBuffer, o: Int32) {
+    let count = bb.read(def: Int32.self, position: Int(o))
+    self = bb.readString(
+      at: Int32(MemoryLayout<Int32>.size) + o,
+      count: count) ?? ""
+  }
+}
+
+extension String: ObjectAPIPacker {
+
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout String?) -> Offset {
+    guard var obj = obj else { return Offset() }
+    return pack(&builder, obj: &obj)
+  }
+
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout String) -> Offset {
+    builder.create(string: obj)
+  }
+
+  public mutating func unpack() -> String {
+    self
+  }
+
+}
+
+extension String: NativeObject {
+
+  public func serialize<T: ObjectAPIPacker>(type: T.Type) -> ByteBuffer where T.T == Self {
+    fatalError("serialize should never be called from string directly")
+  }
+
+  public func serialize<T: ObjectAPIPacker>(builder: inout FlatBufferBuilder, type: T.Type) -> ByteBuffer where T.T == Self {
+    fatalError("serialize should never be called from string directly")
+  }
+}

--- a/swift/Sources/FlatBuffers/Table.swift
+++ b/swift/Sources/FlatBuffers/Table.swift
@@ -80,12 +80,12 @@ public struct Table {
     return r
   }
 
-  public func union<T: FlatBufferObject>(_ o: Int32) -> T {
+  public func union<T: FlatbuffersInitializable>(_ o: Int32) -> T {
     let o = o + postion
     return directUnion(o)
   }
 
-  public func directUnion<T: FlatBufferObject>(_ o: Int32) -> T {
+  public func directUnion<T: FlatbuffersInitializable>(_ o: Int32) -> T {
     T.init(bb, o: o + bb.read(def: Int32.self, position: Int(o)))
   }
 

--- a/tests/FlatBuffers.Benchmarks.swift/Sources/FlatBuffers.Benchmarks.swift/main.swift
+++ b/tests/FlatBuffers.Benchmarks.swift/Sources/FlatBuffers.Benchmarks.swift/main.swift
@@ -87,7 +87,7 @@ func benchmarkThreeMillionStructs() {
 
   var fb = FlatBufferBuilder(initialSize: Int32(rawSize * 1600))
 
-  var offsets: [Offset<UOffset>] = []
+  var offsets: [Offset] = []
   for _ in 0..<structCount {
     fb.startVector(5 * MemoryLayout<AA>.size, elementSize: MemoryLayout<AA>.alignment)
     for _ in 0..<5 {
@@ -96,12 +96,12 @@ func benchmarkThreeMillionStructs() {
     let vector = fb.endVector(len: 5)
     let start = fb.startTable(with: 1)
     fb.add(offset: vector, at: 4)
-    offsets.append(Offset<UOffset>(offset: fb.endTable(at: start)))
+    offsets.append(Offset(offset: fb.endTable(at: start)))
   }
   let vector = fb.createVector(ofOffsets: offsets)
   let start = fb.startTable(with: 1)
   fb.add(offset: vector, at: 4)
-  let root = Offset<UOffset>(offset: fb.endTable(at: start))
+  let root = Offset(offset: fb.endTable(at: start))
   fb.finish(offset: root)
 }
 

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
@@ -130,7 +130,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
   func createMonster(withPrefix prefix: Bool) -> FlatBufferBuilder {
     var fbb = FlatBufferBuilder(initialSize: 1)
     let names = [fbb.create(string: "Frodo"), fbb.create(string: "Barney"), fbb.create(string: "Wilma")]
-    var offsets: [Offset<UOffset>] = []
+    var offsets: [Offset] = []
     let start1 = Monster.startMonster(&fbb)
     Monster.add(name: names[0], &fbb)
     offsets.append(Monster.endMonster(&fbb, start: start1))

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersTests.swift
@@ -24,8 +24,8 @@ final class FlatBuffersTests: XCTestCase {
   func testEndian() { XCTAssertEqual(isLitteEndian, true) }
 
   func testOffset() {
-    let o = Offset<Int>()
-    let b = Offset<Int>(offset: 1)
+    let o = Offset()
+    let b = Offset(offset: 1)
     XCTAssertEqual(o.isEmpty, true)
     XCTAssertEqual(b.isEmpty, false)
   }
@@ -130,7 +130,7 @@ class Country {
     builder: inout FlatBufferBuilder,
     name: String,
     log: Int32,
-    lan: Int32) -> Offset<Country>
+    lan: Int32) -> Offset
   {
     createCountry(builder: &builder, offset: builder.create(string: name), log: log, lan: lan)
   }
@@ -138,9 +138,9 @@ class Country {
   @inlinable
   static func createCountry(
     builder: inout FlatBufferBuilder,
-    offset: Offset<String>,
+    offset: Offset,
     log: Int32,
-    lan: Int32) -> Offset<Country>
+    lan: Int32) -> Offset
   {
     let _start = builder.startTable(with: 3)
     Country.add(builder: &builder, lng: log)
@@ -150,7 +150,7 @@ class Country {
   }
 
   @inlinable
-  static func end(builder: inout FlatBufferBuilder, startOffset: UOffset) -> Offset<Country> {
+  static func end(builder: inout FlatBufferBuilder, startOffset: UOffset) -> Offset {
     Offset(offset: builder.endTable(at: startOffset))
   }
 
@@ -160,7 +160,7 @@ class Country {
   }
 
   @inlinable
-  static func add(builder: inout FlatBufferBuilder, name: Offset<String>) {
+  static func add(builder: inout FlatBufferBuilder, name: Offset) {
     builder.add(offset: name, at: Country.offsets.name)
   }
 

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersVectorsTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersVectorsTests.swift
@@ -109,23 +109,23 @@ struct Numbers {
   var vArrayDouble: [Double]? { __t.getVector(at: 4) }
   var vArrayFloat: [Float32]? { __t.getVector(at: 4) }
 
-  static func createNumbersVector(b: inout FlatBufferBuilder, array: [Int]) -> Offset<UOffset> {
+  static func createNumbersVector(b: inout FlatBufferBuilder, array: [Int]) -> Offset {
     b.createVector(array, size: array.count)
   }
 
-  static func createNumbersVector(b: inout FlatBufferBuilder, array: [Int32]) -> Offset<UOffset> {
+  static func createNumbersVector(b: inout FlatBufferBuilder, array: [Int32]) -> Offset {
     b.createVector(array, size: array.count)
   }
 
-  static func createNumbersVector(b: inout FlatBufferBuilder, array: [Double]) -> Offset<UOffset> {
+  static func createNumbersVector(b: inout FlatBufferBuilder, array: [Double]) -> Offset {
     b.createVector(array, size: array.count)
   }
 
-  static func createNumbersVector(b: inout FlatBufferBuilder, array: [Float32]) -> Offset<UOffset> {
+  static func createNumbersVector(b: inout FlatBufferBuilder, array: [Float32]) -> Offset {
     b.createVector(array, size: array.count)
   }
 
-  static func createNumbers(b: inout FlatBufferBuilder, o: Offset<UOffset>) -> Offset<UOffset> {
+  static func createNumbers(b: inout FlatBufferBuilder, o: Offset) -> Offset {
     let start = b.startTable(with: 1)
     b.add(offset: o, at: 4)
     return Offset(offset: b.endTable(at: start))

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatbuffersDoubleTests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/FlatbuffersDoubleTests.swift
@@ -55,16 +55,16 @@ class CountryDouble {
     builder: inout FlatBufferBuilder,
     name: String,
     log: Double,
-    lan: Double) -> Offset<Country>
+    lan: Double) -> Offset
   {
     createCountry(builder: &builder, offset: builder.create(string: name), log: log, lan: lan)
   }
 
   static func createCountry(
     builder: inout FlatBufferBuilder,
-    offset: Offset<String>,
+    offset: Offset,
     log: Double,
-    lan: Double) -> Offset<Country>
+    lan: Double) -> Offset
   {
     let _start = builder.startTable(with: 3)
     CountryDouble.add(builder: &builder, lng: log)
@@ -73,7 +73,7 @@ class CountryDouble {
     return CountryDouble.end(builder: &builder, startOffset: _start)
   }
 
-  static func end(builder: inout FlatBufferBuilder, startOffset: UOffset) -> Offset<Country> {
+  static func end(builder: inout FlatBufferBuilder, startOffset: UOffset) -> Offset {
     Offset(offset: builder.endTable(at: startOffset))
   }
 
@@ -81,7 +81,7 @@ class CountryDouble {
     add(builder: &builder, name: builder.create(string: name))
   }
 
-  static func add(builder: inout FlatBufferBuilder, name: Offset<String>) {
+  static func add(builder: inout FlatBufferBuilder, name: Offset) {
     builder.add(offset: name, at: Country.offsets.name)
   }
 

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/MutatingBool_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/MutatingBool_generated.swift
@@ -44,6 +44,6 @@ public struct TestMutatingBool: FlatBufferObject {
     public var mutableB: Property_Mutable? { let o = _accessor.offset(VTOFFSET.b.v); return o == 0 ? nil : Property_Mutable(_accessor.bb, o: o + _accessor.postion) }
     public static func startTestMutatingBool(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
     public static func add(b: Property?, _ fbb: inout FlatBufferBuilder) { guard let b = b else { return }; _ = fbb.create(struct: b, position: VTOFFSET.b.p) }
-    public static func endTestMutatingBool(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+    public static func endTestMutatingBool(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
 }
 

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/XCTestManifests.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/XCTestManifests.swift
@@ -88,6 +88,7 @@ extension FlatBuffersUnionTests {
     ("testCreateMonstor", testCreateMonstor),
     ("testEndTableFinish", testEndTableFinish),
     ("testEnumVector", testEnumVector),
+    ("testStringUnion", testStringUnion),
     ("testUnionVector", testUnionVector),
   ]
 }

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/monster_test_generated.swift
@@ -56,7 +56,7 @@ public struct MyGame_Example_Any_Union {
     self.type = type
     self.value = v
   }
-  public func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
+  public func pack(builder: inout FlatBufferBuilder) -> Offset {
     switch type {
     case .monster:
       var __obj = value as? MyGame_Example_MonsterT
@@ -92,7 +92,7 @@ public struct MyGame_Example_AnyUniqueAliasesUnion {
     self.type = type
     self.value = v
   }
-  public func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
+  public func pack(builder: inout FlatBufferBuilder) -> Offset {
     switch type {
     case .m:
       var __obj = value as? MyGame_Example_MonsterT
@@ -128,7 +128,7 @@ public struct MyGame_Example_AnyAmbiguousAliasesUnion {
     self.type = type
     self.value = v
   }
-  public func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
+  public func pack(builder: inout FlatBufferBuilder) -> Offset {
     switch type {
     case .m1:
       var __obj = value as? MyGame_Example_MonsterT
@@ -187,12 +187,12 @@ public struct MyGame_Example_Test_Mutable: FlatBufferObject {
   public mutating func unpack() -> MyGame_Example_Test {
     return MyGame_Example_Test(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Test?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Test?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Test) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Test) -> Offset {
     return builder.create(struct: obj)
   }
 }
@@ -271,12 +271,12 @@ public struct MyGame_Example_Vec3_Mutable: FlatBufferObject {
   public mutating func unpack() -> MyGame_Example_Vec3 {
     return MyGame_Example_Vec3(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Vec3?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Vec3?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Vec3) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Vec3) -> Offset {
     return builder.create(struct: obj)
   }
 }
@@ -324,12 +324,12 @@ public struct MyGame_Example_Ability_Mutable: FlatBufferObject {
   public mutating func unpack() -> MyGame_Example_Ability {
     return MyGame_Example_Ability(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Ability?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Ability?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Ability) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_Ability) -> Offset {
     return builder.create(struct: obj)
   }
 }
@@ -384,12 +384,12 @@ public struct MyGame_Example_StructOfStructs_Mutable: FlatBufferObject {
   public mutating func unpack() -> MyGame_Example_StructOfStructs {
     return MyGame_Example_StructOfStructs(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_StructOfStructs?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_StructOfStructs?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_StructOfStructs) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_StructOfStructs) -> Offset {
     return builder.create(struct: obj)
   }
 }
@@ -400,25 +400,25 @@ public struct MyGame_InParentNamespace: FlatBufferObject, ObjectAPIPacker {
   public var __buffer: ByteBuffer! { return _accessor.bb }
   private var _accessor: Table
 
-  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
   public static func getRootAsInParentNamespace(bb: ByteBuffer) -> MyGame_InParentNamespace { return MyGame_InParentNamespace(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
   private init(_ t: Table) { _accessor = t }
   public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
   public static func startInParentNamespace(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 0) }
-  public static func endInParentNamespace(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  public static func endInParentNamespace(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   
 
   public mutating func unpack() -> MyGame_InParentNamespaceT {
     return MyGame_InParentNamespaceT(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_InParentNamespaceT?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_InParentNamespaceT?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_InParentNamespaceT) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_InParentNamespaceT) -> Offset {
     let __root = MyGame_InParentNamespace.startInParentNamespace(&builder)
     return MyGame_InParentNamespace.endInParentNamespace(&builder, start: __root)
   }
@@ -442,25 +442,25 @@ public struct MyGame_Example2_Monster: FlatBufferObject, ObjectAPIPacker {
   public var __buffer: ByteBuffer! { return _accessor.bb }
   private var _accessor: Table
 
-  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
   public static func getRootAsMonster(bb: ByteBuffer) -> MyGame_Example2_Monster { return MyGame_Example2_Monster(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
   private init(_ t: Table) { _accessor = t }
   public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
   public static func startMonster(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 0) }
-  public static func endMonster(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  public static func endMonster(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   
 
   public mutating func unpack() -> MyGame_Example2_MonsterT {
     return MyGame_Example2_MonsterT(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example2_MonsterT?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example2_MonsterT?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example2_MonsterT) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example2_MonsterT) -> Offset {
     let __root = MyGame_Example2_Monster.startMonster(&builder)
     return MyGame_Example2_Monster.endMonster(&builder, start: __root)
   }
@@ -484,7 +484,7 @@ internal struct MyGame_Example_TestSimpleTableWithEnum: FlatBufferObject, Object
   internal var __buffer: ByteBuffer! { return _accessor.bb }
   private var _accessor: Table
 
-  internal static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+  internal static func finish(_ fbb: inout FlatBufferBuilder, end: Offset, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
   internal static func getRootAsTestSimpleTableWithEnum(bb: ByteBuffer) -> MyGame_Example_TestSimpleTableWithEnum { return MyGame_Example_TestSimpleTableWithEnum(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
   private init(_ t: Table) { _accessor = t }
@@ -500,11 +500,11 @@ internal struct MyGame_Example_TestSimpleTableWithEnum: FlatBufferObject, Object
   @discardableResult internal func mutate(color: MyGame_Example_Color) -> Bool {let o = _accessor.offset(VTOFFSET.color.v);  return _accessor.mutate(color.rawValue, index: o) }
   internal static func startTestSimpleTableWithEnum(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
   internal static func add(color: MyGame_Example_Color, _ fbb: inout FlatBufferBuilder) { fbb.add(element: color.rawValue, def: 2, at: VTOFFSET.color.p) }
-  internal static func endTestSimpleTableWithEnum(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  internal static func endTestSimpleTableWithEnum(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   internal static func createTestSimpleTableWithEnum(
     _ fbb: inout FlatBufferBuilder,
     color: MyGame_Example_Color = .green
-  ) -> Offset<UOffset> {
+  ) -> Offset {
     let __start = MyGame_Example_TestSimpleTableWithEnum.startTestSimpleTableWithEnum(&fbb)
     MyGame_Example_TestSimpleTableWithEnum.add(color: color, &fbb)
     return MyGame_Example_TestSimpleTableWithEnum.endTestSimpleTableWithEnum(&fbb, start: __start)
@@ -514,12 +514,12 @@ internal struct MyGame_Example_TestSimpleTableWithEnum: FlatBufferObject, Object
   internal mutating func unpack() -> MyGame_Example_TestSimpleTableWithEnumT {
     return MyGame_Example_TestSimpleTableWithEnumT(&self)
   }
-  internal static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TestSimpleTableWithEnumT?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  internal static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TestSimpleTableWithEnumT?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  internal static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TestSimpleTableWithEnumT) -> Offset<UOffset> {
+  internal static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TestSimpleTableWithEnumT) -> Offset {
     let __root = MyGame_Example_TestSimpleTableWithEnum.startTestSimpleTableWithEnum(&builder)
     MyGame_Example_TestSimpleTableWithEnum.add(color: obj.color, &builder)
     return MyGame_Example_TestSimpleTableWithEnum.endTestSimpleTableWithEnum(&builder, start: __root)
@@ -547,7 +547,7 @@ public struct MyGame_Example_Stat: FlatBufferObject, ObjectAPIPacker {
   public var __buffer: ByteBuffer! { return _accessor.bb }
   private var _accessor: Table
 
-  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
   public static func getRootAsStat(bb: ByteBuffer) -> MyGame_Example_Stat { return MyGame_Example_Stat(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
   private init(_ t: Table) { _accessor = t }
@@ -568,23 +568,23 @@ public struct MyGame_Example_Stat: FlatBufferObject, ObjectAPIPacker {
   public var count: UInt16 { let o = _accessor.offset(VTOFFSET.count.v); return o == 0 ? 0 : _accessor.readBuffer(of: UInt16.self, at: o) }
   @discardableResult public func mutate(count: UInt16) -> Bool {let o = _accessor.offset(VTOFFSET.count.v);  return _accessor.mutate(count, index: o) }
   public static func startStat(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 3) }
-  public static func add(id: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: id, at: VTOFFSET.id.p) }
+  public static func add(id: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: id, at: VTOFFSET.id.p) }
   public static func add(val: Int64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: val, def: 0, at: VTOFFSET.val.p) }
   public static func add(count: UInt16, _ fbb: inout FlatBufferBuilder) { fbb.add(element: count, def: 0, at: VTOFFSET.count.p) }
-  public static func endStat(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  public static func endStat(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createStat(
     _ fbb: inout FlatBufferBuilder,
-    idOffset id: Offset<String> = Offset(),
+    idOffset id: Offset = Offset(),
     val: Int64 = 0,
     count: UInt16 = 0
-  ) -> Offset<UOffset> {
+  ) -> Offset {
     let __start = MyGame_Example_Stat.startStat(&fbb)
     MyGame_Example_Stat.add(id: id, &fbb)
     MyGame_Example_Stat.add(val: val, &fbb)
     MyGame_Example_Stat.add(count: count, &fbb)
     return MyGame_Example_Stat.endStat(&fbb, start: __start)
   }
-  public static func sortVectorOfStat(offsets:[Offset<UOffset>], _ fbb: inout FlatBufferBuilder) -> Offset<UOffset> {
+  public static func sortVectorOfStat(offsets:[Offset], _ fbb: inout FlatBufferBuilder) -> Offset {
     var off = offsets
     off.sort { Table.compare(Table.offset(Int32($1.o), vOffset: 8, fbb: fbb.buffer), Table.offset(Int32($0.o), vOffset: 8, fbb: fbb.buffer), fbb: fbb.buffer) < 0 } 
     return fbb.createVector(ofOffsets: off)
@@ -613,17 +613,17 @@ public struct MyGame_Example_Stat: FlatBufferObject, ObjectAPIPacker {
   public mutating func unpack() -> MyGame_Example_StatT {
     return MyGame_Example_StatT(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_StatT?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_StatT?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_StatT) -> Offset<UOffset> {
-    let __id: Offset<String>
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_StatT) -> Offset {
+    let __id: Offset
     if let s = obj.id {
       __id = builder.create(string: s)
     } else {
-      __id = Offset<String>()
+      __id = Offset()
     }
 
     let __root = MyGame_Example_Stat.startStat(&builder)
@@ -660,7 +660,7 @@ public struct MyGame_Example_Referrable: FlatBufferObject, ObjectAPIPacker {
   public var __buffer: ByteBuffer! { return _accessor.bb }
   private var _accessor: Table
 
-  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
   public static func getRootAsReferrable(bb: ByteBuffer) -> MyGame_Example_Referrable { return MyGame_Example_Referrable(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
   private init(_ t: Table) { _accessor = t }
@@ -676,16 +676,16 @@ public struct MyGame_Example_Referrable: FlatBufferObject, ObjectAPIPacker {
   @discardableResult public func mutate(id: UInt64) -> Bool {let o = _accessor.offset(VTOFFSET.id.v);  return _accessor.mutate(id, index: o) }
   public static func startReferrable(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
   public static func add(id: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: id, def: 0, at: VTOFFSET.id.p) }
-  public static func endReferrable(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  public static func endReferrable(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createReferrable(
     _ fbb: inout FlatBufferBuilder,
     id: UInt64 = 0
-  ) -> Offset<UOffset> {
+  ) -> Offset {
     let __start = MyGame_Example_Referrable.startReferrable(&fbb)
     MyGame_Example_Referrable.add(id: id, &fbb)
     return MyGame_Example_Referrable.endReferrable(&fbb, start: __start)
   }
-  public static func sortVectorOfReferrable(offsets:[Offset<UOffset>], _ fbb: inout FlatBufferBuilder) -> Offset<UOffset> {
+  public static func sortVectorOfReferrable(offsets:[Offset], _ fbb: inout FlatBufferBuilder) -> Offset {
     var off = offsets
     off.sort { Table.compare(Table.offset(Int32($1.o), vOffset: 4, fbb: fbb.buffer), Table.offset(Int32($0.o), vOffset: 4, fbb: fbb.buffer), fbb: fbb.buffer) < 0 } 
     return fbb.createVector(ofOffsets: off)
@@ -714,12 +714,12 @@ public struct MyGame_Example_Referrable: FlatBufferObject, ObjectAPIPacker {
   public mutating func unpack() -> MyGame_Example_ReferrableT {
     return MyGame_Example_ReferrableT(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_ReferrableT?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_ReferrableT?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_ReferrableT) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_ReferrableT) -> Offset {
     let __root = MyGame_Example_Referrable.startReferrable(&builder)
     MyGame_Example_Referrable.add(id: obj.id, &builder)
     return MyGame_Example_Referrable.endReferrable(&builder, start: __root)
@@ -748,7 +748,7 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
   public var __buffer: ByteBuffer! { return _accessor.bb }
   private var _accessor: Table
 
-  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
   public static func getRootAsMonster(bb: ByteBuffer) -> MyGame_Example_Monster { return MyGame_Example_Monster(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
   private init(_ t: Table) { _accessor = t }
@@ -824,7 +824,7 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
   public var color: MyGame_Example_Color { let o = _accessor.offset(VTOFFSET.color.v); return o == 0 ? .blue : MyGame_Example_Color(rawValue: _accessor.readBuffer(of: UInt8.self, at: o)) ?? .blue }
   @discardableResult public func mutate(color: MyGame_Example_Color) -> Bool {let o = _accessor.offset(VTOFFSET.color.v);  return _accessor.mutate(color.rawValue, index: o) }
   public var testType: MyGame_Example_Any_ { let o = _accessor.offset(VTOFFSET.testType.v); return o == 0 ? .none_ : MyGame_Example_Any_(rawValue: _accessor.readBuffer(of: UInt8.self, at: o)) ?? .none_ }
-  public func test<T: FlatBufferObject>(type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.test.v); return o == 0 ? nil : _accessor.union(o) }
+  public func test<T: FlatbuffersInitializable>(type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.test.v); return o == 0 ? nil : _accessor.union(o) }
   public var test4Count: Int32 { let o = _accessor.offset(VTOFFSET.test4.v); return o == 0 ? 0 : _accessor.vector(count: o) }
   public func test4(at index: Int32) -> MyGame_Example_Test? { let o = _accessor.offset(VTOFFSET.test4.v); return o == 0 ? nil : _accessor.directRead(of: MyGame_Example_Test.self, offset: _accessor.vector(at: o) + index * 4) }
   public func mutableTest4(at index: Int32) -> MyGame_Example_Test_Mutable? { let o = _accessor.offset(VTOFFSET.test4.v); return o == 0 ? nil : MyGame_Example_Test_Mutable(_accessor.bb, o: _accessor.vector(at: o) + index * 4) }
@@ -915,9 +915,9 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
   public var vectorOfNonOwningReferences: [UInt64] { return _accessor.getVector(at: VTOFFSET.vectorOfNonOwningReferences.v) ?? [] }
   public func mutate(vectorOfNonOwningReferences: UInt64, at index: Int32) -> Bool { let o = _accessor.offset(VTOFFSET.vectorOfNonOwningReferences.v); return _accessor.directMutate(vectorOfNonOwningReferences, index: _accessor.vector(at: o) + index * 8) }
   public var anyUniqueType: MyGame_Example_AnyUniqueAliases { let o = _accessor.offset(VTOFFSET.anyUniqueType.v); return o == 0 ? .none_ : MyGame_Example_AnyUniqueAliases(rawValue: _accessor.readBuffer(of: UInt8.self, at: o)) ?? .none_ }
-  public func anyUnique<T: FlatBufferObject>(type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.anyUnique.v); return o == 0 ? nil : _accessor.union(o) }
+  public func anyUnique<T: FlatbuffersInitializable>(type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.anyUnique.v); return o == 0 ? nil : _accessor.union(o) }
   public var anyAmbiguousType: MyGame_Example_AnyAmbiguousAliases { let o = _accessor.offset(VTOFFSET.anyAmbiguousType.v); return o == 0 ? .none_ : MyGame_Example_AnyAmbiguousAliases(rawValue: _accessor.readBuffer(of: UInt8.self, at: o)) ?? .none_ }
-  public func anyAmbiguous<T: FlatBufferObject>(type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.anyAmbiguous.v); return o == 0 ? nil : _accessor.union(o) }
+  public func anyAmbiguous<T: FlatbuffersInitializable>(type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.anyAmbiguous.v); return o == 0 ? nil : _accessor.union(o) }
   public var vectorOfEnumsCount: Int32 { let o = _accessor.offset(VTOFFSET.vectorOfEnums.v); return o == 0 ? 0 : _accessor.vector(count: o) }
   public func vectorOfEnums(at index: Int32) -> MyGame_Example_Color? { let o = _accessor.offset(VTOFFSET.vectorOfEnums.v); return o == 0 ? MyGame_Example_Color.red : MyGame_Example_Color(rawValue: _accessor.directRead(of: UInt8.self, offset: _accessor.vector(at: o) + index * 1)) }
   public var signedEnum: MyGame_Example_Race { let o = _accessor.offset(VTOFFSET.signedEnum.v); return o == 0 ? .none_ : MyGame_Example_Race(rawValue: _accessor.readBuffer(of: Int8.self, at: o)) ?? .none_ }
@@ -933,20 +933,20 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
   public static func add(pos: MyGame_Example_Vec3?, _ fbb: inout FlatBufferBuilder) { guard let pos = pos else { return }; fbb.create(struct: pos, position: VTOFFSET.pos.p) }
   public static func add(mana: Int16, _ fbb: inout FlatBufferBuilder) { fbb.add(element: mana, def: 150, at: VTOFFSET.mana.p) }
   public static func add(hp: Int16, _ fbb: inout FlatBufferBuilder) { fbb.add(element: hp, def: 100, at: VTOFFSET.hp.p) }
-  public static func add(name: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: name, at: VTOFFSET.name.p) }
-  public static func addVectorOf(inventory: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: inventory, at: VTOFFSET.inventory.p) }
+  public static func add(name: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: name, at: VTOFFSET.name.p) }
+  public static func addVectorOf(inventory: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: inventory, at: VTOFFSET.inventory.p) }
   public static func add(color: MyGame_Example_Color, _ fbb: inout FlatBufferBuilder) { fbb.add(element: color.rawValue, def: 8, at: VTOFFSET.color.p) }
   public static func add(testType: MyGame_Example_Any_, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testType.rawValue, def: 0, at: VTOFFSET.testType.p) }
-  public static func add(test: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: test, at: VTOFFSET.test.p) }
-  public static func addVectorOf(test4: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: test4, at: VTOFFSET.test4.p) }
+  public static func add(test: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: test, at: VTOFFSET.test.p) }
+  public static func addVectorOf(test4: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: test4, at: VTOFFSET.test4.p) }
   public static func startVectorOfTest4(_ size: Int, in builder: inout FlatBufferBuilder) {
     builder.startVector(size * MemoryLayout<MyGame_Example_Test>.size, elementSize: MemoryLayout<MyGame_Example_Test>.alignment)
   }
-  public static func addVectorOf(testarrayofstring: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofstring, at: VTOFFSET.testarrayofstring.p) }
-  public static func addVectorOf(testarrayoftables: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayoftables, at: VTOFFSET.testarrayoftables.p) }
-  public static func add(enemy: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: enemy, at: VTOFFSET.enemy.p) }
-  public static func addVectorOf(testnestedflatbuffer: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testnestedflatbuffer, at: VTOFFSET.testnestedflatbuffer.p) }
-  public static func add(testempty: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testempty, at: VTOFFSET.testempty.p) }
+  public static func addVectorOf(testarrayofstring: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofstring, at: VTOFFSET.testarrayofstring.p) }
+  public static func addVectorOf(testarrayoftables: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayoftables, at: VTOFFSET.testarrayoftables.p) }
+  public static func add(enemy: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: enemy, at: VTOFFSET.enemy.p) }
+  public static func addVectorOf(testnestedflatbuffer: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testnestedflatbuffer, at: VTOFFSET.testnestedflatbuffer.p) }
+  public static func add(testempty: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testempty, at: VTOFFSET.testempty.p) }
   public static func add(testbool: Bool, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testbool, def: false,
    at: VTOFFSET.testbool.p) }
   public static func add(testhashs32Fnv1: Int32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashs32Fnv1, def: 0, at: VTOFFSET.testhashs32Fnv1.p) }
@@ -957,56 +957,56 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
   public static func add(testhashu32Fnv1a: UInt32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashu32Fnv1a, def: 0, at: VTOFFSET.testhashu32Fnv1a.p) }
   public static func add(testhashs64Fnv1a: Int64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashs64Fnv1a, def: 0, at: VTOFFSET.testhashs64Fnv1a.p) }
   public static func add(testhashu64Fnv1a: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testhashu64Fnv1a, def: 0, at: VTOFFSET.testhashu64Fnv1a.p) }
-  public static func addVectorOf(testarrayofbools: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofbools, at: VTOFFSET.testarrayofbools.p) }
+  public static func addVectorOf(testarrayofbools: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofbools, at: VTOFFSET.testarrayofbools.p) }
   public static func add(testf: Float32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testf, def: 3.14159, at: VTOFFSET.testf.p) }
   public static func add(testf2: Float32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testf2, def: 3.0, at: VTOFFSET.testf2.p) }
   public static func add(testf3: Float32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: testf3, def: 0.0, at: VTOFFSET.testf3.p) }
-  public static func addVectorOf(testarrayofstring2: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofstring2, at: VTOFFSET.testarrayofstring2.p) }
-  public static func addVectorOf(testarrayofsortedstruct: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofsortedstruct, at: VTOFFSET.testarrayofsortedstruct.p) }
+  public static func addVectorOf(testarrayofstring2: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofstring2, at: VTOFFSET.testarrayofstring2.p) }
+  public static func addVectorOf(testarrayofsortedstruct: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testarrayofsortedstruct, at: VTOFFSET.testarrayofsortedstruct.p) }
   public static func startVectorOfTestarrayofsortedstruct(_ size: Int, in builder: inout FlatBufferBuilder) {
     builder.startVector(size * MemoryLayout<MyGame_Example_Ability>.size, elementSize: MemoryLayout<MyGame_Example_Ability>.alignment)
   }
-  public static func addVectorOf(flex: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: flex, at: VTOFFSET.flex.p) }
-  public static func addVectorOf(test5: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: test5, at: VTOFFSET.test5.p) }
+  public static func addVectorOf(flex: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: flex, at: VTOFFSET.flex.p) }
+  public static func addVectorOf(test5: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: test5, at: VTOFFSET.test5.p) }
   public static func startVectorOfTest5(_ size: Int, in builder: inout FlatBufferBuilder) {
     builder.startVector(size * MemoryLayout<MyGame_Example_Test>.size, elementSize: MemoryLayout<MyGame_Example_Test>.alignment)
   }
-  public static func addVectorOf(vectorOfLongs: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfLongs, at: VTOFFSET.vectorOfLongs.p) }
-  public static func addVectorOf(vectorOfDoubles: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfDoubles, at: VTOFFSET.vectorOfDoubles.p) }
-  public static func add(parentNamespaceTest: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: parentNamespaceTest, at: VTOFFSET.parentNamespaceTest.p) }
-  public static func addVectorOf(vectorOfReferrables: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfReferrables, at: VTOFFSET.vectorOfReferrables.p) }
+  public static func addVectorOf(vectorOfLongs: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfLongs, at: VTOFFSET.vectorOfLongs.p) }
+  public static func addVectorOf(vectorOfDoubles: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfDoubles, at: VTOFFSET.vectorOfDoubles.p) }
+  public static func add(parentNamespaceTest: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: parentNamespaceTest, at: VTOFFSET.parentNamespaceTest.p) }
+  public static func addVectorOf(vectorOfReferrables: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfReferrables, at: VTOFFSET.vectorOfReferrables.p) }
   public static func add(singleWeakReference: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: singleWeakReference, def: 0, at: VTOFFSET.singleWeakReference.p) }
-  public static func addVectorOf(vectorOfWeakReferences: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfWeakReferences, at: VTOFFSET.vectorOfWeakReferences.p) }
-  public static func addVectorOf(vectorOfStrongReferrables: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfStrongReferrables, at: VTOFFSET.vectorOfStrongReferrables.p) }
+  public static func addVectorOf(vectorOfWeakReferences: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfWeakReferences, at: VTOFFSET.vectorOfWeakReferences.p) }
+  public static func addVectorOf(vectorOfStrongReferrables: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfStrongReferrables, at: VTOFFSET.vectorOfStrongReferrables.p) }
   public static func add(coOwningReference: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: coOwningReference, def: 0, at: VTOFFSET.coOwningReference.p) }
-  public static func addVectorOf(vectorOfCoOwningReferences: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfCoOwningReferences, at: VTOFFSET.vectorOfCoOwningReferences.p) }
+  public static func addVectorOf(vectorOfCoOwningReferences: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfCoOwningReferences, at: VTOFFSET.vectorOfCoOwningReferences.p) }
   public static func add(nonOwningReference: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: nonOwningReference, def: 0, at: VTOFFSET.nonOwningReference.p) }
-  public static func addVectorOf(vectorOfNonOwningReferences: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfNonOwningReferences, at: VTOFFSET.vectorOfNonOwningReferences.p) }
+  public static func addVectorOf(vectorOfNonOwningReferences: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfNonOwningReferences, at: VTOFFSET.vectorOfNonOwningReferences.p) }
   public static func add(anyUniqueType: MyGame_Example_AnyUniqueAliases, _ fbb: inout FlatBufferBuilder) { fbb.add(element: anyUniqueType.rawValue, def: 0, at: VTOFFSET.anyUniqueType.p) }
-  public static func add(anyUnique: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: anyUnique, at: VTOFFSET.anyUnique.p) }
+  public static func add(anyUnique: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: anyUnique, at: VTOFFSET.anyUnique.p) }
   public static func add(anyAmbiguousType: MyGame_Example_AnyAmbiguousAliases, _ fbb: inout FlatBufferBuilder) { fbb.add(element: anyAmbiguousType.rawValue, def: 0, at: VTOFFSET.anyAmbiguousType.p) }
-  public static func add(anyAmbiguous: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: anyAmbiguous, at: VTOFFSET.anyAmbiguous.p) }
-  public static func addVectorOf(vectorOfEnums: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfEnums, at: VTOFFSET.vectorOfEnums.p) }
+  public static func add(anyAmbiguous: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: anyAmbiguous, at: VTOFFSET.anyAmbiguous.p) }
+  public static func addVectorOf(vectorOfEnums: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vectorOfEnums, at: VTOFFSET.vectorOfEnums.p) }
   public static func add(signedEnum: MyGame_Example_Race, _ fbb: inout FlatBufferBuilder) { fbb.add(element: signedEnum.rawValue, def: -1, at: VTOFFSET.signedEnum.p) }
-  public static func addVectorOf(testrequirednestedflatbuffer: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testrequirednestedflatbuffer, at: VTOFFSET.testrequirednestedflatbuffer.p) }
-  public static func addVectorOf(scalarKeySortedTables: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: scalarKeySortedTables, at: VTOFFSET.scalarKeySortedTables.p) }
-  public static func endMonster(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); fbb.require(table: end, fields: [10]); return end }
+  public static func addVectorOf(testrequirednestedflatbuffer: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: testrequirednestedflatbuffer, at: VTOFFSET.testrequirednestedflatbuffer.p) }
+  public static func addVectorOf(scalarKeySortedTables: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: scalarKeySortedTables, at: VTOFFSET.scalarKeySortedTables.p) }
+  public static func endMonster(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); fbb.require(table: end, fields: [10]); return end }
   public static func createMonster(
     _ fbb: inout FlatBufferBuilder,
     pos: MyGame_Example_Vec3? = nil,
     mana: Int16 = 150,
     hp: Int16 = 100,
-    nameOffset name: Offset<String> = Offset(),
-    inventoryVectorOffset inventory: Offset<UOffset> = Offset(),
+    nameOffset name: Offset = Offset(),
+    inventoryVectorOffset inventory: Offset = Offset(),
     color: MyGame_Example_Color = .blue,
     testType: MyGame_Example_Any_ = .none_,
-    testOffset test: Offset<UOffset> = Offset(),
-    test4VectorOffset test4: Offset<UOffset> = Offset(),
-    testarrayofstringVectorOffset testarrayofstring: Offset<UOffset> = Offset(),
-    testarrayoftablesVectorOffset testarrayoftables: Offset<UOffset> = Offset(),
-    enemyOffset enemy: Offset<UOffset> = Offset(),
-    testnestedflatbufferVectorOffset testnestedflatbuffer: Offset<UOffset> = Offset(),
-    testemptyOffset testempty: Offset<UOffset> = Offset(),
+    testOffset test: Offset = Offset(),
+    test4VectorOffset test4: Offset = Offset(),
+    testarrayofstringVectorOffset testarrayofstring: Offset = Offset(),
+    testarrayoftablesVectorOffset testarrayoftables: Offset = Offset(),
+    enemyOffset enemy: Offset = Offset(),
+    testnestedflatbufferVectorOffset testnestedflatbuffer: Offset = Offset(),
+    testemptyOffset testempty: Offset = Offset(),
     testbool: Bool = false,
     testhashs32Fnv1: Int32 = 0,
     testhashu32Fnv1: UInt32 = 0,
@@ -1016,34 +1016,34 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
     testhashu32Fnv1a: UInt32 = 0,
     testhashs64Fnv1a: Int64 = 0,
     testhashu64Fnv1a: UInt64 = 0,
-    testarrayofboolsVectorOffset testarrayofbools: Offset<UOffset> = Offset(),
+    testarrayofboolsVectorOffset testarrayofbools: Offset = Offset(),
     testf: Float32 = 3.14159,
     testf2: Float32 = 3.0,
     testf3: Float32 = 0.0,
-    testarrayofstring2VectorOffset testarrayofstring2: Offset<UOffset> = Offset(),
-    testarrayofsortedstructVectorOffset testarrayofsortedstruct: Offset<UOffset> = Offset(),
-    flexVectorOffset flex: Offset<UOffset> = Offset(),
-    test5VectorOffset test5: Offset<UOffset> = Offset(),
-    vectorOfLongsVectorOffset vectorOfLongs: Offset<UOffset> = Offset(),
-    vectorOfDoublesVectorOffset vectorOfDoubles: Offset<UOffset> = Offset(),
-    parentNamespaceTestOffset parentNamespaceTest: Offset<UOffset> = Offset(),
-    vectorOfReferrablesVectorOffset vectorOfReferrables: Offset<UOffset> = Offset(),
+    testarrayofstring2VectorOffset testarrayofstring2: Offset = Offset(),
+    testarrayofsortedstructVectorOffset testarrayofsortedstruct: Offset = Offset(),
+    flexVectorOffset flex: Offset = Offset(),
+    test5VectorOffset test5: Offset = Offset(),
+    vectorOfLongsVectorOffset vectorOfLongs: Offset = Offset(),
+    vectorOfDoublesVectorOffset vectorOfDoubles: Offset = Offset(),
+    parentNamespaceTestOffset parentNamespaceTest: Offset = Offset(),
+    vectorOfReferrablesVectorOffset vectorOfReferrables: Offset = Offset(),
     singleWeakReference: UInt64 = 0,
-    vectorOfWeakReferencesVectorOffset vectorOfWeakReferences: Offset<UOffset> = Offset(),
-    vectorOfStrongReferrablesVectorOffset vectorOfStrongReferrables: Offset<UOffset> = Offset(),
+    vectorOfWeakReferencesVectorOffset vectorOfWeakReferences: Offset = Offset(),
+    vectorOfStrongReferrablesVectorOffset vectorOfStrongReferrables: Offset = Offset(),
     coOwningReference: UInt64 = 0,
-    vectorOfCoOwningReferencesVectorOffset vectorOfCoOwningReferences: Offset<UOffset> = Offset(),
+    vectorOfCoOwningReferencesVectorOffset vectorOfCoOwningReferences: Offset = Offset(),
     nonOwningReference: UInt64 = 0,
-    vectorOfNonOwningReferencesVectorOffset vectorOfNonOwningReferences: Offset<UOffset> = Offset(),
+    vectorOfNonOwningReferencesVectorOffset vectorOfNonOwningReferences: Offset = Offset(),
     anyUniqueType: MyGame_Example_AnyUniqueAliases = .none_,
-    anyUniqueOffset anyUnique: Offset<UOffset> = Offset(),
+    anyUniqueOffset anyUnique: Offset = Offset(),
     anyAmbiguousType: MyGame_Example_AnyAmbiguousAliases = .none_,
-    anyAmbiguousOffset anyAmbiguous: Offset<UOffset> = Offset(),
-    vectorOfEnumsVectorOffset vectorOfEnums: Offset<UOffset> = Offset(),
+    anyAmbiguousOffset anyAmbiguous: Offset = Offset(),
+    vectorOfEnumsVectorOffset vectorOfEnums: Offset = Offset(),
     signedEnum: MyGame_Example_Race = .none_,
-    testrequirednestedflatbufferVectorOffset testrequirednestedflatbuffer: Offset<UOffset> = Offset(),
-    scalarKeySortedTablesVectorOffset scalarKeySortedTables: Offset<UOffset> = Offset()
-  ) -> Offset<UOffset> {
+    testrequirednestedflatbufferVectorOffset testrequirednestedflatbuffer: Offset = Offset(),
+    scalarKeySortedTablesVectorOffset scalarKeySortedTables: Offset = Offset()
+  ) -> Offset {
     let __start = MyGame_Example_Monster.startMonster(&fbb)
     MyGame_Example_Monster.add(pos: pos, &fbb)
     MyGame_Example_Monster.add(mana: mana, &fbb)
@@ -1097,7 +1097,7 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
     MyGame_Example_Monster.addVectorOf(scalarKeySortedTables: scalarKeySortedTables, &fbb)
     return MyGame_Example_Monster.endMonster(&fbb, start: __start)
   }
-  public static func sortVectorOfMonster(offsets:[Offset<UOffset>], _ fbb: inout FlatBufferBuilder) -> Offset<UOffset> {
+  public static func sortVectorOfMonster(offsets:[Offset], _ fbb: inout FlatBufferBuilder) -> Offset {
     var off = offsets
     off.sort { Table.compare(Table.offset(Int32($1.o), vOffset: 10, fbb: fbb.buffer), Table.offset(Int32($0.o), vOffset: 10, fbb: fbb.buffer), fbb: fbb.buffer) < 0 } 
     return fbb.createVector(ofOffsets: off)
@@ -1127,12 +1127,12 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
   public mutating func unpack() -> MyGame_Example_MonsterT {
     return MyGame_Example_MonsterT(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_MonsterT?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_MonsterT?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_MonsterT) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_MonsterT) -> Offset {
     let __name = builder.create(string: obj.name)
     let __inventory = builder.createVector(obj.inventory)
     let __test = obj.test?.pack(builder: &builder) ?? Offset()
@@ -1143,7 +1143,7 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
     }
     let __test4 = builder.endVector(len: obj.test4.count)
     let __testarrayofstring = builder.createVector(ofStrings: obj.testarrayofstring.compactMap({ $0 }) )
-    var __testarrayoftables__: [Offset<UOffset>] = []
+    var __testarrayoftables__: [Offset] = []
     for var i in obj.testarrayoftables {
       __testarrayoftables__.append(MyGame_Example_Monster.pack(&builder, obj: &i))
     }
@@ -1169,13 +1169,13 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
     let __vectorOfLongs = builder.createVector(obj.vectorOfLongs)
     let __vectorOfDoubles = builder.createVector(obj.vectorOfDoubles)
     let __parentNamespaceTest = MyGame_InParentNamespace.pack(&builder, obj: &obj.parentNamespaceTest)
-    var __vectorOfReferrables__: [Offset<UOffset>] = []
+    var __vectorOfReferrables__: [Offset] = []
     for var i in obj.vectorOfReferrables {
       __vectorOfReferrables__.append(MyGame_Example_Referrable.pack(&builder, obj: &i))
     }
     let __vectorOfReferrables = builder.createVector(ofOffsets: __vectorOfReferrables__)
     let __vectorOfWeakReferences = builder.createVector(obj.vectorOfWeakReferences)
-    var __vectorOfStrongReferrables__: [Offset<UOffset>] = []
+    var __vectorOfStrongReferrables__: [Offset] = []
     for var i in obj.vectorOfStrongReferrables {
       __vectorOfStrongReferrables__.append(MyGame_Example_Referrable.pack(&builder, obj: &i))
     }
@@ -1186,7 +1186,7 @@ public struct MyGame_Example_Monster: FlatBufferObject, ObjectAPIPacker {
     let __anyAmbiguous = obj.anyAmbiguous?.pack(builder: &builder) ?? Offset()
     let __vectorOfEnums = builder.createVector(obj.vectorOfEnums)
     let __testrequirednestedflatbuffer = builder.createVector(obj.testrequirednestedflatbuffer)
-    var __scalarKeySortedTables__: [Offset<UOffset>] = []
+    var __scalarKeySortedTables__: [Offset] = []
     for var i in obj.scalarKeySortedTables {
       __scalarKeySortedTables__.append(MyGame_Example_Stat.pack(&builder, obj: &i))
     }
@@ -1511,7 +1511,7 @@ public struct MyGame_Example_TypeAliases: FlatBufferObject, ObjectAPIPacker {
   public var __buffer: ByteBuffer! { return _accessor.bb }
   private var _accessor: Table
 
-  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
+  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MONS", addPrefix: prefix) }
   public static func getRootAsTypeAliases(bb: ByteBuffer) -> MyGame_Example_TypeAliases { return MyGame_Example_TypeAliases(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
   private init(_ t: Table) { _accessor = t }
@@ -1573,9 +1573,9 @@ public struct MyGame_Example_TypeAliases: FlatBufferObject, ObjectAPIPacker {
   public static func add(u64: UInt64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: u64, def: 0, at: VTOFFSET.u64.p) }
   public static func add(f32: Float32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: f32, def: 0.0, at: VTOFFSET.f32.p) }
   public static func add(f64: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: f64, def: 0.0, at: VTOFFSET.f64.p) }
-  public static func addVectorOf(v8: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: v8, at: VTOFFSET.v8.p) }
-  public static func addVectorOf(vf64: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vf64, at: VTOFFSET.vf64.p) }
-  public static func endTypeAliases(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  public static func addVectorOf(v8: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: v8, at: VTOFFSET.v8.p) }
+  public static func addVectorOf(vf64: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: vf64, at: VTOFFSET.vf64.p) }
+  public static func endTypeAliases(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createTypeAliases(
     _ fbb: inout FlatBufferBuilder,
     i8: Int8 = 0,
@@ -1588,9 +1588,9 @@ public struct MyGame_Example_TypeAliases: FlatBufferObject, ObjectAPIPacker {
     u64: UInt64 = 0,
     f32: Float32 = 0.0,
     f64: Double = 0.0,
-    v8VectorOffset v8: Offset<UOffset> = Offset(),
-    vf64VectorOffset vf64: Offset<UOffset> = Offset()
-  ) -> Offset<UOffset> {
+    v8VectorOffset v8: Offset = Offset(),
+    vf64VectorOffset vf64: Offset = Offset()
+  ) -> Offset {
     let __start = MyGame_Example_TypeAliases.startTypeAliases(&fbb)
     MyGame_Example_TypeAliases.add(i8: i8, &fbb)
     MyGame_Example_TypeAliases.add(u8: u8, &fbb)
@@ -1611,12 +1611,12 @@ public struct MyGame_Example_TypeAliases: FlatBufferObject, ObjectAPIPacker {
   public mutating func unpack() -> MyGame_Example_TypeAliasesT {
     return MyGame_Example_TypeAliasesT(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TypeAliasesT?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TypeAliasesT?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TypeAliasesT) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MyGame_Example_TypeAliasesT) -> Offset {
     let __v8 = builder.createVector(obj.v8)
     let __vf64 = builder.createVector(obj.vf64)
     let __root = MyGame_Example_TypeAliases.startTypeAliases(&builder)

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/more_defaults_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/more_defaults_generated.swift
@@ -55,22 +55,22 @@ public struct MoreDefaults: FlatBufferObject, ObjectAPIPacker {
   public func bools(at index: Int32) -> Bool { let o = _accessor.offset(VTOFFSET.bools.v); return o == 0 ? true : _accessor.directRead(of: Bool.self, offset: _accessor.vector(at: o) + index * 1) }
   public var bools: [Bool] { return _accessor.getVector(at: VTOFFSET.bools.v) ?? [] }
   public static func startMoreDefaults(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 6) }
-  public static func addVectorOf(ints: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: ints, at: VTOFFSET.ints.p) }
-  public static func addVectorOf(floats: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: floats, at: VTOFFSET.floats.p) }
-  public static func add(emptyString: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: emptyString, at: VTOFFSET.emptyString.p) }
-  public static func add(someString: Offset<String>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: someString, at: VTOFFSET.someString.p) }
-  public static func addVectorOf(abcs: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: abcs, at: VTOFFSET.abcs.p) }
-  public static func addVectorOf(bools: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: bools, at: VTOFFSET.bools.p) }
-  public static func endMoreDefaults(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  public static func addVectorOf(ints: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: ints, at: VTOFFSET.ints.p) }
+  public static func addVectorOf(floats: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: floats, at: VTOFFSET.floats.p) }
+  public static func add(emptyString: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: emptyString, at: VTOFFSET.emptyString.p) }
+  public static func add(someString: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: someString, at: VTOFFSET.someString.p) }
+  public static func addVectorOf(abcs: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: abcs, at: VTOFFSET.abcs.p) }
+  public static func addVectorOf(bools: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: bools, at: VTOFFSET.bools.p) }
+  public static func endMoreDefaults(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createMoreDefaults(
     _ fbb: inout FlatBufferBuilder,
-    intsVectorOffset ints: Offset<UOffset> = Offset(),
-    floatsVectorOffset floats: Offset<UOffset> = Offset(),
-    emptyStringOffset emptyString: Offset<String> = Offset(),
-    someStringOffset someString: Offset<String> = Offset(),
-    abcsVectorOffset abcs: Offset<UOffset> = Offset(),
-    boolsVectorOffset bools: Offset<UOffset> = Offset()
-  ) -> Offset<UOffset> {
+    intsVectorOffset ints: Offset = Offset(),
+    floatsVectorOffset floats: Offset = Offset(),
+    emptyStringOffset emptyString: Offset = Offset(),
+    someStringOffset someString: Offset = Offset(),
+    abcsVectorOffset abcs: Offset = Offset(),
+    boolsVectorOffset bools: Offset = Offset()
+  ) -> Offset {
     let __start = MoreDefaults.startMoreDefaults(&fbb)
     MoreDefaults.addVectorOf(ints: ints, &fbb)
     MoreDefaults.addVectorOf(floats: floats, &fbb)
@@ -85,26 +85,26 @@ public struct MoreDefaults: FlatBufferObject, ObjectAPIPacker {
   public mutating func unpack() -> MoreDefaultsT {
     return MoreDefaultsT(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MoreDefaultsT?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MoreDefaultsT?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MoreDefaultsT) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MoreDefaultsT) -> Offset {
     let __ints = builder.createVector(obj.ints)
     let __floats = builder.createVector(obj.floats)
-    let __emptyString: Offset<String>
+    let __emptyString: Offset
     if let s = obj.emptyString {
       __emptyString = builder.create(string: s)
     } else {
-      __emptyString = Offset<String>()
+      __emptyString = Offset()
     }
 
-    let __someString: Offset<String>
+    let __someString: Offset
     if let s = obj.someString {
       __someString = builder.create(string: s)
     } else {
-      __someString = Offset<String>()
+      __someString = Offset()
     }
 
     let __abcs = builder.createVector(obj.abcs)

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/optional_scalars_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/optional_scalars_generated.swift
@@ -23,7 +23,7 @@ public struct optional_scalars_ScalarStuff: FlatBufferObject {
   public var __buffer: ByteBuffer! { return _accessor.bb }
   private var _accessor: Table
 
-  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "NULL", addPrefix: prefix) }
+  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset, prefix: Bool = false) { fbb.finish(offset: end, fileId: "NULL", addPrefix: prefix) }
   public static func getRootAsScalarStuff(bb: ByteBuffer) -> optional_scalars_ScalarStuff { return optional_scalars_ScalarStuff(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
   private init(_ t: Table) { _accessor = t }
@@ -145,7 +145,7 @@ public struct optional_scalars_ScalarStuff: FlatBufferObject {
   public static func add(justEnum: optional_scalars_OptionalByte, _ fbb: inout FlatBufferBuilder) { fbb.add(element: justEnum.rawValue, def: 0, at: VTOFFSET.justEnum.p) }
   public static func add(maybeEnum: optional_scalars_OptionalByte?, _ fbb: inout FlatBufferBuilder) { fbb.add(element: maybeEnum?.rawValue, at: VTOFFSET.maybeEnum.p) }
   public static func add(defaultEnum: optional_scalars_OptionalByte, _ fbb: inout FlatBufferBuilder) { fbb.add(element: defaultEnum.rawValue, def: 1, at: VTOFFSET.defaultEnum.p) }
-  public static func endScalarStuff(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  public static func endScalarStuff(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createScalarStuff(
     _ fbb: inout FlatBufferBuilder,
     justI8: Int8 = 0,
@@ -184,7 +184,7 @@ public struct optional_scalars_ScalarStuff: FlatBufferObject {
     justEnum: optional_scalars_OptionalByte = .none_,
     maybeEnum: optional_scalars_OptionalByte? = nil,
     defaultEnum: optional_scalars_OptionalByte = .one
-  ) -> Offset<UOffset> {
+  ) -> Offset {
     let __start = optional_scalars_ScalarStuff.startScalarStuff(&fbb)
     optional_scalars_ScalarStuff.add(justI8: justI8, &fbb)
     optional_scalars_ScalarStuff.add(maybeI8: maybeI8, &fbb)

--- a/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
+++ b/tests/FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests/union_vector_generated.swift
@@ -28,7 +28,7 @@ public struct CharacterUnion {
     self.type = type
     self.value = v
   }
-  public func pack(builder: inout FlatBufferBuilder) -> Offset<UOffset> {
+  public func pack(builder: inout FlatBufferBuilder) -> Offset {
     switch type {
     case .mulan:
       var __obj = value as? AttackerT
@@ -42,6 +42,12 @@ public struct CharacterUnion {
     case .bookfan:
       var __obj = value as? BookReader
       return BookReader_Mutable.pack(&builder, obj: &__obj)
+    case .other:
+      var __obj = value as? String
+      return String.pack(&builder, obj: &__obj)
+    case .unused:
+      var __obj = value as? String
+      return String.pack(&builder, obj: &__obj)
     default: return Offset()
     }
   }
@@ -82,12 +88,12 @@ public struct Rapunzel_Mutable: FlatBufferObject {
   public mutating func unpack() -> Rapunzel {
     return Rapunzel(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout Rapunzel?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout Rapunzel?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout Rapunzel) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout Rapunzel) -> Offset {
     return builder.create(struct: obj)
   }
 }
@@ -128,12 +134,12 @@ public struct BookReader_Mutable: FlatBufferObject {
   public mutating func unpack() -> BookReader {
     return BookReader(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout BookReader?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout BookReader?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout BookReader) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout BookReader) -> Offset {
     return builder.create(struct: obj)
   }
 }
@@ -144,7 +150,7 @@ public struct Attacker: FlatBufferObject, ObjectAPIPacker {
   public var __buffer: ByteBuffer! { return _accessor.bb }
   private var _accessor: Table
 
-  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MOVI", addPrefix: prefix) }
+  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MOVI", addPrefix: prefix) }
   public static func getRootAsAttacker(bb: ByteBuffer) -> Attacker { return Attacker(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
   private init(_ t: Table) { _accessor = t }
@@ -160,11 +166,11 @@ public struct Attacker: FlatBufferObject, ObjectAPIPacker {
   @discardableResult public func mutate(swordAttackDamage: Int32) -> Bool {let o = _accessor.offset(VTOFFSET.swordAttackDamage.v);  return _accessor.mutate(swordAttackDamage, index: o) }
   public static func startAttacker(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
   public static func add(swordAttackDamage: Int32, _ fbb: inout FlatBufferBuilder) { fbb.add(element: swordAttackDamage, def: 0, at: VTOFFSET.swordAttackDamage.p) }
-  public static func endAttacker(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  public static func endAttacker(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createAttacker(
     _ fbb: inout FlatBufferBuilder,
     swordAttackDamage: Int32 = 0
-  ) -> Offset<UOffset> {
+  ) -> Offset {
     let __start = Attacker.startAttacker(&fbb)
     Attacker.add(swordAttackDamage: swordAttackDamage, &fbb)
     return Attacker.endAttacker(&fbb, start: __start)
@@ -174,12 +180,12 @@ public struct Attacker: FlatBufferObject, ObjectAPIPacker {
   public mutating func unpack() -> AttackerT {
     return AttackerT(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout AttackerT?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout AttackerT?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout AttackerT) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout AttackerT) -> Offset {
     let __root = Attacker.startAttacker(&builder)
     Attacker.add(swordAttackDamage: obj.swordAttackDamage, &builder)
     return Attacker.endAttacker(&builder, start: __root)
@@ -207,7 +213,7 @@ public struct Movie: FlatBufferObject, ObjectAPIPacker {
   public var __buffer: ByteBuffer! { return _accessor.bb }
   private var _accessor: Table
 
-  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset<UOffset>, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MOVI", addPrefix: prefix) }
+  public static func finish(_ fbb: inout FlatBufferBuilder, end: Offset, prefix: Bool = false) { fbb.finish(offset: end, fileId: "MOVI", addPrefix: prefix) }
   public static func getRootAsMovie(bb: ByteBuffer) -> Movie { return Movie(Table(bb: bb, position: Int32(bb.read(def: UOffset.self, position: bb.reader)) + Int32(bb.reader))) }
 
   private init(_ t: Table) { _accessor = t }
@@ -223,24 +229,24 @@ public struct Movie: FlatBufferObject, ObjectAPIPacker {
   }
 
   public var mainCharacterType: Character { let o = _accessor.offset(VTOFFSET.mainCharacterType.v); return o == 0 ? .none_ : Character(rawValue: _accessor.readBuffer(of: UInt8.self, at: o)) ?? .none_ }
-  public func mainCharacter<T: FlatBufferObject>(type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.mainCharacter.v); return o == 0 ? nil : _accessor.union(o) }
+  public func mainCharacter<T: FlatbuffersInitializable>(type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.mainCharacter.v); return o == 0 ? nil : _accessor.union(o) }
   public var charactersTypeCount: Int32 { let o = _accessor.offset(VTOFFSET.charactersType.v); return o == 0 ? 0 : _accessor.vector(count: o) }
   public func charactersType(at index: Int32) -> Character? { let o = _accessor.offset(VTOFFSET.charactersType.v); return o == 0 ? Character.none_ : Character(rawValue: _accessor.directRead(of: UInt8.self, offset: _accessor.vector(at: o) + index * 1)) }
   public var charactersCount: Int32 { let o = _accessor.offset(VTOFFSET.characters.v); return o == 0 ? 0 : _accessor.vector(count: o) }
-  public func characters<T: FlatBufferObject>(at index: Int32, type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.characters.v); return o == 0 ? nil : _accessor.directUnion(_accessor.vector(at: o) + index * 4) }
+  public func characters<T: FlatbuffersInitializable>(at index: Int32, type: T.Type) -> T? { let o = _accessor.offset(VTOFFSET.characters.v); return o == 0 ? nil : _accessor.directUnion(_accessor.vector(at: o) + index * 4) }
   public static func startMovie(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 4) }
   public static func add(mainCharacterType: Character, _ fbb: inout FlatBufferBuilder) { fbb.add(element: mainCharacterType.rawValue, def: 0, at: VTOFFSET.mainCharacterType.p) }
-  public static func add(mainCharacter: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: mainCharacter, at: VTOFFSET.mainCharacter.p) }
-  public static func addVectorOf(charactersType: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: charactersType, at: VTOFFSET.charactersType.p) }
-  public static func addVectorOf(characters: Offset<UOffset>, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: characters, at: VTOFFSET.characters.p) }
-  public static func endMovie(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset<UOffset> { let end = Offset<UOffset>(offset: fbb.endTable(at: start)); return end }
+  public static func add(mainCharacter: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: mainCharacter, at: VTOFFSET.mainCharacter.p) }
+  public static func addVectorOf(charactersType: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: charactersType, at: VTOFFSET.charactersType.p) }
+  public static func addVectorOf(characters: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: characters, at: VTOFFSET.characters.p) }
+  public static func endMovie(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createMovie(
     _ fbb: inout FlatBufferBuilder,
     mainCharacterType: Character = .none_,
-    mainCharacterOffset mainCharacter: Offset<UOffset> = Offset(),
-    charactersTypeVectorOffset charactersType: Offset<UOffset> = Offset(),
-    charactersVectorOffset characters: Offset<UOffset> = Offset()
-  ) -> Offset<UOffset> {
+    mainCharacterOffset mainCharacter: Offset = Offset(),
+    charactersTypeVectorOffset charactersType: Offset = Offset(),
+    charactersVectorOffset characters: Offset = Offset()
+  ) -> Offset {
     let __start = Movie.startMovie(&fbb)
     Movie.add(mainCharacterType: mainCharacterType, &fbb)
     Movie.add(mainCharacter: mainCharacter, &fbb)
@@ -253,14 +259,14 @@ public struct Movie: FlatBufferObject, ObjectAPIPacker {
   public mutating func unpack() -> MovieT {
     return MovieT(&self)
   }
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MovieT?) -> Offset<UOffset> {
-    guard var obj = obj else { return Offset<UOffset>() }
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MovieT?) -> Offset {
+    guard var obj = obj else { return Offset() }
     return pack(&builder, obj: &obj)
   }
 
-  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MovieT) -> Offset<UOffset> {
+  public static func pack(_ builder: inout FlatBufferBuilder, obj: inout MovieT) -> Offset {
     let __mainCharacter = obj.mainCharacter?.pack(builder: &builder) ?? Offset()
-    var __characters__: [Offset<UOffset>] = []
+    var __characters__: [Offset] = []
     for i in obj.characters {
       guard let off = i?.pack(builder: &builder) else { continue }
       __characters__.append(off)
@@ -298,6 +304,12 @@ public class MovieT: NativeObject {
     case .bookfan:
       var _v = _t.mainCharacter(type: BookReader_Mutable.self)
       mainCharacter = CharacterUnion(_v?.unpack(), type: .bookfan)
+    case .other:
+      var _v = _t.mainCharacter(type: String.self)
+      mainCharacter = CharacterUnion(_v?.unpack(), type: .other)
+    case .unused:
+      var _v = _t.mainCharacter(type: String.self)
+      mainCharacter = CharacterUnion(_v?.unpack(), type: .unused)
     default: break
     }
     characters = []
@@ -315,6 +327,12 @@ public class MovieT: NativeObject {
         case .bookfan:
           var _v = _t.characters(at: index, type: BookReader_Mutable.self)
           characters.append(CharacterUnion(_v?.unpack(), type: .bookfan))
+        case .other:
+          var _v = _t.characters(at: index, type: String.self)
+          characters.append(CharacterUnion(_v?.unpack(), type: .other))
+        case .unused:
+          var _v = _t.characters(at: index, type: String.self)
+          characters.append(CharacterUnion(_v?.unpack(), type: .unused))
         default: break
         }
     }


### PR DESCRIPTION
This PR includes the support for string within unions in swift. 
This was done by replacing `Offset<UOffset>, and Offset<String>` to only be `Offset`

Master:
```
done 500_000: 0.0805s
done 10 str:  0.0006s
done 100 str: 0.0016s
done 3M strc: 0.7577s
```

This implementation:
```
done 500_000: 0.0745s
done 10 str:  0.0005s
done 100 str: 0.0015s
done 3M strc: 0.6674s
```
As you can see here the benchmarks for this branch sped up