### PR TITLE
Support `--conform` for vector of unions

### DIFF
--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -516,7 +516,7 @@ int FlatCompiler::Compile(int argc, const char **argv) {
       }
       if ((is_schema || is_binary_schema) && !conform_to_schema.empty()) {
         auto err = parser->ConformTo(conform_parser);
-        if (!err.empty()) Error("schemas don\'t conform: " + err);
+        if (!err.empty()) Error("schemas don\'t conform: " + err, false);
       }
       if (schema_binary || opts.binary_schema_gen_embed) {
         parser->Serialize();

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2478,8 +2478,7 @@ bool Parser::SupportsDefaultVectorsAndStrings() const {
 }
 
 bool Parser::SupportsAdvancedUnionFeatures() const {
-  return opts.lang_to_generate != 0 &&
-         (opts.lang_to_generate &
+  return (opts.lang_to_generate &
           ~(IDLOptions::kCpp | IDLOptions::kTs | IDLOptions::kPhp |
             IDLOptions::kJava | IDLOptions::kCSharp | IDLOptions::kKotlin |
             IDLOptions::kBinary | IDLOptions::kSwift)) == 0;
@@ -3255,7 +3254,7 @@ CheckedError Parser::ParseRoot(const char *source, const char **include_paths,
       for (auto val_it = enum_def.Vals().begin();
            val_it != enum_def.Vals().end(); ++val_it) {
         auto &val = **val_it;
-        if (!SupportsAdvancedUnionFeatures() &&
+        if (!(opts.lang_to_generate != 0 && SupportsAdvancedUnionFeatures()) &&
             (IsStruct(val.union_type) || IsString(val.union_type)))
           return Error(
               "only tables can be union elements in the generated language: " +


### PR DESCRIPTION
It seems like `--conform` already works for vectors of unions - there is
just a spurious check that prevents it from running. Fixes #6882

Also, if schemas do not conform, `flatc` no longer prints out the usage
(since the error is not due to bad usage). Fixes #6496
