### PR TITLE
Make idl_parser deterministic

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2152,10 +2152,16 @@ void EnumDef::SortByValue() {
   auto &v = vals.vec;
   if (IsUInt64())
     std::sort(v.begin(), v.end(), [](const EnumVal *e1, const EnumVal *e2) {
+      if (e1->GetAsUInt64() == e2->GetAsUInt64()) {
+        return e1->name < e2->name;
+      }
       return e1->GetAsUInt64() < e2->GetAsUInt64();
     });
   else
     std::sort(v.begin(), v.end(), [](const EnumVal *e1, const EnumVal *e2) {
+      if (e1->GetAsInt64() == e2->GetAsInt64()) {
+        return e1->name < e2->name;
+      }
       return e1->GetAsInt64() < e2->GetAsInt64();
     });
 }


### PR DESCRIPTION
Some golden tests even exercise this [logic](https://github.com/google/flatbuffers/blob/df2df21ec1be2468106fed10c1533eacc1cf0d2e/tests/prototest/test.proto#L16). Let's make the parser fully stable not depending on the implementation of std::sort
