### PR TITLE
[Rust] Add reset for FlexbufferSerializer

### DIFF
--- a/rust/flexbuffers/src/builder/ser.rs
+++ b/rust/flexbuffers/src/builder/ser.rs
@@ -36,6 +36,10 @@ impl FlexbufferSerializer {
     pub fn take_buffer(&mut self) -> Vec<u8> {
         self.builder.take_buffer()
     }
+    pub fn reset(&mut self) {
+      self.builder.reset();
+      self.nesting.clear();
+    }
     fn finish_if_not_nested(&mut self) -> Result<(), Error> {
         if self.nesting.is_empty() {
             assert_eq!(self.builder.values.len(), 1);


### PR DESCRIPTION
This PR allow us to keep the buffer of `FlexbufferSerializer` so that we can reuse `FlexbufferSerializer` object.

This will help performance when serializing a large number of objects. like

```rust
let mut fber = FlexbufferSerializer::new();

for msg in msgs {
    fber.reset();
    msg.serialize(&mut fber).unwrap();
    write(fber.view());
}
```
