### PR TITLE
Fix linker errors on (Free|Open)BSD.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,6 +10,20 @@ exports_files([
     "LICENSE",
 ])
 
+config_setting(
+    name = "platform_freebsd",
+    constraint_values = [
+        "@platforms//os:freebsd",
+    ],
+)
+
+config_setting(
+    name = "platform_openbsd",
+    constraint_values = [
+        "@platforms//os:openbsd",
+    ],
+)
+
 # Public flatc library to compile flatbuffer files at runtime.
 cc_library(
     name = "flatbuffers",

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -5,6 +5,20 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
+config_setting(
+    name = "platform_freebsd",
+    constraint_values = [
+        "@platforms//os:freebsd",
+    ],
+)
+
+config_setting(
+    name = "platform_openbsd",
+    constraint_values = [
+        "@platforms//os:openbsd",
+    ],
+)
+
 # Public flatc library to compile flatbuffer files at runtime.
 cc_library(
     name = "flatbuffers",
@@ -17,6 +31,11 @@ cc_library(
         "util.cpp",
     ],
     hdrs = ["//:public_headers"],
+    linkopts = select({
+        ":platform_freebsd": ["-lm"],
+        ":platform_openbsd": ["-lm"],
+        "//conditions:default": [],
+    }),
     strip_include_prefix = "/include",
     visibility = ["//:__pkg__"],
 )

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -5,20 +5,6 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
-config_setting(
-    name = "platform_freebsd",
-    constraint_values = [
-        "@platforms//os:freebsd",
-    ],
-)
-
-config_setting(
-    name = "platform_openbsd",
-    constraint_values = [
-        "@platforms//os:openbsd",
-    ],
-)
-
 # Public flatc library to compile flatbuffer files at runtime.
 cc_library(
     name = "flatbuffers",
@@ -32,8 +18,12 @@ cc_library(
     ],
     hdrs = ["//:public_headers"],
     linkopts = select({
-        ":platform_freebsd": ["-lm"],
-        ":platform_openbsd": ["-lm"],
+        # TODO: Bazel uses `clang` instead of `clang++` to link
+        # C++ code on BSD. Temporarily adding these linker flags while
+        # we wait for Bazel to resolve
+        # https://github.com/bazelbuild/bazel/issues/12023.
+        "//:platform_freebsd": ["-lm"],
+        "//:platform_openbsd": ["-lm"],
         "//conditions:default": [],
     }),
     strip_include_prefix = "/include",


### PR DESCRIPTION
- [x] Adds `-lm` linker flag for FreeBSD/OpenBSD where we're using cmath to fix #6089 
