### PR TITLE
Dart - make writeString() argument non-nullable

### DIFF
--- a/dart/example/monster_my_game.sample_generated.dart
+++ b/dart/example/monster_my_game.sample_generated.dart
@@ -307,7 +307,8 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? nameOffset = fbBuilder.writeString(_name);
+    final int? nameOffset = _name == null ? null
+        : fbBuilder.writeString(_name!);
     final int? inventoryOffset = _inventory == null ? null
         : fbBuilder.writeListUint8(_inventory!);
     final int? weaponsOffset = _weapons == null ? null
@@ -406,7 +407,8 @@ class WeaponObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? nameOffset = fbBuilder.writeString(_name);
+    final int? nameOffset = _name == null ? null
+        : fbBuilder.writeString(_name!);
     fbBuilder.startTable(2);
     fbBuilder.addOffset(0, nameOffset);
     fbBuilder.addInt16(1, _damage);

--- a/dart/lib/flat_buffers.dart
+++ b/dart/lib/flat_buffers.dart
@@ -668,18 +668,14 @@ class Builder {
     return result;
   }
 
-  /// Write the given string [value] and return its offset, or `null` if
-  /// the [value] is `null`.
-  int? writeString(String? value) {
+  /// Write the given string [value] and return its offset.
+  int writeString(String value) {
     _ensureNoVTable();
-    if (value != null) {
-      if (_strings != null) {
-        return _strings!.putIfAbsent(value, () => _writeString(value));
-      } else {
-        return _writeString(value);
-      }
+    if (_strings != null) {
+      return _strings!.putIfAbsent(value, () => _writeString(value));
+    } else {
+      return _writeString(value);
     }
-    return null;
   }
 
   int _writeString(String value) {

--- a/dart/test/flat_buffers_test.dart
+++ b/dart/test/flat_buffers_test.dart
@@ -589,7 +589,7 @@ class BuilderTest {
       Builder builder = new Builder(initialSize: 0);
       int? str1 = builder.writeString('12345');
       int? str2 = builder.writeString('ABC');
-      int offset = builder.writeList([str1!, str2!]);
+      int offset = builder.writeList([str1, str2]);
       builder.finish(offset);
       byteList = builder.buffer;
     }
@@ -607,7 +607,7 @@ class BuilderTest {
     {
       builder ??= new Builder(initialSize: 0);
       int listOffset = builder.writeList(
-          [builder.writeString('12345')!, builder.writeString('ABC')!]);
+          [builder.writeString('12345'), builder.writeString('ABC')]);
       builder.startTable(1);
       builder.addOffset(0, listOffset);
       int offset = builder.endTable();

--- a/dart/test/monster_test_my_game.example_generated.dart
+++ b/dart/test/monster_test_my_game.example_generated.dart
@@ -846,7 +846,8 @@ class StatT {
       this.count = 0});
 
   int pack(fb.Builder fbBuilder) {
-    final int? idOffset = fbBuilder.writeString(id);
+    final int? idOffset = id == null ? null
+        : fbBuilder.writeString(id!);
     fbBuilder.startTable(3);
     fbBuilder.addOffset(0, idOffset);
     fbBuilder.addInt64(1, val);
@@ -912,7 +913,8 @@ class StatObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? idOffset = fbBuilder.writeString(_id);
+    final int? idOffset = _id == null ? null
+        : fbBuilder.writeString(_id!);
     fbBuilder.startTable(3);
     fbBuilder.addOffset(0, idOffset);
     fbBuilder.addInt64(1, _val);
@@ -1285,7 +1287,8 @@ class MonsterT {
       this.scalarKeySortedTables});
 
   int pack(fb.Builder fbBuilder) {
-    final int? nameOffset = fbBuilder.writeString(name);
+    final int? nameOffset = name == null ? null
+        : fbBuilder.writeString(name!);
     final int? inventoryOffset = inventory == null ? null
         : fbBuilder.writeListUint8(inventory!);
     final int? testOffset = test?.pack(fbBuilder);
@@ -1295,7 +1298,7 @@ class MonsterT {
       test4Offset = fbBuilder.endStructVector(test4!.length);
     }
     final int? testarrayofstringOffset = testarrayofstring == null ? null
-        : fbBuilder.writeList(testarrayofstring!.map((b) => fbBuilder.writeString(b)!).toList());
+        : fbBuilder.writeList(testarrayofstring!.map(fbBuilder.writeString).toList());
     final int? testarrayoftablesOffset = testarrayoftables == null ? null
         : fbBuilder.writeList(testarrayoftables!.map((b) => b.pack(fbBuilder)).toList());
     final int? enemyOffset = enemy?.pack(fbBuilder);
@@ -1305,7 +1308,7 @@ class MonsterT {
     final int? testarrayofboolsOffset = testarrayofbools == null ? null
         : fbBuilder.writeListBool(testarrayofbools!);
     final int? testarrayofstring2Offset = testarrayofstring2 == null ? null
-        : fbBuilder.writeList(testarrayofstring2!.map((b) => fbBuilder.writeString(b)!).toList());
+        : fbBuilder.writeList(testarrayofstring2!.map(fbBuilder.writeString).toList());
     int? testarrayofsortedstructOffset = null;
     if (testarrayofsortedstruct != null) {
       testarrayofsortedstruct!.forEach((e) => e.pack(fbBuilder));
@@ -1784,14 +1787,15 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? nameOffset = fbBuilder.writeString(_name);
+    final int? nameOffset = _name == null ? null
+        : fbBuilder.writeString(_name!);
     final int? inventoryOffset = _inventory == null ? null
         : fbBuilder.writeListUint8(_inventory!);
     final int? testOffset = _test?.getOrCreateOffset(fbBuilder);
     final int? test4Offset = _test4 == null ? null
         : fbBuilder.writeListOfStructs(_test4!);
     final int? testarrayofstringOffset = _testarrayofstring == null ? null
-        : fbBuilder.writeList(_testarrayofstring!.map((b) => fbBuilder.writeString(b)!).toList());
+        : fbBuilder.writeList(_testarrayofstring!.map(fbBuilder.writeString).toList());
     final int? testarrayoftablesOffset = _testarrayoftables == null ? null
         : fbBuilder.writeList(_testarrayoftables!.map((b) => b.getOrCreateOffset(fbBuilder)).toList());
     final int? enemyOffset = _enemy?.getOrCreateOffset(fbBuilder);
@@ -1801,7 +1805,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
     final int? testarrayofboolsOffset = _testarrayofbools == null ? null
         : fbBuilder.writeListBool(_testarrayofbools!);
     final int? testarrayofstring2Offset = _testarrayofstring2 == null ? null
-        : fbBuilder.writeList(_testarrayofstring2!.map((b) => fbBuilder.writeString(b)!).toList());
+        : fbBuilder.writeList(_testarrayofstring2!.map(fbBuilder.writeString).toList());
     final int? testarrayofsortedstructOffset = _testarrayofsortedstruct == null ? null
         : fbBuilder.writeListOfStructs(_testarrayofsortedstruct!);
     final int? flexOffset = _flex == null ? null

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -999,8 +999,8 @@ class DartGenerator : public BaseGenerator {
         code += "        : fbBuilder.writeList";
         switch (field.value.type.VectorType().base_type) {
           case BASE_TYPE_STRING:
-            code += "(" + field_name +
-                    "!.map((b) => fbBuilder.writeString(b)!).toList());\n";
+            code +=
+                "(" + field_name + "!.map(fbBuilder.writeString).toList());\n";
             break;
           case BASE_TYPE_STRUCT:
             if (field.value.type.struct_def->fixed) {
@@ -1020,7 +1020,8 @@ class DartGenerator : public BaseGenerator {
             code += ");\n";
         }
       } else if (IsString(field.value.type)) {
-        code += " = fbBuilder.writeString(" + field_name + ");\n";
+        code += " = " + field_name + " == null ? null\n";
+        code += "        : fbBuilder.writeString(" + field_name + "!);\n";
       } else {
         code += " = " + field_name + "?." +
                 (pack ? "pack" : "getOrCreateOffset") + "(fbBuilder);\n";

--- a/tests/monster_test_my_game.example_generated.dart
+++ b/tests/monster_test_my_game.example_generated.dart
@@ -846,7 +846,8 @@ class StatT {
       this.count = 0});
 
   int pack(fb.Builder fbBuilder) {
-    final int? idOffset = fbBuilder.writeString(id);
+    final int? idOffset = id == null ? null
+        : fbBuilder.writeString(id!);
     fbBuilder.startTable(3);
     fbBuilder.addOffset(0, idOffset);
     fbBuilder.addInt64(1, val);
@@ -912,7 +913,8 @@ class StatObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? idOffset = fbBuilder.writeString(_id);
+    final int? idOffset = _id == null ? null
+        : fbBuilder.writeString(_id!);
     fbBuilder.startTable(3);
     fbBuilder.addOffset(0, idOffset);
     fbBuilder.addInt64(1, _val);
@@ -1285,7 +1287,8 @@ class MonsterT {
       this.scalarKeySortedTables});
 
   int pack(fb.Builder fbBuilder) {
-    final int? nameOffset = fbBuilder.writeString(name);
+    final int? nameOffset = name == null ? null
+        : fbBuilder.writeString(name!);
     final int? inventoryOffset = inventory == null ? null
         : fbBuilder.writeListUint8(inventory!);
     final int? testOffset = test?.pack(fbBuilder);
@@ -1295,7 +1298,7 @@ class MonsterT {
       test4Offset = fbBuilder.endStructVector(test4!.length);
     }
     final int? testarrayofstringOffset = testarrayofstring == null ? null
-        : fbBuilder.writeList(testarrayofstring!.map((b) => fbBuilder.writeString(b)!).toList());
+        : fbBuilder.writeList(testarrayofstring!.map(fbBuilder.writeString).toList());
     final int? testarrayoftablesOffset = testarrayoftables == null ? null
         : fbBuilder.writeList(testarrayoftables!.map((b) => b.pack(fbBuilder)).toList());
     final int? enemyOffset = enemy?.pack(fbBuilder);
@@ -1305,7 +1308,7 @@ class MonsterT {
     final int? testarrayofboolsOffset = testarrayofbools == null ? null
         : fbBuilder.writeListBool(testarrayofbools!);
     final int? testarrayofstring2Offset = testarrayofstring2 == null ? null
-        : fbBuilder.writeList(testarrayofstring2!.map((b) => fbBuilder.writeString(b)!).toList());
+        : fbBuilder.writeList(testarrayofstring2!.map(fbBuilder.writeString).toList());
     int? testarrayofsortedstructOffset = null;
     if (testarrayofsortedstruct != null) {
       testarrayofsortedstruct!.forEach((e) => e.pack(fbBuilder));
@@ -1784,14 +1787,15 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? nameOffset = fbBuilder.writeString(_name);
+    final int? nameOffset = _name == null ? null
+        : fbBuilder.writeString(_name!);
     final int? inventoryOffset = _inventory == null ? null
         : fbBuilder.writeListUint8(_inventory!);
     final int? testOffset = _test?.getOrCreateOffset(fbBuilder);
     final int? test4Offset = _test4 == null ? null
         : fbBuilder.writeListOfStructs(_test4!);
     final int? testarrayofstringOffset = _testarrayofstring == null ? null
-        : fbBuilder.writeList(_testarrayofstring!.map((b) => fbBuilder.writeString(b)!).toList());
+        : fbBuilder.writeList(_testarrayofstring!.map(fbBuilder.writeString).toList());
     final int? testarrayoftablesOffset = _testarrayoftables == null ? null
         : fbBuilder.writeList(_testarrayoftables!.map((b) => b.getOrCreateOffset(fbBuilder)).toList());
     final int? enemyOffset = _enemy?.getOrCreateOffset(fbBuilder);
@@ -1801,7 +1805,7 @@ class MonsterObjectBuilder extends fb.ObjectBuilder {
     final int? testarrayofboolsOffset = _testarrayofbools == null ? null
         : fbBuilder.writeListBool(_testarrayofbools!);
     final int? testarrayofstring2Offset = _testarrayofstring2 == null ? null
-        : fbBuilder.writeList(_testarrayofstring2!.map((b) => fbBuilder.writeString(b)!).toList());
+        : fbBuilder.writeList(_testarrayofstring2!.map(fbBuilder.writeString).toList());
     final int? testarrayofsortedstructOffset = _testarrayofsortedstruct == null ? null
         : fbBuilder.writeListOfStructs(_testarrayofsortedstruct!);
     final int? flexOffset = _flex == null ? null


### PR DESCRIPTION
Aligns `writeString()` with other functions returning an offset (writing lists). This also allows a "tear-off" callback for lists of strings.