### PR TITLE
Correctly add byte offset of underlying data view when extracting som…

### DIFF
--- a/ts/flexbuffers/reference-util.ts
+++ b/ts/flexbuffers/reference-util.ts
@@ -115,5 +115,5 @@ export function keyForIndex(index: number, dataView: DataView, offset: number, p
   while (dataView.getUint8(keyIndirectOffset + length) !== 0) {
     length++;
   }
-  return fromUTF8Array(new Uint8Array(dataView.buffer, keyIndirectOffset, length));
+  return fromUTF8Array(new Uint8Array(dataView.buffer, dataView.byteOffset + keyIndirectOffset, length));
 }

--- a/ts/flexbuffers/reference.ts
+++ b/ts/flexbuffers/reference.ts
@@ -79,7 +79,7 @@ export class Reference {
   stringValue(): string | null {
     if (this.valueType === ValueType.STRING || this.valueType === ValueType.KEY) {
       const begin = indirect(this.dataView, this.offset, this.parentWidth);
-      return fromUTF8Array(new Uint8Array(this.dataView.buffer, begin, this.length()));
+      return fromUTF8Array(new Uint8Array(this.dataView.buffer, this.dataView.byteOffset + begin, this.length()));
     }
     return null;
   }
@@ -87,7 +87,7 @@ export class Reference {
   blobValue(): Uint8Array | null {
     if (this.isBlob()) {
       const begin = indirect(this.dataView, this.offset, this.parentWidth);
-      return new Uint8Array(this.dataView.buffer, begin, this.length());
+      return new Uint8Array(this.dataView.buffer, this.dataView.byteOffset + begin, this.length());
     }
     return null;
   }


### PR DESCRIPTION
This fixes what appears to be a small oversight in the TypeScript FlexBuffer library. If the underlying DataView used is a window into a larger ArrayBuffer (for example, if decoding a FlexBuffer field inside of a FlatBuffer) the underlying DataView's byteOffset was not being taken into account. The result is bad/corrupt values coming out of the FlexBuffer if the DataView has a byteOffset.