### PR TITLE
[C++] Restore FlatBufferBuilder::kFileIdentifierLength.

### DIFF
--- a/include/flatbuffers/flatbuffer_builder.h
+++ b/include/flatbuffers/flatbuffer_builder.h
@@ -1074,6 +1074,10 @@ class FlatBufferBuilder {
   void SwapBufAllocator(FlatBufferBuilder &other) {
     buf_.swap_allocator(other.buf_);
   }
+  
+  /// @brief The length of a FlatBuffer file header.
+  static const size_t kFileIdentifierLength =
+      ::flatbuffers::kFileIdentifierLength;
 
  protected:
   // You shouldn't really be copying instances of this class.


### PR DESCRIPTION
Restore flatbuffers::FlatBufferBuilder::kFileIdentifierLength, which was a documented part of the public API, but the identifier was lost during the refactoring effected by commit 6c8c291559053f90a35c138499053449a40e3b9a.