### PR TITLE
[Java] Prevent generation of enum names when underlying type is long

### DIFF
--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -355,7 +355,7 @@ class JavaGenerator : public BaseGenerator {
       code += ";\n";
     }
 
-    // Generate a generate string table for enum values.
+    // Generate a string table for enum values.
     // Problem is, if values are very sparse that could generate really big
     // tables. Ideally in that case we generate a map lookup instead, but for
     // the moment we simply don't output a table at all.
@@ -363,7 +363,9 @@ class JavaGenerator : public BaseGenerator {
     // Average distance between values above which we consider a table
     // "too sparse". Change at will.
     static const uint64_t kMaxSparseness = 5;
-    if (range / static_cast<uint64_t>(enum_def.size()) < kMaxSparseness) {
+    if (range / static_cast<uint64_t>(enum_def.size()) < kMaxSparseness &&
+        GenTypeBasic(DestinationType(enum_def.underlying_type, false)) !=
+            "long") {
       code += "\n  public static final String";
       code += "[] names = { ";
       auto val = enum_def.Vals().front();


### PR DESCRIPTION
Change to resolve issue #6781

Adds a check to ensure that the string table for enum values is not generated when an enum with an underlying type that resolves to a Java long is specified. This change also prevents the `names` accessor method from being generated under the same conditions.

This is necessary because Java arrays must be indexed by int, short, byte, or char values only. If a long value is provided a compile time error is returned. A flatbuffer schema which includes an enum with an underlying type that resolves to a Java long will generate Java classes that cannot be compiled.