### PR TITLE
Jsonschema: Issue error if root type is missing

### DIFF
--- a/src/idl_gen_json_schema.cpp
+++ b/src/idl_gen_json_schema.cpp
@@ -198,7 +198,10 @@ class JsonSchemaGenerator : public BaseGenerator {
 
   bool generate() {
     code_ = "";
-    if (parser_.root_struct_def_ == nullptr) { return false; }
+    if (parser_.root_struct_def_ == nullptr) { 
+      std::cerr << "Error: Binary schema not generated, no root struct found\n";
+      return false; 
+    }
     code_ += "{" + NewLine();
     code_ += Indent(1) +
              "\"$schema\": \"https://json-schema.org/draft/2019-09/schema\"," +


### PR DESCRIPTION
The jsonschema generator now prints an error message via stderr if no root type was specified in the schema file.