### PR TITLE
Provide backing map for shared strings

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -45,6 +45,7 @@
 #include <algorithm>
 #include <iterator>
 #include <memory>
+#include <map>
 
 #if defined(__unix__) && !defined(FLATBUFFERS_LOCALE_INDEPENDENT)
   #include <unistd.h>

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -3272,8 +3272,9 @@ void LoadVerifyBinaryTest() {
   }
 }
 
-void CreateSharedStringTest() {
+void CreateSharedStringTest(flatbuffers::StringPoolMap *map) {
   flatbuffers::FlatBufferBuilder builder;
+  if (map) { builder.SetStringPool(map); }
   const auto one1 = builder.CreateSharedString("one");
   const auto two = builder.CreateSharedString("two");
   const auto one2 = builder.CreateSharedString("one");
@@ -4037,7 +4038,9 @@ int FlatBufferTests() {
   ParseProtoBufAsciiTest();
   TypeAliasesTest();
   EndianSwapTest();
-  CreateSharedStringTest();
+  CreateSharedStringTest(nullptr);
+  flatbuffers::StringPoolMap shared_pool_map;
+  CreateSharedStringTest(&shared_pool_map);
   JsonDefaultTest();
   JsonEnumsTest();
   FlexBuffersTest();


### PR DESCRIPTION
Addresses #6619 

This is one way to move the backing container of the shared strings to the caller. 

This implementation is less than ideal, but I ran into issues with other approaches. Other thoughts would be appreciated!

Currently the data structure is a `std::set<Offset<String>>` which uses a custom comparator to do the string comparison by looking up the string in the buffer already. This is nice in that the set is just storing offsets and doesn't duplicate the string data. I couldn't figure out a good way to replicate this, since the comparator depends on the hidden `buf_` to do the indirection and I didn't want to expose that through the API.

So I changed the data structure to a `std:map<std::string, uoffset_t>` as this would use the normal `std::string` comparator. This allows callers to pass in their own `map` that flatbuffers will use to store the share strings. I originally tried to make it a `std::map<const char*, uffoset_t>` to reduce the memory usage, but because the flatbuffer buffer dynamically resizes, the `const char *` get invalidated. So that led me to just make a copy of the string.

Because this would be a breaking change, I still allow flatbuffers to create its own internal map that it manages. This led me to also require adding logic to keep track if the map is owned or not owned, so we can properly clean up the memory. All of this can be removed once we allow enough time for people to migrate to the new way of using `SetStringPool` method to supply their map.
