### PR TITLE
Add FlatBuffers::FlatBuffers interface, needed for FetchContent_Declare

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,3 +757,11 @@ endif()
 if(FLATBUFFERS_BUILD_BENCHMARKS AND CMAKE_VERSION VERSION_GREATER 3.13)
   add_subdirectory(benchmarks)
 endif()
+
+# Add FlatBuffers::FlatBuffers interface, needed for FetchContent_Declare
+add_library(FlatBuffers INTERFACE)
+add_library(FlatBuffers::FlatBuffers ALIAS FlatBuffers)
+target_include_directories(
+  FlatBuffers
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>)


### PR DESCRIPTION
This patch enables cmake users to use FetchContent to add flatbuffers to thier projects as floowings:
```
include(FetchContent)
FetchContent_Declare(
    FlatBuffers
    GIT_REPOSITORY https://github.com/google/flatbuffers.git
    GIT_TAG master
    CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}
    GIT_SHALLOW TRUE
    GIT_PROGRESS TRUE)
FetchContent_MakeAvailable(FlatBuffers)

# ...
add_executable(MyExecutable main.cpp)
target_link_libraries(MyExecutable PRIVATE FlatBuffers::FlatBuffers) # now we can include <flatbuffers/flatbuffers.h> in our main.cpp
```
