### PR TITLE
[cmake] Fix getting version info from tags during the build

### DIFF
--- a/CMake/Version.cmake
+++ b/CMake/Version.cmake
@@ -6,7 +6,7 @@ set(VERSION_COMMIT 0)
 find_program(GIT git)
 if(GIT)
   execute_process(
-      COMMAND ${GIT} describe
+      COMMAND ${GIT} describe --tags
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       OUTPUT_VARIABLE GIT_DESCRIBE_DIRTY
       OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
Use `git describe --tags` to query for lightweight tags along with the annotated ones.

Closes #6933.

Note: this fix might not be needed if release tags are always made annotated (and existing non-annotated tags are dropped and re-created as annotated as well).