### PR TITLE
[C++] Emit include for bfbs-gen-embed

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -283,6 +283,9 @@ class CppGenerator : public BaseGenerator {
         code_ += "#pragma clang system_header\n\n";
       }
 
+      code_ += "#include \"flatbuffers/flatbuffers.h\"";
+      code_ += "";
+
       SetNameSpace(struct_def.defined_namespace);
       auto name = Name(struct_def);
       code_.SetValue("STRUCT_NAME", name);

--- a/tests/monster_test_bfbs_generated.h
+++ b/tests/monster_test_bfbs_generated.h
@@ -4,6 +4,8 @@
 #ifndef FLATBUFFERS_GENERATED_MONSTERTEST_MYGAME_EXAMPLE_BFBS_H_
 #define FLATBUFFERS_GENERATED_MONSTERTEST_MYGAME_EXAMPLE_BFBS_H_
 
+#include "flatbuffers/flatbuffers.h"
+
 namespace MyGame {
 namespace Example {
 


### PR DESCRIPTION
Fixes: #7027

Looks like we didn't include anything in the generated bfbs embed file. I just included the flatbuffers.h which should work.