### PR TITLE
Add .NET test to github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,34 @@ jobs:
     - name: test
       run: Release\flattests.exe
 
+  build-dotnet-windows:
+    name: Build .NET Windows
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        configuration: [
+          '',
+          '-p:UnsafeByteBuffer=true', 
+          # Fails two tests currently.
+          #'-p:EnableSpanT=true,UnsafeByteBuffer=true'
+          ]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1.9.0
+      with: 
+        dotnet-version: '3.1.x'
+    - name: Build
+      run: |
+        cd tests\FlatBuffers.Test
+        dotnet new sln --force --name FlatBuffers.Core.Test
+        dotnet sln FlatBuffers.Core.Test.sln add FlatBuffers.Core.Test.csproj
+        dotnet build -c Release ${{matrix.configuration}} -o out FlatBuffers.Core.Test.sln
+    - name: Run
+      run: |
+        cd tests\FlatBuffers.Test
+        out\FlatBuffers.Core.Test.exe
+
   build-mac:
     name: Build Mac
     runs-on: macos-latest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,19 +55,6 @@ test_script:
   - "npm run compile"
   - "cd tests"
   - "TypeScriptTest.bat"
-  - rem "---------------- C# -----------------"
-  # Have to compile this here rather than in "build" above because AppVeyor only
-  # supports building one project??
-  - "cd FlatBuffers.Test"
-  - "dotnet new sln"
-  - "dotnet sln add FlatBuffers.Test.csproj"
-  - "nuget restore"
-  - "mkdir .tmp"
-  - "msbuild.exe /property:Configuration=Release;OutputPath=.tmp /verbosity:minimal FlatBuffers.Test.csproj"
-  - ".tmp\\FlatBuffers.Test.exe"
-  # Run tests with UNSAFE_BYTEBUFFER
-  - "msbuild.exe /property:Configuration=Release;UnsafeByteBuffer=true;OutputPath=.tmp /verbosity:minimal FlatBuffers.Test.csproj"
-  - ".tmp\\FlatBuffers.Test.exe"
 
 artifacts:
   - path: $(CONFIGURATION)\flatc.exe

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -116,13 +116,13 @@ namespace FlatBuffers.Test
             // Dump to output directory so we can inspect later, if needed
             #if ENABLE_SPAN_T
             var data = fbb.DataBuffer.ToSizedArray();
-            string filename = @".tmp/monsterdata_cstest" + (sizePrefix ? "_sp" : "") + ".mon";
+            string filename = @"monsterdata_cstest" + (sizePrefix ? "_sp" : "") + ".mon";
             File.WriteAllBytes(filename, data);
             #else
             using (var ms = fbb.DataBuffer.ToMemoryStream(fbb.DataBuffer.Position, fbb.Offset))
             {
                 var data = ms.ToArray();
-                string filename = @".tmp/monsterdata_cstest" + (sizePrefix ? "_sp" : "") + ".mon";
+                string filename = @"monsterdata_cstest" + (sizePrefix ? "_sp" : "") + ".mon";
                 File.WriteAllBytes(filename, data);
             }
             #endif


### PR DESCRIPTION
Adds the .NET test to github workflows. 

Unfortunately github workflows doesn't support .NET Framework 3.5, the lowest I could find is in the 4.6+. Fortunately, we do have a build against .NET Core 3.1, which is available. I think this is fine coverage.

I removed the ones from appveyor in preparation of removing appveyor altogether.