### PR TITLE
chore: dart 2.0.5 release changes

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0
+## 2.0.5
 
 - switch to null safety (#6696)
 - add Object APIs (pack/unpack) (#6682, #6723, #6846)

--- a/dart/README.md
+++ b/dart/README.md
@@ -2,10 +2,8 @@
 
 This package is used to read and write [FlatBuffers](https://google.github.io/flatbuffers/).
 
-Most consumers will want to use the [`flatc` - FlatBuffer compiler](https://github.com/google/flatbuffers) binary for your platform:
-* [Linux](https://github.com/google/flatbuffers/suites/4363603985/artifacts/114682272)
-* [macOS](https://github.com/google/flatbuffers/suites/4363603985/artifacts/114682273)
-* [Windows](https://github.com/google/flatbuffers/suites/4363603985/artifacts/114682274)
+Most consumers will want to use the [`flatc` - FlatBuffer compiler](https://github.com/google/flatbuffers) binary for your platform.
+You can find it in the `generator/{Platform}` directory of the [released package archive](https://pub.dev/packages/flat_buffers/versions/2.0.5.tar.gz).
 
 The FlatBuffer compiler `flatc` reads a FlatBuffers IDL schema and generates Dart code.
 The generated classes can be used to read or write binary data/files that are interoperable with
@@ -15,3 +13,11 @@ examples folder.
 For more details and documentation, head over to the official site and read the
 [Tutorial](https://google.github.io/flatbuffers/flatbuffers_guide_tutorial.html) and how to
 [use FlatBuffers in Dart](https://google.github.io/flatbuffers/flatbuffers_guide_use_dart.html).
+
+## Dart 2.0 notes
+Version 2.0.5 ships with it's own custom build of `flatc` because this is an extraordinary release to catch-up
+with FlatBuffers for other platforms. This generator can only generate dart code (to avoid generating code for other platforms which isn't released yet).
+On the other hand, the generated code still produces standard binary FlatBuffers compatible with other languages.
+In other words: only `flatc --dart ...` works with this generator, but your app will be able to produce and read standard binary (`Uint8List`) FlatBuffers that are fully compotible with other languages supporting FlatBuffers (e.g. Java, C++, ...).
+
+In the future a common `flatc` binary for all platforms would be shipped through GitHub release page instead.

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flat_buffers
-version: 2.0.0
+version: 2.0.5
 description: FlatBuffers reading and writing library for Dart. Based on original work by Konstantin Scheglov and Paul Berry of the Dart SDK team.
 homepage: https://github.com/google/flatbuffers
 documentation: https://google.github.io/flatbuffers/index.html


### PR DESCRIPTION
So I've finished the release to pub.dev, using the repo tag v2.0.5, with a custom `flatc` build (dart-only), as created by #6937, packaged in the pub.dev package.

In the future, my idea is to just use the `flatc` coming out from the next FB release, whenever that is, and align the version on pub.dev with that.

This PR just brings the docs in the version they're pushed to pub.dev