### PR TITLE
[TS/JS] Updates the grpc

### DIFF
--- a/grpc/examples/go/greeter/server/go.mod
+++ b/grpc/examples/go/greeter/server/go.mod
@@ -7,5 +7,5 @@ replace github.com/google/flatbuffers/grpc/examples/go/greeter/models v0.0.0 => 
 require (
 	github.com/google/flatbuffers v1.12.0
 	github.com/google/flatbuffers/grpc/examples/go/greeter/models v0.0.0
-	google.golang.org/grpc v1.35.0
+	google.golang.org/grpc v1.39.0-dev
 )

--- a/grpc/examples/go/greeter/server/main.go
+++ b/grpc/examples/go/greeter/server/main.go
@@ -9,7 +9,6 @@ import (
 	flatbuffers "github.com/google/flatbuffers/go"
 	models "github.com/google/flatbuffers/grpc/examples/go/greeter/models"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/encoding"
 )
 
 var (
@@ -68,8 +67,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
-	grpcServer := grpc.NewServer()
-	encoding.RegisterCodec(flatbuffers.FlatbuffersCodec{})
+	codec := &flatbuffers.FlatbuffersCodec{}
+	grpcServer := grpc.NewServer(grpc.ForceServerCodec(codec))
 	models.RegisterGreeterServer(grpcServer, newServer())
 	if err := grpcServer.Serve(lis); err != nil {
 		fmt.Print(err)

--- a/grpc/examples/ts/greeter/package.json
+++ b/grpc/examples/ts/greeter/package.json
@@ -8,7 +8,7 @@
     "server": "node dist/server.js"
   },
   "dependencies": {
-    "flatbuffers": "^2.0.0",
-    "grpc": "^1.24.3"
+    "@grpc/grpc-js": "^1.3.2",
+    "flatbuffers": "^2.0.0"
   }
 }

--- a/grpc/examples/ts/greeter/src/client.ts
+++ b/grpc/examples/ts/greeter/src/client.ts
@@ -1,22 +1,22 @@
-import grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
+import * as flatbuffers from 'flatbuffers';
 import { HelloReply } from './models/hello-reply';
 import { HelloRequest } from './models/hello-request';
 import { GreeterClient } from './greeter_grpc';
-import { flatbuffers } from 'flatbuffers';
 
