### PR TITLE
Add html and latex to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ yarn-error.log
 **/go.sum
 flatbuffers.pc
 **/FlatBuffers.Test.Swift.xcodeproj
+**/html/**
+**/latex/**


### PR DESCRIPTION
@aardappel, I have these directories generated whenever I build the docs but they weren't committed by anyone so I'm adding them to .gitignore so we won't accidentally commit them. 