### PR TITLE
Default Arguments for Mutators C++ [Updated]

### DIFF
--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -262,13 +262,13 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int16_t mana() const {
     return GetField<int16_t>(VT_MANA, 150);
   }
-  bool mutate_mana(int16_t _mana) {
+  bool mutate_mana(int16_t _mana = 150) {
     return SetField<int16_t>(VT_MANA, _mana, 150);
   }
   int16_t hp() const {
     return GetField<int16_t>(VT_HP, 100);
   }
-  bool mutate_hp(int16_t _hp) {
+  bool mutate_hp(int16_t _hp = 100) {
     return SetField<int16_t>(VT_HP, _hp, 100);
   }
   const flatbuffers::String *name() const {
@@ -286,7 +286,7 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   MyGame::Sample::Color color() const {
     return static_cast<MyGame::Sample::Color>(GetField<int8_t>(VT_COLOR, 2));
   }
-  bool mutate_color(MyGame::Sample::Color _color) {
+  bool mutate_color(MyGame::Sample::Color _color = static_cast<MyGame::Sample::Color>(2)) {
     return SetField<int8_t>(VT_COLOR, static_cast<int8_t>(_color), 2);
   }
   const flatbuffers::Vector<flatbuffers::Offset<MyGame::Sample::Weapon>> *weapons() const {
@@ -471,7 +471,7 @@ struct Weapon FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int16_t damage() const {
     return GetField<int16_t>(VT_DAMAGE, 0);
   }
-  bool mutate_damage(int16_t _damage) {
+  bool mutate_damage(int16_t _damage = 0) {
     return SetField<int16_t>(VT_DAMAGE, _damage, 0);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2237,26 +2237,23 @@ class CppGenerator : public BaseGenerator {
       code_.SetValue("FIELD_VALUE",
                      GenUnderlyingCast(field, false, "_" + Name(field)));
 
+      code_ += "  bool mutate_{{FIELD_NAME}}({{FIELD_TYPE}} \\";
       if (false == field.IsScalarOptional()) {
         code_.SetValue("DEFAULT_VALUE", GenDefaultConstant(field));
-        code_.SetValue("FIELD_DEFAULT_VALUE", GenUnderlyingCast(field, true, GenDefaultConstant(field)));
+        code_.SetValue("INTERFACE_DEFAULT_VALUE", GenUnderlyingCast(field, true, GenDefaultConstant(field)));
 
         // GenUnderlyingCast for a bool field generates 0 != 0
         // So the type has to be checked and the appropriate default chosen
         if (IsBool(field.value.type.base_type)) {
-          code_ += "  bool mutate_{{FIELD_NAME}}({{FIELD_TYPE}} "
-          "_{{FIELD_NAME}} = {{DEFAULT_VALUE}}) {";
+          code_ += "_{{FIELD_NAME}} = {{DEFAULT_VALUE}}) {";
         } else {
-          code_ += "  bool mutate_{{FIELD_NAME}}({{FIELD_TYPE}} "
-          "_{{FIELD_NAME}} = {{FIELD_DEFAULT_VALUE}}) {";
+          code_ += "_{{FIELD_NAME}} = {{INTERFACE_DEFAULT_VALUE}}) {";
         }
         code_ +=
             "    return {{SET_FN}}({{OFFSET_NAME}}, {{FIELD_VALUE}}, "
             "{{DEFAULT_VALUE}});";
       } else {
-        code_ +=
-            "  bool mutate_{{FIELD_NAME}}({{FIELD_TYPE}} "
-            "_{{FIELD_NAME}}) {";
+        code_ += "_{{FIELD_NAME}}) {";
         code_ += "    return {{SET_FN}}({{OFFSET_NAME}}, {{FIELD_VALUE}});";
       }
       code_ += "  }";

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2237,7 +2237,7 @@ class CppGenerator : public BaseGenerator {
       code_.SetValue("FIELD_VALUE",
                      GenUnderlyingCast(field, false, "_" + Name(field)));
 
-      code_ += "  bool mutate_{{FIELD_NAME}}({{FIELD_TYPE}} \\";
+      code_ += "  bool mutate_{{FIELD_NAME}}({{FIELD_TYPE}} _{{FIELD_NAME}}\\";
       if (false == field.IsScalarOptional()) {
         code_.SetValue("DEFAULT_VALUE", GenDefaultConstant(field));
         code_.SetValue("INTERFACE_DEFAULT_VALUE", GenUnderlyingCast(field, true, GenDefaultConstant(field)));
@@ -2245,15 +2245,15 @@ class CppGenerator : public BaseGenerator {
         // GenUnderlyingCast for a bool field generates 0 != 0
         // So the type has to be checked and the appropriate default chosen
         if (IsBool(field.value.type.base_type)) {
-          code_ += "_{{FIELD_NAME}} = {{DEFAULT_VALUE}}) {";
+          code_ += " = {{DEFAULT_VALUE}}) {";
         } else {
-          code_ += "_{{FIELD_NAME}} = {{INTERFACE_DEFAULT_VALUE}}) {";
+          code_ += " = {{INTERFACE_DEFAULT_VALUE}}) {";
         }
         code_ +=
             "    return {{SET_FN}}({{OFFSET_NAME}}, {{FIELD_VALUE}}, "
             "{{DEFAULT_VALUE}});";
       } else {
-        code_ += "_{{FIELD_NAME}}) {";
+        code_ += ") {";
         code_ += "    return {{SET_FN}}({{OFFSET_NAME}}, {{FIELD_VALUE}});";
       }
       code_ += "  }";

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2237,15 +2237,26 @@ class CppGenerator : public BaseGenerator {
       code_.SetValue("FIELD_VALUE",
                      GenUnderlyingCast(field, false, "_" + Name(field)));
 
-      code_ +=
-          "  bool mutate_{{FIELD_NAME}}({{FIELD_TYPE}} "
-          "_{{FIELD_NAME}}) {";
       if (false == field.IsScalarOptional()) {
         code_.SetValue("DEFAULT_VALUE", GenDefaultConstant(field));
+        code_.SetValue("FIELD_DEFAULT_VALUE", GenUnderlyingCast(field, true, GenDefaultConstant(field)));
+
+        // GenUnderlyingCast for a bool field generates 0 != 0
+        // So the type has to be checked and the appropriate default chosen
+        if (IsBool(field.value.type.base_type)) {
+          code_ += "  bool mutate_{{FIELD_NAME}}({{FIELD_TYPE}} "
+          "_{{FIELD_NAME}} = {{DEFAULT_VALUE}}) {";
+        } else {
+          code_ += "  bool mutate_{{FIELD_NAME}}({{FIELD_TYPE}} "
+          "_{{FIELD_NAME}} = {{FIELD_DEFAULT_VALUE}}) {";
+        }
         code_ +=
             "    return {{SET_FN}}({{OFFSET_NAME}}, {{FIELD_VALUE}}, "
             "{{DEFAULT_VALUE}});";
       } else {
+        code_ +=
+            "  bool mutate_{{FIELD_NAME}}({{FIELD_TYPE}} "
+            "_{{FIELD_NAME}}) {";
         code_ += "    return {{SET_FN}}({{OFFSET_NAME}}, {{FIELD_VALUE}});";
       }
       code_ += "  }";

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -890,7 +890,7 @@ struct TestSimpleTableWithEnum FLATBUFFERS_FINAL_CLASS : private flatbuffers::Ta
   MyGame::Example::Color color() const {
     return static_cast<MyGame::Example::Color>(GetField<uint8_t>(VT_COLOR, 2));
   }
-  bool mutate_color(MyGame::Example::Color _color) {
+  bool mutate_color(MyGame::Example::Color _color = static_cast<MyGame::Example::Color>(2)) {
     return SetField<uint8_t>(VT_COLOR, static_cast<uint8_t>(_color), 2);
   }
   template<size_t Index>
@@ -977,13 +977,13 @@ struct Stat FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int64_t val() const {
     return GetField<int64_t>(VT_VAL, 0);
   }
-  bool mutate_val(int64_t _val) {
+  bool mutate_val(int64_t _val = 0) {
     return SetField<int64_t>(VT_VAL, _val, 0);
   }
   uint16_t count() const {
     return GetField<uint16_t>(VT_COUNT, 0);
   }
-  bool mutate_count(uint16_t _count) {
+  bool mutate_count(uint16_t _count = 0) {
     return SetField<uint16_t>(VT_COUNT, _count, 0);
   }
   bool KeyCompareLessThan(const Stat *o) const {
@@ -1096,7 +1096,7 @@ struct Referrable FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint64_t id() const {
     return GetField<uint64_t>(VT_ID, 0);
   }
-  bool mutate_id(uint64_t _id) {
+  bool mutate_id(uint64_t _id = 0) {
     return SetField<uint64_t>(VT_ID, _id, 0);
   }
   bool KeyCompareLessThan(const Referrable *o) const {
@@ -1281,13 +1281,13 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int16_t mana() const {
     return GetField<int16_t>(VT_MANA, 150);
   }
-  bool mutate_mana(int16_t _mana) {
+  bool mutate_mana(int16_t _mana = 150) {
     return SetField<int16_t>(VT_MANA, _mana, 150);
   }
   int16_t hp() const {
     return GetField<int16_t>(VT_HP, 100);
   }
-  bool mutate_hp(int16_t _hp) {
+  bool mutate_hp(int16_t _hp = 100) {
     return SetField<int16_t>(VT_HP, _hp, 100);
   }
   const flatbuffers::String *name() const {
@@ -1311,7 +1311,7 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   MyGame::Example::Color color() const {
     return static_cast<MyGame::Example::Color>(GetField<uint8_t>(VT_COLOR, 8));
   }
-  bool mutate_color(MyGame::Example::Color _color) {
+  bool mutate_color(MyGame::Example::Color _color = static_cast<MyGame::Example::Color>(8)) {
     return SetField<uint8_t>(VT_COLOR, static_cast<uint8_t>(_color), 8);
   }
   MyGame::Example::Any test_type() const {
@@ -1377,55 +1377,55 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool testbool() const {
     return GetField<uint8_t>(VT_TESTBOOL, 0) != 0;
   }
-  bool mutate_testbool(bool _testbool) {
+  bool mutate_testbool(bool _testbool = 0) {
     return SetField<uint8_t>(VT_TESTBOOL, static_cast<uint8_t>(_testbool), 0);
   }
   int32_t testhashs32_fnv1() const {
     return GetField<int32_t>(VT_TESTHASHS32_FNV1, 0);
   }
-  bool mutate_testhashs32_fnv1(int32_t _testhashs32_fnv1) {
+  bool mutate_testhashs32_fnv1(int32_t _testhashs32_fnv1 = 0) {
     return SetField<int32_t>(VT_TESTHASHS32_FNV1, _testhashs32_fnv1, 0);
   }
   uint32_t testhashu32_fnv1() const {
     return GetField<uint32_t>(VT_TESTHASHU32_FNV1, 0);
   }
-  bool mutate_testhashu32_fnv1(uint32_t _testhashu32_fnv1) {
+  bool mutate_testhashu32_fnv1(uint32_t _testhashu32_fnv1 = 0) {
     return SetField<uint32_t>(VT_TESTHASHU32_FNV1, _testhashu32_fnv1, 0);
   }
   int64_t testhashs64_fnv1() const {
     return GetField<int64_t>(VT_TESTHASHS64_FNV1, 0);
   }
-  bool mutate_testhashs64_fnv1(int64_t _testhashs64_fnv1) {
+  bool mutate_testhashs64_fnv1(int64_t _testhashs64_fnv1 = 0) {
     return SetField<int64_t>(VT_TESTHASHS64_FNV1, _testhashs64_fnv1, 0);
   }
   uint64_t testhashu64_fnv1() const {
     return GetField<uint64_t>(VT_TESTHASHU64_FNV1, 0);
   }
-  bool mutate_testhashu64_fnv1(uint64_t _testhashu64_fnv1) {
+  bool mutate_testhashu64_fnv1(uint64_t _testhashu64_fnv1 = 0) {
     return SetField<uint64_t>(VT_TESTHASHU64_FNV1, _testhashu64_fnv1, 0);
   }
   int32_t testhashs32_fnv1a() const {
     return GetField<int32_t>(VT_TESTHASHS32_FNV1A, 0);
   }
-  bool mutate_testhashs32_fnv1a(int32_t _testhashs32_fnv1a) {
+  bool mutate_testhashs32_fnv1a(int32_t _testhashs32_fnv1a = 0) {
     return SetField<int32_t>(VT_TESTHASHS32_FNV1A, _testhashs32_fnv1a, 0);
   }
   uint32_t testhashu32_fnv1a() const {
     return GetField<uint32_t>(VT_TESTHASHU32_FNV1A, 0);
   }
-  bool mutate_testhashu32_fnv1a(uint32_t _testhashu32_fnv1a) {
+  bool mutate_testhashu32_fnv1a(uint32_t _testhashu32_fnv1a = 0) {
     return SetField<uint32_t>(VT_TESTHASHU32_FNV1A, _testhashu32_fnv1a, 0);
   }
   int64_t testhashs64_fnv1a() const {
     return GetField<int64_t>(VT_TESTHASHS64_FNV1A, 0);
   }
-  bool mutate_testhashs64_fnv1a(int64_t _testhashs64_fnv1a) {
+  bool mutate_testhashs64_fnv1a(int64_t _testhashs64_fnv1a = 0) {
     return SetField<int64_t>(VT_TESTHASHS64_FNV1A, _testhashs64_fnv1a, 0);
   }
   uint64_t testhashu64_fnv1a() const {
     return GetField<uint64_t>(VT_TESTHASHU64_FNV1A, 0);
   }
-  bool mutate_testhashu64_fnv1a(uint64_t _testhashu64_fnv1a) {
+  bool mutate_testhashu64_fnv1a(uint64_t _testhashu64_fnv1a = 0) {
     return SetField<uint64_t>(VT_TESTHASHU64_FNV1A, _testhashu64_fnv1a, 0);
   }
   const flatbuffers::Vector<uint8_t> *testarrayofbools() const {
@@ -1437,19 +1437,19 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   float testf() const {
     return GetField<float>(VT_TESTF, 3.14159f);
   }
-  bool mutate_testf(float _testf) {
+  bool mutate_testf(float _testf = 3.14159f) {
     return SetField<float>(VT_TESTF, _testf, 3.14159f);
   }
   float testf2() const {
     return GetField<float>(VT_TESTF2, 3.0f);
   }
-  bool mutate_testf2(float _testf2) {
+  bool mutate_testf2(float _testf2 = 3.0f) {
     return SetField<float>(VT_TESTF2, _testf2, 3.0f);
   }
   float testf3() const {
     return GetField<float>(VT_TESTF3, 0.0f);
   }
-  bool mutate_testf3(float _testf3) {
+  bool mutate_testf3(float _testf3 = 0.0f) {
     return SetField<float>(VT_TESTF3, _testf3, 0.0f);
   }
   const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *testarrayofstring2() const {
@@ -1506,7 +1506,7 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint64_t single_weak_reference() const {
     return GetField<uint64_t>(VT_SINGLE_WEAK_REFERENCE, 0);
   }
-  bool mutate_single_weak_reference(uint64_t _single_weak_reference) {
+  bool mutate_single_weak_reference(uint64_t _single_weak_reference = 0) {
     return SetField<uint64_t>(VT_SINGLE_WEAK_REFERENCE, _single_weak_reference, 0);
   }
   const flatbuffers::Vector<uint64_t> *vector_of_weak_references() const {
@@ -1524,7 +1524,7 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint64_t co_owning_reference() const {
     return GetField<uint64_t>(VT_CO_OWNING_REFERENCE, 0);
   }
-  bool mutate_co_owning_reference(uint64_t _co_owning_reference) {
+  bool mutate_co_owning_reference(uint64_t _co_owning_reference = 0) {
     return SetField<uint64_t>(VT_CO_OWNING_REFERENCE, _co_owning_reference, 0);
   }
   const flatbuffers::Vector<uint64_t> *vector_of_co_owning_references() const {
@@ -1536,7 +1536,7 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint64_t non_owning_reference() const {
     return GetField<uint64_t>(VT_NON_OWNING_REFERENCE, 0);
   }
-  bool mutate_non_owning_reference(uint64_t _non_owning_reference) {
+  bool mutate_non_owning_reference(uint64_t _non_owning_reference = 0) {
     return SetField<uint64_t>(VT_NON_OWNING_REFERENCE, _non_owning_reference, 0);
   }
   const flatbuffers::Vector<uint64_t> *vector_of_non_owning_references() const {
@@ -1591,7 +1591,7 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   MyGame::Example::Race signed_enum() const {
     return static_cast<MyGame::Example::Race>(GetField<int8_t>(VT_SIGNED_ENUM, -1));
   }
-  bool mutate_signed_enum(MyGame::Example::Race _signed_enum) {
+  bool mutate_signed_enum(MyGame::Example::Race _signed_enum = static_cast<MyGame::Example::Race>(-1)) {
     return SetField<int8_t>(VT_SIGNED_ENUM, static_cast<int8_t>(_signed_enum), -1);
   }
   const flatbuffers::Vector<uint8_t> *testrequirednestedflatbuffer() const {
@@ -2282,61 +2282,61 @@ struct TypeAliases FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int8_t i8() const {
     return GetField<int8_t>(VT_I8, 0);
   }
-  bool mutate_i8(int8_t _i8) {
+  bool mutate_i8(int8_t _i8 = 0) {
     return SetField<int8_t>(VT_I8, _i8, 0);
   }
   uint8_t u8() const {
     return GetField<uint8_t>(VT_U8, 0);
   }
-  bool mutate_u8(uint8_t _u8) {
+  bool mutate_u8(uint8_t _u8 = 0) {
     return SetField<uint8_t>(VT_U8, _u8, 0);
   }
   int16_t i16() const {
     return GetField<int16_t>(VT_I16, 0);
   }
-  bool mutate_i16(int16_t _i16) {
+  bool mutate_i16(int16_t _i16 = 0) {
     return SetField<int16_t>(VT_I16, _i16, 0);
   }
   uint16_t u16() const {
     return GetField<uint16_t>(VT_U16, 0);
   }
-  bool mutate_u16(uint16_t _u16) {
+  bool mutate_u16(uint16_t _u16 = 0) {
     return SetField<uint16_t>(VT_U16, _u16, 0);
   }
   int32_t i32() const {
     return GetField<int32_t>(VT_I32, 0);
   }
-  bool mutate_i32(int32_t _i32) {
+  bool mutate_i32(int32_t _i32 = 0) {
     return SetField<int32_t>(VT_I32, _i32, 0);
   }
   uint32_t u32() const {
     return GetField<uint32_t>(VT_U32, 0);
   }
-  bool mutate_u32(uint32_t _u32) {
+  bool mutate_u32(uint32_t _u32 = 0) {
     return SetField<uint32_t>(VT_U32, _u32, 0);
   }
   int64_t i64() const {
     return GetField<int64_t>(VT_I64, 0);
   }
-  bool mutate_i64(int64_t _i64) {
+  bool mutate_i64(int64_t _i64 = 0) {
     return SetField<int64_t>(VT_I64, _i64, 0);
   }
   uint64_t u64() const {
     return GetField<uint64_t>(VT_U64, 0);
   }
-  bool mutate_u64(uint64_t _u64) {
+  bool mutate_u64(uint64_t _u64 = 0) {
     return SetField<uint64_t>(VT_U64, _u64, 0);
   }
   float f32() const {
     return GetField<float>(VT_F32, 0.0f);
   }
-  bool mutate_f32(float _f32) {
+  bool mutate_f32(float _f32 = 0.0f) {
     return SetField<float>(VT_F32, _f32, 0.0f);
   }
   double f64() const {
     return GetField<double>(VT_F64, 0.0);
   }
-  bool mutate_f64(double _f64) {
+  bool mutate_f64(double _f64 = 0.0) {
     return SetField<double>(VT_F64, _f64, 0.0);
   }
   const flatbuffers::Vector<int8_t> *v8() const {

--- a/tests/cpp17/generated_cpp17/optional_scalars_generated.h
+++ b/tests/cpp17/generated_cpp17/optional_scalars_generated.h
@@ -135,7 +135,7 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int8_t just_i8() const {
     return GetField<int8_t>(VT_JUST_I8, 0);
   }
-  bool mutate_just_i8(int8_t _just_i8) {
+  bool mutate_just_i8(int8_t _just_i8 = 0) {
     return SetField<int8_t>(VT_JUST_I8, _just_i8, 0);
   }
   flatbuffers::Optional<int8_t> maybe_i8() const {
@@ -147,13 +147,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int8_t default_i8() const {
     return GetField<int8_t>(VT_DEFAULT_I8, 42);
   }
-  bool mutate_default_i8(int8_t _default_i8) {
+  bool mutate_default_i8(int8_t _default_i8 = 42) {
     return SetField<int8_t>(VT_DEFAULT_I8, _default_i8, 42);
   }
   uint8_t just_u8() const {
     return GetField<uint8_t>(VT_JUST_U8, 0);
   }
-  bool mutate_just_u8(uint8_t _just_u8) {
+  bool mutate_just_u8(uint8_t _just_u8 = 0) {
     return SetField<uint8_t>(VT_JUST_U8, _just_u8, 0);
   }
   flatbuffers::Optional<uint8_t> maybe_u8() const {
@@ -165,13 +165,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint8_t default_u8() const {
     return GetField<uint8_t>(VT_DEFAULT_U8, 42);
   }
-  bool mutate_default_u8(uint8_t _default_u8) {
+  bool mutate_default_u8(uint8_t _default_u8 = 42) {
     return SetField<uint8_t>(VT_DEFAULT_U8, _default_u8, 42);
   }
   int16_t just_i16() const {
     return GetField<int16_t>(VT_JUST_I16, 0);
   }
-  bool mutate_just_i16(int16_t _just_i16) {
+  bool mutate_just_i16(int16_t _just_i16 = 0) {
     return SetField<int16_t>(VT_JUST_I16, _just_i16, 0);
   }
   flatbuffers::Optional<int16_t> maybe_i16() const {
@@ -183,13 +183,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int16_t default_i16() const {
     return GetField<int16_t>(VT_DEFAULT_I16, 42);
   }
-  bool mutate_default_i16(int16_t _default_i16) {
+  bool mutate_default_i16(int16_t _default_i16 = 42) {
     return SetField<int16_t>(VT_DEFAULT_I16, _default_i16, 42);
   }
   uint16_t just_u16() const {
     return GetField<uint16_t>(VT_JUST_U16, 0);
   }
-  bool mutate_just_u16(uint16_t _just_u16) {
+  bool mutate_just_u16(uint16_t _just_u16 = 0) {
     return SetField<uint16_t>(VT_JUST_U16, _just_u16, 0);
   }
   flatbuffers::Optional<uint16_t> maybe_u16() const {
@@ -201,13 +201,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint16_t default_u16() const {
     return GetField<uint16_t>(VT_DEFAULT_U16, 42);
   }
-  bool mutate_default_u16(uint16_t _default_u16) {
+  bool mutate_default_u16(uint16_t _default_u16 = 42) {
     return SetField<uint16_t>(VT_DEFAULT_U16, _default_u16, 42);
   }
   int32_t just_i32() const {
     return GetField<int32_t>(VT_JUST_I32, 0);
   }
-  bool mutate_just_i32(int32_t _just_i32) {
+  bool mutate_just_i32(int32_t _just_i32 = 0) {
     return SetField<int32_t>(VT_JUST_I32, _just_i32, 0);
   }
   flatbuffers::Optional<int32_t> maybe_i32() const {
@@ -219,13 +219,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int32_t default_i32() const {
     return GetField<int32_t>(VT_DEFAULT_I32, 42);
   }
-  bool mutate_default_i32(int32_t _default_i32) {
+  bool mutate_default_i32(int32_t _default_i32 = 42) {
     return SetField<int32_t>(VT_DEFAULT_I32, _default_i32, 42);
   }
   uint32_t just_u32() const {
     return GetField<uint32_t>(VT_JUST_U32, 0);
   }
-  bool mutate_just_u32(uint32_t _just_u32) {
+  bool mutate_just_u32(uint32_t _just_u32 = 0) {
     return SetField<uint32_t>(VT_JUST_U32, _just_u32, 0);
   }
   flatbuffers::Optional<uint32_t> maybe_u32() const {
@@ -237,13 +237,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint32_t default_u32() const {
     return GetField<uint32_t>(VT_DEFAULT_U32, 42);
   }
-  bool mutate_default_u32(uint32_t _default_u32) {
+  bool mutate_default_u32(uint32_t _default_u32 = 42) {
     return SetField<uint32_t>(VT_DEFAULT_U32, _default_u32, 42);
   }
   int64_t just_i64() const {
     return GetField<int64_t>(VT_JUST_I64, 0);
   }
-  bool mutate_just_i64(int64_t _just_i64) {
+  bool mutate_just_i64(int64_t _just_i64 = 0) {
     return SetField<int64_t>(VT_JUST_I64, _just_i64, 0);
   }
   flatbuffers::Optional<int64_t> maybe_i64() const {
@@ -255,13 +255,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int64_t default_i64() const {
     return GetField<int64_t>(VT_DEFAULT_I64, 42LL);
   }
-  bool mutate_default_i64(int64_t _default_i64) {
+  bool mutate_default_i64(int64_t _default_i64 = 42LL) {
     return SetField<int64_t>(VT_DEFAULT_I64, _default_i64, 42LL);
   }
   uint64_t just_u64() const {
     return GetField<uint64_t>(VT_JUST_U64, 0);
   }
-  bool mutate_just_u64(uint64_t _just_u64) {
+  bool mutate_just_u64(uint64_t _just_u64 = 0) {
     return SetField<uint64_t>(VT_JUST_U64, _just_u64, 0);
   }
   flatbuffers::Optional<uint64_t> maybe_u64() const {
@@ -273,13 +273,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint64_t default_u64() const {
     return GetField<uint64_t>(VT_DEFAULT_U64, 42ULL);
   }
-  bool mutate_default_u64(uint64_t _default_u64) {
+  bool mutate_default_u64(uint64_t _default_u64 = 42ULL) {
     return SetField<uint64_t>(VT_DEFAULT_U64, _default_u64, 42ULL);
   }
   float just_f32() const {
     return GetField<float>(VT_JUST_F32, 0.0f);
   }
-  bool mutate_just_f32(float _just_f32) {
+  bool mutate_just_f32(float _just_f32 = 0.0f) {
     return SetField<float>(VT_JUST_F32, _just_f32, 0.0f);
   }
   flatbuffers::Optional<float> maybe_f32() const {
@@ -291,13 +291,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   float default_f32() const {
     return GetField<float>(VT_DEFAULT_F32, 42.0f);
   }
-  bool mutate_default_f32(float _default_f32) {
+  bool mutate_default_f32(float _default_f32 = 42.0f) {
     return SetField<float>(VT_DEFAULT_F32, _default_f32, 42.0f);
   }
   double just_f64() const {
     return GetField<double>(VT_JUST_F64, 0.0);
   }
-  bool mutate_just_f64(double _just_f64) {
+  bool mutate_just_f64(double _just_f64 = 0.0) {
     return SetField<double>(VT_JUST_F64, _just_f64, 0.0);
   }
   flatbuffers::Optional<double> maybe_f64() const {
@@ -309,13 +309,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   double default_f64() const {
     return GetField<double>(VT_DEFAULT_F64, 42.0);
   }
-  bool mutate_default_f64(double _default_f64) {
+  bool mutate_default_f64(double _default_f64 = 42.0) {
     return SetField<double>(VT_DEFAULT_F64, _default_f64, 42.0);
   }
   bool just_bool() const {
     return GetField<uint8_t>(VT_JUST_BOOL, 0) != 0;
   }
-  bool mutate_just_bool(bool _just_bool) {
+  bool mutate_just_bool(bool _just_bool = 0) {
     return SetField<uint8_t>(VT_JUST_BOOL, static_cast<uint8_t>(_just_bool), 0);
   }
   flatbuffers::Optional<bool> maybe_bool() const {
@@ -327,13 +327,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool default_bool() const {
     return GetField<uint8_t>(VT_DEFAULT_BOOL, 1) != 0;
   }
-  bool mutate_default_bool(bool _default_bool) {
+  bool mutate_default_bool(bool _default_bool = 1) {
     return SetField<uint8_t>(VT_DEFAULT_BOOL, static_cast<uint8_t>(_default_bool), 1);
   }
   optional_scalars::OptionalByte just_enum() const {
     return static_cast<optional_scalars::OptionalByte>(GetField<int8_t>(VT_JUST_ENUM, 0));
   }
-  bool mutate_just_enum(optional_scalars::OptionalByte _just_enum) {
+  bool mutate_just_enum(optional_scalars::OptionalByte _just_enum = static_cast<optional_scalars::OptionalByte>(0)) {
     return SetField<int8_t>(VT_JUST_ENUM, static_cast<int8_t>(_just_enum), 0);
   }
   flatbuffers::Optional<optional_scalars::OptionalByte> maybe_enum() const {
@@ -345,7 +345,7 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   optional_scalars::OptionalByte default_enum() const {
     return static_cast<optional_scalars::OptionalByte>(GetField<int8_t>(VT_DEFAULT_ENUM, 1));
   }
-  bool mutate_default_enum(optional_scalars::OptionalByte _default_enum) {
+  bool mutate_default_enum(optional_scalars::OptionalByte _default_enum = static_cast<optional_scalars::OptionalByte>(1)) {
     return SetField<int8_t>(VT_DEFAULT_ENUM, static_cast<int8_t>(_default_enum), 1);
   }
   template<size_t Index>

--- a/tests/cpp17/generated_cpp17/union_vector_generated.h
+++ b/tests/cpp17/generated_cpp17/union_vector_generated.h
@@ -244,7 +244,7 @@ struct Attacker FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int32_t sword_attack_damage() const {
     return GetField<int32_t>(VT_SWORD_ATTACK_DAMAGE, 0);
   }
-  bool mutate_sword_attack_damage(int32_t _sword_attack_damage) {
+  bool mutate_sword_attack_damage(int32_t _sword_attack_damage = 0) {
     return SetField<int32_t>(VT_SWORD_ATTACK_DAMAGE, _sword_attack_damage, 0);
   }
   template<size_t Index>

--- a/tests/monster_extra_generated.h
+++ b/tests/monster_extra_generated.h
@@ -52,49 +52,49 @@ struct MonsterExtra FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   double d0() const {
     return GetField<double>(VT_D0, std::numeric_limits<double>::quiet_NaN());
   }
-  bool mutate_d0(double _d0) {
+  bool mutate_d0(double _d0 = std::numeric_limits<double>::quiet_NaN()) {
     return SetField<double>(VT_D0, _d0, std::numeric_limits<double>::quiet_NaN());
   }
   double d1() const {
     return GetField<double>(VT_D1, std::numeric_limits<double>::quiet_NaN());
   }
-  bool mutate_d1(double _d1) {
+  bool mutate_d1(double _d1 = std::numeric_limits<double>::quiet_NaN()) {
     return SetField<double>(VT_D1, _d1, std::numeric_limits<double>::quiet_NaN());
   }
   double d2() const {
     return GetField<double>(VT_D2, std::numeric_limits<double>::infinity());
   }
-  bool mutate_d2(double _d2) {
+  bool mutate_d2(double _d2 = std::numeric_limits<double>::infinity()) {
     return SetField<double>(VT_D2, _d2, std::numeric_limits<double>::infinity());
   }
   double d3() const {
     return GetField<double>(VT_D3, -std::numeric_limits<double>::infinity());
   }
-  bool mutate_d3(double _d3) {
+  bool mutate_d3(double _d3 = -std::numeric_limits<double>::infinity()) {
     return SetField<double>(VT_D3, _d3, -std::numeric_limits<double>::infinity());
   }
   float f0() const {
     return GetField<float>(VT_F0, std::numeric_limits<float>::quiet_NaN());
   }
-  bool mutate_f0(float _f0) {
+  bool mutate_f0(float _f0 = std::numeric_limits<float>::quiet_NaN()) {
     return SetField<float>(VT_F0, _f0, std::numeric_limits<float>::quiet_NaN());
   }
   float f1() const {
     return GetField<float>(VT_F1, std::numeric_limits<float>::quiet_NaN());
   }
-  bool mutate_f1(float _f1) {
+  bool mutate_f1(float _f1 = std::numeric_limits<float>::quiet_NaN()) {
     return SetField<float>(VT_F1, _f1, std::numeric_limits<float>::quiet_NaN());
   }
   float f2() const {
     return GetField<float>(VT_F2, std::numeric_limits<float>::infinity());
   }
-  bool mutate_f2(float _f2) {
+  bool mutate_f2(float _f2 = std::numeric_limits<float>::infinity()) {
     return SetField<float>(VT_F2, _f2, std::numeric_limits<float>::infinity());
   }
   float f3() const {
     return GetField<float>(VT_F3, -std::numeric_limits<float>::infinity());
   }
-  bool mutate_f3(float _f3) {
+  bool mutate_f3(float _f3 = -std::numeric_limits<float>::infinity()) {
     return SetField<float>(VT_F3, _f3, -std::numeric_limits<float>::infinity());
   }
   const flatbuffers::Vector<double> *dvec() const {

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -945,7 +945,7 @@ struct TestSimpleTableWithEnum FLATBUFFERS_FINAL_CLASS : private flatbuffers::Ta
   MyGame::Example::Color color() const {
     return static_cast<MyGame::Example::Color>(GetField<uint8_t>(VT_COLOR, 2));
   }
-  bool mutate_color(MyGame::Example::Color _color) {
+  bool mutate_color(MyGame::Example::Color _color = static_cast<MyGame::Example::Color>(2)) {
     return SetField<uint8_t>(VT_COLOR, static_cast<uint8_t>(_color), 2);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
@@ -1013,13 +1013,13 @@ struct Stat FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int64_t val() const {
     return GetField<int64_t>(VT_VAL, 0);
   }
-  bool mutate_val(int64_t _val) {
+  bool mutate_val(int64_t _val = 0) {
     return SetField<int64_t>(VT_VAL, _val, 0);
   }
   uint16_t count() const {
     return GetField<uint16_t>(VT_COUNT, 0);
   }
-  bool mutate_count(uint16_t _count) {
+  bool mutate_count(uint16_t _count = 0) {
     return SetField<uint16_t>(VT_COUNT, _count, 0);
   }
   bool KeyCompareLessThan(const Stat *o) const {
@@ -1109,7 +1109,7 @@ struct Referrable FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint64_t id() const {
     return GetField<uint64_t>(VT_ID, 0);
   }
-  bool mutate_id(uint64_t _id) {
+  bool mutate_id(uint64_t _id = 0) {
     return SetField<uint64_t>(VT_ID, _id, 0);
   }
   bool KeyCompareLessThan(const Referrable *o) const {
@@ -1275,13 +1275,13 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int16_t mana() const {
     return GetField<int16_t>(VT_MANA, 150);
   }
-  bool mutate_mana(int16_t _mana) {
+  bool mutate_mana(int16_t _mana = 150) {
     return SetField<int16_t>(VT_MANA, _mana, 150);
   }
   int16_t hp() const {
     return GetField<int16_t>(VT_HP, 100);
   }
-  bool mutate_hp(int16_t _hp) {
+  bool mutate_hp(int16_t _hp = 100) {
     return SetField<int16_t>(VT_HP, _hp, 100);
   }
   const flatbuffers::String *name() const {
@@ -1305,7 +1305,7 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   MyGame::Example::Color color() const {
     return static_cast<MyGame::Example::Color>(GetField<uint8_t>(VT_COLOR, 8));
   }
-  bool mutate_color(MyGame::Example::Color _color) {
+  bool mutate_color(MyGame::Example::Color _color = static_cast<MyGame::Example::Color>(8)) {
     return SetField<uint8_t>(VT_COLOR, static_cast<uint8_t>(_color), 8);
   }
   MyGame::Example::Any test_type() const {
@@ -1371,55 +1371,55 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool testbool() const {
     return GetField<uint8_t>(VT_TESTBOOL, 0) != 0;
   }
-  bool mutate_testbool(bool _testbool) {
+  bool mutate_testbool(bool _testbool = 0) {
     return SetField<uint8_t>(VT_TESTBOOL, static_cast<uint8_t>(_testbool), 0);
   }
   int32_t testhashs32_fnv1() const {
     return GetField<int32_t>(VT_TESTHASHS32_FNV1, 0);
   }
-  bool mutate_testhashs32_fnv1(int32_t _testhashs32_fnv1) {
+  bool mutate_testhashs32_fnv1(int32_t _testhashs32_fnv1 = 0) {
     return SetField<int32_t>(VT_TESTHASHS32_FNV1, _testhashs32_fnv1, 0);
   }
   uint32_t testhashu32_fnv1() const {
     return GetField<uint32_t>(VT_TESTHASHU32_FNV1, 0);
   }
-  bool mutate_testhashu32_fnv1(uint32_t _testhashu32_fnv1) {
+  bool mutate_testhashu32_fnv1(uint32_t _testhashu32_fnv1 = 0) {
     return SetField<uint32_t>(VT_TESTHASHU32_FNV1, _testhashu32_fnv1, 0);
   }
   int64_t testhashs64_fnv1() const {
     return GetField<int64_t>(VT_TESTHASHS64_FNV1, 0);
   }
-  bool mutate_testhashs64_fnv1(int64_t _testhashs64_fnv1) {
+  bool mutate_testhashs64_fnv1(int64_t _testhashs64_fnv1 = 0) {
     return SetField<int64_t>(VT_TESTHASHS64_FNV1, _testhashs64_fnv1, 0);
   }
   uint64_t testhashu64_fnv1() const {
     return GetField<uint64_t>(VT_TESTHASHU64_FNV1, 0);
   }
-  bool mutate_testhashu64_fnv1(uint64_t _testhashu64_fnv1) {
+  bool mutate_testhashu64_fnv1(uint64_t _testhashu64_fnv1 = 0) {
     return SetField<uint64_t>(VT_TESTHASHU64_FNV1, _testhashu64_fnv1, 0);
   }
   int32_t testhashs32_fnv1a() const {
     return GetField<int32_t>(VT_TESTHASHS32_FNV1A, 0);
   }
-  bool mutate_testhashs32_fnv1a(int32_t _testhashs32_fnv1a) {
+  bool mutate_testhashs32_fnv1a(int32_t _testhashs32_fnv1a = 0) {
     return SetField<int32_t>(VT_TESTHASHS32_FNV1A, _testhashs32_fnv1a, 0);
   }
   uint32_t testhashu32_fnv1a() const {
     return GetField<uint32_t>(VT_TESTHASHU32_FNV1A, 0);
   }
-  bool mutate_testhashu32_fnv1a(uint32_t _testhashu32_fnv1a) {
+  bool mutate_testhashu32_fnv1a(uint32_t _testhashu32_fnv1a = 0) {
     return SetField<uint32_t>(VT_TESTHASHU32_FNV1A, _testhashu32_fnv1a, 0);
   }
   int64_t testhashs64_fnv1a() const {
     return GetField<int64_t>(VT_TESTHASHS64_FNV1A, 0);
   }
-  bool mutate_testhashs64_fnv1a(int64_t _testhashs64_fnv1a) {
+  bool mutate_testhashs64_fnv1a(int64_t _testhashs64_fnv1a = 0) {
     return SetField<int64_t>(VT_TESTHASHS64_FNV1A, _testhashs64_fnv1a, 0);
   }
   uint64_t testhashu64_fnv1a() const {
     return GetField<uint64_t>(VT_TESTHASHU64_FNV1A, 0);
   }
-  bool mutate_testhashu64_fnv1a(uint64_t _testhashu64_fnv1a) {
+  bool mutate_testhashu64_fnv1a(uint64_t _testhashu64_fnv1a = 0) {
     return SetField<uint64_t>(VT_TESTHASHU64_FNV1A, _testhashu64_fnv1a, 0);
   }
   const flatbuffers::Vector<uint8_t> *testarrayofbools() const {
@@ -1431,19 +1431,19 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   float testf() const {
     return GetField<float>(VT_TESTF, 3.14159f);
   }
-  bool mutate_testf(float _testf) {
+  bool mutate_testf(float _testf = 3.14159f) {
     return SetField<float>(VT_TESTF, _testf, 3.14159f);
   }
   float testf2() const {
     return GetField<float>(VT_TESTF2, 3.0f);
   }
-  bool mutate_testf2(float _testf2) {
+  bool mutate_testf2(float _testf2 = 3.0f) {
     return SetField<float>(VT_TESTF2, _testf2, 3.0f);
   }
   float testf3() const {
     return GetField<float>(VT_TESTF3, 0.0f);
   }
-  bool mutate_testf3(float _testf3) {
+  bool mutate_testf3(float _testf3 = 0.0f) {
     return SetField<float>(VT_TESTF3, _testf3, 0.0f);
   }
   const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *testarrayofstring2() const {
@@ -1500,7 +1500,7 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint64_t single_weak_reference() const {
     return GetField<uint64_t>(VT_SINGLE_WEAK_REFERENCE, 0);
   }
-  bool mutate_single_weak_reference(uint64_t _single_weak_reference) {
+  bool mutate_single_weak_reference(uint64_t _single_weak_reference = 0) {
     return SetField<uint64_t>(VT_SINGLE_WEAK_REFERENCE, _single_weak_reference, 0);
   }
   const flatbuffers::Vector<uint64_t> *vector_of_weak_references() const {
@@ -1518,7 +1518,7 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint64_t co_owning_reference() const {
     return GetField<uint64_t>(VT_CO_OWNING_REFERENCE, 0);
   }
-  bool mutate_co_owning_reference(uint64_t _co_owning_reference) {
+  bool mutate_co_owning_reference(uint64_t _co_owning_reference = 0) {
     return SetField<uint64_t>(VT_CO_OWNING_REFERENCE, _co_owning_reference, 0);
   }
   const flatbuffers::Vector<uint64_t> *vector_of_co_owning_references() const {
@@ -1530,7 +1530,7 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint64_t non_owning_reference() const {
     return GetField<uint64_t>(VT_NON_OWNING_REFERENCE, 0);
   }
-  bool mutate_non_owning_reference(uint64_t _non_owning_reference) {
+  bool mutate_non_owning_reference(uint64_t _non_owning_reference = 0) {
     return SetField<uint64_t>(VT_NON_OWNING_REFERENCE, _non_owning_reference, 0);
   }
   const flatbuffers::Vector<uint64_t> *vector_of_non_owning_references() const {
@@ -1585,7 +1585,7 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   MyGame::Example::Race signed_enum() const {
     return static_cast<MyGame::Example::Race>(GetField<int8_t>(VT_SIGNED_ENUM, -1));
   }
-  bool mutate_signed_enum(MyGame::Example::Race _signed_enum) {
+  bool mutate_signed_enum(MyGame::Example::Race _signed_enum = static_cast<MyGame::Example::Race>(-1)) {
     return SetField<int8_t>(VT_SIGNED_ENUM, static_cast<int8_t>(_signed_enum), -1);
   }
   const flatbuffers::Vector<uint8_t> *testrequirednestedflatbuffer() const {
@@ -2159,61 +2159,61 @@ struct TypeAliases FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int8_t i8() const {
     return GetField<int8_t>(VT_I8, 0);
   }
-  bool mutate_i8(int8_t _i8) {
+  bool mutate_i8(int8_t _i8 = 0) {
     return SetField<int8_t>(VT_I8, _i8, 0);
   }
   uint8_t u8() const {
     return GetField<uint8_t>(VT_U8, 0);
   }
-  bool mutate_u8(uint8_t _u8) {
+  bool mutate_u8(uint8_t _u8 = 0) {
     return SetField<uint8_t>(VT_U8, _u8, 0);
   }
   int16_t i16() const {
     return GetField<int16_t>(VT_I16, 0);
   }
-  bool mutate_i16(int16_t _i16) {
+  bool mutate_i16(int16_t _i16 = 0) {
     return SetField<int16_t>(VT_I16, _i16, 0);
   }
   uint16_t u16() const {
     return GetField<uint16_t>(VT_U16, 0);
   }
-  bool mutate_u16(uint16_t _u16) {
+  bool mutate_u16(uint16_t _u16 = 0) {
     return SetField<uint16_t>(VT_U16, _u16, 0);
   }
   int32_t i32() const {
     return GetField<int32_t>(VT_I32, 0);
   }
-  bool mutate_i32(int32_t _i32) {
+  bool mutate_i32(int32_t _i32 = 0) {
     return SetField<int32_t>(VT_I32, _i32, 0);
   }
   uint32_t u32() const {
     return GetField<uint32_t>(VT_U32, 0);
   }
-  bool mutate_u32(uint32_t _u32) {
+  bool mutate_u32(uint32_t _u32 = 0) {
     return SetField<uint32_t>(VT_U32, _u32, 0);
   }
   int64_t i64() const {
     return GetField<int64_t>(VT_I64, 0);
   }
-  bool mutate_i64(int64_t _i64) {
+  bool mutate_i64(int64_t _i64 = 0) {
     return SetField<int64_t>(VT_I64, _i64, 0);
   }
   uint64_t u64() const {
     return GetField<uint64_t>(VT_U64, 0);
   }
-  bool mutate_u64(uint64_t _u64) {
+  bool mutate_u64(uint64_t _u64 = 0) {
     return SetField<uint64_t>(VT_U64, _u64, 0);
   }
   float f32() const {
     return GetField<float>(VT_F32, 0.0f);
   }
-  bool mutate_f32(float _f32) {
+  bool mutate_f32(float _f32 = 0.0f) {
     return SetField<float>(VT_F32, _f32, 0.0f);
   }
   double f64() const {
     return GetField<double>(VT_F64, 0.0);
   }
-  bool mutate_f64(double _f64) {
+  bool mutate_f64(double _f64 = 0.0) {
     return SetField<double>(VT_F64, _f64, 0.0);
   }
   const flatbuffers::Vector<int8_t> *v8() const {

--- a/tests/namespace_test/namespace_test1_generated.h
+++ b/tests/namespace_test/namespace_test1_generated.h
@@ -230,7 +230,7 @@ struct TableInNestedNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int32_t foo() const {
     return GetField<int32_t>(VT_FOO, 0);
   }
-  bool mutate_foo(int32_t _foo) {
+  bool mutate_foo(int32_t _foo = 0) {
     return SetField<int32_t>(VT_FOO, _foo, 0);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -93,7 +93,7 @@ struct TableInFirstNS FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   NamespaceA::NamespaceB::EnumInNestedNS foo_enum() const {
     return static_cast<NamespaceA::NamespaceB::EnumInNestedNS>(GetField<int8_t>(VT_FOO_ENUM, 0));
   }
-  bool mutate_foo_enum(NamespaceA::NamespaceB::EnumInNestedNS _foo_enum) {
+  bool mutate_foo_enum(NamespaceA::NamespaceB::EnumInNestedNS _foo_enum = static_cast<NamespaceA::NamespaceB::EnumInNestedNS>(0)) {
     return SetField<int8_t>(VT_FOO_ENUM, static_cast<int8_t>(_foo_enum), 0);
   }
   NamespaceA::NamespaceB::UnionInNestedNS foo_union_type() const {

--- a/tests/optional_scalars_generated.h
+++ b/tests/optional_scalars_generated.h
@@ -137,7 +137,7 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int8_t just_i8() const {
     return GetField<int8_t>(VT_JUST_I8, 0);
   }
-  bool mutate_just_i8(int8_t _just_i8) {
+  bool mutate_just_i8(int8_t _just_i8 = 0) {
     return SetField<int8_t>(VT_JUST_I8, _just_i8, 0);
   }
   flatbuffers::Optional<int8_t> maybe_i8() const {
@@ -149,13 +149,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int8_t default_i8() const {
     return GetField<int8_t>(VT_DEFAULT_I8, 42);
   }
-  bool mutate_default_i8(int8_t _default_i8) {
+  bool mutate_default_i8(int8_t _default_i8 = 42) {
     return SetField<int8_t>(VT_DEFAULT_I8, _default_i8, 42);
   }
   uint8_t just_u8() const {
     return GetField<uint8_t>(VT_JUST_U8, 0);
   }
-  bool mutate_just_u8(uint8_t _just_u8) {
+  bool mutate_just_u8(uint8_t _just_u8 = 0) {
     return SetField<uint8_t>(VT_JUST_U8, _just_u8, 0);
   }
   flatbuffers::Optional<uint8_t> maybe_u8() const {
@@ -167,13 +167,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint8_t default_u8() const {
     return GetField<uint8_t>(VT_DEFAULT_U8, 42);
   }
-  bool mutate_default_u8(uint8_t _default_u8) {
+  bool mutate_default_u8(uint8_t _default_u8 = 42) {
     return SetField<uint8_t>(VT_DEFAULT_U8, _default_u8, 42);
   }
   int16_t just_i16() const {
     return GetField<int16_t>(VT_JUST_I16, 0);
   }
-  bool mutate_just_i16(int16_t _just_i16) {
+  bool mutate_just_i16(int16_t _just_i16 = 0) {
     return SetField<int16_t>(VT_JUST_I16, _just_i16, 0);
   }
   flatbuffers::Optional<int16_t> maybe_i16() const {
@@ -185,13 +185,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int16_t default_i16() const {
     return GetField<int16_t>(VT_DEFAULT_I16, 42);
   }
-  bool mutate_default_i16(int16_t _default_i16) {
+  bool mutate_default_i16(int16_t _default_i16 = 42) {
     return SetField<int16_t>(VT_DEFAULT_I16, _default_i16, 42);
   }
   uint16_t just_u16() const {
     return GetField<uint16_t>(VT_JUST_U16, 0);
   }
-  bool mutate_just_u16(uint16_t _just_u16) {
+  bool mutate_just_u16(uint16_t _just_u16 = 0) {
     return SetField<uint16_t>(VT_JUST_U16, _just_u16, 0);
   }
   flatbuffers::Optional<uint16_t> maybe_u16() const {
@@ -203,13 +203,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint16_t default_u16() const {
     return GetField<uint16_t>(VT_DEFAULT_U16, 42);
   }
-  bool mutate_default_u16(uint16_t _default_u16) {
+  bool mutate_default_u16(uint16_t _default_u16 = 42) {
     return SetField<uint16_t>(VT_DEFAULT_U16, _default_u16, 42);
   }
   int32_t just_i32() const {
     return GetField<int32_t>(VT_JUST_I32, 0);
   }
-  bool mutate_just_i32(int32_t _just_i32) {
+  bool mutate_just_i32(int32_t _just_i32 = 0) {
     return SetField<int32_t>(VT_JUST_I32, _just_i32, 0);
   }
   flatbuffers::Optional<int32_t> maybe_i32() const {
@@ -221,13 +221,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int32_t default_i32() const {
     return GetField<int32_t>(VT_DEFAULT_I32, 42);
   }
-  bool mutate_default_i32(int32_t _default_i32) {
+  bool mutate_default_i32(int32_t _default_i32 = 42) {
     return SetField<int32_t>(VT_DEFAULT_I32, _default_i32, 42);
   }
   uint32_t just_u32() const {
     return GetField<uint32_t>(VT_JUST_U32, 0);
   }
-  bool mutate_just_u32(uint32_t _just_u32) {
+  bool mutate_just_u32(uint32_t _just_u32 = 0) {
     return SetField<uint32_t>(VT_JUST_U32, _just_u32, 0);
   }
   flatbuffers::Optional<uint32_t> maybe_u32() const {
@@ -239,13 +239,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint32_t default_u32() const {
     return GetField<uint32_t>(VT_DEFAULT_U32, 42);
   }
-  bool mutate_default_u32(uint32_t _default_u32) {
+  bool mutate_default_u32(uint32_t _default_u32 = 42) {
     return SetField<uint32_t>(VT_DEFAULT_U32, _default_u32, 42);
   }
   int64_t just_i64() const {
     return GetField<int64_t>(VT_JUST_I64, 0);
   }
-  bool mutate_just_i64(int64_t _just_i64) {
+  bool mutate_just_i64(int64_t _just_i64 = 0) {
     return SetField<int64_t>(VT_JUST_I64, _just_i64, 0);
   }
   flatbuffers::Optional<int64_t> maybe_i64() const {
@@ -257,13 +257,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int64_t default_i64() const {
     return GetField<int64_t>(VT_DEFAULT_I64, 42LL);
   }
-  bool mutate_default_i64(int64_t _default_i64) {
+  bool mutate_default_i64(int64_t _default_i64 = 42LL) {
     return SetField<int64_t>(VT_DEFAULT_I64, _default_i64, 42LL);
   }
   uint64_t just_u64() const {
     return GetField<uint64_t>(VT_JUST_U64, 0);
   }
-  bool mutate_just_u64(uint64_t _just_u64) {
+  bool mutate_just_u64(uint64_t _just_u64 = 0) {
     return SetField<uint64_t>(VT_JUST_U64, _just_u64, 0);
   }
   flatbuffers::Optional<uint64_t> maybe_u64() const {
@@ -275,13 +275,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint64_t default_u64() const {
     return GetField<uint64_t>(VT_DEFAULT_U64, 42ULL);
   }
-  bool mutate_default_u64(uint64_t _default_u64) {
+  bool mutate_default_u64(uint64_t _default_u64 = 42ULL) {
     return SetField<uint64_t>(VT_DEFAULT_U64, _default_u64, 42ULL);
   }
   float just_f32() const {
     return GetField<float>(VT_JUST_F32, 0.0f);
   }
-  bool mutate_just_f32(float _just_f32) {
+  bool mutate_just_f32(float _just_f32 = 0.0f) {
     return SetField<float>(VT_JUST_F32, _just_f32, 0.0f);
   }
   flatbuffers::Optional<float> maybe_f32() const {
@@ -293,13 +293,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   float default_f32() const {
     return GetField<float>(VT_DEFAULT_F32, 42.0f);
   }
-  bool mutate_default_f32(float _default_f32) {
+  bool mutate_default_f32(float _default_f32 = 42.0f) {
     return SetField<float>(VT_DEFAULT_F32, _default_f32, 42.0f);
   }
   double just_f64() const {
     return GetField<double>(VT_JUST_F64, 0.0);
   }
-  bool mutate_just_f64(double _just_f64) {
+  bool mutate_just_f64(double _just_f64 = 0.0) {
     return SetField<double>(VT_JUST_F64, _just_f64, 0.0);
   }
   flatbuffers::Optional<double> maybe_f64() const {
@@ -311,13 +311,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   double default_f64() const {
     return GetField<double>(VT_DEFAULT_F64, 42.0);
   }
-  bool mutate_default_f64(double _default_f64) {
+  bool mutate_default_f64(double _default_f64 = 42.0) {
     return SetField<double>(VT_DEFAULT_F64, _default_f64, 42.0);
   }
   bool just_bool() const {
     return GetField<uint8_t>(VT_JUST_BOOL, 0) != 0;
   }
-  bool mutate_just_bool(bool _just_bool) {
+  bool mutate_just_bool(bool _just_bool = 0) {
     return SetField<uint8_t>(VT_JUST_BOOL, static_cast<uint8_t>(_just_bool), 0);
   }
   flatbuffers::Optional<bool> maybe_bool() const {
@@ -329,13 +329,13 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool default_bool() const {
     return GetField<uint8_t>(VT_DEFAULT_BOOL, 1) != 0;
   }
-  bool mutate_default_bool(bool _default_bool) {
+  bool mutate_default_bool(bool _default_bool = 1) {
     return SetField<uint8_t>(VT_DEFAULT_BOOL, static_cast<uint8_t>(_default_bool), 1);
   }
   optional_scalars::OptionalByte just_enum() const {
     return static_cast<optional_scalars::OptionalByte>(GetField<int8_t>(VT_JUST_ENUM, 0));
   }
-  bool mutate_just_enum(optional_scalars::OptionalByte _just_enum) {
+  bool mutate_just_enum(optional_scalars::OptionalByte _just_enum = static_cast<optional_scalars::OptionalByte>(0)) {
     return SetField<int8_t>(VT_JUST_ENUM, static_cast<int8_t>(_just_enum), 0);
   }
   flatbuffers::Optional<optional_scalars::OptionalByte> maybe_enum() const {
@@ -347,7 +347,7 @@ struct ScalarStuff FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   optional_scalars::OptionalByte default_enum() const {
     return static_cast<optional_scalars::OptionalByte>(GetField<int8_t>(VT_DEFAULT_ENUM, 1));
   }
-  bool mutate_default_enum(optional_scalars::OptionalByte _default_enum) {
+  bool mutate_default_enum(optional_scalars::OptionalByte _default_enum = static_cast<optional_scalars::OptionalByte>(1)) {
     return SetField<int8_t>(VT_DEFAULT_ENUM, static_cast<int8_t>(_default_enum), 1);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {

--- a/tests/union_vector/union_vector_generated.h
+++ b/tests/union_vector/union_vector_generated.h
@@ -289,7 +289,7 @@ struct Attacker FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int32_t sword_attack_damage() const {
     return GetField<int32_t>(VT_SWORD_ATTACK_DAMAGE, 0);
   }
-  bool mutate_sword_attack_damage(int32_t _sword_attack_damage) {
+  bool mutate_sword_attack_damage(int32_t _sword_attack_damage = 0) {
     return SetField<int32_t>(VT_SWORD_ATTACK_DAMAGE, _sword_attack_damage, 0);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {


### PR DESCRIPTION
## Changes
Mutator functions with a compatible type now use a default argument from the schema.

## Motive
Make a simple way to mutate a value to its schema default value. Inspired by the Create functions that can create a 'default' instance using the default arguments given in the schema. I use this on an embedded system where mutating is preferred over allocating a builder. It enables things like factory resetting values without needing to store the default value and prevents a default constant being out of sync with the schema.

## Effects on Current Code
To the best of my knowledge, this is a non-breaking feature as no mutator functions are being called with 0 parameters and the mutator functions' behavior is not changing when called with one parameter.

## Next Steps
I am open to making this a compiler flag such as --default-mutator or similar if this is too big or niche of a change to be generated with all mutators.

I would also be open to adding such functionality to other languages, I just targeted C++ as it is the language I use flatbuffers with.

Of course feel free to let me know of any changes/improvements.