### PR TITLE
BuildFlatBuffers.cmake: fix arguments not passed properly to flatc

### DIFF
--- a/CMake/BuildFlatBuffers.cmake
+++ b/CMake/BuildFlatBuffers.cmake
@@ -95,7 +95,7 @@ function(build_flatbuffers flatbuffers_schemas
       set(generated_include ${generated_includes_dir}/${filename}_generated.h)
       add_custom_command(
         OUTPUT ${generated_include}
-        COMMAND ${FLATC} ${FLATC_ARGS}
+        COMMAND ${FLATC} ${FLATC_SCHEMA_ARGS}
         -o ${generated_includes_dir}
         ${include_params}
         -c ${schema}


### PR DESCRIPTION
Fix regression introduced by commit e9d45324012ed04af97cbe99bab0e6afe475e95d

Arguments where never passed to the build_helper
