### PR TITLE
Bump Rust to 0.9.0

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatbuffers"
-version = "0.8.6"
+version = "0.9.0"
 edition = "2018"
 authors = ["Robert Winslow <hello@rwinslow.com>", "FlatBuffers Maintainers"]
 license = "Apache-2.0"


### PR DESCRIPTION
0.8.6 should've been released as 0.9.0 since it's a breaking change. See #6608

I've yanked 0.8.6 and will republish as 0.9.0 once this gets submitted