### PR TITLE
Provide a short help text and default in error case

### DIFF
--- a/include/flatbuffers/flatc.h
+++ b/include/flatbuffers/flatc.h
@@ -84,6 +84,7 @@ class FlatCompiler {
 
   int Compile(int argc, const char **argv);
 
+  std::string GetShortUsageString(const char *program_name) const;
   std::string GetUsageString(const char *program_name) const;
 
  private:

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -65,7 +65,7 @@ const static FlatCOption options[] = {
   { "I", "", "PATH", "Search for includes in the specified path." },
   { "M", "", "", "Print make rules for generated files." },
   { "", "version", "", "Print the version number of flatc and exit." },
-  { "", "help", "", "Prints this help text and exit." },
+  { "h", "help", "", "Prints this help text and exit." },
   { "", "string-json", "",
     "Strict JSON: field names must be / will be quoted, no trailing commas in "
     "tables/vectors." },
@@ -270,6 +270,35 @@ static void AppendOption(std::stringstream &ss, const FlatCOption &option,
   ss << "\n";
 }
 
+static void AppendShortOption(std::stringstream &ss,
+                              const FlatCOption &option) {
+  if (!option.short_opt.empty()) {
+    ss << "-" << option.short_opt;
+    if (!option.long_opt.empty()) { ss << "|"; }
+  }
+  if (!option.long_opt.empty()) { ss << "--" << option.long_opt; }
+}
+
+std::string FlatCompiler::GetShortUsageString(const char *program_name) const {
+  std::stringstream ss;
+  ss << "\nUsage: " << program_name << " [";
+  for (size_t i = 0; i < params_.num_generators; ++i) {
+    const Generator &g = params_.generators[i];
+    AppendShortOption(ss, g.option);
+    ss << ", ";
+  }
+  for (const FlatCOption &option : options) {
+    AppendShortOption(ss, option);
+    ss << ", ";
+  }
+  ss.seekp(-2, ss.cur);
+  ss << "]... FILE... [-- FILE...]";
+  std::string help = ss.str();
+  std::stringstream ss_textwrap; 
+  AppendTextWrappedString(ss_textwrap, help, 80, 0);
+  return ss_textwrap.str();
+}
+
 std::string FlatCompiler::GetUsageString(const char *program_name) const {
   std::stringstream ss;
   ss << "Usage: " << program_name << " [OPTION]... FILE... [-- FILE...]\n";
@@ -455,7 +484,7 @@ int FlatCompiler::Compile(int argc, const char **argv) {
       } else if (arg == "--version") {
         printf("flatc version %s\n", FLATC_VERSION());
         exit(0);
-      } else if (arg == "--help") {
+      } else if (arg == "--help" || arg == "-h") {
         printf("%s\n", GetUsageString(program_name).c_str());
         exit(0);
       } else if (arg == "--grpc") {

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -184,7 +184,8 @@ const static FlatCOption options[] = {
   { "", "reflect-types", "",
     "Add minimal type reflection to code generation." },
   { "", "reflect-names", "", "Add minimal type/name reflection." },
-  { "", "rust-serialize", "", "Implement serde::Serialize on generated Rust types." },
+  { "", "rust-serialize", "",
+    "Implement serde::Serialize on generated Rust types." },
   { "", "root-type", "T", "Select or override the default root_type." },
   { "", "require-explicit-ids", "",
     "When parsing schemas, require explicit ids (id: x)." },
@@ -281,7 +282,7 @@ static void AppendShortOption(std::stringstream &ss,
 
 std::string FlatCompiler::GetShortUsageString(const char *program_name) const {
   std::stringstream ss;
-  ss << "\nUsage: " << program_name << " [";
+  ss << "Usage: " << program_name << " [";
   for (size_t i = 0; i < params_.num_generators; ++i) {
     const Generator &g = params_.generators[i];
     AppendShortOption(ss, g.option);
@@ -294,7 +295,7 @@ std::string FlatCompiler::GetShortUsageString(const char *program_name) const {
   ss.seekp(-2, ss.cur);
   ss << "]... FILE... [-- FILE...]";
   std::string help = ss.str();
-  std::stringstream ss_textwrap; 
+  std::stringstream ss_textwrap;
   AppendTextWrappedString(ss_textwrap, help, 80, 0);
   return ss_textwrap.str();
 }
@@ -329,6 +330,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
   if (params_.generators == nullptr || params_.num_generators == 0) {
     return 0;
   }
+
+  if (argc <= 1) { Error("Need to provide at least one argument."); }
 
   flatbuffers::IDLOptions opts;
   std::string output_path;

--- a/src/flatc_main.cpp
+++ b/src/flatc_main.cpp
@@ -34,7 +34,7 @@ static void Error(const flatbuffers::FlatCompiler *flatc,
                   const std::string &err, bool usage, bool show_exe_name) {
   if (show_exe_name) { printf("%s: ", g_program_name); }
   if (usage && flatc) {
-    fprintf(stderr, "%s\n", flatc->GetUsageString(g_program_name).c_str());
+    fprintf(stderr, "%s\n", flatc->GetShortUsageString(g_program_name).c_str());
   }
   fprintf(stderr, "error:\n  %s\n\n", err.c_str());
   exit(1);

--- a/src/flatc_main.cpp
+++ b/src/flatc_main.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cstdio>
 #include <memory>
 
 #include "bfbs_gen_lua.h"
@@ -27,7 +28,7 @@ static void Warn(const flatbuffers::FlatCompiler *flatc,
                  const std::string &warn, bool show_exe_name) {
   (void)flatc;
   if (show_exe_name) { printf("%s: ", g_program_name); }
-  fprintf(stderr, "warning:\n  %s\n\n", warn.c_str());
+  fprintf(stderr, "\nwarning:\n  %s\n\n", warn.c_str());
 }
 
 static void Error(const flatbuffers::FlatCompiler *flatc,
@@ -36,7 +37,7 @@ static void Error(const flatbuffers::FlatCompiler *flatc,
   if (usage && flatc) {
     fprintf(stderr, "%s\n", flatc->GetShortUsageString(g_program_name).c_str());
   }
-  fprintf(stderr, "error:\n  %s\n\n", err.c_str());
+  fprintf(stderr, "\nerror:\n  %s\n\n", err.c_str());
   exit(1);
 }
 


### PR DESCRIPTION
Defaults to outputting a `short` help on error. This just show the valid options flags without their descriptions to be more compact. To get full description, the `-h|--help` option will display it.