### PR TITLE
[Java] lookup by byteArray is giving back wrong entry

### DIFF
--- a/java/com/google/flatbuffers/FlexBuffers.java
+++ b/java/com/google/flatbuffers/FlexBuffers.java
@@ -788,7 +788,12 @@ public class FlexBuffers {
                 if (io == other.length) {
                     // in our buffer we have an additional \0 byte
                     // but this does not exist in regular Java strings, so we return now
-                    return c1 - c2;
+                    int cmp = c1 - c2;
+                    if (cmp != 0 || bb.get(ia) == '\0') {
+                        return cmp;
+                    } else {
+                        return 1;
+                    }
                 }
             }
             while (c1 == c2);
@@ -961,7 +966,12 @@ public class FlexBuffers {
                 if (l2 == other.length) {
                     // in our buffer we have an additional \0 byte
                     // but this does not exist in regular Java strings, so we return now
-                    return c1 - c2;
+                    int cmp = c1 - c2;
+                    if (cmp != 0 || bb.get(l1) == '\0') {
+                        return cmp;
+                    } else {
+                        return 1;
+                    }
                 }
             }
             while (c1 == c2);

--- a/tests/JavaTest.java
+++ b/tests/JavaTest.java
@@ -1097,6 +1097,30 @@ class JavaTest {
         TestEq(m.get(key4).asString(), utf8keys[4]);
     }
 
+    public static void testFlexBuffersMapLookup() {
+        FlexBuffersBuilder builder = new FlexBuffersBuilder(ByteBuffer.allocate(512),
+                FlexBuffersBuilder.BUILDER_FLAG_SHARE_KEYS_AND_STRINGS);
+
+        String key0 = "123";
+        String key1 = "1234";
+        String key2 = "12345";
+        String[] keys = new String[]{key0, key1, key2};
+
+        int map = builder.startMap();
+
+        for (int i=0; i< keys.length; i++) {
+            builder.putString(keys[i], keys[i]);  // Testing key and string reuse.
+        }
+        builder.endMap(null, map);
+        builder.finish();
+
+        FlexBuffers.Map m = FlexBuffers.getRoot(builder.getBuffer()).asMap();
+        for (int i=0; i< keys.length; i++) {
+            TestEq(m.get(keys[i]).asString(), keys[i]);
+            TestEq(m.get(keys[i].getBytes(StandardCharsets.UTF_8)).asString(), keys[i]);
+        }
+    }
+
     public static void TestFlexBuffers() {
         testSingleElementByte();
         testSingleElementShort();
@@ -1121,6 +1145,7 @@ class JavaTest {
         testDeprecatedTypedVectorString();
         testBuilderGrowth();
         testFlexBuffersUtf8Map();
+        testFlexBuffersMapLookup();
     }
 
     static void TestVectorOfBytes() {


### PR DESCRIPTION
FlexBuffer's map returns a wrong entry for a key that is a prefix match. Say, if a Map has these entries 
```
{
  "123": 1,
  "1234": 2,
  "12345": 3
}
```
Looking up with a key "123" may return any of entries, this PR is to fix this prefix match problem.
