### PR TITLE
Dart test fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,3 +227,18 @@ jobs:
     - name: test
       working-directory: tests
       run: sh TypeScriptTest.sh
+
+  build-dart:
+    name: Build Dart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: flatc
+        # FIXME: make test script not rely on flatc
+        run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF . && make -j4
+      - name: test
+        working-directory: tests
+        run: bash DartTest.sh

--- a/dart/test/flat_buffers_test.dart
+++ b/dart/test/flat_buffers_test.dart
@@ -29,7 +29,8 @@ int indexToField(int index) {
 class CheckOtherLangaugesData {
   test_cppData() async {
     List<int> data = await new io.File(path.join(
-      path.dirname(io.Platform.script.path),
+      path.context.current,
+      'test',
       'monsterdata_test.mon',
     )).readAsBytes();
     example.Monster mon = new example.Monster(data);
@@ -643,7 +644,9 @@ class GeneratorTest {
     expect(example.Color.values, same(example.Color.values));
     expect(example.Race.values, same(example.Race.values));
     expect(example.AnyTypeId.values, same(example.AnyTypeId.values));
-    expect(example.AnyUniqueAliasesTypeId.values, same(example.AnyUniqueAliasesTypeId.values));
-    expect(example.AnyAmbiguousAliasesTypeId.values, same(example.AnyAmbiguousAliasesTypeId.values));
+    expect(example.AnyUniqueAliasesTypeId.values,
+        same(example.AnyUniqueAliasesTypeId.values));
+    expect(example.AnyAmbiguousAliasesTypeId.values,
+        same(example.AnyAmbiguousAliasesTypeId.values));
   }
 }

--- a/dart/test/flat_buffers_test.dart
+++ b/dart/test/flat_buffers_test.dart
@@ -83,7 +83,7 @@ class CheckOtherLangaugesData {
       'anyUniqueType: AnyUniqueAliasesTypeId{value: 0}, anyUnique: null, '
       'anyAmbiguousType: AnyAmbiguousAliasesTypeId{value: 0}, '
       'anyAmbiguous: null, vectorOfEnums: null, signedEnum: Race{value: -1}, '
-      'testrequirednestedflatbuffer: null}, '
+      'testrequirednestedflatbuffer: null, scalarKeySortedTables: null}, '
       'test4: [Test{a: 10, b: 20}, Test{a: 30, b: 40}], '
       'testarrayofstring: [test1, test2], testarrayoftables: null, '
       'enemy: Monster{pos: null, mana: 150, hp: 100, name: Fred, '
@@ -104,7 +104,7 @@ class CheckOtherLangaugesData {
       'anyUniqueType: AnyUniqueAliasesTypeId{value: 0}, anyUnique: null, '
       'anyAmbiguousType: AnyAmbiguousAliasesTypeId{value: 0}, '
       'anyAmbiguous: null, vectorOfEnums: null, signedEnum: Race{value: -1}, '
-      'testrequirednestedflatbuffer: null}, '
+      'testrequirednestedflatbuffer: null, scalarKeySortedTables: null}, '
       'testnestedflatbuffer: null, testempty: null, testbool: true, '
       'testhashs32Fnv1: -579221183, testhashu32Fnv1: 3715746113, '
       'testhashs64Fnv1: 7930699090847568257, '
@@ -113,7 +113,9 @@ class CheckOtherLangaugesData {
       'testhashs64Fnv1a: 4898026182817603057, '
       'testhashu64Fnv1a: 4898026182817603057, '
       'testarrayofbools: [true, false, true], testf: 3.14159, testf2: 3.0, '
-      'testf3: 0.0, testarrayofstring2: null, testarrayofsortedstruct: null, '
+      'testf3: 0.0, testarrayofstring2: null, testarrayofsortedstruct: ['
+      'Ability{id: 0, distance: 45}, Ability{id: 1, distance: 21}, '
+      'Ability{id: 5, distance: 12}], '
       'flex: null, test5: [Test{a: 10, b: 20}, Test{a: 30, b: 40}], '
       'vectorOfLongs: [1, 100, 10000, 1000000, 100000000], '
       'vectorOfDoubles: [-1.7976931348623157e+308, 0.0, 1.7976931348623157e+308], '
@@ -125,7 +127,8 @@ class CheckOtherLangaugesData {
       'anyUniqueType: AnyUniqueAliasesTypeId{value: 0}, anyUnique: null, '
       'anyAmbiguousType: AnyAmbiguousAliasesTypeId{value: 0}, '
       'anyAmbiguous: null, vectorOfEnums: null, signedEnum: Race{value: -1}, '
-      'testrequirednestedflatbuffer: null}',
+      'testrequirednestedflatbuffer: null, scalarKeySortedTables: [Stat{id: '
+      'miss, val: 0, count: 0}, Stat{id: hit, val: 10, count: 1}]}',
     );
   }
 }


### PR DESCRIPTION
Fixes dart tests - no changes to the actual repo code. Executed on Dart 2.12, Linux.

* the first commit - previously the test failed with `FileSystemException: Cannot open file, path = 'application/dart;charset=utf-8,%20%20%20%20//%20@dart=2.0%0A%20%20%20%20import%20%22dart:isolate%22;%0A%0A%20%20%20%20import%20%22package:test_core/src/bootstrap/vm.dart%22;%0A%0A%20%20%20%20import%20%22file:///home/<path-shortened/flatbuffers/dart/test/monsterdata_test.mon' (OS Error: No such file or directory, errno = 2)`

* the second commit - seems like some changes were made to the test data. I haven't investigated whether those are expected or not, just updated so that tests pass.

* bonus: adds CI to test dart...
