### PR TITLE
fix go_test implement error

### DIFF
--- a/grpc/tests/go_test.go
+++ b/grpc/tests/go_test.go
@@ -69,7 +69,7 @@ func RetrieveClient(c Example.MonsterStorageClient, t *testing.T) {
 	}
 	monster, err := out.Recv()
 	if err != nil {
-		return
+		t.Fatalf("Recv failed: %v", err)
 	}
 	if string(monster.Name()) != test {
 		t.Errorf("RetrieveClient failed: expected=%s, got=%s\n", test, monster.Name())

--- a/grpc/tests/go_test.go
+++ b/grpc/tests/go_test.go
@@ -1,8 +1,8 @@
 package testing
 
 import (
-	"../../tests/MyGame/Example"
 	flatbuffers "github.com/google/flatbuffers/go"
+	"github.com/google/flatbuffers/tests/MyGame/Example"
 
 	"context"
 	"net"
@@ -12,7 +12,9 @@ import (
 	"google.golang.org/grpc/encoding"
 )
 
-type server struct{}
+type server struct {
+	Example.UnimplementedMonsterStorageServer
+}
 
 // test used to send and receive in grpc methods
 var test = "Flatbuffers"
@@ -65,8 +67,12 @@ func RetrieveClient(c Example.MonsterStorageClient, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Retrieve client failed: %v", err)
 	}
-	if string(out.Name()) != test {
-		t.Errorf("RetrieveClient failed: expected=%s, got=%s\n", test, out.Name())
+	monster, err := out.Recv()
+	if err != nil {
+		return
+	}
+	if string(monster.Name()) != test {
+		t.Errorf("RetrieveClient failed: expected=%s, got=%s\n", test, monster.Name())
 		t.Fail()
 	}
 }


### PR DESCRIPTION
1, The test file does not implement internal interface(`Example.UnimplementedMonsterStorageServer`) resulting in code error.
2, I changed the path of the import to the absolute path of the package
       ../../tests/MyGame/Example => github.com/google/flatbuffers/tests/MyGame/Example