### PR TITLE
Include subdirectories in published npm JS package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,10 @@ android/build/
 samples/android/.externalNativeBuild/
 samples/android/.gradle/
 samples/android/build/
-js/flatbuffers.mjs
+js/**/*.js
+js/**/*.d.ts
+mjs/**/*.js
+mjs/**/*.d.ts
 /bazel-bin
 /bazel-flatbuffers
 /bazel-genfiles

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "2.0.3",
   "description": "Memory Efficient Serialization Library",
   "files": [
-    "js/*.js",
-    "js/*.d.ts",
-    "mjs/*.js",
-    "mjs/*.d.ts",
-    "ts/*.ts"
+    "js/**/*.js",
+    "js/**/*.d.ts",
+    "mjs/**/*.js",
+    "mjs/**/*.d.ts",
+    "ts/**/*.ts"
   ],
   "main": "js/flatbuffers.js",
   "module": "mjs/flatbuffers.js",


### PR DESCRIPTION
Updates the `files` globs in package.json to include subdirectories in order to also include the flexbuffers directory in the published npm package.

Updates .gitignore to include the tsc-generated JS files.

Fixes #6849.