### PR TITLE
[TS/JS] make empty string encoding compitable with other languages

### DIFF
--- a/ts/builder.ts
+++ b/ts/builder.ts
@@ -501,7 +501,7 @@ export class Builder {
      * @return The offset in the buffer where the encoded string starts
      */
     createSharedString(s: string | Uint8Array): Offset {
-      if (!s) { return 0 }
+      if (!s && s !== '') { return 0 }
   
       if (!this.string_maps) {
         this.string_maps = new Map();
@@ -523,7 +523,7 @@ export class Builder {
      * @return The offset in the buffer where the encoded string starts
      */
     createString(s: string | Uint8Array): Offset {
-      if (!s) { return 0 }
+      if (!s && s !== '') { return 0 }
       let utf8: string | Uint8Array | number[];
       if (s instanceof Uint8Array) {
         utf8 = s;


### PR DESCRIPTION
When encoding empty string to flatbuffer, the behaviour should be the same with other languages.
When user pass an empty string, we should append a '\0' string instead of nothing
