### PR TITLE
Add support for Apple silicon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,11 @@ jobs:
     - name: build
       # NOTE: we need this _build dir to not have xcodebuild's default ./build dir clash with the BUILD file.
       run: xcodebuild -toolchain clang -configuration Release -target flattests SYMROOT=$(PWD)/_build
+    - name: check that the binary is "universal"
+      run: |
+        info=$(file _build/Release/flatc)
+        echo $info
+        echo $info | grep "universal binary with 2 architectures"
     - name: test
       run: _build/Release/flattests
     - name: upload build artifacts
@@ -133,7 +138,7 @@ jobs:
     - name: Build
       working-directory: kotlin
       run: ./gradlew clean iosX64Test macosX64Test jsTest jsBrowserTest
-  
+
   build-kotlin-linux:
     name: Build Kotlin Linux
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
 
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
   if(APPLE)
+    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
   else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")


### PR DESCRIPTION
Before and after:

```shell
% file flatc
flatc: Mach-O 64-bit executable arm64
% file flatc
flatc: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
flatc (for architecture x86_64):        Mach-O 64-bit executable x86_64
flatc (for architecture arm64): Mach-O 64-bit executable arm64
```