### PR TITLE
Use ArrayBuffer type for JS flexbuffer's toObject method

### DIFF
--- a/ts/flexbuffers.ts
+++ b/ts/flexbuffers.ts
@@ -7,7 +7,7 @@ export function builder(): Builder {
     return new Builder();
 }
 
-export function toObject(buffer: Uint8Array): unknown {
+export function toObject(buffer: ArrayBuffer): unknown {
     return toReference(buffer).toObject();
 }
 

--- a/ts/flexbuffers/reference.ts
+++ b/ts/flexbuffers/reference.ts
@@ -6,7 +6,7 @@ import { Long } from '../long';
 import { fromUTF8Array } from './flexbuffers-util';
 import { BitWidth } from './bit-width';
 
-export function toReference(buffer: Uint8Array): Reference {
+export function toReference(buffer: ArrayBuffer): Reference {
   const len = buffer.byteLength;
   
   if (len < 3) {


### PR DESCRIPTION
Corrects the type of the JS flexbuffers toObject method. It appears the tests didn't catch the mistake since they're in JS. Using the correct type causes a runtime exception: `Uncaught TypeError: First argument to DataView constructor must be an ArrayBuffer`.