### PR TITLE
Prepare for rust 2021 edition and fix (some) clippy warnings

### DIFF
--- a/rust/flatbuffers/src/follow.rs
+++ b/rust/flatbuffers/src/follow.rs
@@ -53,6 +53,11 @@ impl<'a, T: Follow<'a> + 'a> FollowStart<T> {
         T::follow(buf, loc)
     }
 }
+impl<'a, T: Follow<'a> + 'a> Default for FollowStart<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl<'a, T: Follow<'a>> Follow<'a> for FollowStart<T> {
     type Inner = T::Inner;
     #[inline]

--- a/rust/flatbuffers/src/primitives.rs
+++ b/rust/flatbuffers/src/primitives.rs
@@ -84,7 +84,7 @@ impl<T> Copy for WIPOffset<T> {}
 impl<T> Clone for WIPOffset<T> {
     #[inline]
     fn clone(&self) -> WIPOffset<T> {
-        WIPOffset::new(self.0.clone())
+        WIPOffset::new(self.0)
     }
 }
 impl<T> PartialEq for WIPOffset<T> {

--- a/rust/flatbuffers/src/table.rs
+++ b/rust/flatbuffers/src/table.rs
@@ -27,7 +27,7 @@ pub struct Table<'a> {
 impl<'a> Table<'a> {
     #[inline]
     pub fn new(buf: &'a [u8], loc: usize) -> Self {
-        Table { buf: buf, loc: loc }
+        Table { buf, loc }
     }
     #[inline]
     pub fn vtable(&self) -> VTable<'a> {
@@ -51,7 +51,7 @@ impl<'a> Follow<'a> for Table<'a> {
     type Inner = Table<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Table { buf: buf, loc: loc }
+        Table { buf, loc }
     }
 }
 

--- a/rust/flatbuffers/src/vtable.rs
+++ b/rust/flatbuffers/src/vtable.rs
@@ -35,8 +35,8 @@ impl<'a> PartialEq for VTable<'a> {
 impl<'a> VTable<'a> {
     pub fn init(buf: &'a [u8], loc: usize) -> Self {
         VTable {
-            buf: buf,
-            loc: loc,
+            buf,
+            loc,
         }
     }
     pub fn num_fields(&self) -> usize {

--- a/rust/flatbuffers/src/vtable_writer.rs
+++ b/rust/flatbuffers/src/vtable_writer.rs
@@ -28,7 +28,7 @@ pub struct VTableWriter<'a> {
 impl<'a> VTableWriter<'a> {
     #[inline(always)]
     pub fn init(buf: &'a mut [u8]) -> Self {
-        VTableWriter { buf: buf }
+        VTableWriter { buf }
     }
 
     /// Writes the vtable length (in bytes) into the vtable.


### PR DESCRIPTION
Small changes to the rust runtime that should be backward compatible with prior rust versions while being compatible with edition 2021.