### PR TITLE
Dart - make vTable deduplication optional

### DIFF
--- a/dart/example/monster_my_game.sample_generated.dart
+++ b/dart/example/monster_my_game.sample_generated.dart
@@ -166,7 +166,7 @@ class Vec3ObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     return fbBuilder.finish(offset, fileIdentifier);
   }
@@ -336,7 +336,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     return fbBuilder.finish(offset, fileIdentifier);
   }
@@ -417,7 +417,7 @@ class WeaponObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     return fbBuilder.finish(offset, fileIdentifier);
   }

--- a/dart/test/monster_test_my_game.example2_generated.dart
+++ b/dart/test/monster_test_my_game.example2_generated.dart
@@ -69,7 +69,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;

--- a/dart/test/monster_test_my_game.example_generated.dart
+++ b/dart/test/monster_test_my_game.example_generated.dart
@@ -346,7 +346,7 @@ class TestObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -444,7 +444,7 @@ class TestSimpleTableWithEnumObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -591,7 +591,7 @@ class Vec3ObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -689,7 +689,7 @@ class AbilityObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -797,7 +797,7 @@ class StructOfStructsObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -923,7 +923,7 @@ class StatObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -1021,7 +1021,7 @@ class ReferrableObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -1890,7 +1890,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -2139,7 +2139,7 @@ class TypeAliasesObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;

--- a/dart/test/monster_test_my_game_generated.dart
+++ b/dart/test/monster_test_my_game_generated.dart
@@ -69,7 +69,7 @@ class InParentNamespaceObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -953,7 +953,7 @@ class DartGenerator : public BaseGenerator {
     code += "  @override\n";
     code += "  Uint8List toBytes([String? fileIdentifier]) {\n";
     code += "    " + _kFb + ".Builder fbBuilder = new ";
-    code += _kFb + ".Builder();\n";
+    code += _kFb + ".Builder(deduplicateTables: false);\n";
     code += "    int offset = finish(fbBuilder);\n";
     code += "    fbBuilder.finish(offset, fileIdentifier);\n";
     code += "    return fbBuilder.buffer;\n";

--- a/tests/monster_extra_my_game_generated.dart
+++ b/tests/monster_extra_my_game_generated.dart
@@ -224,7 +224,7 @@ class MonsterExtraObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;

--- a/tests/monster_test_my_game.example2_generated.dart
+++ b/tests/monster_test_my_game.example2_generated.dart
@@ -69,7 +69,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;

--- a/tests/monster_test_my_game.example_generated.dart
+++ b/tests/monster_test_my_game.example_generated.dart
@@ -346,7 +346,7 @@ class TestObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -444,7 +444,7 @@ class TestSimpleTableWithEnumObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -591,7 +591,7 @@ class Vec3ObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -689,7 +689,7 @@ class AbilityObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -797,7 +797,7 @@ class StructOfStructsObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -923,7 +923,7 @@ class StatObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -1021,7 +1021,7 @@ class ReferrableObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -1890,7 +1890,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -2139,7 +2139,7 @@ class TypeAliasesObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;

--- a/tests/monster_test_my_game_generated.dart
+++ b/tests/monster_test_my_game_generated.dart
@@ -69,7 +69,7 @@ class InParentNamespaceObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;

--- a/tests/namespace_test/namespace_test1_namespace_a.namespace_b_generated.dart
+++ b/tests/namespace_test/namespace_test1_namespace_a.namespace_b_generated.dart
@@ -189,7 +189,7 @@ class TableInNestedNSObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -287,7 +287,7 @@ class StructInNestedNSObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;

--- a/tests/namespace_test/namespace_test2_namespace_a_generated.dart
+++ b/tests/namespace_test/namespace_test2_namespace_a_generated.dart
@@ -165,7 +165,7 @@ class TableInFirstNSObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;
@@ -265,7 +265,7 @@ class SecondTableInAObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;

--- a/tests/namespace_test/namespace_test2_namespace_c_generated.dart
+++ b/tests/namespace_test/namespace_test2_namespace_c_generated.dart
@@ -117,7 +117,7 @@ class TableInCObjectBuilder extends fb.ObjectBuilder {
   /// Convenience method to serialize to byte list.
   @override
   Uint8List toBytes([String? fileIdentifier]) {
-    fb.Builder fbBuilder = new fb.Builder();
+    fb.Builder fbBuilder = new fb.Builder(deduplicateTables: false);
     int offset = finish(fbBuilder);
     fbBuilder.finish(offset, fileIdentifier);
     return fbBuilder.buffer;


### PR DESCRIPTION
Similar to the c++ Builder - make vTable deduplication optional. This improves performance (~ 5 % in [the benchmark I use](https://github.com/objectbox/flatbuffers-benchmark)) for uses that don't require deduplication, e.g. if there's only one vTable in the buffer