### PR TITLE
Rust Remove SafeSliceAccess for Arrays, and fix miri.

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatbuffers"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2018"
 authors = ["Robert Winslow <hello@rwinslow.com>", "FlatBuffers Maintainers"]
 license = "Apache-2.0"

--- a/rust/flatbuffers/src/array.rs
+++ b/rust/flatbuffers/src/array.rs
@@ -52,6 +52,9 @@ impl<'a, T: 'a, const N: usize> Array<'a, T, N> {
     pub fn len(&self) -> usize {
         N
     }
+    pub fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
+    }
 }
 
 impl<'a, T: Follow<'a> + 'a, const N: usize> Array<'a, T, N> {
@@ -75,14 +78,7 @@ impl<'a, T: Follow<'a> + Debug, const N: usize> Into<[T::Inner; N]> for Array<'a
     }
 }
 
-impl<'a, T: SafeSliceAccess + 'a, const N: usize> Array<'a, T, N> {
-    pub fn safe_slice(self) -> &'a [T] {
-        let sz = size_of::<T>();
-        debug_assert!(sz > 0);
-        let ptr = self.0.as_ptr() as *const T;
-        unsafe { from_raw_parts(ptr, N) }
-    }
-}
+// TODO(caspern): Implement some future safe version of SafeSliceAccess.
 
 /// Implement Follow for all possible Arrays that have Follow-able elements.
 impl<'a, T: Follow<'a> + 'a, const N: usize> Follow<'a> for Array<'a, T, N> {
@@ -98,12 +94,16 @@ pub fn emplace_scalar_array<T: EndianScalar, const N: usize>(
     loc: usize,
     src: &[T; N],
 ) {
-    let mut buf_ptr = buf[loc..].as_mut_ptr() as *mut T;
+    let mut buf_ptr = buf[loc..].as_mut_ptr();
     for item in src.iter() {
         let item_le = item.to_little_endian();
         unsafe {
-            buf_ptr.write(item_le);
-            buf_ptr = buf_ptr.add(1);
+            core::ptr::copy_nonoverlapping(
+                &item_le as *const T as *const u8,
+                buf_ptr,
+                size_of::<T>(),
+            );
+            buf_ptr = buf_ptr.add(size_of::<T>());
         }
     }
 }

--- a/tests/RustTest.sh
+++ b/tests/RustTest.sh
@@ -63,5 +63,5 @@ fi
 # RUST_NIGHTLY environment variable set in dockerfile.
 if [[ $RUST_NIGHTLY == 1 ]]; then
   rustup +nightly component add miri
-  cargo +nightly miri test -- -Zmiri-disable-isolation
+  MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test
 fi

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -1115,6 +1115,7 @@ mod roundtrip_byteswap {
     // fn fuzz_f64() { quickcheck::QuickCheck::new().max_tests(N).quickcheck(prop_f64 as fn(f64)); }
 }
 
+#[cfg(not(miri))]
 quickcheck! {
   fn struct_of_structs(
     a_id: u32,


### PR DESCRIPTION
Resubmitting #6583 and fixing associated problems.

Looks like the Miri test in `RustTest.sh` didn't catch errors in #6548 related to the unsoundness of `SafeSliceAccess`.
I removed `SafeSliceAccess` for Arrays, and probably should do so for Vectors in the future too.

Calling `safe_slice() -> &[T]` requires `T` to be
1. readable on both LE and BE targets
2. `align_of::<T>() == 1`. 

I actually almost saw this error in #6548 but figured it was fine because I thought SafeSliceAccess was only implemented in endian-safe, alignment-1, types; u8, i8, bool, and flatbuffers structs; however we do conditional compilation that adds SafeSliceAccess to larger scalars on little-endian targets... 🤦  This is just wrong and callers of `safe_slice()` may get alignment errors.

I left in the conditional compilation since `create_vector_direct` depends on `SafeSliceAccess` but only requires property 1 (its doing memcpy, no dereferencing). We test and advertise that function for vectors of larger scalars so people may be using it. `create_vector_direct` is fine but if clients use `flatbuffers::Vector<f32>::safe_slice()`, that triggers UB.

In a future PR, I will split SafeSliceAccess into the two properties to deprecate the conditional compilation and make things safe. 


@3ddi @krojew 