### PR TITLE
Include a SizePrefixed..HasIdentifier for c++.

### DIFF
--- a/include/flatbuffers/reflection_generated.h
+++ b/include/flatbuffers/reflection_generated.h
@@ -1413,6 +1413,11 @@ inline bool SchemaBufferHasIdentifier(const void *buf) {
       buf, SchemaIdentifier());
 }
 
+inline bool SizePrefixedSchemaBufferHasIdentifier(const void *buf) {
+  return flatbuffers::BufferHasIdentifier(
+      buf, SchemaIdentifier(), true);
+}
+
 inline bool VerifySchemaBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<reflection::Schema>(SchemaIdentifier());

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -532,6 +532,14 @@ class CppGenerator : public BaseGenerator {
         code_ += "      buf, {{STRUCT_NAME}}Identifier());";
         code_ += "}";
         code_ += "";
+
+        // Check if a size-prefixed buffer has the identifier.
+        code_ += "inline \\";
+        code_ += "bool SizePrefixed{{STRUCT_NAME}}BufferHasIdentifier(const void *buf) {";
+        code_ += "  return flatbuffers::BufferHasIdentifier(";
+        code_ += "      buf, {{STRUCT_NAME}}Identifier(), true);";
+        code_ += "}";
+        code_ += "";
       }
 
       // The root verifier.

--- a/tests/arrays_test_generated.h
+++ b/tests/arrays_test_generated.h
@@ -470,6 +470,11 @@ inline bool ArrayTableBufferHasIdentifier(const void *buf) {
       buf, ArrayTableIdentifier());
 }
 
+inline bool SizePrefixedArrayTableBufferHasIdentifier(const void *buf) {
+  return flatbuffers::BufferHasIdentifier(
+      buf, ArrayTableIdentifier(), true);
+}
+
 inline bool VerifyArrayTableBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<MyGame::Example::ArrayTable>(ArrayTableIdentifier());

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -3727,6 +3727,11 @@ inline bool MonsterBufferHasIdentifier(const void *buf) {
       buf, MonsterIdentifier());
 }
 
+inline bool SizePrefixedMonsterBufferHasIdentifier(const void *buf) {
+  return flatbuffers::BufferHasIdentifier(
+      buf, MonsterIdentifier(), true);
+}
+
 inline bool VerifyMonsterBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<MyGame::Example::Monster>(MonsterIdentifier());

--- a/tests/cpp17/generated_cpp17/optional_scalars_generated.h
+++ b/tests/cpp17/generated_cpp17/optional_scalars_generated.h
@@ -946,6 +946,11 @@ inline bool ScalarStuffBufferHasIdentifier(const void *buf) {
       buf, ScalarStuffIdentifier());
 }
 
+inline bool SizePrefixedScalarStuffBufferHasIdentifier(const void *buf) {
+  return flatbuffers::BufferHasIdentifier(
+      buf, ScalarStuffIdentifier(), true);
+}
+
 inline bool VerifyScalarStuffBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<optional_scalars::ScalarStuff>(ScalarStuffIdentifier());

--- a/tests/cpp17/generated_cpp17/union_vector_generated.h
+++ b/tests/cpp17/generated_cpp17/union_vector_generated.h
@@ -1214,6 +1214,11 @@ inline bool MovieBufferHasIdentifier(const void *buf) {
       buf, MovieIdentifier());
 }
 
+inline bool SizePrefixedMovieBufferHasIdentifier(const void *buf) {
+  return flatbuffers::BufferHasIdentifier(
+      buf, MovieIdentifier(), true);
+}
+
 inline bool VerifyMovieBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<Movie>(MovieIdentifier());

--- a/tests/monster_extra_generated.h
+++ b/tests/monster_extra_generated.h
@@ -362,6 +362,11 @@ inline bool MonsterExtraBufferHasIdentifier(const void *buf) {
       buf, MonsterExtraIdentifier());
 }
 
+inline bool SizePrefixedMonsterExtraBufferHasIdentifier(const void *buf) {
+  return flatbuffers::BufferHasIdentifier(
+      buf, MonsterExtraIdentifier(), true);
+}
+
 inline bool VerifyMonsterExtraBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<MyGame::MonsterExtra>(MonsterExtraIdentifier());

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -3698,6 +3698,11 @@ inline bool MonsterBufferHasIdentifier(const void *buf) {
       buf, MonsterIdentifier());
 }
 
+inline bool SizePrefixedMonsterBufferHasIdentifier(const void *buf) {
+  return flatbuffers::BufferHasIdentifier(
+      buf, MonsterIdentifier(), true);
+}
+
 inline bool VerifyMonsterBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<MyGame::Example::Monster>(MonsterIdentifier());

--- a/tests/optional_scalars_generated.h
+++ b/tests/optional_scalars_generated.h
@@ -906,6 +906,11 @@ inline bool ScalarStuffBufferHasIdentifier(const void *buf) {
       buf, ScalarStuffIdentifier());
 }
 
+inline bool SizePrefixedScalarStuffBufferHasIdentifier(const void *buf) {
+  return flatbuffers::BufferHasIdentifier(
+      buf, ScalarStuffIdentifier(), true);
+}
+
 inline bool VerifyScalarStuffBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<optional_scalars::ScalarStuff>(ScalarStuffIdentifier());

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -1267,6 +1267,11 @@ inline bool MovieBufferHasIdentifier(const void *buf) {
       buf, MovieIdentifier());
 }
 
+inline bool SizePrefixedMovieBufferHasIdentifier(const void *buf) {
+  return flatbuffers::BufferHasIdentifier(
+      buf, MovieIdentifier(), true);
+}
+
 inline bool VerifyMovieBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<Movie>(MovieIdentifier());


### PR DESCRIPTION
This PR adds a method for checking if a size-prefixed buffer has a file identifier to the generated C++ code.

```cpp
inline bool SizePrefixed{{STRUCT_NAME}}BufferHasIdentifier(const void *buf) {
  return flatbuffers::BufferHasIdentifier(
      buf, {{STRUCT_NAME}}Identifier(), true);
}
```