### PR TITLE
[WIP] Adding support for swift wasm

### DIFF
--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+#if !os(WASI)
 import Foundation
+#else
+import SwiftOverlayShims
+#endif
 
 /// `ByteBuffer` is the interface that stores the data for a `Flatbuffers` object
 /// it allows users to write and read data directly from memory thus the use of its
@@ -125,6 +129,7 @@ public struct ByteBuffer {
     }
   }
 
+    #if !os(WASI)
   /// Constructor that creates a Flatbuffer from the Swift Data type object
   /// - Parameter data: Swift data Object
   public init(data: Data) {
@@ -135,6 +140,7 @@ public struct ByteBuffer {
       self._storage.copy(from: bufferPointer.baseAddress!, count: data.count)
     }
   }
+    #endif
 
   /// Constructor that creates a Flatbuffer instance with a size
   /// - Parameter size: Length of the buffer
@@ -144,7 +150,7 @@ public struct ByteBuffer {
     _storage.initialize(for: size)
   }
 
-  #if swift(>=5.0)
+  #if swift(>=5.0) && !os(WASI)
   /// Constructor that creates a Flatbuffer object from a ContiguousBytes
   /// - Parameters:
   ///   - contiguousBytes: Binary stripe to use as the buffer
@@ -355,6 +361,7 @@ public struct ByteBuffer {
     return Array(array)
   }
 
+    #if !os(WASI)
   /// Reads a string from the buffer and encodes it to a swift string
   /// - Parameters:
   ///   - index: index of the string in the buffer
@@ -373,6 +380,24 @@ public struct ByteBuffer {
     let bufprt = UnsafeBufferPointer(start: start, count: count)
     return String(bytes: Array(bufprt), encoding: type)
   }
+    #else
+    /// Reads a string from the buffer and encodes it to a swift string
+    /// - Parameters:
+    ///   - index: index of the string in the buffer
+    ///   - count: length of the string
+    ///   - type: Encoding of the string
+    public func readString(
+      at index: Int,
+      count: Int) -> String?
+    {
+      assert(
+        index + count <= _storage.capacity,
+        "Reading out of bounds is illegal")
+      let start = _storage.memory.advanced(by: index)
+        .assumingMemoryBound(to: UInt8.self)
+      return String(cString: UnsafePointer(start))
+    }
+    #endif
 
   /// Creates a new Flatbuffer object that's duplicated from the current one
   /// - Parameter removeBytes: the amount of bytes to remove from the current Size

--- a/swift/Sources/FlatBuffers/Constants.swift
+++ b/swift/Sources/FlatBuffers/Constants.swift
@@ -14,15 +14,28 @@
  * limitations under the License.
  */
 
+/// A boolean to see if the system is littleEndian
+#if os(WASI)
+let isLitteEndian: Bool = {
+    let number: UInt32 = 0x12345678
+    let converted = number.bigEndian
+    if number == converted {
+        return false // We Are Big Endian
+    } else {
+        return true // We are Little-Endian
+    }
+}()
+#else
 #if os(Linux)
 import CoreFoundation
 #else
 import Foundation
 #endif
 
-/// A boolean to see if the system is littleEndian
 let isLitteEndian = CFByteOrderGetCurrent() ==
   Int(CFByteOrderLittleEndian.rawValue)
+#endif
+
 /// Constant for the file id length
 let FileIdLength = 4
 /// Type aliases

--- a/swift/Sources/FlatBuffers/Enum.swift
+++ b/swift/Sources/FlatBuffers/Enum.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// Enum is a protocol that all flatbuffers enums should conform to
 /// Since it allows us to get the actual `ByteSize` and `Value` from
 /// a swift enum.

--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+#if !os(WASI)
 import Foundation
+#endif
+
+import SwiftOverlayShims
 
 /// ``FlatBufferBuilder`` builds a `FlatBuffer` through manipulating its internal state.
 ///
@@ -55,6 +59,7 @@ public struct FlatBufferBuilder {
   /// Gives a read access to the buffer's size
   public var size: UOffset { _bb.size }
 
+    #if !os(WASI)
   /// Data representation of the buffer
   ///
   /// Should only be used after ``finish(offset:addPrefix:)`` is called
@@ -64,6 +69,7 @@ public struct FlatBufferBuilder {
       bytes: _bb.memory.advanced(by: _bb.writerIndex),
       count: _bb.capacity &- _bb.writerIndex)
   }
