### PR TITLE
Fixed LuaJIT when not compiled with COMPAT mode

### DIFF
--- a/lua/flatbuffers/builder.lua
+++ b/lua/flatbuffers/builder.lua
@@ -70,7 +70,7 @@ function mt:Clear()
     self.minalign = 1
     self.currentVTable = nil
     self.objectEnd = nil
-    self.head = #self.bytes -- place the head at the end of the binary array
+    self.head = self.bytes.size -- place the head at the end of the binary array
 
     -- clear vtables instead of making a new table
     local vtable = self.vtables
@@ -118,7 +118,7 @@ function mt:WriteVtable()
     while i >= 1 do
 
         local vt2Offset = self.vtables[i]
-        local vt2Start = #self.bytes - vt2Offset
+        local vt2Start = self.bytes.size - vt2Offset
         local vt2lenstr = self.bytes:Slice(vt2Start, vt2Start+1)
         local vt2Len = string_unpack(VOffsetT.packFmt, vt2lenstr, 1)
 
@@ -154,12 +154,12 @@ function mt:WriteVtable()
         vBytes = vBytes * 2
         self:PrependVOffsetT(vBytes)
 
-        local objectStart = #self.bytes - objectOffset
+        local objectStart = self.bytes.size - objectOffset
         self.bytes:Set(SOffsetT:Pack(self:Offset() - objectOffset),objectStart)
 
         table.insert(self.vtables, self:Offset())
     else
-        local objectStart = #self.bytes - objectOffset
+        local objectStart = self.bytes.size - objectOffset
         self.head = objectStart
         self.bytes:Set(SOffsetT:Pack(exisitingVTable - objectOffset),self.head)
     end
@@ -175,7 +175,7 @@ function mt:EndObject()
 end
 
 local function growByteBuffer(self, desiredSize)
-    local s = #self.bytes
+    local s = self.bytes.size
     assert(s < MAX_BUFFER_SIZE, "Flat Buffers cannot grow buffer beyond 2 gigabytes")
     local newsize = s
     repeat
@@ -191,7 +191,7 @@ function mt:Head()
 end
 
 function mt:Offset()
-   return #self.bytes - self.head
+   return self.bytes.size - self.head
 end
 
 function mt:Pad(n)
@@ -210,15 +210,15 @@ function mt:Prep(size, additionalBytes)
 
     local h = self.head
 
-    local k = #self.bytes - h + additionalBytes
+    local k = self.bytes.size - h + additionalBytes
     local alignsize = getAlignSize(k, size)
 
     local desiredSize = alignsize + size + additionalBytes
 
     while self.head < desiredSize do
-        local oldBufSize = #self.bytes
+        local oldBufSize = self.bytes.size
         growByteBuffer(self, desiredSize)
-        local updatedHead = self.head + #self.bytes - oldBufSize
+        local updatedHead = self.head + self.bytes.size - oldBufSize
         self.head = updatedHead
     end
 
@@ -301,7 +301,7 @@ local function finish(self, rootTable, sizePrefix)
     self:Prep(self.minalign, sizePrefix and 8 or 4)
     self:PrependUOffsetTRelative(rootTable)
     if sizePrefix then
-        local size = #self.bytes - self.head
+        local size = self.bytes.size - self.head
         Int32:EnforceNumber(size)
         self:PrependInt32(size)
     end

--- a/lua/flatbuffers/compat_luajit.lua
+++ b/lua/flatbuffers/compat_luajit.lua
@@ -9,6 +9,13 @@ local Uint8Bound = 256 -- bound is the max uintN + 1
 local Uint16Bound = 65536
 local Uint32Bound = 4294967296
 
+if not table.unpack then
+    table.unpack = unpack
+end
+
+if not table.pack then
+    table.pack = pack
+end
 
 m.GetAlignSize = function(k, size)
     return band((bnot(k) + 1), (size - 1))

--- a/tests/LuaTest.sh
+++ b/tests/LuaTest.sh
@@ -19,7 +19,13 @@ test_dir="$(pwd)"
 
 ${test_dir}/../flatc --lua -I include_test monster_test.fbs
 
-echo "Run with LuaJIT:"
-luajit luatest.lua
-echo "Run with Lua 5.3:"
-lua5.3 luatest.lua
+declare -a versions=(luajit lua5.3)
+
+for i in "${versions[@]}"
+do
+    if command -v $i &> /dev/null
+    then
+        echo "[$i]"
+        $i luatest.lua
+    fi
+done

--- a/tests/luatest.lua
+++ b/tests/luatest.lua
@@ -1,4 +1,5 @@
 package.path = string.format("../lua/?.lua;./?.lua;%s",package.path)
+local compat = require("flatbuffers.compat")
 
 local performBenchmarkTests = false
 
@@ -20,7 +21,7 @@ local function checkReadBuffer(buf, offset, sizePrefix)
     
     if sizePrefix then               
         local size = flatbuffers.N.Int32:Unpack(buf, offset)
-        assert(size == #buf - offset - 4)
+        assert(size == buf.size - offset - 4)
         offset = offset + flatbuffers.N.Int32.bytewidth
     end    
     


### PR DESCRIPTION
LuaJIT as installed by apt doesn't include the COMPAT mode for using
Lua5.2 features. So this change just makes the flatbuffer code use a
common implementation.
