### PR TITLE
[Kotlin] Change Java Compiler to 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,18 +120,36 @@ jobs:
       working-directory: tests
       run: bash JavaTest.sh
 
-  build-kotlin:
-    name: Build Kotlin
+  build-kotlin-macos:
+    name: Build Kotlin MacOS
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt-hotspot'
+        java-version: '11'
     - name: Build
       working-directory: kotlin
-      run: ./gradlew clean build allTests
+      run: ./gradlew clean iosX64Test macosX64Test jsTest jsBrowserTest
+  
+  build-kotlin-linux:
+    name: Build Kotlin Linux
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt-hotspot'
+        java-version: '11'
+    - name: Build
+      working-directory: kotlin
+      run: ./gradlew jvmMainClasses jvmTest
     - name: Run Benchmark
       working-directory: kotlin
-      run: ./gradlew benchmark
+      run: ./gradlew jvmBenchmark
     - name: Generate Benchmark Report
       working-directory: kotlin
       run: |


### PR DESCRIPTION
With the changes introduced on #6729, #6671, #6658 it seems that using java
compiler version 8 is no longer possible. We are adjusting our CI build for
Kotlin to use Java 11 as compiler, while still emitting 1.8 bytecode.

The Kotlin CI action is also being breakdown into two: Mac & Linux.
Kotlin mac will test ios & mac builds while Linux will test js and JVM.
This change will improve build times for Kotlin on CI, which is currently
taking long times.