### PR TITLE
[Java] Flexbuffers - Negative signed object length

### DIFF
--- a/java/com/google/flatbuffers/FlexBuffers.java
+++ b/java/com/google/flatbuffers/FlexBuffers.java
@@ -655,7 +655,7 @@ public class FlexBuffers {
 
         Sized(ReadBuf buff, int end, int byteWidth) {
             super(buff, end, byteWidth);
-            size = readInt(bb, end - byteWidth, byteWidth);
+            size = (int) readUInt(bb, end - byteWidth, byteWidth);
         }
 
         public int size() {

--- a/tests/JavaTest.java
+++ b/tests/JavaTest.java
@@ -862,6 +862,27 @@ class JavaTest {
         TestEq((byte)-1, result[3]);
     }
 
+    public static void testSingleElementLongBlob() {
+
+        // verifies blobs of up to 2^16 in length
+        for (int i = 2; i <= 1<<16; i = i<<1) {
+            byte[] input = new byte[i-1];
+            for (int index = 0; index < input.length; index++) {
+                input[index] = (byte)(index % 64);
+            }
+
+            FlexBuffersBuilder builder = new FlexBuffersBuilder();
+            builder.putBlob(input);
+            ByteBuffer b = builder.finish();
+            FlexBuffers.Reference r = FlexBuffers.getRoot(b);
+            byte[] result = r.asBlob().getBytes();
+            
+            for (int index = 0; index < input.length; index++) {
+                TestEq((byte)(index % 64), result[index]);
+            }
+        }
+    }
+
     public static void testSingleElementUByte() {
         FlexBuffersBuilder builder = new FlexBuffersBuilder();
         builder.putUInt(0xFF);
@@ -1084,6 +1105,7 @@ class JavaTest {
         testSingleElementSmallString();
         testSingleElementBigString();
         testSingleElementBlob();
+        testSingleElementLongBlob();
         testSingleElementVector();
         testSingleFixedTypeVector();
         testSingleElementUShort();


### PR DESCRIPTION
When using Flexbuffers, sizes are interpreted as singed integers

This is particular problematic if your vector or blob is between the following sizes in length.  

2^7 < size < 2^8 
2^15 < size <2^16
2^31 < size < 2^32

The current code will interpret these as signed integers and thus `size` will be negative. 

This would mean that FlexBuffers java cannot read any vector/blob that is 129 to 255 characters in length but can if its say 126 or 257 - because the size is used determine the index position.  

Example repro steps

```java
import com.google.flatbuffers.ByteBufferReadWriteBuf;
import com.google.flatbuffers.FlexBuffers;
import com.google.flatbuffers.FlexBuffers.Reference;
import com.google.flatbuffers.FlexBuffersBuilder;

import java.nio.ByteBuffer;
import java.nio.charset.StandardCharsets;

class Main {  
  public static void main(String args[]) { 
    System.out.println("Pack binary less than 128 bytes"); 

    String lessThan128 = "Lorem ipsum";
    System.out.println("Pack binary of length = " + lessThan128.length()); 

    FlexBuffersBuilder builder = new FlexBuffersBuilder(ByteBuffer.allocate(1024));
    builder.putBlob(lessThan128.getBytes(StandardCharsets.UTF_8));
    ByteBuffer bb = builder.finish();
    Reference root = FlexBuffers.getRoot(new ByteBufferReadWriteBuf(bb));System.out.println("Size = " + root.asBlob().size());
    System.out.println("Now try to get first byte 'L' ascii 76): " + (char)root.asBlob().data().get(0));


    String moreThan128LessThan256 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";

    System.out.println("Pack binary of length = " + moreThan128LessThan256.length()); 

    builder = new FlexBuffersBuilder(ByteBuffer.allocate(1024));
    builder.putBlob(moreThan128LessThan256.getBytes(StandardCharsets.UTF_8));
    bb = builder.finish();
    root = FlexBuffers.getRoot(new ByteBufferReadWriteBuf(bb));System.out.println("Size = " + root.asBlob().size());

    System.out.println("Now try to get first byte 'L' ascii 76): " + (char)root.asBlob().data().get(100));
  } 
}
```

will yield the following

```
Pack binary less than 128 bytes
Pack binary of length = 11
Size = 11
Now try to get first byte 'L' ascii 76): L
Pack binary of length = 231
Size = -25
Exception in thread "main" java.lang.IllegalArgumentException: newLimit < 0: (-24 < 0)
    at java.base/java.nio.Buffer.createLimitException(Buffer.java:372)
    at java.base/java.nio.Buffer.limit(Buffer.java:346)
    at java.base/java.nio.ByteBuffer.limit(ByteBuffer.java:1107)
    at com.google.flatbuffers.FlexBuffers$Blob.data(FlexBuffers.java:692)
    at Main.main(Main.java:32)
```

Example run here 
https://replit.com/@samirahmed1/Flatbuffer-Java-Negative-Sized#Main.java

