### PR TITLE
[CMake]: Fix version in pkgconfig file

### DIFF
--- a/CMake/Version.cmake
+++ b/CMake/Version.cmake
@@ -4,7 +4,7 @@ set(VERSION_PATCH 5)
 set(VERSION_COMMIT 0)
 
 find_program(GIT git)
-if(GIT)
+if(GIT AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   execute_process(
       COMMAND ${GIT} describe --tags
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
This change checks if the current source directory is a git repository.
If this is not checked the git command picks the commit hash from
parent directory. e.g. when tarball is extracted in a packaging repository.
