### PR TITLE
[C++] Add mutable version of LookupByKey and test

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -376,7 +376,7 @@ template<typename T> class Vector {
     return IndirectHelper<T>::Read(element, 0);
   }
 
-  template<typename K> mutable_return_type mutable_LookupByKey(K key) {
+  template<typename K> mutable_return_type MutableLookupByKey(K key) {
     return const_cast<mutable_return_type>(LookupByKey(key));
   }
 

--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -376,6 +376,10 @@ template<typename T> class Vector {
     return IndirectHelper<T>::Read(element, 0);
   }
 
+  template<typename K> mutable_return_type mutable_LookupByKey(K key) {
+    return const_cast<mutable_return_type>(LookupByKey(key));
+  }
+
  protected:
   // This class is only used to access pre-existing data. Don't ever
   // try to construct these manually.

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -501,13 +501,13 @@ void MutateFlatBuffersTest(uint8_t *flatbuf, std::size_t length) {
   first->mutate_hp(1000);
 
   // Mutate via LookupByKey
-  TEST_NOTNULL(tables->mutable_LookupByKey("Barney"));
+  TEST_NOTNULL(tables->MutableLookupByKey("Barney"));
   TEST_EQ(static_cast<Monster *>(nullptr),
-          tables->mutable_LookupByKey("DoesntExist"));
-  TEST_EQ(tables->mutable_LookupByKey("Barney")->hp(), 1000);
-  TEST_EQ(tables->mutable_LookupByKey("Barney")->mutate_hp(0), true);
+          tables->MutableLookupByKey("DoesntExist"));
+  TEST_EQ(tables->MutableLookupByKey("Barney")->hp(), 1000);
+  TEST_EQ(tables->MutableLookupByKey("Barney")->mutate_hp(0), true);
   TEST_EQ(tables->LookupByKey("Barney")->hp(), 0);
-  TEST_EQ(tables->mutable_LookupByKey("Barney")->mutate_hp(1000), true);
+  TEST_EQ(tables->MutableLookupByKey("Barney")->mutate_hp(1000), true);
 
   // Run the verifier and the regular test to make sure we didn't trample on
   // anything.

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -500,6 +500,15 @@ void MutateFlatBuffersTest(uint8_t *flatbuf, std::size_t length) {
   TEST_EQ(first->hp(), 0);
   first->mutate_hp(1000);
 
+  // Mutate via LookupByKey
+  TEST_NOTNULL(tables->mutable_LookupByKey("Barney"));
+  TEST_EQ(static_cast<Monster *>(nullptr),
+          tables->mutable_LookupByKey("DoesntExist"));
+  TEST_EQ(tables->mutable_LookupByKey("Barney")->hp(), 1000);
+  TEST_EQ(tables->mutable_LookupByKey("Barney")->mutate_hp(0), true);
+  TEST_EQ(tables->LookupByKey("Barney")->hp(), 0);
+  TEST_EQ(tables->mutable_LookupByKey("Barney")->mutate_hp(1000), true);
+
   // Run the verifier and the regular test to make sure we didn't trample on
   // anything.
   AccessFlatBufferTest(flatbuf, length);


### PR DESCRIPTION
This adds an overload of LookupByKey to allow lookup in sorted Vectors to
return a mutable instance of the object (or nullptr if not found).

Googler here, first time contributing to the project. This is a useful API for my purposes, but let me know if it is not of interest to be upstreamed.