### PR TITLE
[Java] Avoid casting ByteBuffer to Buffer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         distribution: 'adopt-hotspot'
-        java-version: '11'
+        java-version: '8'
     - name: Build
       working-directory: kotlin
       run: ./gradlew jvmMainClasses jvmTest

--- a/java/com/google/flatbuffers/ByteBufferReadWriteBuf.java
+++ b/java/com/google/flatbuffers/ByteBufferReadWriteBuf.java
@@ -15,7 +15,7 @@ public class ByteBufferReadWriteBuf implements ReadWriteBuf {
 
   @Override
   public void clear() {
-    ((Buffer) buffer).clear();
+    buffer.clear();
   }
 
   @Override

--- a/java/com/google/flatbuffers/ByteBufferReadWriteBuf.java
+++ b/java/com/google/flatbuffers/ByteBufferReadWriteBuf.java
@@ -2,7 +2,6 @@ package com.google.flatbuffers;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.Buffer;
 
 public class ByteBufferReadWriteBuf implements ReadWriteBuf {
 
@@ -118,9 +117,9 @@ public class ByteBufferReadWriteBuf implements ReadWriteBuf {
   public void set(int index, byte[] value, int start, int length) {
     requestCapacity(index + (length - start));
     int curPos = buffer.position();
-    ((Buffer) buffer).position(index);
+    buffer.position(index);
     buffer.put(value, start, length);
-    ((Buffer) buffer).position(curPos);
+    buffer.position(curPos);
   }
 
   @Override

--- a/java/com/google/flatbuffers/ByteBufferUtil.java
+++ b/java/com/google/flatbuffers/ByteBufferUtil.java
@@ -19,7 +19,6 @@ package com.google.flatbuffers;
 import static com.google.flatbuffers.Constants.*;
 
 import java.nio.ByteBuffer;
-import java.nio.Buffer;
 
 /// @file
 /// @addtogroup flatbuffers_java_api
@@ -50,7 +49,7 @@ public class ByteBufferUtil {
      */
     public static ByteBuffer removeSizePrefix(ByteBuffer bb) {
         ByteBuffer s = bb.duplicate();
-        ((Buffer) s).position(s.position() + SIZE_PREFIX_LENGTH);
+        s.position(s.position() + SIZE_PREFIX_LENGTH);
         return s;
     }
 

--- a/java/com/google/flatbuffers/ByteBufferUtil.java
+++ b/java/com/google/flatbuffers/ByteBufferUtil.java
@@ -49,9 +49,9 @@ public class ByteBufferUtil {
      *         size prefix
      */
     public static ByteBuffer removeSizePrefix(ByteBuffer bb) {
-        Buffer s = ((Buffer) bb).duplicate();
-        s.position(s.position() + SIZE_PREFIX_LENGTH);
-        return (ByteBuffer) s;
+        ByteBuffer s = bb.duplicate();
+        ((Buffer) s).position(s.position() + SIZE_PREFIX_LENGTH);
+        return s;
     }
 
 }

--- a/java/com/google/flatbuffers/FlatBufferBuilder.java
+++ b/java/com/google/flatbuffers/FlatBufferBuilder.java
@@ -92,7 +92,7 @@ public class FlatBufferBuilder {
         this.bb_factory = bb_factory;
         if (existing_bb != null) {
           bb = existing_bb;
-          ((Buffer) bb).clear();
+          bb.clear();
           bb.order(ByteOrder.LITTLE_ENDIAN);
         } else {
           bb = bb_factory.newByteBuffer(initial_size);
@@ -154,7 +154,7 @@ public class FlatBufferBuilder {
     public FlatBufferBuilder init(ByteBuffer existing_bb, ByteBufferFactory bb_factory){
         this.bb_factory = bb_factory;
         bb = existing_bb;
-        ((Buffer) bb).clear();
+        bb.clear();
         bb.order(ByteOrder.LITTLE_ENDIAN);
         minalign = 1;
         space = bb.capacity();
@@ -235,7 +235,7 @@ public class FlatBufferBuilder {
      */
     public void clear(){
         space = bb.capacity();
-        ((Buffer) bb).clear();
+        bb.clear();
         minalign = 1;
         while(vtable_in_use > 0) vtable[--vtable_in_use] = 0;
         vtable_in_use = 0;
@@ -275,7 +275,7 @@ public class FlatBufferBuilder {
 
         ((Buffer) bb).position(0);
         ByteBuffer nbb = bb_factory.newByteBuffer(new_buf_size);
-        new_buf_size = ((Buffer) nbb).clear().capacity(); // Ensure the returned buffer is treated as empty
+        new_buf_size = nbb.clear().capacity(); // Ensure the returned buffer is treated as empty
         ((Buffer) nbb).position(new_buf_size - old_buf_size);
         nbb.put(bb);
         return nbb;

--- a/java/com/google/flatbuffers/FlatBufferBuilder.java
+++ b/java/com/google/flatbuffers/FlatBufferBuilder.java
@@ -273,10 +273,10 @@ public class FlatBufferBuilder {
             new_buf_size = (old_buf_size & 0xC0000000) != 0 ? MAX_BUFFER_SIZE : old_buf_size << 1;
         }
 
-        ((Buffer) bb).position(0);
+        bb.position(0);
         ByteBuffer nbb = bb_factory.newByteBuffer(new_buf_size);
         new_buf_size = nbb.clear().capacity(); // Ensure the returned buffer is treated as empty
-        ((Buffer) nbb).position(new_buf_size - old_buf_size);
+        nbb.position(new_buf_size - old_buf_size);
         nbb.put(bb);
         return nbb;
     }
@@ -527,7 +527,7 @@ public class FlatBufferBuilder {
         int length = elem_size * num_elems;
         startVector(elem_size, num_elems, alignment);
 
-        ((Buffer) bb).position(space -= length);
+        bb.position(space -= length);
 
         // Slice and limit the copy vector to point to the 'array'
         ByteBuffer copy = bb.slice().order(ByteOrder.LITTLE_ENDIAN);
@@ -602,7 +602,7 @@ public class FlatBufferBuilder {
         int length = utf8.encodedLength(s);
         addByte((byte)0);
         startVector(1, length, 1);
-        ((Buffer) bb).position(space -= length);
+        bb.position(space -= length);
         utf8.encodeUtf8(s, bb);
         return endVector();
     }
@@ -617,7 +617,7 @@ public class FlatBufferBuilder {
         int length = s.remaining();
         addByte((byte)0);
         startVector(1, length, 1);
-        ((Buffer) bb).position(space -= length);
+        bb.position(space -= length);
         bb.put(s);
         return endVector();
     }
@@ -631,7 +631,7 @@ public class FlatBufferBuilder {
     public int createByteVector(byte[] arr) {
         int length = arr.length;
         startVector(1, length, 1);
-        ((Buffer) bb).position(space -= length);
+        bb.position(space -= length);
         bb.put(arr);
         return endVector();
     }
@@ -646,7 +646,7 @@ public class FlatBufferBuilder {
      */
     public int createByteVector(byte[] arr, int offset, int length) {
         startVector(1, length, 1);
-        ((Buffer) bb).position(space -= length);
+        bb.position(space -= length);
         bb.put(arr, offset, length);
         return endVector();
     }
@@ -663,7 +663,7 @@ public class FlatBufferBuilder {
     public int createByteVector(ByteBuffer byteBuffer) {
         int length = byteBuffer.remaining();
         startVector(1, length, 1);
-        ((Buffer) bb).position(space -= length);
+        bb.position(space -= length);
         bb.put(byteBuffer);
         return endVector();
     }
@@ -953,7 +953,7 @@ public class FlatBufferBuilder {
         if (size_prefix) {
             addInt(bb.capacity() - space);
         }
-        ((Buffer) bb).position(space);
+        bb.position(space);
         finished = true;
     }
 
@@ -1067,7 +1067,7 @@ public class FlatBufferBuilder {
     public byte[] sizedByteArray(int start, int length){
         finished();
         byte[] array = new byte[length];
-        ((Buffer) bb).position(start);
+        bb.position(start);
         bb.get(array);
         return array;
     }
@@ -1090,7 +1090,7 @@ public class FlatBufferBuilder {
     public InputStream sizedInputStream() {
         finished();
         ByteBuffer duplicate = bb.duplicate();
-        ((Buffer) duplicate).position(space);
+        duplicate.position(space);
         duplicate.limit(bb.capacity());
         return new ByteBufferBackedInputStream(duplicate);
     }

--- a/java/com/google/flatbuffers/FlatBufferBuilder.java
+++ b/java/com/google/flatbuffers/FlatBufferBuilder.java
@@ -1089,10 +1089,10 @@ public class FlatBufferBuilder {
      */
     public InputStream sizedInputStream() {
         finished();
-        Buffer duplicate = ((Buffer) bb).duplicate();
-        duplicate.position(space);
+        ByteBuffer duplicate = bb.duplicate();
+        ((Buffer) duplicate).position(space);
         duplicate.limit(bb.capacity());
-        return new ByteBufferBackedInputStream((ByteBuffer) duplicate);
+        return new ByteBufferBackedInputStream(duplicate);
     }
 
     /**

--- a/java/com/google/flatbuffers/FlexBuffers.java
+++ b/java/com/google/flatbuffers/FlexBuffers.java
@@ -23,7 +23,6 @@ import static com.google.flatbuffers.FlexBuffers.Unsigned.shortToUnsignedInt;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.nio.Buffer;
 import java.nio.charset.StandardCharsets;
 
 /// @file
@@ -689,7 +688,7 @@ public class FlexBuffers {
          */
         public ByteBuffer data() {
             ByteBuffer dup = ByteBuffer.wrap(bb.data());
-            ((Buffer) dup).position(end);
+            dup.position(end);
             dup.limit(end + size());
             return dup.asReadOnlyBuffer().slice();
         }

--- a/java/com/google/flatbuffers/Table.java
+++ b/java/com/google/flatbuffers/Table.java
@@ -151,9 +151,9 @@ public class Table {
   protected ByteBuffer __vector_as_bytebuffer(int vector_offset, int elem_size) {
     int o = __offset(vector_offset);
     if (o == 0) return null;
-    ByteBuffer bb = ((ByteBuffer) (((Buffer) this.bb).duplicate())).order(ByteOrder.LITTLE_ENDIAN);
+    ByteBuffer bb = this.bb.duplicate().order(ByteOrder.LITTLE_ENDIAN);
     int vectorstart = __vector(o);
-    bb.position(vectorstart);
+    ((Buffer) bb).position(vectorstart);
     bb.limit(vectorstart + __vector_len(o) * elem_size);
     return bb;
   }

--- a/java/com/google/flatbuffers/Table.java
+++ b/java/com/google/flatbuffers/Table.java
@@ -18,7 +18,6 @@ package com.google.flatbuffers;
 
 import static com.google.flatbuffers.Constants.*;
 import java.nio.ByteBuffer;
-import java.nio.Buffer;
 import java.nio.ByteOrder;
 
 /// @cond FLATBUFFERS_INTERNAL
@@ -153,7 +152,7 @@ public class Table {
     if (o == 0) return null;
     ByteBuffer bb = this.bb.duplicate().order(ByteOrder.LITTLE_ENDIAN);
     int vectorstart = __vector(o);
-    ((Buffer) bb).position(vectorstart);
+    bb.position(vectorstart);
     bb.limit(vectorstart + __vector_len(o) * elem_size);
     return bb;
   }
@@ -175,7 +174,7 @@ public class Table {
     int vectorstart = __vector(o);
     bb.rewind();
     bb.limit(vectorstart + __vector_len(o) * elem_size);
-    ((Buffer) bb).position(vectorstart);
+    bb.position(vectorstart);
     return bb;
   }
 

--- a/java/com/google/flatbuffers/Utf8Old.java
+++ b/java/com/google/flatbuffers/Utf8Old.java
@@ -87,11 +87,11 @@ public class Utf8Old extends Utf8 {
   public String decodeUtf8(ByteBuffer buffer, int offset, int length) {
     CharsetDecoder decoder = CACHE.get().decoder;
     decoder.reset();
-    Buffer b = ((Buffer) buffer).duplicate();
-    b.position(offset);
-    b.limit(offset + length);
+    buffer = buffer.duplicate();
+    ((Buffer) buffer).position(offset);
+    buffer.limit(offset + length);
     try {
-      CharBuffer result = decoder.decode((ByteBuffer) b);
+      CharBuffer result = decoder.decode(buffer);
       return result.toString();
     } catch (CharacterCodingException e) {
       throw new IllegalArgumentException("Bad encoding", e);

--- a/java/com/google/flatbuffers/Utf8Old.java
+++ b/java/com/google/flatbuffers/Utf8Old.java
@@ -17,7 +17,6 @@
 package com.google.flatbuffers;
 
 import java.nio.ByteBuffer;
-import java.nio.Buffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
@@ -88,7 +87,7 @@ public class Utf8Old extends Utf8 {
     CharsetDecoder decoder = CACHE.get().decoder;
     decoder.reset();
     buffer = buffer.duplicate();
-    ((Buffer) buffer).position(offset);
+    buffer.position(offset);
     buffer.limit(offset + length);
     try {
       CharBuffer result = decoder.decode(buffer);

--- a/java/com/google/flatbuffers/Utf8Old.java
+++ b/java/com/google/flatbuffers/Utf8Old.java
@@ -56,7 +56,7 @@ public class Utf8Old extends Utf8 {
     if (cache.lastOutput == null || cache.lastOutput.capacity() < estimated) {
       cache.lastOutput = ByteBuffer.allocate(Math.max(128, estimated));
     }
-    ((Buffer) cache.lastOutput).clear();
+    cache.lastOutput.clear();
     cache.lastInput = in;
     CharBuffer wrap = (in instanceof CharBuffer) ?
                           (CharBuffer) in : CharBuffer.wrap(in);
@@ -68,7 +68,7 @@ public class Utf8Old extends Utf8 {
         throw new IllegalArgumentException("bad character encoding", e);
       }
     }
-    ((Buffer) cache.lastOutput).flip();
+    cache.lastOutput.flip();
     return cache.lastOutput.remaining();
   }
 

--- a/java/com/google/flatbuffers/Utf8Safe.java
+++ b/java/com/google/flatbuffers/Utf8Safe.java
@@ -31,7 +31,6 @@
 package com.google.flatbuffers;
 
 import java.nio.ByteBuffer;
-import java.nio.Buffer;
 import static java.lang.Character.MAX_SURROGATE;
 import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
 import static java.lang.Character.MIN_SURROGATE;
@@ -311,7 +310,7 @@ final public class Utf8Safe extends Utf8 {
       }
       if (inIx == inLength) {
         // Successfully encoded the entire string.
-        ((Buffer) out).position(outIx + inIx);
+        out.position(outIx + inIx);
         return;
       }
 
@@ -354,7 +353,7 @@ final public class Utf8Safe extends Utf8 {
       }
 
       // Successfully encoded the entire string.
-      ((Buffer) out).position(outIx);
+      out.position(outIx);
     } catch (IndexOutOfBoundsException e) {
       // TODO(nathanmittler): Consider making the API throw IndexOutOfBoundsException instead.
 
@@ -435,7 +434,7 @@ final public class Utf8Safe extends Utf8 {
       int start = out.arrayOffset();
       int end = encodeUtf8Array(in, out.array(), start + out.position(),
           out.remaining());
-      ((Buffer) out).position(end - start);
+      out.position(end - start);
     } else {
       encodeUtf8Buffer(in, out);
     }


### PR DESCRIPTION
I think it causes flatbuffers to be incompatible with Java 8 and it was the wrong course of action to take for the original issue.