### PR TITLE
Update c++ flatbuffers.h fix to Vector<T>rbegin() / rend()

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -295,15 +295,11 @@ template<typename T> class Vector {
   iterator end() { return iterator(Data(), size()); }
   const_iterator end() const { return const_iterator(Data(), size()); }
 
-  reverse_iterator rbegin() { return reverse_iterator(end() - 1); }
-  const_reverse_iterator rbegin() const {
-    return const_reverse_iterator(end() - 1);
-  }
+  reverse_iterator rbegin() { return reverse_iterator(end()); }
+  const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
 
-  reverse_iterator rend() { return reverse_iterator(begin() - 1); }
-  const_reverse_iterator rend() const {
-    return const_reverse_iterator(begin() - 1);
-  }
+  reverse_iterator rend() { return reverse_iterator(begin()); }
+  const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
 
   const_iterator cbegin() const { return begin(); }
 


### PR DESCRIPTION
rbegin() and rend() were initializing the returned reverse_iterator with an offset of -1.
This seemed to be leading to a defunct iterator that does not loop at all. 
Removed offset, functions are now equivalent to version in flatbuffers::Array (and std.:vector).