### PR TITLE
Introduce new_from_vec in Rust (also fix formatting)

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatbuffers"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 authors = ["Robert Winslow <hello@rwinslow.com>", "FlatBuffers Maintainers"]
 license = "Apache-2.0"

--- a/rust/flatbuffers/src/array.rs
+++ b/rust/flatbuffers/src/array.rs
@@ -15,14 +15,11 @@
  */
 
 use crate::follow::Follow;
-use crate::{
-    vector::{SafeSliceAccess, VectorIter},
-    EndianScalar,
-};
+use crate::vector::VectorIter;
+use crate::EndianScalar;
 use std::fmt::{Debug, Formatter, Result};
 use std::marker::PhantomData;
 use std::mem::size_of;
-use std::slice::from_raw_parts;
 
 #[derive(Copy, Clone)]
 pub struct Array<'a, T: 'a, const N: usize>(&'a [u8], PhantomData<T>);
@@ -38,7 +35,7 @@ where
 }
 
 #[allow(clippy::len_without_is_empty)]
-#[allow(clippy::from_over_into)]  // TODO(caspern): Go from From to Into.
+#[allow(clippy::from_over_into)] // TODO(caspern): Go from From to Into.
 impl<'a, T: 'a, const N: usize> Array<'a, T, N> {
     #[inline(always)]
     pub fn new(buf: &'a [u8]) -> Self {

--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -62,24 +62,32 @@ pub struct FlatBufferBuilder<'fbb> {
 impl<'fbb> FlatBufferBuilder<'fbb> {
     /// Create a FlatBufferBuilder that is ready for writing.
     pub fn new() -> Self {
-        Self::new_with_capacity(0)
+        Self::with_capacity(0)
     }
-
+    #[deprecated(note = "replaced with `with_capacity`", since = "0.8.5")]
+    pub fn new_with_capacity(size: usize) -> Self {
+        Self::with_capacity(size)
+    }
     /// Create a FlatBufferBuilder that is ready for writing, with a
     /// ready-to-use capacity of the provided size.
     ///
     /// The maximum valid value is `FLATBUFFERS_MAX_BUFFER_SIZE`.
-    pub fn new_with_capacity(size: usize) -> Self {
+    pub fn with_capacity(size: usize) -> Self {
+        Self::from_vec(vec![0; size])
+    }
+    /// Create a FlatBufferBuilder that is ready for writing, reusing
+    /// an existing vector.
+    pub fn from_vec(buffer: Vec<u8>) -> Self {
         // we need to check the size here because we create the backing buffer
         // directly, bypassing the typical way of using grow_owned_buf:
         assert!(
-            size <= FLATBUFFERS_MAX_BUFFER_SIZE,
+            buffer.len() <= FLATBUFFERS_MAX_BUFFER_SIZE,
             "cannot initialize buffer bigger than 2 gigabytes"
         );
-
+        let head = buffer.len();
         FlatBufferBuilder {
-            owned_buf: vec![0u8; size],
-            head: size,
+            owned_buf: buffer,
+            head,
 
             field_locs: Vec::new(),
             written_vtable_revpos: Vec::new(),
@@ -765,6 +773,6 @@ fn padding_bytes(buf_size: usize, scalar_size: usize) -> usize {
 
 impl<'fbb> Default for FlatBufferBuilder<'fbb> {
     fn default() -> Self {
-        Self::new_with_capacity(0)
+        Self::with_capacity(0)
     }
 }

--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -415,10 +415,20 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
     }
     /// Get the byte slice for the data that has been written after a call to
     /// one of the `finish` functions.
+    /// # Panics
+    /// Panics if the buffer is not finished.
     #[inline]
     pub fn finished_data(&self) -> &[u8] {
         self.assert_finished("finished_bytes cannot be called when the buffer is not yet finished");
         &self.owned_buf[self.head..]
+    }
+    /// Returns a mutable view of a finished buffer and location of where the flatbuffer starts.
+    /// Note that modifying the flatbuffer data may corrupt it.
+    /// # Panics
+    /// Panics if the flatbuffer is not finished.
+    #[inline]
+    pub fn mut_finished_buffer(&mut self) -> (&mut [u8], usize) {
+        (&mut self.owned_buf, self.head)
     }
     /// Assert that a field is present in the just-finished Table.
     ///


### PR DESCRIPTION
This PR does 3 things:
1. Introduce `from_vec` to fix #6594 (@danielrh @dbaileychess)
2. Fix some formatting and unused imports in `array.rs`
3. Renaming `new_with_capacity` to `with_capacity` to match how `std` does it with `Vec`.