### PR TITLE
[Lua] Adds support for Lua 5.2, 5.2 and 5.4

### DIFF
--- a/lua/flatbuffers/compat.lua
+++ b/lua/flatbuffers/compat.lua
@@ -1,12 +1,15 @@
-local m
-if _VERSION == "Lua 5.3" then
-    m = require("flatbuffers.compat_5_3")
-else
-    local ok = pcall(require, "jit")
-    if not ok then
-        error("Only Lua 5.3 or LuaJIT is supported")
-    else
-        m = require("flatbuffers.compat_luajit")
-    end
-end
-return m
+local compats = {
+    ["Lua 5.1"] = function()  
+        -- Check if Lua JIT is installed first
+        local ok = pcall(require, "jit")
+        if not ok then
+            return require("flatbuffers.compat_5_1")
+        else
+            return require("flatbuffers.compat_luajit")
+        end
+    end,
+    ["Lua 5.2"] = function() return require("flatbuffers.compat_5_1") end,
+    ["Lua 5.3"] = function() return require("flatbuffers.compat_5_3") end,
+    ["Lua 5.4"] = function() return require("flatbuffers.compat_5_3") end,
+}
+return assert(compats[_VERSION], "Unsupported Lua Version: ".._VERSION)()

--- a/lua/flatbuffers/compat_5_1.lua
+++ b/lua/flatbuffers/compat_5_1.lua
@@ -1,0 +1,21 @@
+local m = {}
+local ok, bit = pcall(require, "bit32")
+assert(ok, "The Bit32 library must be installed")
+assert(pcall(require, "compat53"), "The Compat 5.3 library must be installed")
+
+m.GetAlignSize = function(k, size)
+    return bit.band(bit.bnot(k) + 1,(size - 1))
+end
+
+if not table.unpack then
+    table.unpack = unpack
+end
+
+if not table.pack then
+    table.pack = pack
+end
+
+m.string_pack = string.pack
+m.string_unpack = string.unpack
+
+return m

--- a/tests/LuaTest.sh
+++ b/tests/LuaTest.sh
@@ -19,7 +19,7 @@ test_dir="$(pwd)"
 
 ${test_dir}/../flatc --lua -I include_test monster_test.fbs
 
-declare -a versions=(luajit lua5.3)
+declare -a versions=(luajit lua5.1 lua5.2 lua5.3 lua5.4)
 
 for i in "${versions[@]}"
 do

--- a/tests/luatest.lua
+++ b/tests/luatest.lua
@@ -370,4 +370,4 @@ if not result then
     print("Unable to run tests due to test framework error: ",err)
 end
 
-os.exit(result or -1)
+os.exit(result and 0 or -1)


### PR DESCRIPTION
This adds basic support for different Lua versions.

For Lua 5.2 and Lua 5.3, both the Bit32 and Compat53 Lua modules must be
installed for it to work. You can typically get these on Linux using

apt install lua-compat53 lua-bit32

For Lua 5.4, it should work as is, as it is a clean superset of Lua 5.3,
which is what the original Lua Flatbuffers supported.