### PR TITLE
[C++] Add GetMutableSizePrefixedRoot and generate GetMutableSizePrefixedXxx functions

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -2327,6 +2327,11 @@ template<typename T> T *GetMutableRoot(void *buf) {
       EndianScalar(*reinterpret_cast<uoffset_t *>(buf)));
 }
 
+template<typename T> T *GetMutableSizePrefixedRoot(void *buf) {
+  return GetMutableRoot<T>(reinterpret_cast<uint8_t *>(buf) +
+                           sizeof(uoffset_t));
+}
+
 template<typename T> const T *GetRoot(const void *buf) {
   return GetMutableRoot<T>(const_cast<void *>(buf));
 }

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -834,6 +834,10 @@ inline Monster *GetMutableMonster(void *buf) {
   return flatbuffers::GetMutableRoot<Monster>(buf);
 }
 
+inline MyGame::Sample::Monster *GetMutableSizePrefixedMonster(void *buf) {
+  return flatbuffers::GetMutableSizePrefixedRoot<MyGame::Sample::Monster>(buf);
+}
+
 inline bool VerifyMonsterBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<MyGame::Sample::Monster>(nullptr);

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -505,6 +505,16 @@ class CppGenerator : public BaseGenerator {
         code_ += "  return flatbuffers::GetMutableRoot<{{STRUCT_NAME}}>(buf);";
         code_ += "}";
         code_ += "";
+
+        code_ += "inline \\";
+        code_ +=
+            "{{CPP_NAME}} "
+            "*{{NULLABLE_EXT}}GetMutableSizePrefixed{{STRUCT_NAME}}(void "
+            "*buf) {";
+        code_ +=
+            "  return flatbuffers::GetMutableSizePrefixedRoot<{{CPP_NAME}}>(buf);";
+        code_ += "}";
+        code_ += "";
       }
 
       if (parser_.file_identifier_.length()) {

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -512,7 +512,8 @@ class CppGenerator : public BaseGenerator {
             "*{{NULLABLE_EXT}}GetMutableSizePrefixed{{STRUCT_NAME}}(void "
             "*buf) {";
         code_ +=
-            "  return flatbuffers::GetMutableSizePrefixedRoot<{{CPP_NAME}}>(buf);";
+            "  return "
+            "flatbuffers::GetMutableSizePrefixedRoot<{{CPP_NAME}}>(buf);";
         code_ += "}";
         code_ += "";
       }

--- a/tests/arrays_test_generated.h
+++ b/tests/arrays_test_generated.h
@@ -457,6 +457,10 @@ inline ArrayTable *GetMutableArrayTable(void *buf) {
   return flatbuffers::GetMutableRoot<ArrayTable>(buf);
 }
 
+inline MyGame::Example::ArrayTable *GetMutableSizePrefixedArrayTable(void *buf) {
+  return flatbuffers::GetMutableSizePrefixedRoot<MyGame::Example::ArrayTable>(buf);
+}
+
 inline const char *ArrayTableIdentifier() {
   return "ARRT";
 }

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -3677,6 +3677,10 @@ inline Monster *GetMutableMonster(void *buf) {
   return flatbuffers::GetMutableRoot<Monster>(buf);
 }
 
+inline MyGame::Example::Monster *GetMutableSizePrefixedMonster(void *buf) {
+  return flatbuffers::GetMutableSizePrefixedRoot<MyGame::Example::Monster>(buf);
+}
+
 inline const char *MonsterIdentifier() {
   return "MONS";
 }

--- a/tests/cpp17/generated_cpp17/optional_scalars_generated.h
+++ b/tests/cpp17/generated_cpp17/optional_scalars_generated.h
@@ -933,6 +933,10 @@ inline ScalarStuff *GetMutableScalarStuff(void *buf) {
   return flatbuffers::GetMutableRoot<ScalarStuff>(buf);
 }
 
+inline optional_scalars::ScalarStuff *GetMutableSizePrefixedScalarStuff(void *buf) {
+  return flatbuffers::GetMutableSizePrefixedRoot<optional_scalars::ScalarStuff>(buf);
+}
+
 inline const char *ScalarStuffIdentifier() {
   return "NULL";
 }

--- a/tests/cpp17/generated_cpp17/union_vector_generated.h
+++ b/tests/cpp17/generated_cpp17/union_vector_generated.h
@@ -798,6 +798,10 @@ inline Movie *GetMutableMovie(void *buf) {
   return flatbuffers::GetMutableRoot<Movie>(buf);
 }
 
+inline Movie *GetMutableSizePrefixedMovie(void *buf) {
+  return flatbuffers::GetMutableSizePrefixedRoot<Movie>(buf);
+}
+
 inline const char *MovieIdentifier() {
   return "MOVI";
 }

--- a/tests/cpp17/stringify_util.h
+++ b/tests/cpp17/stringify_util.h
@@ -83,6 +83,8 @@ std::string StringifyTableOrStructImpl(const FBS &fbs,
 
 template<typename FBS>
 std::string StringifyTableOrStruct(const FBS &fbs, const std::string &indent) {
+  (void)fbs;
+  (void)indent;
   static constexpr size_t field_count = FBS::Traits::fields_number;
   std::string out;
   if constexpr (field_count > 0) {
@@ -125,6 +127,7 @@ template<typename T> std::string StringifyArithmeticType(T val) {
 template<typename T>
 std::optional<std::string> StringifyFlatbufferValue(T &&val,
                                                     const std::string &indent) {
+  (void)indent;
   constexpr bool is_pointer = std::is_pointer_v<std::remove_reference_t<T>>;
   if constexpr (is_pointer) {
     if (val == nullptr) return std::nullopt;  // Field is absent.

--- a/tests/cpp17/stringify_util.h
+++ b/tests/cpp17/stringify_util.h
@@ -83,8 +83,6 @@ std::string StringifyTableOrStructImpl(const FBS &fbs,
 
 template<typename FBS>
 std::string StringifyTableOrStruct(const FBS &fbs, const std::string &indent) {
-  (void)fbs;
-  (void)indent;
   static constexpr size_t field_count = FBS::Traits::fields_number;
   std::string out;
   if constexpr (field_count > 0) {
@@ -127,7 +125,6 @@ template<typename T> std::string StringifyArithmeticType(T val) {
 template<typename T>
 std::optional<std::string> StringifyFlatbufferValue(T &&val,
                                                     const std::string &indent) {
-  (void)indent;
   constexpr bool is_pointer = std::is_pointer_v<std::remove_reference_t<T>>;
   if constexpr (is_pointer) {
     if (val == nullptr) return std::nullopt;  // Field is absent.

--- a/tests/monster_extra_generated.h
+++ b/tests/monster_extra_generated.h
@@ -349,6 +349,10 @@ inline MonsterExtra *GetMutableMonsterExtra(void *buf) {
   return flatbuffers::GetMutableRoot<MonsterExtra>(buf);
 }
 
+inline MyGame::MonsterExtra *GetMutableSizePrefixedMonsterExtra(void *buf) {
+  return flatbuffers::GetMutableSizePrefixedRoot<MyGame::MonsterExtra>(buf);
+}
+
 inline const char *MonsterExtraIdentifier() {
   return "MONE";
 }

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -3648,6 +3648,10 @@ inline Monster *GetMutableMonster(void *buf) {
   return flatbuffers::GetMutableRoot<Monster>(buf);
 }
 
+inline MyGame::Example::Monster *GetMutableSizePrefixedMonster(void *buf) {
+  return flatbuffers::GetMutableSizePrefixedRoot<MyGame::Example::Monster>(buf);
+}
+
 inline const char *MonsterIdentifier() {
   return "MONS";
 }

--- a/tests/native_type_test_generated.h
+++ b/tests/native_type_test_generated.h
@@ -288,6 +288,10 @@ inline ApplicationData *GetMutableApplicationData(void *buf) {
   return flatbuffers::GetMutableRoot<ApplicationData>(buf);
 }
 
+inline Geometry::ApplicationData *GetMutableSizePrefixedApplicationData(void *buf) {
+  return flatbuffers::GetMutableSizePrefixedRoot<Geometry::ApplicationData>(buf);
+}
+
 inline bool VerifyApplicationDataBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<Geometry::ApplicationData>(nullptr);

--- a/tests/optional_scalars_generated.h
+++ b/tests/optional_scalars_generated.h
@@ -893,6 +893,10 @@ inline ScalarStuff *GetMutableScalarStuff(void *buf) {
   return flatbuffers::GetMutableRoot<ScalarStuff>(buf);
 }
 
+inline optional_scalars::ScalarStuff *GetMutableSizePrefixedScalarStuff(void *buf) {
+  return flatbuffers::GetMutableSizePrefixedRoot<optional_scalars::ScalarStuff>(buf);
+}
+
 inline const char *ScalarStuffIdentifier() {
   return "NULL";
 }

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -829,6 +829,10 @@ inline Movie *GetMutableMovie(void *buf) {
   return flatbuffers::GetMutableRoot<Movie>(buf);
 }
 
+inline Movie *GetMutableSizePrefixedMovie(void *buf) {
+  return flatbuffers::GetMutableSizePrefixedRoot<Movie>(buf);
+}
+
 inline const char *MovieIdentifier() {
   return "MOVI";
 }


### PR DESCRIPTION
This adds GetMutableSizePrefixedRoot to flatbuffers.h and generates GetMutableSizePrefixedXxx functions for C++.

https://stackoverflow.com/questions/68952645/may-i-add-a-getmutablesizeprefixedroot-or-getsizeprefixedmutableroot
