### PR TITLE
Fixing linker warnings with Arm Compiler toolchain (C++)

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -2941,7 +2941,7 @@ struct TypeTable {
 
 // Weak linkage is culled by VS & doesn't work on cygwin.
 // clang-format off
-#if !defined(_WIN32) && !defined(__CYGWIN__)
+#if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__ARMCC_VERSION)
 
 extern volatile __attribute__((weak)) const char *flatbuffer_version_string;
 volatile __attribute__((weak)) const char *flatbuffer_version_string =
@@ -2950,7 +2950,7 @@ volatile __attribute__((weak)) const char *flatbuffer_version_string =
   FLATBUFFERS_STRING(FLATBUFFERS_VERSION_MINOR) "."
   FLATBUFFERS_STRING(FLATBUFFERS_VERSION_REVISION);
 
-#endif  // !defined(_WIN32) && !defined(__CYGWIN__)
+#endif  // !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__ARMCC_VERSION)
 
 #define FLATBUFFERS_DEFINE_BITMASK_OPERATORS(E, T)\
     inline E operator | (E lhs, E rhs){\


### PR DESCRIPTION
The Arm Compiler toolchains will issue warnings about multiple definitions of flatbuffer_version_string, despite the weak attribute. 
`Warning: L6439W: Multiply defined Global Symbol flatbuffers::flatbuffer_version_string defined in .data._ZN11flatbuffers25flatbuffer_version_stringE(op_resolver.o) rejected in favor of Symbol defined in .data._ZN11flatbuffers25flatbuffer_version_stringE(flatbuffer_conversions.o).`

This affects some projects, mainly embedded, where this compiler is popular. This can be seen in issues, like:
https://github.com/tensorflow/tensorflow/issues/45686
https://forum.edgeimpulse.com/t/not-compiling-symbol-multiply-defined/496

I recommend to mimic the MSVC builds and not compile in the version string. It will not be used for the documented statistical purpose on those embedded platforms anyways.

