### PR TITLE
Avoid implicit conversion from float to double.

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -95,7 +95,7 @@ template<typename T> size_t IntToDigitCount(T t) {
   // Count a single 0 left of the dot for fractional numbers
   if (-1 < t && t < 1) digit_count++;
   // Count digits until fractional part
-  T eps = std::numeric_limits<float>::epsilon();
+  T eps = std::numeric_limits<T>::epsilon();
   while (t <= (-1 + eps) || (1 - eps) <= t) {
     t /= 10;
     digit_count++;


### PR DESCRIPTION
https://github.com/tensorflow/tflite-micro makes use of flatbuffers with a variety of DSP toolchains.

Without the change from this PR, we can get a double-promotion warning with some of these DSP toolchains:
```
flatbuffers/include/flatbuffers/util.h:104:11: error: implicit conversion increases floating-point precision: 'std::numeric_limits<float>::_Ty' (aka 'float') to 'double' [-Werror,-Wdouble-promotion]
  T eps = std::numeric_limits<float>::epsilon();
    ~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
