### PR TITLE
Add a split on ':' to build_defs.bzl

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -209,7 +209,7 @@ def flatbuffer_cc_library(
         Happy dependent Flatbuffering!
     '''
     output_headers = [
-        (out_prefix + "%s_generated.h") % (s.replace(".fbs", "").split("/")[-1])
+        (out_prefix + "%s_generated.h") % (s.replace(".fbs", "").split("/")[-1].split(":")[-1])
         for s in srcs
     ]
     reflection_name = "%s_reflection" % name if gen_reflections else ""


### PR DESCRIPTION
This allows the rule to properly process targets of the format: "//foo/bar:baz.fbs"

Now it outputs "baz_generated.h" whereas prior to this change it output "bar:baz_generated.h" which is invalid.
