### PR TITLE
move [[ ]] to calling sites

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -294,7 +294,7 @@ template<typename T> FLATBUFFERS_CONSTEXPR inline bool IsConstTrue(T t) {
 #if ((__cplusplus >= 201703L) \
     || (defined(_MSVC_LANG) &&  (_MSVC_LANG >= 201703L)))
   // All attributes unknown to an implementation are ignored without causing an error.
-  #define FLATBUFFERS_ATTRIBUTE(attr) [[attr]]
+  #define FLATBUFFERS_ATTRIBUTE(attr) attr
 
   #define FLATBUFFERS_FALLTHROUGH() [[fallthrough]]
 #else

--- a/include/flatbuffers/flatbuffer_builder.h
+++ b/include/flatbuffers/flatbuffer_builder.h
@@ -194,7 +194,7 @@ class FlatBufferBuilder {
   /// @warning Do NOT attempt to use this FlatBufferBuilder afterwards!
   /// @return A `FlatBuffer` that owns the buffer and its allocator and
   /// behaves similar to a `unique_ptr` with a deleter.
-  FLATBUFFERS_ATTRIBUTE(deprecated("use Release() instead"))
+  FLATBUFFERS_ATTRIBUTE([[deprecated("use Release() instead")]])
   DetachedBuffer ReleaseBufferPointer() {
     Finished();
     return buf_.release();
@@ -430,7 +430,7 @@ class FlatBufferBuilder {
     return vtableoffsetloc;
   }
 
-  FLATBUFFERS_ATTRIBUTE(deprecated("call the version above instead"))
+  FLATBUFFERS_ATTRIBUTE([[deprecated("call the version above instead")]])
   uoffset_t EndTable(uoffset_t start, voffset_t /*numfields*/) {
     return EndTable(start);
   }

--- a/include/flatbuffers/vector.h
+++ b/include/flatbuffers/vector.h
@@ -162,7 +162,7 @@ template<typename T> class Vector {
   uoffset_t size() const { return EndianScalar(length_); }
 
   // Deprecated: use size(). Here for backwards compatibility.
-  FLATBUFFERS_ATTRIBUTE(deprecated("use size() instead"))
+  FLATBUFFERS_ATTRIBUTE([[deprecated("use size() instead")]])
   uoffset_t Length() const { return size(); }
 
   typedef typename IndirectHelper<T>::return_type return_type;


### PR DESCRIPTION
Fixes: #6912 

Having the [[ ]] in the macro definition caused some weird syntax highlighting. This just moves it to the calling site which seems to fix the issue.