### PR TITLE
Fix incorrect assertion usage in Rust generator.

### DIFF
--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -960,7 +960,7 @@ class RustGenerator : public BaseGenerator {
             field.IsRequired() ? "\"\"" : "\"" + field.value.constant + "\"";
         if (context == kObject) return defval + ".to_string()";
         if (context == kAccessor) return "&" + defval;
-        FLATBUFFERS_ASSERT("Unreachable.");
+        FLATBUFFERS_ASSERT(false);
         return "INVALID_CODE_GENERATION";
       }
 
@@ -986,7 +986,7 @@ class RustGenerator : public BaseGenerator {
         return "Default::default()";
       }
     }
-    FLATBUFFERS_ASSERT("Unreachable.");
+    FLATBUFFERS_ASSERT(false);
     return "INVALID_CODE_GENERATION";
   }
 


### PR DESCRIPTION
assert() takes a scalar, not a string.  In fact, due to the compiler coercing char*, assert("Unreachable") has the opposite of the intended effect (it never asserts, instead of always asserting).

This change fixes compilation in clang with -Wstring-conversion, which is the configuration in Chromium downstream.