+    #endif
 
   /// Returns the underlying bytes in the ``ByteBuffer``
   ///

--- a/swift/Sources/FlatBuffers/FlatBufferObject.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferObject.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// NativeStruct is a protocol that indicates if the struct is a native `swift` struct
 /// since now we will be serializing native structs into the buffer.
 public protocol NativeStruct {}

--- a/swift/Sources/FlatBuffers/FlatBuffersUtils.swift
+++ b/swift/Sources/FlatBuffers/FlatBuffersUtils.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// FlatBuffersUtils hosts some utility functions that might be useful
 public enum FlatBuffersUtils {
 

--- a/swift/Sources/FlatBuffers/FlatbuffersErrors.swift
+++ b/swift/Sources/FlatBuffers/FlatbuffersErrors.swift
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// Collection of thrown from the Flatbuffer verifier
-public enum FlatbuffersErrors: Error, Equatable {
+public enum FlatbuffersErrors: Error {
 
   /// Thrown when buffer is bigger than the allowed 2GiB
   case exceedsMaxSizeAllowed
@@ -57,6 +55,59 @@ public enum FlatbuffersErrors: Error, Equatable {
     lhs: FlatbuffersErrors,
     rhs: FlatbuffersErrors) -> Bool
   {
-    lhs.localizedDescription == rhs.localizedDescription
+      switch lhs {
+      case .unknownUnionCase:
+          return rhs == .unknownUnionCase
+      case .exceedsMaxSizeAllowed:
+          return rhs == .exceedsMaxSizeAllowed
+      case .missAlignedPointer(position: let position, type: let type):
+          if case .missAlignedPointer(let rhsPosition, let rhsType) = rhs {
+              return position == rhsPosition && type == rhsType
+          } else {
+              return false
+          }
+      case .outOfBounds(position: let position, end: let end):
+          if case .outOfBounds(let rhsPosition, let rhsEnd) = rhs {
+              return position == rhsPosition && end == rhsEnd
+          } else {
+              return false
+          }
+      case .signedOffsetOutOfBounds(offset: let offset, position: let position):
+          if case .signedOffsetOutOfBounds(let rhsOffset, let rhsPosition) = rhs {
+              return offset == rhsOffset && rhsPosition == position
+          } else {
+              return false
+          }
+      case .requiredFieldDoesntExist(position: let position, name: let name):
+          if case .requiredFieldDoesntExist(let rhsPosition, let rhsName) = rhs {
+              return rhsPosition == position && rhsName == name
+          } else {
+              return false
+          }
+      case .missingNullTerminator(position: let position, str: let str):
+          if case .missingNullTerminator(let rhsPosition, let rhsStr) = rhs {
+              return rhsPosition == position && rhsStr == str
+          } else {
+              return false
+          }
+      case .maximumTables:
+          return rhs == .maximumTables
+      case .maximumDepth:
+          return rhs == .maximumDepth
+      case .valueNotFound(key: let key, keyName: let keyName, field: let field, fieldName: let fieldName):
+          if case .valueNotFound(let rhsKey, let rhsKeyName, let rhsField, let rhsFieldName) = rhs {
+              return rhsKey == key && rhsKeyName == keyName && rhsField == field && rhsFieldName == fieldName
+          } else {
+              return false
+          }
+      case .unionVectorSize(keyVectorSize: let keyVectorSize, fieldVectorSize: let fieldVectorSize, unionKeyName: let unionKeyName, fieldName: let fieldName):
+          if case .unionVectorSize(let rhsKeyVectorSize, let rhsFieldVectorSize, let rhsUnionKeyName, let rhsFieldName) = rhs {
+              return rhsKeyVectorSize == keyVectorSize && rhsFieldVectorSize == fieldVectorSize && rhsUnionKeyName == unionKeyName && rhsFieldName == fieldName
+          } else {
+              return false
+          }
+      case .apparentSizeTooLarge:
+          return rhs == .apparentSizeTooLarge
+      }
   }
 }

--- a/swift/Sources/FlatBuffers/Int+extension.swift
+++ b/swift/Sources/FlatBuffers/Int+extension.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 extension Int {
 
   /// Moves the current int into the nearest power of two

--- a/swift/Sources/FlatBuffers/Message.swift
+++ b/swift/Sources/FlatBuffers/Message.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// FlatBufferGRPCMessage protocol that should allow us to invoke
 /// initializers directly from the GRPC generated code
 public protocol FlatBufferGRPCMessage {

--- a/swift/Sources/FlatBuffers/Mutable.swift
+++ b/swift/Sources/FlatBuffers/Mutable.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// Mutable is a protocol that allows us to mutate Scalar values within a ``ByteBuffer``
 public protocol Mutable {
   /// makes Flatbuffer accessed within the Protocol

--- a/swift/Sources/FlatBuffers/NativeObject.swift
+++ b/swift/Sources/FlatBuffers/NativeObject.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// NativeObject is a protocol that all of the `Object-API` generated code should be
 /// conforming to since it allows developers the ease of use to pack and unpack their
 /// Flatbuffers objects

--- a/swift/Sources/FlatBuffers/Offset.swift
+++ b/swift/Sources/FlatBuffers/Offset.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// Offset object for all the Objects that are written into the buffer
 public struct Offset {
   /// Offset of the object in the buffer

--- a/swift/Sources/FlatBuffers/Root.swift
+++ b/swift/Sources/FlatBuffers/Root.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// Takes in a prefixed sized buffer, where the prefixed size would be skipped.
 /// And would verify that the buffer passed is a valid `Flatbuffers` Object.
 /// - Parameters:

--- a/swift/Sources/FlatBuffers/String+extension.swift
+++ b/swift/Sources/FlatBuffers/String+extension.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 extension String: Verifiable {
 
   /// Verifies that the current value is which the bounds of the buffer, and if

--- a/swift/Sources/FlatBuffers/Struct.swift
+++ b/swift/Sources/FlatBuffers/Struct.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// Struct is a representation of a mutable `Flatbuffers` struct
 /// since native structs are value types and cant be mutated
 @frozen

--- a/swift/Sources/FlatBuffers/Table.swift
+++ b/swift/Sources/FlatBuffers/Table.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// `Table` is a Flatbuffers object that can read,
 /// mutate scalar fields within a valid flatbuffers buffer
 @frozen

--- a/swift/Sources/FlatBuffers/TableVerifier.swift
+++ b/swift/Sources/FlatBuffers/TableVerifier.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// `TableVerifier` verifies a table object is within a provided memory.
 /// It checks if all the objects for a specific generated table, are within
 /// the bounds of the buffer, aligned.

--- a/swift/Sources/FlatBuffers/VeriferOptions.swift
+++ b/swift/Sources/FlatBuffers/VeriferOptions.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// `VerifierOptions` is a set of options to verify a flatbuffer
 public struct VerifierOptions {
 

--- a/swift/Sources/FlatBuffers/Verifiable.swift
+++ b/swift/Sources/FlatBuffers/Verifiable.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// Verifiable is a protocol all swift flatbuffers object should conform to,
 /// since swift is similar to `cpp` and `rust` where the data is read directly
 /// from `unsafeMemory` thus the need to verify if the buffer received is a valid one

--- a/swift/Sources/FlatBuffers/Verifier.swift
+++ b/swift/Sources/FlatBuffers/Verifier.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
 /// Verifier that check if the buffer passed into it is a valid,
 /// safe, aligned Flatbuffers object since swift read from `unsafeMemory`
 public struct Verifier {


### PR DESCRIPTION
cc: @mzaks 

These are some changes to make swift flatbuffers compatible with the swift web assembly compiler.

### The tl;dr is:

* Many unnecessary `import Foundation` statements were removed.
* In some cases, Foundation types like `Date` or `Data` are pound defined out (e.g `#if !os(WASI)`).
* CoreFoundation is not available in wasm, so I wrote a small computed property leveraging the builtin `.bigEndian` property. Inspired by a stack overflow post :p.
* The error enum's `==` overload leveraged the byproducts of some string description functionality I couldn't get working. So I ended up doing the laborious task of expanding it into a switch statement, although,  I couldn't actually find any usage of the `==` so it could be safe to just remove.

### Still todo:
* Add a an automation build step that will actually verify these changes (Just running everything by hand locally). 
* Verify there's no missing functionality in code compiling for WASM with the `#if !os(WASI)` changes. 