### PR TITLE
rust: Allow for usage of flatbuffers in #![no_std] environment

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatbuffers"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2018"
 authors = ["Robert Winslow <hello@rwinslow.com>", "FlatBuffers Maintainers"]
 license = "Apache-2.0"
@@ -11,7 +11,13 @@ keywords = ["flatbuffers", "serialization", "zero-copy"]
 categories = ["encoding", "data-structures", "memory-management"]
 rust = "1.51"
 
+[features]
+default = ["thiserror"]
+no_std = ["core2", "thiserror_core2"]
+
 [dependencies]
 smallvec = "1.6.1"
 bitflags = "1.2.1"
-thiserror = "1.0.23"
+thiserror = { version = "1.0.23", optional = true }
+core2 = { version = "0.3.3", optional = true }
+thiserror_core2 = { git = "https://github.com/antmicro/thiserror-core2.git", branch = "remaining-errors", optional = true }

--- a/rust/flatbuffers/src/array.rs
+++ b/rust/flatbuffers/src/array.rs
@@ -17,9 +17,9 @@
 use crate::follow::Follow;
 use crate::vector::VectorIter;
 use crate::EndianScalar;
-use std::fmt::{Debug, Formatter, Result};
-use std::marker::PhantomData;
-use std::mem::size_of;
+use core::fmt::{Debug, Formatter, Result};
+use core::marker::PhantomData;
+use core::mem::size_of;
 
 #[derive(Copy, Clone)]
 pub struct Array<'a, T: 'a, const N: usize>(&'a [u8], PhantomData<T>);

--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -16,11 +16,13 @@
 
 extern crate smallvec;
 
-use std::cmp::max;
-use std::iter::{DoubleEndedIterator, ExactSizeIterator};
-use std::marker::PhantomData;
-use std::ptr::write_bytes;
-use std::slice::from_raw_parts;
+use core::cmp::max;
+use core::iter::{DoubleEndedIterator, ExactSizeIterator};
+use core::marker::PhantomData;
+use core::ptr::write_bytes;
+use core::slice::from_raw_parts;
+#[cfg(feature = "no_std")]
+use alloc::{vec, vec::Vec};
 
 use crate::endian_scalar::{emplace_scalar, read_scalar_at};
 use crate::primitives::*;

--- a/rust/flatbuffers/src/endian_scalar.rs
+++ b/rust/flatbuffers/src/endian_scalar.rs
@@ -15,7 +15,7 @@
  */
 #![allow(clippy::wrong_self_convention)]
 
-use std::mem::size_of;
+use core::mem::size_of;
 
 /// Trait for values that must be stored in little-endian byte order, but
 /// might be represented in memory as big-endian. Every type that implements

--- a/rust/flatbuffers/src/follow.rs
+++ b/rust/flatbuffers/src/follow.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Follow is a trait that allows us to access FlatBuffers in a declarative,
 /// type safe, and fast way. They compile down to almost no code (after

--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -28,6 +28,11 @@
 //! At this time, to generate Rust code, you will need the latest `master` version of `flatc`, available from here: <https://github.com/google/flatbuffers>
 //! (On OSX, you can install FlatBuffers from `HEAD` with the Homebrew package manager.)
 
+#![cfg_attr(feature = "no_std", no_std)]
+
+#[cfg(feature = "no_std")]
+extern crate alloc;
+
 mod array;
 mod builder;
 mod endian_scalar;

--- a/rust/flatbuffers/src/primitives.rs
+++ b/rust/flatbuffers/src/primitives.rs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-use std::marker::PhantomData;
-use std::mem::size_of;
-use std::ops::Deref;
+use core::marker::PhantomData;
+use core::mem::size_of;
+use core::ops::Deref;
 
 use crate::endian_scalar::{emplace_scalar, read_scalar, read_scalar_at};
 use crate::follow::Follow;

--- a/rust/flatbuffers/src/push.rs
+++ b/rust/flatbuffers/src/push.rs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-use std::cmp::max;
-use std::mem::{align_of, size_of};
+use core::cmp::max;
+use core::mem::{align_of, size_of};
 
 use crate::endian_scalar::emplace_scalar;
 

--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-use std::fmt::{Debug, Formatter, Result};
-use std::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator};
-use std::marker::PhantomData;
-use std::mem::size_of;
-use std::slice::from_raw_parts;
-use std::str::from_utf8_unchecked;
+use core::fmt::{Debug, Formatter, Result};
+use core::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator};
+use core::marker::PhantomData;
+use core::mem::size_of;
+use core::slice::from_raw_parts;
+use core::str::from_utf8_unchecked;
 
 use crate::endian_scalar::read_scalar_at;
 #[cfg(target_endian = "little")]

--- a/rust/flatbuffers/src/vtable_writer.rs
+++ b/rust/flatbuffers/src/vtable_writer.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::ptr::write_bytes;
+use core::ptr::write_bytes;
 
 use crate::endian_scalar::emplace_scalar;
 use crate::primitives::*;

--- a/tests/RustTest.sh
+++ b/tests/RustTest.sh
@@ -35,6 +35,8 @@ cd ./rust_usage_test
 cargo test $TARGET_FLAG -- --quiet
 check_test_result "Rust tests"
 
+cargo test $TARGET_FLAG --no-default-features --features no_std -- --quiet
+check_test_result "Rust tests (no_std)"
 
 cargo run $TARGET_FLAG --bin=flatbuffers_alloc_check
 check_test_result "Rust flatbuffers heap alloc test"

--- a/tests/rust_usage_test/Cargo.toml
+++ b/tests/rust_usage_test/Cargo.toml
@@ -6,11 +6,16 @@ authors = ["Robert Winslow <hello@rwinslow.com>",
            "FlatBuffers Maintainers"]
 
 [dependencies]
-flatbuffers = { path = "../../rust/flatbuffers" }
+flatbuffers = { path = "../../rust/flatbuffers", default-features = false }
 flexbuffers = { path = "../../rust/flexbuffers" }
 serde_derive = "1.0"
 serde = "1.0"
 serde_bytes = "0.11"
+libc_alloc = { version = "1.0.3", optional = true }
+
+[features]
+default = ["flatbuffers/default"]
+no_std = ["flatbuffers/no_std", "libc_alloc"]
 
 [[bin]]
 name = "monster_example"

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -15,6 +15,10 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "no_std")]
+#[global_allocator]
+static ALLOCATOR: libc_alloc::LibcAlloc = libc_alloc::LibcAlloc;
+
 #[macro_use]
 #[cfg(not(miri))] // slow.
 extern crate quickcheck;


### PR DESCRIPTION
Hey,

this PR introduces changes that allow for usage of flatbuffers in `#![no_std]` environments. The main difference to [this PR](https://github.com/google/flatbuffers/pull/5366) is that instead of removing `thiserror` for `no_std` builds it uses `core2` and `thiserror_core2` in its place. The `core2` crate needed some small changes, so I had to use fork for the time being.