### PR TITLE
[Lua] GetRootAs can accept strings. Made Luatest Benchmarks optional

### DIFF
--- a/src/idl_gen_lua.cpp
+++ b/src/idl_gen_lua.cpp
@@ -124,6 +124,10 @@ class LuaGenerator : public BaseGenerator {
 
     code += "function " + NormalizedName(struct_def) + ".GetRootAs" +
             NormalizedName(struct_def) + "(buf, offset)\n";
+    code += std::string(Indent) + "if type(buf) == \"string\" then\n";
+    code += std::string(Indent) + Indent +
+            "buf = flatbuffers.binaryArray.New(buf)\n";
+    code += std::string(Indent) + "end\n";
     code += std::string(Indent) +
             "local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)\n";
     code += std::string(Indent) + "local o = " + NormalizedName(struct_def) +

--- a/tests/MyGame/Example/Monster.lua
+++ b/tests/MyGame/Example/Monster.lua
@@ -14,6 +14,9 @@ function Monster.New()
     return o
 end
 function Monster.GetRootAsMonster(buf, offset)
+    if type(buf) == "string" then
+        buf = flatbuffers.binaryArray.New(buf)
+    end
     local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)
     local o = Monster.New()
     o:Init(buf, n + offset)

--- a/tests/MyGame/Example/Referrable.lua
+++ b/tests/MyGame/Example/Referrable.lua
@@ -13,6 +13,9 @@ function Referrable.New()
     return o
 end
 function Referrable.GetRootAsReferrable(buf, offset)
+    if type(buf) == "string" then
+        buf = flatbuffers.binaryArray.New(buf)
+    end
     local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)
     local o = Referrable.New()
     o:Init(buf, n + offset)

--- a/tests/MyGame/Example/Stat.lua
+++ b/tests/MyGame/Example/Stat.lua
@@ -13,6 +13,9 @@ function Stat.New()
     return o
 end
 function Stat.GetRootAsStat(buf, offset)
+    if type(buf) == "string" then
+        buf = flatbuffers.binaryArray.New(buf)
+    end
     local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)
     local o = Stat.New()
     o:Init(buf, n + offset)

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.lua
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.lua
@@ -13,6 +13,9 @@ function TestSimpleTableWithEnum.New()
     return o
 end
 function TestSimpleTableWithEnum.GetRootAsTestSimpleTableWithEnum(buf, offset)
+    if type(buf) == "string" then
+        buf = flatbuffers.binaryArray.New(buf)
+    end
     local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)
     local o = TestSimpleTableWithEnum.New()
     o:Init(buf, n + offset)

--- a/tests/MyGame/Example/TypeAliases.lua
+++ b/tests/MyGame/Example/TypeAliases.lua
@@ -13,6 +13,9 @@ function TypeAliases.New()
     return o
 end
 function TypeAliases.GetRootAsTypeAliases(buf, offset)
+    if type(buf) == "string" then
+        buf = flatbuffers.binaryArray.New(buf)
+    end
     local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)
     local o = TypeAliases.New()
     o:Init(buf, n + offset)

--- a/tests/MyGame/Example2/Monster.lua
+++ b/tests/MyGame/Example2/Monster.lua
@@ -13,6 +13,9 @@ function Monster.New()
     return o
 end
 function Monster.GetRootAsMonster(buf, offset)
+    if type(buf) == "string" then
+        buf = flatbuffers.binaryArray.New(buf)
+    end
     local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)
     local o = Monster.New()
     o:Init(buf, n + offset)

--- a/tests/MyGame/InParentNamespace.lua
+++ b/tests/MyGame/InParentNamespace.lua
@@ -13,6 +13,9 @@ function InParentNamespace.New()
     return o
 end
 function InParentNamespace.GetRootAsInParentNamespace(buf, offset)
+    if type(buf) == "string" then
+        buf = flatbuffers.binaryArray.New(buf)
+    end
     local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)
     local o = InParentNamespace.New()
     o:Init(buf, n + offset)

--- a/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.lua
+++ b/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.lua
@@ -13,6 +13,9 @@ function TableInNestedNS.New()
     return o
 end
 function TableInNestedNS.GetRootAsTableInNestedNS(buf, offset)
+    if type(buf) == "string" then
+        buf = flatbuffers.binaryArray.New(buf)
+    end
     local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)
     local o = TableInNestedNS.New()
     o:Init(buf, n + offset)

--- a/tests/namespace_test/NamespaceA/SecondTableInA.lua
+++ b/tests/namespace_test/NamespaceA/SecondTableInA.lua
@@ -13,6 +13,9 @@ function SecondTableInA.New()
     return o
 end
 function SecondTableInA.GetRootAsSecondTableInA(buf, offset)
+    if type(buf) == "string" then
+        buf = flatbuffers.binaryArray.New(buf)
+    end
     local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)
     local o = SecondTableInA.New()
     o:Init(buf, n + offset)

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.lua
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.lua
@@ -13,6 +13,9 @@ function TableInFirstNS.New()
     return o
 end
 function TableInFirstNS.GetRootAsTableInFirstNS(buf, offset)
+    if type(buf) == "string" then
+        buf = flatbuffers.binaryArray.New(buf)
+    end
     local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)
     local o = TableInFirstNS.New()
     o:Init(buf, n + offset)

--- a/tests/namespace_test/NamespaceC/TableInC.lua
+++ b/tests/namespace_test/NamespaceC/TableInC.lua
@@ -13,6 +13,9 @@ function TableInC.New()
     return o
 end
 function TableInC.GetRootAsTableInC(buf, offset)
+    if type(buf) == "string" then
+        buf = flatbuffers.binaryArray.New(buf)
+    end
     local n = flatbuffers.N.UOffsetT:Unpack(buf, offset)
     local o = TableInC.New()
     o:Init(buf, n + offset)


### PR DESCRIPTION
Previously the user had to convert the binary strings into the flatbuffers.binaryArray before using the flatbuffer. Now the GetRootAs<type> generated methods support reading a string directly. This should make the flow from reading the buffer as a string to its flatbuffer view simpler for most people.

Updated Lua tests to add this case.

Made the Lua Test benchmarks optional by requiring a `benchmark` flag be set. This should speed up the testing a bit.

ran `tests/generate_code.sh`