### PR TITLE
Dart - make vTable fixed size

### DIFF
--- a/dart/example/monster_my_game.sample_generated.dart
+++ b/dart/example/monster_my_game.sample_generated.dart
@@ -220,7 +220,7 @@ class MonsterBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(10);
   }
 
   int addPos(int offset) {
@@ -315,7 +315,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
     final int? equippedOffset = _equipped?.getOrCreateOffset(fbBuilder);
     final int? pathOffset = _path == null ? null
         : fbBuilder.writeListOfStructs(_path!);
-    fbBuilder.startTable();
+    fbBuilder.startTable(10);
     if (_pos != null) {
       fbBuilder.addStruct(0, _pos!.finish(fbBuilder));
     }
@@ -375,7 +375,7 @@ class WeaponBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(2);
   }
 
   int addNameOffset(int? offset) {
@@ -407,7 +407,7 @@ class WeaponObjectBuilder extends fb.ObjectBuilder {
   @override
   int finish(fb.Builder fbBuilder) {
     final int? nameOffset = fbBuilder.writeString(_name);
-    fbBuilder.startTable();
+    fbBuilder.startTable(2);
     fbBuilder.addOffset(0, nameOffset);
     fbBuilder.addInt16(1, _damage);
     return fbBuilder.endTable();

--- a/dart/test/flat_buffers_test.dart
+++ b/dart/test/flat_buffers_test.dart
@@ -224,15 +224,15 @@ class BuilderTest {
 
   void test_error_startTable_duringTable() {
     Builder builder = new Builder();
-    builder.startTable();
+    builder.startTable(0);
     expect(() {
-      builder.startTable();
+      builder.startTable(0);
     }, throwsStateError);
   }
 
   void test_error_writeString_duringTable() {
     Builder builder = new Builder();
-    builder.startTable();
+    builder.startTable(1);
     expect(() {
       builder.writeString('12345');
     }, throwsStateError);
@@ -242,7 +242,7 @@ class BuilderTest {
     Uint8List byteList;
     {
       Builder builder = new Builder(initialSize: 0);
-      builder.startTable();
+      builder.startTable(0);
       int offset = builder.endTable();
       builder.finish(offset, 'Az~ÿ');
       byteList = builder.buffer;
@@ -298,7 +298,7 @@ class BuilderTest {
     List<int> byteList;
     {
       final builder = Builder(initialSize: 0, allocator: CustomAllocator());
-      builder.startTable();
+      builder.startTable(2);
       builder.addInt32(0, 10, 10);
       builder.addInt32(1, 20, 10);
       int offset = builder.endTable();
@@ -325,7 +325,7 @@ class BuilderTest {
     Uint8List byteList;
     {
       builder ??= new Builder(initialSize: 0);
-      builder.startTable();
+      builder.startTable(3);
       builder.addInt32(0, 10);
       builder.addInt32(1, 20);
       builder.addInt32(2, 30);
@@ -362,7 +362,7 @@ class BuilderTest {
       Builder builder = new Builder(initialSize: 0);
       int? latinStringOffset = builder.writeString(latinString);
       int? unicodeStringOffset = builder.writeString(unicodeString);
-      builder.startTable();
+      builder.startTable(2);
       builder.addOffset(0, latinStringOffset);
       builder.addOffset(1, unicodeStringOffset);
       int offset = builder.endTable();
@@ -387,7 +387,7 @@ class BuilderTest {
     {
       builder ??= new Builder(initialSize: 0);
       int? stringOffset = builder.writeString('12345');
-      builder.startTable();
+      builder.startTable(7);
       builder.addBool(0, true);
       builder.addInt8(1, 10);
       builder.addInt32(2, 20);
@@ -554,7 +554,7 @@ class BuilderTest {
       // write the object #1
       int object1;
       {
-        builder.startTable();
+        builder.startTable(2);
         builder.addInt32(0, 10);
         builder.addInt32(1, 20);
         object1 = builder.endTable();
@@ -562,7 +562,7 @@ class BuilderTest {
       // write the object #1
       int object2;
       {
-        builder.startTable();
+        builder.startTable(2);
         builder.addInt32(0, 100);
         builder.addInt32(1, 200);
         object2 = builder.endTable();
@@ -608,7 +608,7 @@ class BuilderTest {
       builder ??= new Builder(initialSize: 0);
       int listOffset = builder.writeList(
           [builder.writeString('12345')!, builder.writeString('ABC')!]);
-      builder.startTable();
+      builder.startTable(1);
       builder.addOffset(0, listOffset);
       int offset = builder.endTable();
       builder.finish(offset);

--- a/dart/test/monster_test_my_game.example2_generated.dart
+++ b/dart/test/monster_test_my_game.example2_generated.dart
@@ -37,7 +37,7 @@ class Monster {
 
 class MonsterT {
   int pack(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(0);
     return fbBuilder.endTable();
   }
 
@@ -62,7 +62,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(0);
     return fbBuilder.endTable();
   }
 

--- a/dart/test/monster_test_my_game.example_generated.dart
+++ b/dart/test/monster_test_my_game.example_generated.dart
@@ -387,7 +387,7 @@ class TestSimpleTableWithEnumT {
       this.color = Color.Green});
 
   int pack(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addUint8(0, color.value);
     return fbBuilder.endTable();
   }
@@ -412,7 +412,7 @@ class TestSimpleTableWithEnumBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
   }
 
   int addColor(Color? color) {
@@ -436,7 +436,7 @@ class TestSimpleTableWithEnumObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addUint8(0, _color?.value);
     return fbBuilder.endTable();
   }
@@ -847,7 +847,7 @@ class StatT {
 
   int pack(fb.Builder fbBuilder) {
     final int? idOffset = fbBuilder.writeString(id);
-    fbBuilder.startTable();
+    fbBuilder.startTable(3);
     fbBuilder.addOffset(0, idOffset);
     fbBuilder.addInt64(1, val);
     fbBuilder.addUint16(2, count);
@@ -874,7 +874,7 @@ class StatBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(3);
   }
 
   int addIdOffset(int? offset) {
@@ -913,7 +913,7 @@ class StatObjectBuilder extends fb.ObjectBuilder {
   @override
   int finish(fb.Builder fbBuilder) {
     final int? idOffset = fbBuilder.writeString(_id);
-    fbBuilder.startTable();
+    fbBuilder.startTable(3);
     fbBuilder.addOffset(0, idOffset);
     fbBuilder.addInt64(1, _val);
     fbBuilder.addUint16(2, _count);
@@ -964,7 +964,7 @@ class ReferrableT {
       this.id = 0});
 
   int pack(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addUint64(0, id);
     return fbBuilder.endTable();
   }
@@ -989,7 +989,7 @@ class ReferrableBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
   }
 
   int addId(int? id) {
@@ -1013,7 +1013,7 @@ class ReferrableObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addUint64(0, _id);
     return fbBuilder.endTable();
   }
@@ -1341,7 +1341,7 @@ class MonsterT {
         : fbBuilder.writeListUint8(testrequirednestedflatbuffer!);
     final int? scalarKeySortedTablesOffset = scalarKeySortedTables == null ? null
         : fbBuilder.writeList(scalarKeySortedTables!.map((b) => b.pack(fbBuilder)).toList());
-    fbBuilder.startTable();
+    fbBuilder.startTable(50);
     if (pos != null) {
       fbBuilder.addStruct(0, pos!.pack(fbBuilder));
     }
@@ -1417,7 +1417,7 @@ class MonsterBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(50);
   }
 
   int addPos(int offset) {
@@ -1831,7 +1831,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
         : fbBuilder.writeListUint8(_testrequirednestedflatbuffer!);
     final int? scalarKeySortedTablesOffset = _scalarKeySortedTables == null ? null
         : fbBuilder.writeList(_scalarKeySortedTables!.map((b) => b.getOrCreateOffset(fbBuilder)).toList());
-    fbBuilder.startTable();
+    fbBuilder.startTable(50);
     if (_pos != null) {
       fbBuilder.addStruct(0, _pos!.finish(fbBuilder));
     }
@@ -1979,7 +1979,7 @@ class TypeAliasesT {
         : fbBuilder.writeListInt8(v8!);
     final int? vf64Offset = vf64 == null ? null
         : fbBuilder.writeListFloat64(vf64!);
-    fbBuilder.startTable();
+    fbBuilder.startTable(12);
     fbBuilder.addInt8(0, i8);
     fbBuilder.addUint8(1, u8);
     fbBuilder.addInt16(2, i16);
@@ -2015,7 +2015,7 @@ class TypeAliasesBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(12);
   }
 
   int addI8(int? i8) {
@@ -2120,7 +2120,7 @@ class TypeAliasesObjectBuilder extends fb.ObjectBuilder {
         : fbBuilder.writeListInt8(_v8!);
     final int? vf64Offset = _vf64 == null ? null
         : fbBuilder.writeListFloat64(_vf64!);
-    fbBuilder.startTable();
+    fbBuilder.startTable(12);
     fbBuilder.addInt8(0, _i8);
     fbBuilder.addUint8(1, _u8);
     fbBuilder.addInt16(2, _i16);

--- a/dart/test/monster_test_my_game_generated.dart
+++ b/dart/test/monster_test_my_game_generated.dart
@@ -37,7 +37,7 @@ class InParentNamespace {
 
 class InParentNamespaceT {
   int pack(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(0);
     return fbBuilder.endTable();
   }
 
@@ -62,7 +62,7 @@ class InParentNamespaceObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(0);
     return fbBuilder.endTable();
   }
 

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -850,7 +850,8 @@ class DartGenerator : public BaseGenerator {
     auto &code = *code_ptr;
 
     code += "  void begin() {\n";
-    code += "    fbBuilder.startTable();\n";
+    code += "    fbBuilder.startTable(" +
+            NumToString(non_deprecated_fields.size()) + ");\n";
     code += "  }\n\n";
 
     for (auto it = non_deprecated_fields.begin();
@@ -1071,7 +1072,8 @@ class DartGenerator : public BaseGenerator {
       const std::vector<std::pair<int, FieldDef *>> &non_deprecated_fields,
       bool prependUnderscore = true, bool pack = false) {
     std::string code;
-    code += "    fbBuilder.startTable();\n";
+    code += "    fbBuilder.startTable(" +
+            NumToString(non_deprecated_fields.size()) + ");\n";
 
     for (auto it = non_deprecated_fields.begin();
          it != non_deprecated_fields.end(); ++it) {

--- a/tests/monster_extra_my_game_generated.dart
+++ b/tests/monster_extra_my_game_generated.dart
@@ -82,7 +82,7 @@ class MonsterExtraT {
         : fbBuilder.writeListFloat64(dvec!);
     final int? fvecOffset = fvec == null ? null
         : fbBuilder.writeListFloat32(fvec!);
-    fbBuilder.startTable();
+    fbBuilder.startTable(10);
     fbBuilder.addFloat64(0, d0);
     fbBuilder.addFloat64(1, d1);
     fbBuilder.addFloat64(2, d2);
@@ -116,7 +116,7 @@ class MonsterExtraBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(10);
   }
 
   int addD0(double? d0) {
@@ -207,7 +207,7 @@ class MonsterExtraObjectBuilder extends fb.ObjectBuilder {
         : fbBuilder.writeListFloat64(_dvec!);
     final int? fvecOffset = _fvec == null ? null
         : fbBuilder.writeListFloat32(_fvec!);
-    fbBuilder.startTable();
+    fbBuilder.startTable(10);
     fbBuilder.addFloat64(0, _d0);
     fbBuilder.addFloat64(1, _d1);
     fbBuilder.addFloat64(2, _d2);

--- a/tests/monster_test_my_game.example2_generated.dart
+++ b/tests/monster_test_my_game.example2_generated.dart
@@ -37,7 +37,7 @@ class Monster {
 
 class MonsterT {
   int pack(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(0);
     return fbBuilder.endTable();
   }
 
@@ -62,7 +62,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(0);
     return fbBuilder.endTable();
   }
 

--- a/tests/monster_test_my_game.example_generated.dart
+++ b/tests/monster_test_my_game.example_generated.dart
@@ -387,7 +387,7 @@ class TestSimpleTableWithEnumT {
       this.color = Color.Green});
 
   int pack(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addUint8(0, color.value);
     return fbBuilder.endTable();
   }
@@ -412,7 +412,7 @@ class TestSimpleTableWithEnumBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
   }
 
   int addColor(Color? color) {
@@ -436,7 +436,7 @@ class TestSimpleTableWithEnumObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addUint8(0, _color?.value);
     return fbBuilder.endTable();
   }
@@ -847,7 +847,7 @@ class StatT {
 
   int pack(fb.Builder fbBuilder) {
     final int? idOffset = fbBuilder.writeString(id);
-    fbBuilder.startTable();
+    fbBuilder.startTable(3);
     fbBuilder.addOffset(0, idOffset);
     fbBuilder.addInt64(1, val);
     fbBuilder.addUint16(2, count);
@@ -874,7 +874,7 @@ class StatBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(3);
   }
 
   int addIdOffset(int? offset) {
@@ -913,7 +913,7 @@ class StatObjectBuilder extends fb.ObjectBuilder {
   @override
   int finish(fb.Builder fbBuilder) {
     final int? idOffset = fbBuilder.writeString(_id);
-    fbBuilder.startTable();
+    fbBuilder.startTable(3);
     fbBuilder.addOffset(0, idOffset);
     fbBuilder.addInt64(1, _val);
     fbBuilder.addUint16(2, _count);
@@ -964,7 +964,7 @@ class ReferrableT {
       this.id = 0});
 
   int pack(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addUint64(0, id);
     return fbBuilder.endTable();
   }
@@ -989,7 +989,7 @@ class ReferrableBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
   }
 
   int addId(int? id) {
@@ -1013,7 +1013,7 @@ class ReferrableObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addUint64(0, _id);
     return fbBuilder.endTable();
   }
@@ -1341,7 +1341,7 @@ class MonsterT {
         : fbBuilder.writeListUint8(testrequirednestedflatbuffer!);
     final int? scalarKeySortedTablesOffset = scalarKeySortedTables == null ? null
         : fbBuilder.writeList(scalarKeySortedTables!.map((b) => b.pack(fbBuilder)).toList());
-    fbBuilder.startTable();
+    fbBuilder.startTable(50);
     if (pos != null) {
       fbBuilder.addStruct(0, pos!.pack(fbBuilder));
     }
@@ -1417,7 +1417,7 @@ class MonsterBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(50);
   }
 
   int addPos(int offset) {
@@ -1831,7 +1831,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
         : fbBuilder.writeListUint8(_testrequirednestedflatbuffer!);
     final int? scalarKeySortedTablesOffset = _scalarKeySortedTables == null ? null
         : fbBuilder.writeList(_scalarKeySortedTables!.map((b) => b.getOrCreateOffset(fbBuilder)).toList());
-    fbBuilder.startTable();
+    fbBuilder.startTable(50);
     if (_pos != null) {
       fbBuilder.addStruct(0, _pos!.finish(fbBuilder));
     }
@@ -1979,7 +1979,7 @@ class TypeAliasesT {
         : fbBuilder.writeListInt8(v8!);
     final int? vf64Offset = vf64 == null ? null
         : fbBuilder.writeListFloat64(vf64!);
-    fbBuilder.startTable();
+    fbBuilder.startTable(12);
     fbBuilder.addInt8(0, i8);
     fbBuilder.addUint8(1, u8);
     fbBuilder.addInt16(2, i16);
@@ -2015,7 +2015,7 @@ class TypeAliasesBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(12);
   }
 
   int addI8(int? i8) {
@@ -2120,7 +2120,7 @@ class TypeAliasesObjectBuilder extends fb.ObjectBuilder {
         : fbBuilder.writeListInt8(_v8!);
     final int? vf64Offset = _vf64 == null ? null
         : fbBuilder.writeListFloat64(_vf64!);
-    fbBuilder.startTable();
+    fbBuilder.startTable(12);
     fbBuilder.addInt8(0, _i8);
     fbBuilder.addUint8(1, _u8);
     fbBuilder.addInt16(2, _i16);

--- a/tests/monster_test_my_game_generated.dart
+++ b/tests/monster_test_my_game_generated.dart
@@ -37,7 +37,7 @@ class InParentNamespace {
 
 class InParentNamespaceT {
   int pack(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(0);
     return fbBuilder.endTable();
   }
 
@@ -62,7 +62,7 @@ class InParentNamespaceObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(0);
     return fbBuilder.endTable();
   }
 

--- a/tests/namespace_test/namespace_test1_namespace_a.namespace_b_generated.dart
+++ b/tests/namespace_test/namespace_test1_namespace_a.namespace_b_generated.dart
@@ -132,7 +132,7 @@ class TableInNestedNST {
       this.foo = 0});
 
   int pack(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addInt32(0, foo);
     return fbBuilder.endTable();
   }
@@ -157,7 +157,7 @@ class TableInNestedNSBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
   }
 
   int addFoo(int? foo) {
@@ -181,7 +181,7 @@ class TableInNestedNSObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addInt32(0, _foo);
     return fbBuilder.endTable();
   }

--- a/tests/namespace_test/namespace_test2_namespace_a_generated.dart
+++ b/tests/namespace_test/namespace_test2_namespace_a_generated.dart
@@ -66,7 +66,7 @@ class TableInFirstNST {
   int pack(fb.Builder fbBuilder) {
     final int? fooTableOffset = fooTable?.pack(fbBuilder);
     final int? fooUnionOffset = fooUnion?.pack(fbBuilder);
-    fbBuilder.startTable();
+    fbBuilder.startTable(5);
     fbBuilder.addOffset(0, fooTableOffset);
     fbBuilder.addInt8(1, fooEnum.value);
     fbBuilder.addUint8(2, fooUnionType?.value);
@@ -97,7 +97,7 @@ class TableInFirstNSBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(5);
   }
 
   int addFooTableOffset(int? offset) {
@@ -151,7 +151,7 @@ class TableInFirstNSObjectBuilder extends fb.ObjectBuilder {
   int finish(fb.Builder fbBuilder) {
     final int? fooTableOffset = _fooTable?.getOrCreateOffset(fbBuilder);
     final int? fooUnionOffset = _fooUnion?.getOrCreateOffset(fbBuilder);
-    fbBuilder.startTable();
+    fbBuilder.startTable(5);
     fbBuilder.addOffset(0, fooTableOffset);
     fbBuilder.addInt8(1, _fooEnum?.value);
     fbBuilder.addUint8(2, _fooUnionType?.value);
@@ -207,7 +207,7 @@ class SecondTableInAT {
 
   int pack(fb.Builder fbBuilder) {
     final int? referToCOffset = referToC?.pack(fbBuilder);
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addOffset(0, referToCOffset);
     return fbBuilder.endTable();
   }
@@ -232,7 +232,7 @@ class SecondTableInABuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
   }
 
   int addReferToCOffset(int? offset) {
@@ -257,7 +257,7 @@ class SecondTableInAObjectBuilder extends fb.ObjectBuilder {
   @override
   int finish(fb.Builder fbBuilder) {
     final int? referToCOffset = _referToC?.getOrCreateOffset(fbBuilder);
-    fbBuilder.startTable();
+    fbBuilder.startTable(1);
     fbBuilder.addOffset(0, referToCOffset);
     return fbBuilder.endTable();
   }

--- a/tests/namespace_test/namespace_test2_namespace_c_generated.dart
+++ b/tests/namespace_test/namespace_test2_namespace_c_generated.dart
@@ -49,7 +49,7 @@ class TableInCT {
   int pack(fb.Builder fbBuilder) {
     final int? referToA1Offset = referToA1?.pack(fbBuilder);
     final int? referToA2Offset = referToA2?.pack(fbBuilder);
-    fbBuilder.startTable();
+    fbBuilder.startTable(2);
     fbBuilder.addOffset(0, referToA1Offset);
     fbBuilder.addOffset(1, referToA2Offset);
     return fbBuilder.endTable();
@@ -75,7 +75,7 @@ class TableInCBuilder {
   final fb.Builder fbBuilder;
 
   void begin() {
-    fbBuilder.startTable();
+    fbBuilder.startTable(2);
   }
 
   int addReferToA1Offset(int? offset) {
@@ -108,7 +108,7 @@ class TableInCObjectBuilder extends fb.ObjectBuilder {
   int finish(fb.Builder fbBuilder) {
     final int? referToA1Offset = _referToA1?.getOrCreateOffset(fbBuilder);
     final int? referToA2Offset = _referToA2?.getOrCreateOffset(fbBuilder);
-    fbBuilder.startTable();
+    fbBuilder.startTable(2);
     fbBuilder.addOffset(0, referToA1Offset);
     fbBuilder.addOffset(1, referToA2Offset);
     return fbBuilder.endTable();


### PR DESCRIPTION
Changes vtables to be internally stored in a fixed-size list to improve performance - by about 12 % in [the benchmark I use](https://github.com/objectbox/flatbuffers-benchmark).