### PR TITLE
[Rust] Removed some unsafe.

### DIFF
--- a/rust/flatbuffers/src/array.rs
+++ b/rust/flatbuffers/src/array.rs
@@ -93,18 +93,12 @@ pub fn emplace_scalar_array<T: EndianScalar, const N: usize>(
     loc: usize,
     src: &[T; N],
 ) {
-    let mut buf_ptr = buf[loc..].as_mut_ptr();
-    for item in src.iter() {
-        let item_le = item.to_little_endian();
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                &item_le as *const T as *const u8,
-                buf_ptr,
-                size_of::<T>(),
-            );
-            buf_ptr = buf_ptr.add(size_of::<T>());
-        }
-    }
+    let chunks = &mut buf[loc..].chunks_exact_mut(N);
+
+    chunks.zip(src.iter()).for_each(|(dst, item)| {
+        //let item = ;
+        dst.copy_from_slice(item.to_le_bytes().as_ref());
+    });
 }
 
 impl<'a, T: Follow<'a> + 'a, const N: usize> IntoIterator for Array<'a, T, N> {

--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -43,9 +43,7 @@ mod vtable_writer;
 
 pub use crate::array::{array_init, emplace_scalar_array, Array};
 pub use crate::builder::FlatBufferBuilder;
-pub use crate::endian_scalar::{
-    byte_swap_f32, byte_swap_f64, emplace_scalar, read_scalar, read_scalar_at, EndianScalar,
-};
+pub use crate::endian_scalar::EndianScalar;
 pub use crate::follow::{Follow, FollowStart};
 pub use crate::primitives::*;
 pub use crate::push::Push;

--- a/rust/flatbuffers/src/push.rs
+++ b/rust/flatbuffers/src/push.rs
@@ -17,7 +17,7 @@
 use std::cmp::max;
 use std::mem::{align_of, size_of};
 
-use crate::endian_scalar::emplace_scalar;
+use crate::endian_scalar::EndianScalar;
 
 /// Trait to abstract over functionality needed to write values (either owned
 /// or referenced). Used in FlatBufferBuilder and implemented for generated
@@ -61,9 +61,7 @@ macro_rules! impl_push_for_endian_scalar {
 
             #[inline]
             fn push(&self, dst: &mut [u8], _rest: &[u8]) {
-                unsafe {
-                    emplace_scalar::<$ty>(dst, *self);
-                }
+                dst.copy_from_slice((*self).to_le_bytes().as_ref())
             }
         }
     };


### PR DESCRIPTION
This PR is aimed at removing some `unsafe` code from the Rust implementation, which is a common source of UB and security vulnerabilities.

The basic idea is that we can make the code mostly endianess-independent, safe, and equally performant by using the following idiom:

```rust
pub trait EndianScalar: Sized + PartialEq + Copy + Clone {
    type Bytes: AsRef<[u8]> + for<'a> TryFrom<&'a [u8]>;
    const N: usize;
    fn to_le_bytes(self) -> Self::Bytes;
    fn from_le_bytes(v: Self::Bytes) -> Self;

    /// Reads a chunk into Self; panics if the chunk does not fit into `Self`.
    #[inline]
    fn from_le_chunk(chunk: &[u8]) -> Self {
        let chunk: Self::Bytes = match chunk.try_into() {
            Ok(v) => v,
            Err(_) => panic!(),
        };
        Self::from_le_bytes(chunk)
    }
```

and implement it for the native types as 

```rust
impl EndianScalar for $ty {
    type Bytes = [u8; size_of::<Self>()];
    const N: usize = size_of::<Self>();

    #[inline]
    fn to_le_bytes(self) -> Self {
        Self::to_le_bytes(self)

    #[inline]
    fn from_le_bytes(bytes: Self::Bytes) -> Self {
        <$ty>::from_le_bytes(bytes)
    }
}
```

From my experience from [arrow](https://github.com/jorgecarleitao/arrow2) and [parquet](https://github.com/jorgecarleitao/parquet2), either the compiler is able to prove that the panic never happens and removes it, or it is unable to prove and we most likely want to panic to avoid UB.

I was unable to find any unit-test or bench, so I can't really test this very well. I was hoping the CI would run here ^_^