### PR TITLE
Dart - fix flex-builder compilation error

### DIFF
--- a/dart/lib/src/builder.dart
+++ b/dart/lib/src/builder.dart
@@ -559,12 +559,13 @@ class _StackValue {
 
   BitWidth elementWidth(int size, int index) {
     if (ValueTypeUtils.isInline(_type)) return _width;
-    final offset = offsetLoc - _offset!;
+    final offset = _offset!;
     for (var i = 0; i < 4; i++) {
       final width = 1 << i;
-      final offsetLoc =
-          size + BitWidthUtil.paddingSize(size, width) + index * width;
-      final bitWidth = BitWidthUtil.uwidth(offset);
+      final bitWidth = BitWidthUtil.uwidth(size +
+          BitWidthUtil.paddingSize(size, width) +
+          index * width -
+          offset);
       if (1 << bitWidth.index == width) {
         return bitWidth;
       }
@@ -643,6 +644,7 @@ class _StackValue {
 class _StackPointer {
   int stackPosition;
   bool isVector;
+
   _StackPointer(this.stackPosition, this.isVector);
 }
 

--- a/tests/DartTest.sh
+++ b/tests/DartTest.sh
@@ -27,7 +27,7 @@ cd ../dart
 # update packages
 dart pub get
 # Execute the sample.
-dart test/flat_buffers_test.dart
+dart test
 
 # cleanup
 rm ../dart/test/monsterdata_test.mon


### PR DESCRIPTION
Not sure how this got here during the null-safety MR... it doesn't even compile. The original code had line `final offset = offsetLoc - _offset!;` on line 567