### PR TITLE
[GO] Update GRPC code to allow go to communicate with other languages 

### DIFF
--- a/grpc/examples/go/greeter/server/go.mod
+++ b/grpc/examples/go/greeter/server/go.mod
@@ -7,5 +7,5 @@ replace github.com/google/flatbuffers/grpc/examples/go/greeter/models v0.0.0 => 
 require (
 	github.com/google/flatbuffers v1.12.0
 	github.com/google/flatbuffers/grpc/examples/go/greeter/models v0.0.0
-	google.golang.org/grpc v1.35.0
+	google.golang.org/grpc v1.39.0-dev
 )

--- a/grpc/examples/go/greeter/server/main.go
+++ b/grpc/examples/go/greeter/server/main.go
@@ -9,7 +9,6 @@ import (
 	flatbuffers "github.com/google/flatbuffers/go"
 	models "github.com/google/flatbuffers/grpc/examples/go/greeter/models"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/encoding"
 )
 
 var (
@@ -68,8 +67,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
-	grpcServer := grpc.NewServer()
-	encoding.RegisterCodec(flatbuffers.FlatbuffersCodec{})
+	codec := &flatbuffers.FlatbuffersCodec{}
+	grpcServer := grpc.NewServer(grpc.ForceServerCodec(codec))
 	models.RegisterGreeterServer(grpcServer, newServer())
 	if err := grpcServer.Serve(lis); err != nil {
 		fmt.Print(err)


### PR DESCRIPTION
Updates the golang code, to use `grpc.ForceServerCodec` instead of the normal codec which allows golang to communicate with other languages without any of the old issues. 

ref:
- https://github.com/grpc/grpc/issues/25478
- https://github.com/grpc/grpc-go/issues/4213