### PR TITLE
[C#] Remove superfluous semicolon in C# structs

### DIFF
--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -1335,7 +1335,7 @@ class CSharpGenerator : public BaseGenerator {
       GenPackUnPack_ObjectAPI(struct_def, code_ptr, opts, struct_has_create,
                               field_has_create_set);
     }
-    code += "};\n\n";
+    code += "}\n\n";
 
     if (opts.generate_object_based_api) {
       GenStruct_ObjectAPI(struct_def, code_ptr, opts);

--- a/tests/MyGame/Example/Ability.cs
+++ b/tests/MyGame/Example/Ability.cs
@@ -43,7 +43,7 @@ public struct Ability : IFlatbufferObject
       _o.Id,
       _o.Distance);
   }
-};
+}
 
 public class AbilityT
 {

--- a/tests/MyGame/Example/ArrayStruct.cs
+++ b/tests/MyGame/Example/ArrayStruct.cs
@@ -97,7 +97,7 @@ public struct ArrayStruct : IFlatbufferObject
       _o.E,
       _f);
   }
-};
+}
 
 public class ArrayStructT
 {

--- a/tests/MyGame/Example/ArrayTable.cs
+++ b/tests/MyGame/Example/ArrayTable.cs
@@ -44,7 +44,7 @@ public struct ArrayTable : IFlatbufferObject
     AddA(builder, MyGame.Example.ArrayStruct.Pack(builder, _o.A));
     return EndArrayTable(builder);
   }
-};
+}
 
 public class ArrayTableT
 {

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -741,7 +741,7 @@ public struct Monster : IFlatbufferObject
       _testrequirednestedflatbuffer,
       _scalar_key_sorted_tables);
   }
-};
+}
 
 public class MonsterT
 {

--- a/tests/MyGame/Example/NestedStruct.cs
+++ b/tests/MyGame/Example/NestedStruct.cs
@@ -66,7 +66,7 @@ public struct NestedStruct : IFlatbufferObject
       _c,
       _d);
   }
-};
+}
 
 public class NestedStructT
 {

--- a/tests/MyGame/Example/Referrable.cs
+++ b/tests/MyGame/Example/Referrable.cs
@@ -74,7 +74,7 @@ public struct Referrable : IFlatbufferObject
       builder,
       _o.Id);
   }
-};
+}
 
 public class ReferrableT
 {

--- a/tests/MyGame/Example/Stat.cs
+++ b/tests/MyGame/Example/Stat.cs
@@ -94,7 +94,7 @@ public struct Stat : IFlatbufferObject
       _o.Val,
       _o.Count);
   }
-};
+}
 
 public class StatT
 {

--- a/tests/MyGame/Example/StructOfStructs.cs
+++ b/tests/MyGame/Example/StructOfStructs.cs
@@ -61,7 +61,7 @@ public struct StructOfStructs : IFlatbufferObject
       _c_id,
       _c_distance);
   }
-};
+}
 
 public class StructOfStructsT
 {

--- a/tests/MyGame/Example/Test.cs
+++ b/tests/MyGame/Example/Test.cs
@@ -44,7 +44,7 @@ public struct Test : IFlatbufferObject
       _o.A,
       _o.B);
   }
-};
+}
 
 public class TestT
 {

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.cs
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.cs
@@ -49,7 +49,7 @@ internal partial struct TestSimpleTableWithEnum : IFlatbufferObject
       builder,
       _o.Color);
   }
-};
+}
 
 internal partial class TestSimpleTableWithEnumT
 {

--- a/tests/MyGame/Example/TypeAliases.cs
+++ b/tests/MyGame/Example/TypeAliases.cs
@@ -158,7 +158,7 @@ public struct TypeAliases : IFlatbufferObject
       _v8,
       _vf64);
   }
-};
+}
 
 public class TypeAliasesT
 {

--- a/tests/MyGame/Example/Vec3.cs
+++ b/tests/MyGame/Example/Vec3.cs
@@ -71,7 +71,7 @@ public struct Vec3 : IFlatbufferObject
       _test3_a,
       _test3_b);
   }
-};
+}
 
 public class Vec3T
 {

--- a/tests/MyGame/Example2/Monster.cs
+++ b/tests/MyGame/Example2/Monster.cs
@@ -37,7 +37,7 @@ public struct Monster : IFlatbufferObject
     StartMonster(builder);
     return EndMonster(builder);
   }
