### PR TITLE
[Python] Verify EnumDef is not generated in GenUnionCreator

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -1595,6 +1595,8 @@ class PythonGenerator : public BaseGenerator {
 
   // Creates an union object based on union type.
   void GenUnionCreator(const EnumDef &enum_def, std::string *code_ptr) {
+    if (enum_def.generated) return;
+
     auto &code = *code_ptr;
     auto union_name = MakeUpperCamel(enum_def);
 


### PR DESCRIPTION
This fixes an issue I noticed with Python output when using the `--gen-object-api` flag. Included files with `union` definitions are compiled into `.py` outputs that are missing the typical enum.

Here are a simple set of repro files and steps:

test.fbs
```
include "test-import.fbs";

table EmptyTest {
  field:string;
}
```

test-import.fbs
```
union IncludedUnion {TypeA, TypeB}

table TypeA {
  field:string;
}

table TypeB {
  field:string;
}
```

Before the proposed change, `flatc --gen-object-api --python test.fbs` would generate an `IncludedUnion.py` without

```python
class IncludedUnion(object):                   
    NONE = 0                                                      
    TypeA = 1                  
    TypeB = 2
```

Now, that command does not generate `IncludedUnion.py`.

`cd tests && bash generate_code.sh` did not generate any changes.