### PR TITLE
fix parser string=null

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -812,8 +812,7 @@ CheckedError Parser::ParseField(StructDef &struct_def) {
           "or in structs.");
     if (IsString(type) || IsVector(type)) {
       advanced_features_ |= reflection::DefaultVectorsAndStrings;
-      if (field->value.constant != "0" && field->value.constant != "null" &&
-          !SupportsDefaultVectorsAndStrings()) {
+      if (field->value.constant != "0" && !SupportsDefaultVectorsAndStrings()) {
         return Error(
             "Default values for strings and vectors are not supported in one "
             "of the specified programming languages");

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -3883,6 +3883,7 @@ void StringVectorDefaultsTest() {
   schemas.push_back("table Monster { mana: string = \"\"; }");
   schemas.push_back("table Monster { mana: string = \"mystr\"; }");
   schemas.push_back("table Monster { mana: string = \"  \"; }");
+  schemas.push_back("table Monster { mana: string = \"null\"; }");
   schemas.push_back("table Monster { mana: [int] = []; }");
   schemas.push_back("table Monster { mana: [uint] = [  ]; }");
   schemas.push_back("table Monster { mana: [byte] = [\t\t\n]; }");


### PR DESCRIPTION
Fixes #6786. @llongi

Originally I wanted `table T { s: string = null; }` to be valid syntax, leading to existing behavior of optional strings. This didn't actually work and I lost the feature somewhere in development leading to the above bug. 