### PR TITLE
Rearrange #include directives to pass to compilation with a particula…

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -18,18 +18,19 @@
 #define FLATBUFFERS_UTIL_H_
 
 #include <errno.h>
+#include <ctype.h>
 
 #include "flatbuffers/base.h"
 #include "flatbuffers/stl_emulation.h"
 
 #ifndef FLATBUFFERS_PREFER_PRINTF
 #  include <sstream>
+#  include <iomanip>
 #else  // FLATBUFFERS_PREFER_PRINTF
 #  include <float.h>
 #  include <stdio.h>
 #endif  // FLATBUFFERS_PREFER_PRINTF
 
-#include <iomanip>
 #include <string>
 
 namespace flatbuffers {


### PR DESCRIPTION
…r DSP toolchain

iomanip isn't available for our DSP. Luckily, we compile with FLATBUFFERS_PREFER_PRINTF, so moved the #include directive there.
ctype.h has to be included explicilty for tolower() and toupper().
