### PR TITLE
[C++] flatc --cpp-field-case-style option to permit camel-case field names in C++

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -536,6 +536,10 @@ struct ServiceDef : public Definition {
 
 // Container of options that may apply to any of the source/text generators.
 struct IDLOptions {
+
+  // field case style options for C++
+  enum Case { Case_Snake = 0, Case_Upper, Case_Lower };
+
   bool gen_jvmstatic;
   // Use flexbuffers instead for binary and text generation
   bool use_flexbuffers;
@@ -558,6 +562,7 @@ struct IDLOptions {
   std::string cpp_object_api_pointer_type;
   std::string cpp_object_api_string_type;
   bool cpp_object_api_string_flexible_constructor;
+  int cpp_object_api_field_case;
   bool cpp_direct_copy;
   bool gen_nullable;
   bool java_checkerframework;
@@ -651,6 +656,7 @@ struct IDLOptions {
         gen_compare(false),
         cpp_object_api_pointer_type("std::unique_ptr"),
         cpp_object_api_string_flexible_constructor(false),
+	cpp_object_api_field_case(Case_Snake),
         cpp_direct_copy(true),
         gen_nullable(false),
         java_checkerframework(false),

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -537,7 +537,7 @@ struct ServiceDef : public Definition {
 // Container of options that may apply to any of the source/text generators.
 struct IDLOptions {
   // field case style options for C++
-  enum Case { Case_Snake = 0, Case_Upper, Case_Lower };
+  enum Case { Case_Unchanged = 0, Case_Upper, Case_Lower };
 
   bool gen_jvmstatic;
   // Use flexbuffers instead for binary and text generation
@@ -655,7 +655,7 @@ struct IDLOptions {
         gen_compare(false),
         cpp_object_api_pointer_type("std::unique_ptr"),
         cpp_object_api_string_flexible_constructor(false),
-        cpp_object_api_field_case(Case_Snake),
+        cpp_object_api_field_case(Case_Unchanged),
         cpp_direct_copy(true),
         gen_nullable(false),
         java_checkerframework(false),

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -536,7 +536,6 @@ struct ServiceDef : public Definition {
 
 // Container of options that may apply to any of the source/text generators.
 struct IDLOptions {
-
   // field case style options for C++
   enum Case { Case_Snake = 0, Case_Upper, Case_Lower };
 
@@ -656,7 +655,7 @@ struct IDLOptions {
         gen_compare(false),
         cpp_object_api_pointer_type("std::unique_ptr"),
         cpp_object_api_string_flexible_constructor(false),
-	cpp_object_api_field_case(Case_Snake),
+        cpp_object_api_field_case(Case_Snake),
         cpp_direct_copy(true),
         gen_nullable(false),
         java_checkerframework(false),

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -537,7 +537,7 @@ struct ServiceDef : public Definition {
 // Container of options that may apply to any of the source/text generators.
 struct IDLOptions {
   // field case style options for C++
-  enum Case { Case_Unchanged = 0, Case_Upper, Case_Lower };
+  enum CaseStyle { CaseStyle_Unchanged = 0, CaseStyle_Upper, CaseStyle_Lower };
 
   bool gen_jvmstatic;
   // Use flexbuffers instead for binary and text generation
@@ -561,7 +561,7 @@ struct IDLOptions {
   std::string cpp_object_api_pointer_type;
   std::string cpp_object_api_string_type;
   bool cpp_object_api_string_flexible_constructor;
-  int cpp_object_api_field_case;
+  CaseStyle cpp_object_api_field_case_style;
   bool cpp_direct_copy;
   bool gen_nullable;
   bool java_checkerframework;
@@ -655,7 +655,7 @@ struct IDLOptions {
         gen_compare(false),
         cpp_object_api_pointer_type("std::unique_ptr"),
         cpp_object_api_string_flexible_constructor(false),
-        cpp_object_api_field_case(Case_Unchanged),
+        cpp_object_api_field_case_style(CaseStyle_Unchanged),
         cpp_direct_copy(true),
         gen_nullable(false),
         java_checkerframework(false),

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -121,6 +121,11 @@ std::string FlatCompiler::GetUsageString(const char *program_name) const {
     "                         (see the --cpp-str-flex-ctor option to change this behavior).\n"
     "  --cpp-str-flex-ctor    Don't construct custom string types by passing std::string\n"
     "                         from Flatbuffers, but (char* + length).\n"
+    "  --cpp-field-case STYLE Generate C++ fields using selected case style.\n"
+    "                         Supported STYLE values:\n"
+    "                          * 'snake' - leave unchanged (default);\n"
+    "                          * 'upper' - upper camel case;\n"
+    "                          * 'lower' - lower camel case.\n"
     "  --cpp-std CPP_STD      Generate a C++ code using features of selected C++ standard.\n"
     "                         Supported CPP_STD values:\n"
     "                          * 'c++0x' - generate code compatible with old compilers;\n"
@@ -275,6 +280,16 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.cpp_object_api_string_flexible_constructor = true;
       } else if (arg == "--no-cpp-direct-copy") {
         opts.cpp_direct_copy = false;
+      } else if (arg == "--cpp-case-style") {
+        if (++argi >= argc) Error("missing case style following: " + arg, true);
+	if (!strcmp(argv[argi], "snake"))
+	  opts.cpp_object_api_field_case = IDLOptions::Case_Snake;
+	else if (!strcmp(argv[argi], "upper"))
+	  opts.cpp_object_api_field_case = IDLOptions::Case_Upper;
+	else if (!strcmp(argv[argi], "lower"))
+	  opts.cpp_object_api_field_case = IDLOptions::Case_Lower;
+	else
+	  Error("unknown case style: " + std::string(argv[argi]), true);
       } else if (arg == "--gen-nullable") {
         opts.gen_nullable = true;
       } else if (arg == "--java-checkerframework") {

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -123,9 +123,9 @@ std::string FlatCompiler::GetUsageString(const char *program_name) const {
     "                         from Flatbuffers, but (char* + length).\n"
     "  --cpp-field-case STYLE Generate C++ fields using selected case style.\n"
     "                         Supported STYLE values:\n"
-    "                          * 'snake' - leave unchanged (default);\n"
-    "                          * 'upper' - upper camel case;\n"
-    "                          * 'lower' - lower camel case.\n"
+    "                          * 'unchanged' - leave unchanged (default);\n"
+    "                          * 'upper' - schema snake_case emits UpperCamel;\n"
+    "                          * 'lower' - schema snake_case emits lowerCamel.\n"
     "  --cpp-std CPP_STD      Generate a C++ code using features of selected C++ standard.\n"
     "                         Supported CPP_STD values:\n"
     "                          * 'c++0x' - generate code compatible with old compilers;\n"
@@ -282,8 +282,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.cpp_direct_copy = false;
       } else if (arg == "--cpp-field-case") {
         if (++argi >= argc) Error("missing case style following: " + arg, true);
-        if (!strcmp(argv[argi], "snake"))
-          opts.cpp_object_api_field_case = IDLOptions::Case_Snake;
+        if (!strcmp(argv[argi], "unchanged"))
+          opts.cpp_object_api_field_case = IDLOptions::Case_Unchanged;
         else if (!strcmp(argv[argi], "upper"))
           opts.cpp_object_api_field_case = IDLOptions::Case_Upper;
         else if (!strcmp(argv[argi], "lower"))

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -121,7 +121,7 @@ std::string FlatCompiler::GetUsageString(const char *program_name) const {
     "                         (see the --cpp-str-flex-ctor option to change this behavior).\n"
     "  --cpp-str-flex-ctor    Don't construct custom string types by passing std::string\n"
     "                         from Flatbuffers, but (char* + length).\n"
-    "  --cpp-field-case STYLE Generate C++ fields using selected case style.\n"
+    "  --cpp-field-case-style STYLE Generate C++ fields using selected case style.\n"
     "                         Supported STYLE values:\n"
     "                          * 'unchanged' - leave unchanged (default);\n"
     "                          * 'upper' - schema snake_case emits UpperCamel;\n"
@@ -280,14 +280,17 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.cpp_object_api_string_flexible_constructor = true;
       } else if (arg == "--no-cpp-direct-copy") {
         opts.cpp_direct_copy = false;
-      } else if (arg == "--cpp-field-case") {
+      } else if (arg == "--cpp-field-case-style") {
         if (++argi >= argc) Error("missing case style following: " + arg, true);
         if (!strcmp(argv[argi], "unchanged"))
-          opts.cpp_object_api_field_case = IDLOptions::Case_Unchanged;
+          opts.cpp_object_api_field_case_style =
+	    IDLOptions::CaseStyle_Unchanged;
         else if (!strcmp(argv[argi], "upper"))
-          opts.cpp_object_api_field_case = IDLOptions::Case_Upper;
+          opts.cpp_object_api_field_case_style =
+	    IDLOptions::CaseStyle_Upper;
         else if (!strcmp(argv[argi], "lower"))
-          opts.cpp_object_api_field_case = IDLOptions::Case_Lower;
+          opts.cpp_object_api_field_case_style =
+	    IDLOptions::CaseStyle_Lower;
         else
           Error("unknown case style: " + std::string(argv[argi]), true);
       } else if (arg == "--gen-nullable") {

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -280,16 +280,16 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.cpp_object_api_string_flexible_constructor = true;
       } else if (arg == "--no-cpp-direct-copy") {
         opts.cpp_direct_copy = false;
-      } else if (arg == "--cpp-case-style") {
+      } else if (arg == "--cpp-field-case") {
         if (++argi >= argc) Error("missing case style following: " + arg, true);
-	if (!strcmp(argv[argi], "snake"))
-	  opts.cpp_object_api_field_case = IDLOptions::Case_Snake;
-	else if (!strcmp(argv[argi], "upper"))
-	  opts.cpp_object_api_field_case = IDLOptions::Case_Upper;
-	else if (!strcmp(argv[argi], "lower"))
-	  opts.cpp_object_api_field_case = IDLOptions::Case_Lower;
-	else
-	  Error("unknown case style: " + std::string(argv[argi]), true);
+        if (!strcmp(argv[argi], "snake"))
+          opts.cpp_object_api_field_case = IDLOptions::Case_Snake;
+        else if (!strcmp(argv[argi], "upper"))
+          opts.cpp_object_api_field_case = IDLOptions::Case_Upper;
+        else if (!strcmp(argv[argi], "lower"))
+          opts.cpp_object_api_field_case = IDLOptions::Case_Lower;
+        else
+          Error("unknown case style: " + std::string(argv[argi]), true);
       } else if (arg == "--gen-nullable") {
         opts.gen_nullable = true;
       } else if (arg == "--java-checkerframework") {

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -284,13 +284,11 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         if (++argi >= argc) Error("missing case style following: " + arg, true);
         if (!strcmp(argv[argi], "unchanged"))
           opts.cpp_object_api_field_case_style =
-	    IDLOptions::CaseStyle_Unchanged;
+              IDLOptions::CaseStyle_Unchanged;
         else if (!strcmp(argv[argi], "upper"))
-          opts.cpp_object_api_field_case_style =
-	    IDLOptions::CaseStyle_Upper;
+          opts.cpp_object_api_field_case_style = IDLOptions::CaseStyle_Upper;
         else if (!strcmp(argv[argi], "lower"))
-          opts.cpp_object_api_field_case_style =
-	    IDLOptions::CaseStyle_Lower;
+          opts.cpp_object_api_field_case_style = IDLOptions::CaseStyle_Lower;
         else
           Error("unknown case style: " + std::string(argv[argi]), true);
       } else if (arg == "--gen-nullable") {

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -238,11 +238,9 @@ class CppGenerator : public BaseGenerator {
     static size_t union_suffix_len = strlen(UnionTypeFieldSuffix());
     // early return if no case transformation required
     switch (opts_.cpp_object_api_field_case) {
-      default:
-        return EscapeKeyword(field.name);
+      default: return EscapeKeyword(field.name);
       case IDLOptions::Case_Upper:
-      case IDLOptions::Case_Lower:
-        break;
+      case IDLOptions::Case_Lower: break;
     }
     std::string name = field.name;
     switch (field.value.type.base_type) {
@@ -251,26 +249,19 @@ class CppGenerator : public BaseGenerator {
         if (name.length() > union_suffix_len)
           name.erase(name.length() - union_suffix_len, union_suffix_len);
       } break;
-      default:
-        break;
+      default: break;
     }
     switch (opts_.cpp_object_api_field_case) {
-      case IDLOptions::Case_Upper:
-        name = MakeCamel(name, true);
-        break;
-      case IDLOptions::Case_Lower:
-        name = MakeCamel(name, false);
-        break;
-      default:
-        break;
+      case IDLOptions::Case_Upper: name = MakeCamel(name, true); break;
+      case IDLOptions::Case_Lower: name = MakeCamel(name, false); break;
+      default: break;
     }
     switch (field.value.type.base_type) {
       // restore the union field type suffix
       case BASE_TYPE_UTYPE:
         name.append(UnionTypeFieldSuffix(), union_suffix_len);
         break;
-      default:
-        break;
+      default: break;
     }
     return EscapeKeyword(name);
   }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -239,38 +239,38 @@ class CppGenerator : public BaseGenerator {
     // early return if no case transformation required
     switch (opts_.cpp_object_api_field_case) {
       default:
-	return EscapeKeyword(field.name);
+        return EscapeKeyword(field.name);
       case IDLOptions::Case_Upper:
       case IDLOptions::Case_Lower:
-	break;
+        break;
     }
     std::string name = field.name;
     switch (field.value.type.base_type) {
       // do not change the case style of the union type field suffix
       case BASE_TYPE_UTYPE: {
-	if (name.length() > union_suffix_len)
-	  name.erase(name.length() - union_suffix_len, union_suffix_len);
+        if (name.length() > union_suffix_len)
+          name.erase(name.length() - union_suffix_len, union_suffix_len);
       } break;
       default:
-	break;
+        break;
     }
     switch (opts_.cpp_object_api_field_case) {
       case IDLOptions::Case_Upper:
-	name = MakeCamel(name, true);
-	break;
+        name = MakeCamel(name, true);
+        break;
       case IDLOptions::Case_Lower:
-	name = MakeCamel(name, false);
-	break;
+        name = MakeCamel(name, false);
+        break;
       default:
-	break;
+        break;
     }
     switch (field.value.type.base_type) {
       // restore the union field type suffix
       case BASE_TYPE_UTYPE:
-	name.append(UnionTypeFieldSuffix(), union_suffix_len);
-	break;
+        name.append(UnionTypeFieldSuffix(), union_suffix_len);
+        break;
       default:
-	break;
+        break;
     }
     return EscapeKeyword(name);
   }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -243,8 +243,10 @@ class CppGenerator : public BaseGenerator {
       return EscapeKeyword(field.name);
     std::string name = field.name;
     // do not change the case style of the union type field suffix
-    if (is_union_type && name.length() > union_suffix_len)
+    if (is_union_type) {
+      FLATBUFFERS_ASSERT(name.length() > union_suffix_len);
       name.erase(name.length() - union_suffix_len, union_suffix_len);
+    }
     if (opts_.cpp_object_api_field_case_style == IDLOptions::CaseStyle_Upper)
       name = MakeCamel(name, true); /* upper */
     else if (opts_.cpp_object_api_field_case_style ==

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -236,20 +236,23 @@ class CppGenerator : public BaseGenerator {
   std::string Name(const FieldDef &field) const {
     // the union type field suffix is immutable
     static size_t union_suffix_len = strlen(UnionTypeFieldSuffix());
+    const bool is_union_type = field.value.type.base_type == BASE_TYPE_UTYPE;
     // early return if no case transformation required
-    if (opts_.cpp_object_api_field_case == IDLOptions::Case_Unchanged)
+    if (opts_.cpp_object_api_field_case_style ==
+	IDLOptions::CaseStyle_Unchanged)
       return EscapeKeyword(field.name);
     std::string name = field.name;
-    if (field.value.type.base_type == BASE_TYPE_UTYPE &&
-        name.length() > union_suffix_len)
-      // do not change the case style of the union type field suffix
+    // do not change the case style of the union type field suffix
+    if (is_union_type && name.length() > union_suffix_len)
       name.erase(name.length() - union_suffix_len, union_suffix_len);
-    if (opts_.cpp_object_api_field_case == IDLOptions::Case_Upper)
+    if (opts_.cpp_object_api_field_case_style ==
+	IDLOptions::CaseStyle_Upper)
       name = MakeCamel(name, true); /* upper */
-    else if (opts_.cpp_object_api_field_case == IDLOptions::Case_Lower)
+    else if (opts_.cpp_object_api_field_case_style ==
+	IDLOptions::CaseStyle_Lower)
       name = MakeCamel(name, false); /* lower */
-    if (field.value.type.base_type == BASE_TYPE_UTYPE)
-      // restore the union field type suffix
+    // restore the union field type suffix
+    if (is_union_type)
       name.append(UnionTypeFieldSuffix(), union_suffix_len);
     return EscapeKeyword(name);
   }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -234,7 +234,7 @@ class CppGenerator : public BaseGenerator {
   }
 
   std::string Name(const FieldDef &field) const {
-    // the union type field suffix is immutable
+    // the union type field suffix is immutable.
     static size_t union_suffix_len = strlen(UnionTypeFieldSuffix());
     const bool is_union_type = field.value.type.base_type == BASE_TYPE_UTYPE;
     // early return if no case transformation required

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -237,32 +237,21 @@ class CppGenerator : public BaseGenerator {
     // the union type field suffix is immutable
     static size_t union_suffix_len = strlen(UnionTypeFieldSuffix());
     // early return if no case transformation required
-    switch (opts_.cpp_object_api_field_case) {
-      default: return EscapeKeyword(field.name);
-      case IDLOptions::Case_Upper:
-      case IDLOptions::Case_Lower: break;
-    }
+    if (opts_.cpp_object_api_field_case != IDLOptions::Case_Upper &&
+	opts_.cpp_object_api_field_case != IDLOptions::Case_Lower)
+      return EscapeKeyword(field.name);
     std::string name = field.name;
-    switch (field.value.type.base_type) {
+    if (field.value.type.base_type == BASE_TYPE_UTYPE &&
+	name.length() > union_suffix_len)
       // do not change the case style of the union type field suffix
-      case BASE_TYPE_UTYPE: {
-        if (name.length() > union_suffix_len)
-          name.erase(name.length() - union_suffix_len, union_suffix_len);
-      } break;
-      default: break;
-    }
-    switch (opts_.cpp_object_api_field_case) {
-      case IDLOptions::Case_Upper: name = MakeCamel(name, true); break;
-      case IDLOptions::Case_Lower: name = MakeCamel(name, false); break;
-      default: break;
-    }
-    switch (field.value.type.base_type) {
+      name.erase(name.length() - union_suffix_len, union_suffix_len);
+    if (opts_.cpp_object_api_field_case == IDLOptions::Case_Upper)
+      name = MakeCamel(name, true);
+    else if (opts_.cpp_object_api_field_case == IDLOptions::Case_Lower)
+      name = MakeCamel(name, false);
+    if (field.value.type.base_type == BASE_TYPE_UTYPE)
       // restore the union field type suffix
-      case BASE_TYPE_UTYPE:
-        name.append(UnionTypeFieldSuffix(), union_suffix_len);
-        break;
-      default: break;
-    }
+      name.append(UnionTypeFieldSuffix(), union_suffix_len);
     return EscapeKeyword(name);
   }
 

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -239,21 +239,19 @@ class CppGenerator : public BaseGenerator {
     const bool is_union_type = field.value.type.base_type == BASE_TYPE_UTYPE;
     // early return if no case transformation required
     if (opts_.cpp_object_api_field_case_style ==
-	IDLOptions::CaseStyle_Unchanged)
+        IDLOptions::CaseStyle_Unchanged)
       return EscapeKeyword(field.name);
     std::string name = field.name;
     // do not change the case style of the union type field suffix
     if (is_union_type && name.length() > union_suffix_len)
       name.erase(name.length() - union_suffix_len, union_suffix_len);
-    if (opts_.cpp_object_api_field_case_style ==
-	IDLOptions::CaseStyle_Upper)
+    if (opts_.cpp_object_api_field_case_style == IDLOptions::CaseStyle_Upper)
       name = MakeCamel(name, true); /* upper */
     else if (opts_.cpp_object_api_field_case_style ==
-	IDLOptions::CaseStyle_Lower)
+             IDLOptions::CaseStyle_Lower)
       name = MakeCamel(name, false); /* lower */
     // restore the union field type suffix
-    if (is_union_type)
-      name.append(UnionTypeFieldSuffix(), union_suffix_len);
+    if (is_union_type) name.append(UnionTypeFieldSuffix(), union_suffix_len);
     return EscapeKeyword(name);
   }
 

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -237,8 +237,7 @@ class CppGenerator : public BaseGenerator {
     // the union type field suffix is immutable
     static size_t union_suffix_len = strlen(UnionTypeFieldSuffix());
     // early return if no case transformation required
-    if (opts_.cpp_object_api_field_case != IDLOptions::Case_Upper &&
-        opts_.cpp_object_api_field_case != IDLOptions::Case_Lower)
+    if (opts_.cpp_object_api_field_case == IDLOptions::Case_Unchanged)
       return EscapeKeyword(field.name);
     std::string name = field.name;
     if (field.value.type.base_type == BASE_TYPE_UTYPE &&

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -233,6 +233,48 @@ class CppGenerator : public BaseGenerator {
     return keywords_.find(name) == keywords_.end() ? name : name + "_";
   }
 
+  std::string Name(const FieldDef &field) const {
+    // the union type field suffix is immutable
+    static size_t union_suffix_len = strlen(UnionTypeFieldSuffix());
+    // early return if no case transformation required
+    switch (opts_.cpp_object_api_field_case) {
+      default:
+	return EscapeKeyword(field.name);
+      case IDLOptions::Case_Upper:
+      case IDLOptions::Case_Lower:
+	break;
+    }
+    std::string name = field.name;
+    switch (field.value.type.base_type) {
+      // do not change the case style of the union type field suffix
+      case BASE_TYPE_UTYPE: {
+	if (name.length() > union_suffix_len)
+	  name.erase(name.length() - union_suffix_len, union_suffix_len);
+      } break;
+      default:
+	break;
+    }
+    switch (opts_.cpp_object_api_field_case) {
+      case IDLOptions::Case_Upper:
+	name = MakeCamel(name, true);
+	break;
+      case IDLOptions::Case_Lower:
+	name = MakeCamel(name, false);
+	break;
+      default:
+	break;
+    }
+    switch (field.value.type.base_type) {
+      // restore the union field type suffix
+      case BASE_TYPE_UTYPE:
+	name.append(UnionTypeFieldSuffix(), union_suffix_len);
+	break;
+      default:
+	break;
+    }
+    return EscapeKeyword(name);
+  }
+
   std::string Name(const Definition &def) const {
     return EscapeKeyword(def.name);
   }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -246,9 +246,9 @@ class CppGenerator : public BaseGenerator {
       // do not change the case style of the union type field suffix
       name.erase(name.length() - union_suffix_len, union_suffix_len);
     if (opts_.cpp_object_api_field_case == IDLOptions::Case_Upper)
-      name = MakeCamel(name, true);
+      name = MakeCamel(name, true); /* upper */
     else if (opts_.cpp_object_api_field_case == IDLOptions::Case_Lower)
-      name = MakeCamel(name, false);
+      name = MakeCamel(name, false); /* lower */
     if (field.value.type.base_type == BASE_TYPE_UTYPE)
       // restore the union field type suffix
       name.append(UnionTypeFieldSuffix(), union_suffix_len);

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -238,11 +238,11 @@ class CppGenerator : public BaseGenerator {
     static size_t union_suffix_len = strlen(UnionTypeFieldSuffix());
     // early return if no case transformation required
     if (opts_.cpp_object_api_field_case != IDLOptions::Case_Upper &&
-	opts_.cpp_object_api_field_case != IDLOptions::Case_Lower)
+        opts_.cpp_object_api_field_case != IDLOptions::Case_Lower)
       return EscapeKeyword(field.name);
     std::string name = field.name;
     if (field.value.type.base_type == BASE_TYPE_UTYPE &&
-	name.length() > union_suffix_len)
+        name.length() > union_suffix_len)
       // do not change the case style of the union type field suffix
       name.erase(name.length() - union_suffix_len, union_suffix_len);
     if (opts_.cpp_object_api_field_case == IDLOptions::Case_Upper)

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -234,7 +234,7 @@ class CppGenerator : public BaseGenerator {
   }
 
   std::string Name(const FieldDef &field) const {
-    // the union type field suffix is immutable.
+    // the union type field suffix is immutable
     static size_t union_suffix_len = strlen(UnionTypeFieldSuffix());
     const bool is_union_type = field.value.type.base_type == BASE_TYPE_UTYPE;
     // early return if no case transformation required


### PR DESCRIPTION
Added --cpp-field-case-style option to flatc as suggested in #6005  comments.

This permits migrating schemas to snake_case without disrupting existing C++ code that uses camelCase field names.

--cpp-field-case-style STYLE   Generate C++ fields using selected case style.
Supported STYLE values:
* 'unchanged' - leave unchanged (default);
* 'upper' - upper camel case;
* 'lower' - lower camel case.