### PR TITLE
[C++] Fix undefined behaviour in CreateVectorOfStructs in case of an empty vector

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1914,7 +1914,9 @@ class FlatBufferBuilder {
   template<typename T>
   Offset<Vector<const T *>> CreateVectorOfStructs(const T *v, size_t len) {
     StartVector(len * sizeof(T) / AlignOf<T>(), AlignOf<T>());
-    PushBytes(reinterpret_cast<const uint8_t *>(v), sizeof(T) * len);
+    if (len > 0) {
+      PushBytes(reinterpret_cast<const uint8_t *>(v), sizeof(T) * len);
+    }
     return Offset<Vector<const T *>>(EndVector(len));
   }
 


### PR DESCRIPTION
If a vector is empty, then `CreateVectorOfStructs(const T *v, size_t len)` is called with `v == nullptr`, and then `v` is passed into `PushBytes`, which calls `memcpy`. It is declared like this: `extern void *memcpy (void *__restrict __dest, const void *__restrict __src, size_t __n) __THROW __nonnull ((1, 2))`, so we cannot pass `nullptr` into it.

I've added a check that `len > 0`.