-};
+}
 
 public class MonsterT
 {

--- a/tests/MyGame/InParentNamespace.cs
+++ b/tests/MyGame/InParentNamespace.cs
@@ -37,7 +37,7 @@ public struct InParentNamespace : IFlatbufferObject
     StartInParentNamespace(builder);
     return EndInParentNamespace(builder);
   }
-};
+}
 
 public class InParentNamespaceT
 {

--- a/tests/MyGame/MonsterExtra.cs
+++ b/tests/MyGame/MonsterExtra.cs
@@ -147,7 +147,7 @@ public struct MonsterExtra : IFlatbufferObject
       _dvec,
       _fvec);
   }
-};
+}
 
 public class MonsterExtraT
 {

--- a/tests/keyword_test/KeywordsInTable.cs
+++ b/tests/keyword_test/KeywordsInTable.cs
@@ -53,7 +53,7 @@ public struct KeywordsInTable : IFlatbufferObject
       _o.Is,
       _o.Private);
   }
-};
+}
 
 public class KeywordsInTableT
 {

--- a/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.cs
+++ b/tests/namespace_test/NamespaceA/NamespaceB/StructInNestedNS.cs
@@ -43,7 +43,7 @@ public struct StructInNestedNS : IFlatbufferObject
       _o.A,
       _o.B);
   }
-};
+}
 
 public class StructInNestedNST
 {

--- a/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.cs
+++ b/tests/namespace_test/NamespaceA/NamespaceB/TableInNestedNS.cs
@@ -49,7 +49,7 @@ public struct TableInNestedNS : IFlatbufferObject
       builder,
       _o.Foo);
   }
-};
+}
 
 public class TableInNestedNST
 {

--- a/tests/namespace_test/NamespaceA/SecondTableInA.cs
+++ b/tests/namespace_test/NamespaceA/SecondTableInA.cs
@@ -49,7 +49,7 @@ public struct SecondTableInA : IFlatbufferObject
       builder,
       _refer_to_c);
   }
-};
+}
 
 public class SecondTableInAT
 {

--- a/tests/namespace_test/NamespaceA/TableInFirstNS.cs
+++ b/tests/namespace_test/NamespaceA/TableInFirstNS.cs
@@ -83,7 +83,7 @@ public struct TableInFirstNS : IFlatbufferObject
       _foo_union,
       _o.FooStruct);
   }
-};
+}
 
 public class TableInFirstNST
 {

--- a/tests/namespace_test/NamespaceC/TableInC.cs
+++ b/tests/namespace_test/NamespaceC/TableInC.cs
@@ -56,7 +56,7 @@ public struct TableInC : IFlatbufferObject
       _refer_to_a1,
       _refer_to_a2);
   }
-};
+}
 
 public class TableInCT
 {

--- a/tests/optional_scalars/ScalarStuff.cs
+++ b/tests/optional_scalars/ScalarStuff.cs
@@ -261,7 +261,7 @@ public struct ScalarStuff : IFlatbufferObject
       _o.MaybeEnum,
       _o.DefaultEnum);
   }
-};
+}
 
 public class ScalarStuffT
 {

--- a/tests/union_vector/Attacker.cs
+++ b/tests/union_vector/Attacker.cs
@@ -46,7 +46,7 @@ public struct Attacker : IFlatbufferObject
       builder,
       _o.SwordAttackDamage);
   }
-};
+}
 
 public class AttackerT
 {

--- a/tests/union_vector/BookReader.cs
+++ b/tests/union_vector/BookReader.cs
@@ -35,7 +35,7 @@ public struct BookReader : IFlatbufferObject
       builder,
       _o.BooksRead);
   }
-};
+}
 
 public class BookReaderT
 {

--- a/tests/union_vector/Movie.cs
+++ b/tests/union_vector/Movie.cs
@@ -148,7 +148,7 @@ public struct Movie : IFlatbufferObject
       _characters_type,
       _characters);
   }
-};
+}
 
 public class MovieT
 {

--- a/tests/union_vector/Rapunzel.cs
+++ b/tests/union_vector/Rapunzel.cs
@@ -35,7 +35,7 @@ public struct Rapunzel : IFlatbufferObject
       builder,
       _o.HairLength);
   }
-};
+}
 
 public class RapunzelT
 {


### PR DESCRIPTION
Aims to resolve #6788

-Remove superfluous semicolon in C# structs