-async function main(PORT: Number, name: String) {
-    const _server = new GreeterClient(`localhost:${PORT}`, grpc.credentials.createInsecure());
+async function main(PORT: Number, name: string) {
+    const client = new GreeterClient(`localhost:${PORT}`, grpc.credentials.createInsecure());
     const builder = new flatbuffers.Builder();
     const offset = builder.createString(name);
     const root = HelloRequest.createHelloRequest(builder, offset);
     builder.finish(root);
     const buffer = HelloRequest.getRootAsHelloRequest(new flatbuffers.ByteBuffer(builder.asUint8Array()));
 
-    _server.SayHello(buffer, (err, response) => {
+    client.SayHello(buffer, (err, response) => {
         console.log(response.message());
     });
 
-    const data = _server.SayManyHellos(buffer, null);
+    const data = client.SayManyHellos(buffer, null);
 
     data.on('data', (data) => {
         console.log(data.message());
@@ -25,7 +25,7 @@ async function main(PORT: Number, name: String) {
 
 const args = process.argv.slice(2)
 const PORT = Number(args[0]);
-const name = String(args[1] ?? "flatbuffers");
+const name: string = args[1] ?? "flatbuffers";
 
 if (PORT) {
     main(PORT, name);

--- a/grpc/examples/ts/greeter/src/greeter_grpc.d.ts
+++ b/grpc/examples/ts/greeter/src/greeter_grpc.d.ts
@@ -3,7 +3,7 @@ import * as flatbuffers from 'flatbuffers';
 import { HelloReply as models_HelloReply } from './models/hello-reply';
 import { HelloRequest as models_HelloRequest } from './models/hello-request';
 
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 
 interface IGreeterService extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {
   SayHello: IGreeterService_ISayHello;
@@ -32,7 +32,7 @@ interface IGreeterService_ISayManyHellos extends grpc.MethodDefinition<models_He
 
 export const GreeterService: IGreeterService;
 
-export interface IGreeterServer {
+export interface IGreeterServer extends grpc.UntypedServiceImplementation {
   SayHello: grpc.handleUnaryCall<models_HelloRequest, models_HelloReply>;
   SayManyHellos: grpc.handleServerStreamingCall<models_HelloRequest, models_HelloReply>;
 }
@@ -46,7 +46,8 @@ export interface IGreeterClient {
 }
 
 export class GreeterClient extends grpc.Client implements IGreeterClient {
-  constructor(address: string, credentials: grpc.ChannelCredentials, options?: object);  public SayHello(request: models_HelloRequest, callback: (error: grpc.ServiceError | null, response: models_HelloReply) => void): grpc.ClientUnaryCall;
+  constructor(address: string, credentials: grpc.ChannelCredentials, options?: object);
+  public SayHello(request: models_HelloRequest, callback: (error: grpc.ServiceError | null, response: models_HelloReply) => void): grpc.ClientUnaryCall;
   public SayHello(request: models_HelloRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: models_HelloReply) => void): grpc.ClientUnaryCall;
   public SayHello(request: models_HelloRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: models_HelloReply) => void): grpc.ClientUnaryCall;
   public SayManyHellos(request: models_HelloRequest, metadata: grpc.Metadata): grpc.ClientReadableStream<models_HelloReply>;

--- a/grpc/examples/ts/greeter/src/greeter_grpc.js
+++ b/grpc/examples/ts/greeter/src/greeter_grpc.js
@@ -3,13 +3,13 @@ import * as flatbuffers from 'flatbuffers';
 import { HelloReply as models_HelloReply } from './models/hello-reply';
 import { HelloRequest as models_HelloRequest } from './models/hello-request';
 
-var grpc = require('grpc');
+var grpc = require('@grpc/grpc-js');
 
 function serialize_models_HelloReply(buffer_args) {
   if (!(buffer_args instanceof models_HelloReply)) {
     throw new Error('Expected argument of type HelloReply');
   }
-  return buffer_args.serialize();
+  return Buffer.from(buffer_args.serialize());
 }
 
 function deserialize_models_HelloReply(buffer) {
@@ -21,7 +21,7 @@ function serialize_models_HelloRequest(buffer_args) {
   if (!(buffer_args instanceof models_HelloRequest)) {
     throw new Error('Expected argument of type HelloRequest');
   }
-  return buffer_args.serialize();
+  return Buffer.from(buffer_args.serialize());
 }
 
 function deserialize_models_HelloRequest(buffer) {

--- a/grpc/src/compiler/ts_generator.cc
+++ b/grpc/src/compiler/ts_generator.cc
@@ -46,6 +46,7 @@ grpc::string ToDasherizedCase(const grpc::string pascal_case) {
   return dasherized_case;
 }
 
+
 grpc::string GenerateNamespace(const std::vector<std::string> namepsace,
                                const std::string filename,
                                const bool include_separator) {
@@ -105,9 +106,9 @@ void GenerateImports(const grpc_generator::Service *service,
   }
   printer->Print("\n");
   if (grpc_var_import)
-    printer->Print("var grpc = require('grpc');\n");
+    printer->Print("var grpc = require('@grpc/grpc-js');\n");
   else
-    printer->Print("import * as grpc from 'grpc';\n");
+    printer->Print("import * as grpc from '@grpc/grpc-js';\n");
   printer->Print("\n");
 }
 
@@ -136,7 +137,7 @@ void GenerateSerializeMethod(grpc_generator::Printer *printer,
                  "throw new Error('Expected argument of type $VALUE$');\n");
   printer->Outdent();
   printer->Print("}\n");
-  printer->Print(vars, "return buffer_args.serialize();\n");
+  printer->Print(vars, "return Buffer.from(buffer_args.serialize());\n");
   printer->Outdent();
   printer->Print("}\n\n");
 }
@@ -288,7 +289,9 @@ void GenerateExportedInterface(
     const grpc_generator::Service *service, grpc_generator::Printer *printer,
     std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
-  printer->Print(vars, "export interface I$ServiceName$Server {\n");
+  printer->Print(vars,
+                 "export interface I$ServiceName$Server extends "
+                 "grpc.UntypedServiceImplementation {\n");
   printer->Indent();
   for (auto it = 0; it < service->method_count(); it++) {
     auto method = service->method(it);
@@ -463,7 +466,7 @@ void GenerateClientClassInterface(
   printer->Indent();
   printer->Print(
       "constructor(address: string, credentials: grpc.ChannelCredentials, "
-      "options?: object);");
+      "options?: object);\n");
   for (auto it = 0; it < service->method_count(); it++) {
     auto method = service->method(it);
     vars["MethodName"] = method->name();

--- a/tests/monster_test_grpc.d.ts
+++ b/tests/monster_test_grpc.d.ts
@@ -3,7 +3,7 @@ import * as flatbuffers from 'flatbuffers';
 import { Stat as MyGame_Example_Stat } from './my-game/example/stat';
 import { Monster as MyGame_Example_Monster } from './my-game/example/monster';
 
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 
 interface IMonsterStorageService extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {
   Store: IMonsterStorageService_IStore;
@@ -54,7 +54,7 @@ interface IMonsterStorageService_IGetMinMaxHitPoints extends grpc.MethodDefiniti
 
 export const MonsterStorageService: IMonsterStorageService;
 
-export interface IMonsterStorageServer {
+export interface IMonsterStorageServer extends grpc.UntypedServiceImplementation {
   Store: grpc.handleUnaryCall<MyGame_Example_Monster, MyGame_Example_Stat>;
   Retrieve: grpc.handleServerStreamingCall<MyGame_Example_Stat, MyGame_Example_Monster>;
   GetMaxHitPoint: grpc.handleClientStreamingCall<MyGame_Example_Monster, MyGame_Example_Stat>;
@@ -77,7 +77,8 @@ export interface IMonsterStorageClient {
 }
 
 export class MonsterStorageClient extends grpc.Client implements IMonsterStorageClient {
-  constructor(address: string, credentials: grpc.ChannelCredentials, options?: object);  public Store(request: MyGame_Example_Monster, callback: (error: grpc.ServiceError | null, response: MyGame_Example_Stat) => void): grpc.ClientUnaryCall;
+  constructor(address: string, credentials: grpc.ChannelCredentials, options?: object);
+  public Store(request: MyGame_Example_Monster, callback: (error: grpc.ServiceError | null, response: MyGame_Example_Stat) => void): grpc.ClientUnaryCall;
   public Store(request: MyGame_Example_Monster, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: MyGame_Example_Stat) => void): grpc.ClientUnaryCall;
   public Store(request: MyGame_Example_Monster, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: MyGame_Example_Stat) => void): grpc.ClientUnaryCall;
   public Retrieve(request: MyGame_Example_Stat, metadata: grpc.Metadata): grpc.ClientReadableStream<MyGame_Example_Monster>;

--- a/tests/monster_test_grpc.js
+++ b/tests/monster_test_grpc.js
@@ -3,13 +3,13 @@ import * as flatbuffers from 'flatbuffers';
 import { Stat as MyGame_Example_Stat } from './my-game/example/stat';
 import { Monster as MyGame_Example_Monster } from './my-game/example/monster';
 
-var grpc = require('grpc');
+var grpc = require('@grpc/grpc-js');
 
 function serialize_MyGame_Example_Stat(buffer_args) {
   if (!(buffer_args instanceof MyGame_Example_Stat)) {
     throw new Error('Expected argument of type Stat');
   }
-  return buffer_args.serialize();
+  return Buffer.from(buffer_args.serialize());
 }
 
 function deserialize_MyGame_Example_Stat(buffer) {
@@ -21,7 +21,7 @@ function serialize_MyGame_Example_Monster(buffer_args) {
   if (!(buffer_args instanceof MyGame_Example_Monster)) {
     throw new Error('Expected argument of type Monster');
   }
-  return buffer_args.serialize();
+  return Buffer.from(buffer_args.serialize());
 }
 
 function deserialize_MyGame_Example_Monster(buffer) {


### PR DESCRIPTION
This PR updates the `GRPC` lib from the core one to use the `GRPC-JS` instead.

requires https://github.com/google/flatbuffers/pull/6653 to be merged