### PR TITLE
flatc --cpp-field-case option to permit camel-case field names in C++

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -536,6 +536,10 @@ struct ServiceDef : public Definition {
 
 // Container of options that may apply to any of the source/text generators.
 struct IDLOptions {
+
+  // field case style options for C++
+  enum Case { Case_Snake = 0, Case_Upper, Case_Lower };
+
   bool gen_jvmstatic;
   // Use flexbuffers instead for binary and text generation
   bool use_flexbuffers;
@@ -558,6 +562,7 @@ struct IDLOptions {
   std::string cpp_object_api_pointer_type;
   std::string cpp_object_api_string_type;
   bool cpp_object_api_string_flexible_constructor;
+  int cpp_object_api_field_case;
   bool cpp_direct_copy;
   bool gen_nullable;
   bool java_checkerframework;
@@ -651,6 +656,7 @@ struct IDLOptions {
         gen_compare(false),
         cpp_object_api_pointer_type("std::unique_ptr"),
         cpp_object_api_string_flexible_constructor(false),
+	cpp_object_api_field_case(Case_Snake),
         cpp_direct_copy(true),
         gen_nullable(false),
         java_checkerframework(false),

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -121,6 +121,11 @@ std::string FlatCompiler::GetUsageString(const char *program_name) const {
     "                         (see the --cpp-str-flex-ctor option to change this behavior).\n"
     "  --cpp-str-flex-ctor    Don't construct custom string types by passing std::string\n"
     "                         from Flatbuffers, but (char* + length).\n"
+    "  --cpp-field-case STYLE Generate C++ fields using selected case style.\n"
+    "                         Supported STYLE values:\n"
+    "                          * 'snake' - leave unchanged (default);\n"
+    "                          * 'upper' - upper camel case;\n"
+    "                          * 'lower' - lower camel case.\n"
     "  --cpp-std CPP_STD      Generate a C++ code using features of selected C++ standard.\n"
     "                         Supported CPP_STD values:\n"
     "                          * 'c++0x' - generate code compatible with old compilers;\n"
@@ -275,6 +280,16 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.cpp_object_api_string_flexible_constructor = true;
       } else if (arg == "--no-cpp-direct-copy") {
         opts.cpp_direct_copy = false;
+      } else if (arg == "--cpp-case-style") {
+        if (++argi >= argc) Error("missing case style following: " + arg, true);
+	if (!strcmp(argv[argi], "snake"))
+	  opts.cpp_object_api_field_case = IDLOptions::Case_Snake;
+	else if (!strcmp(argv[argi], "upper"))
+	  opts.cpp_object_api_field_case = IDLOptions::Case_Upper;
+	else if (!strcmp(argv[argi], "lower"))
+	  opts.cpp_object_api_field_case = IDLOptions::Case_Lower;
+	else
+	  Error("unknown case style: " + std::string(argv[argi]), true);
       } else if (arg == "--gen-nullable") {
         opts.gen_nullable = true;
       } else if (arg == "--java-checkerframework") {

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -233,6 +233,48 @@ class CppGenerator : public BaseGenerator {
     return keywords_.find(name) == keywords_.end() ? name : name + "_";
   }
 
+  std::string Name(const FieldDef &field) const {
+    // the union type field suffix is immutable
+    static size_t union_suffix_len = strlen(UnionTypeFieldSuffix());
+    // early return if no case transformation required
+    switch (opts_.cpp_object_api_field_case) {
+      default:
+	return EscapeKeyword(field.name);
+      case IDLOptions::Case_Upper:
+      case IDLOptions::Case_Lower:
+	break;
+    }
+    std::string name = field.name;
+    switch (field.value.type.base_type) {
+      // do not change the case style of the union type field suffix
+      case BASE_TYPE_UTYPE: {
+	if (name.length() > union_suffix_len)
+	  name.erase(name.length() - union_suffix_len, union_suffix_len);
+      } break;
+      default:
+	break;
+    }
+    switch (opts_.cpp_object_api_field_case) {
+      case IDLOptions::Case_Upper:
+	name = MakeCamel(name, true);
+	break;
+      case IDLOptions::Case_Lower:
+	name = MakeCamel(name, false);
+	break;
+      default:
+	break;
+    }
+    switch (field.value.type.base_type) {
+      // restore the union field type suffix
+      case BASE_TYPE_UTYPE:
+	name.append(UnionTypeFieldSuffix(), union_suffix_len);
+	break;
+      default:
+	break;
+    }
+    return EscapeKeyword(name);
+  }
+
   std::string Name(const Definition &def) const {
     return EscapeKeyword(def.name);
   }


### PR DESCRIPTION
As suggested in the comments in #6005 , I added the --cpp-field-case option to permit migrating schemas to snake-case without disrupting C++ code using camel-case field names. This permits C++ code generation with snake (unchanged), upper camel and lower camel casing.

`  --cpp-field-case STYLE Generate C++ fields using selected case style.
                         Supported STYLE values:
                          * 'snake' - leave unchanged (default);
                          * 'upper' - upper camel case;
                          * 'lower' - lower camel case.`
