### PR TITLE
Make flatbuffer builder deterministic

### DIFF
--- a/include/flatbuffers/flatbuffer_builder.h
+++ b/include/flatbuffers/flatbuffer_builder.h
@@ -922,7 +922,7 @@ class FlatBufferBuilder {
   /// where the vector is stored.
   template<typename T>
   Offset<Vector<const T *>> CreateVectorOfSortedStructs(T *v, size_t len) {
-    std::sort(v, v + len, StructKeyComparator<T>());
+    std::stable_sort(v, v + len, StructKeyComparator<T>());
     return CreateVectorOfStructs(v, len);
   }
 
@@ -941,7 +941,7 @@ class FlatBufferBuilder {
     extern T Pack(const S &);
     auto structs = StartVectorOfStructs<T>(len);
     for (size_t i = 0; i < len; i++) { structs[i] = Pack(v[i]); }
-    std::sort(structs, structs + len, StructKeyComparator<T>());
+    std::stable_sort(structs, structs + len, StructKeyComparator<T>());
     return EndVectorOfStructs<T>(len);
   }
 
@@ -973,7 +973,7 @@ class FlatBufferBuilder {
   template<typename T>
   Offset<Vector<Offset<T>>> CreateVectorOfSortedTables(Offset<T> *v,
                                                        size_t len) {
-    std::sort(v, v + len, TableKeyComparator<T>(buf_));
+    std::stable_sort(v, v + len, TableKeyComparator<T>(buf_));
     return CreateVector(v, len);
   }
 


### PR DESCRIPTION
Building different flatbuffers from compiler to compiler is unlikely to be desired. Yet, I am open for feedback