### PR TITLE
flattests_cpp17 doesn't compile with Visual Studio 2017: warning C410…

### DIFF
--- a/tests/cpp17/stringify_util.h
+++ b/tests/cpp17/stringify_util.h
@@ -83,6 +83,8 @@ std::string StringifyTableOrStructImpl(const FBS &fbs,
 
 template<typename FBS>
 std::string StringifyTableOrStruct(const FBS &fbs, const std::string &indent) {
+  (void)fbs;
+  (void)indent;
   static constexpr size_t field_count = FBS::Traits::fields_number;
   std::string out;
   if constexpr (field_count > 0) {
@@ -125,6 +127,7 @@ template<typename T> std::string StringifyArithmeticType(T val) {
 template<typename T>
 std::optional<std::string> StringifyFlatbufferValue(T &&val,
                                                     const std::string &indent) {
+  (void)indent;
   constexpr bool is_pointer = std::is_pointer_v<std::remove_reference_t<T>>;
   if constexpr (is_pointer) {
     if (val == nullptr) return std::nullopt;  // Field is absent.


### PR DESCRIPTION
…0: 'indent': unreferenced formal parameter

stringify_util.h(127): error C2220: warning treated as error - no 'object' file generated
stringify_util.h(127): warning C4100: 'indent': unreferenced formal parameter
stringify_util.h(85): warning C4100: 'indent': unreferenced formal parameter
stringify_util.h(85): warning C4100: 'fbs': unreferenced formal parameter

Thank you for submitting a PR!

Please delete this standard text once you've created your own description.

Make sure you include the names of the affected language(s) in your PR title.
This helps us get the correct maintainers to look at your issue.

If you make changes to any of the code generators, be sure to run
`cd tests && bash generate_code.sh` (or equivalent .bat) and include the generated
code changes in the PR. This allows us to better see the effect of the PR.

If your PR includes C++ code, please adhere to the Google C++ Style Guide,
and don't forget we try to support older compilers (e.g. VS2010, GCC 4.6.3),
so only some C++11 support is available.

For any C++ changes, please make sure to run `sh scripts/clang-format-git.sh`

Include other details as appropriate.

Thanks!
