### PR TITLE
[CMake]: Fix python command for mingw environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,7 +523,7 @@ if(PYTHONINTERP_FOUND AND
   # Skip doing this if the MSVC version is below VS 12.
   # https://cmake.org/cmake/help/latest/variable/MSVC_VERSION.html
   (NOT MSVC OR MSVC_VERSION GREATER 1800))
-  if(WIN32)
+  if(MSVC)
     set(GENERATION_SCRIPT py scripts/generate_code.py) 
    else()
     set(GENERATION_SCRIPT scripts/generate_code.py)


### PR DESCRIPTION
In mingw build environment, this fixes the build error:
'py' is not recognized as an internal or external command
The 'py' launcher is available for MSVC python only. More
https://docs.python.org/3/using/windows.html#from-the-command-line
