### PR TITLE
fuzzers: fix typo in file path

### DIFF
--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -88,7 +88,7 @@ set(FlatBuffers_Library_SRCS
     ${FLATBUFFERS_DIR}/include/flatbuffers/allocator.h
     ${FLATBUFFERS_DIR}/include/flatbuffers/array.h
     ${FLATBUFFERS_DIR}/include/flatbuffers/base.h
-    ${FLATBUFFERS_DIR}/include/flatbuffer/buffer.h
+    ${FLATBUFFERS_DIR}/include/flatbuffers/buffer.h
     ${FLATBUFFERS_DIR}/include/flatbuffers/buffer_ref.h
     ${FLATBUFFERS_DIR}/include/flatbuffers/default_allocator.h
     ${FLATBUFFERS_DIR}/include/flatbuffers/detached_buffer.h


### PR DESCRIPTION
This would fix the oss-fuzz build.
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40939

This typo was introduced in 6c8c291559053f90a35c138499053449a40e3b9a
cc @dbaileychess 