### PR TITLE
[C++] Let builder accept custom-alloc std::vector

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -1812,7 +1812,8 @@ class FlatBufferBuilder {
   /// buffer as a `vector`.
   /// @return Returns a typed `Offset` into the serialized data indicating
   /// where the vector is stored.
-  template<typename T> Offset<Vector<T>> CreateVector(const std::vector<T> &v) {
+  template<typename T, typename Alloc>
+  Offset<Vector<T>> CreateVector(const std::vector<T, Alloc> &v) {
     return CreateVector(data(v), v.size());
   }
 
@@ -1871,8 +1872,9 @@ class FlatBufferBuilder {
   /// buffer as a `vector`.
   /// @return Returns a typed `Offset` into the serialized data indicating
   /// where the vector is stored.
+  template<typename Alloc>
   Offset<Vector<Offset<String>>> CreateVectorOfStrings(
-      const std::vector<std::string> &v) {
+      const std::vector<std::string, Alloc> &v) {
     return CreateVectorOfStrings(v.cbegin(), v.cend());
   }
 
@@ -2018,9 +2020,9 @@ class FlatBufferBuilder {
   /// to the FlatBuffer struct.
   /// @return Returns a typed `Offset` into the serialized data indicating
   /// where the vector is stored.
-  template<typename T, typename S>
+  template<typename T, typename S, typename Alloc>
   Offset<Vector<const T *>> CreateVectorOfNativeStructs(
-      const std::vector<S> &v, T (*const pack_func)(const S &)) {
+      const std::vector<S, Alloc> &v, T (*const pack_func)(const S &)) {
     return CreateVectorOfNativeStructs<T, S>(data(v), v.size(), pack_func);
   }
 
@@ -2032,9 +2034,9 @@ class FlatBufferBuilder {
   /// serialize into the buffer as a `vector`.
   /// @return Returns a typed `Offset` into the serialized data indicating
   /// where the vector is stored.
-  template<typename T, typename S>
+  template<typename T, typename S, typename Alloc>
   Offset<Vector<const T *>> CreateVectorOfNativeStructs(
-      const std::vector<S> &v) {
+      const std::vector<S, Alloc> &v) {
     return CreateVectorOfNativeStructs<T, S>(data(v), v.size());
   }
 
@@ -2053,8 +2055,9 @@ class FlatBufferBuilder {
   /// serialize into the buffer as a `vector`.
   /// @return Returns a typed `Offset` into the serialized data indicating
   /// where the vector is stored.
-  template<typename T>
-  Offset<Vector<const T *>> CreateVectorOfSortedStructs(std::vector<T> *v) {
+  template<typename T, typename Alloc>
+  Offset<Vector<const T *>> CreateVectorOfSortedStructs(
+      std::vector<T, Alloc> *v) {
     return CreateVectorOfSortedStructs(data(*v), v->size());
   }
 
@@ -2066,9 +2069,9 @@ class FlatBufferBuilder {
   /// serialize into the buffer as a `vector`.
   /// @return Returns a typed `Offset` into the serialized data indicating
   /// where the vector is stored.
-  template<typename T, typename S>
+  template<typename T, typename S, typename Alloc>
   Offset<Vector<const T *>> CreateVectorOfSortedNativeStructs(
-      std::vector<S> *v) {
+      std::vector<S, Alloc> *v) {
     return CreateVectorOfSortedNativeStructs<T, S>(data(*v), v->size());
   }
 
@@ -2144,9 +2147,9 @@ class FlatBufferBuilder {
   /// offsets to store in the buffer in sorted order.
   /// @return Returns a typed `Offset` into the serialized data indicating
   /// where the vector is stored.
-  template<typename T>
+  template<typename T, typename Alloc>
   Offset<Vector<Offset<T>>> CreateVectorOfSortedTables(
-      std::vector<Offset<T>> *v) {
+      std::vector<Offset<T>, Alloc> *v) {
     return CreateVectorOfSortedTables(data(*v), v->size());
   }
 


### PR DESCRIPTION
Change the FlatBufferBuilder's methods to accept std::vector parameters
with non-default allocator, by adding another template parameter to
them. This should make using the builder slightly more convenient, as
one won't need to manually pass data() and size() separately.