### PR TITLE
Dart - optimize writeString for ASCII

### DIFF
--- a/dart/test/flat_buffers_test.dart
+++ b/dart/test/flat_buffers_test.dart
@@ -160,7 +160,7 @@ class BuilderTest {
     final str = fbBuilder.writeString('MyMonster');
 
     fbBuilder.writeString('test1');
-    fbBuilder.writeString('test2');
+    fbBuilder.writeString('test2', asciiOptimization: true);
     final testArrayOfString = fbBuilder.endStructVector(2);
 
     final fred = fbBuilder.writeString('Fred');
@@ -360,8 +360,10 @@ class BuilderTest {
     List<int> byteList;
     {
       Builder builder = new Builder(initialSize: 0);
-      int? latinStringOffset = builder.writeString(latinString);
-      int? unicodeStringOffset = builder.writeString(unicodeString);
+      int? latinStringOffset =
+          builder.writeString(latinString, asciiOptimization: true);
+      int? unicodeStringOffset =
+          builder.writeString(unicodeString, asciiOptimization: true);
       builder.startTable(2);
       builder.addOffset(0, latinStringOffset);
       builder.addOffset(1, unicodeStringOffset);


### PR DESCRIPTION
With utf8.encoder being quite slow (requires two additional allocations and copies), this optimizes the case for ASCII strings. While this change is a bit controversial, it assumes ASII strings in general and optimizes that use case. Maybe this should be something configurable, either on the builder level or field level...

For ASCII strings, `writeString()` runtime is reduced by about 50 % (tested on strings with length = 3 and length = 1000, the improvement is always ~50 %).

For non-ASCII strings, it depends on where the non-ASCII character is found. If it's at the very end of a 1000 character string, the runtime is increased by about 40 %, compared to the current master...