### PR TITLE
Add --warnings-as-errors to flatc compiler.

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -591,6 +591,7 @@ struct IDLOptions {
   std::string filename_suffix;
   std::string filename_extension;
   bool no_warnings;
+  bool warnings_as_errors;
   std::string project_root;
   bool cs_global_alias;
   bool json_nested_flatbuffers;
@@ -681,6 +682,7 @@ struct IDLOptions {
         filename_suffix("_generated"),
         filename_extension(),
         no_warnings(false),
+        warnings_as_errors(false),
         project_root(""),
         cs_global_alias(false),
         json_nested_flatbuffers(true),
@@ -787,6 +789,7 @@ class Parser : public ParserState {
         root_struct_def_(nullptr),
         opts(options),
         uses_flexbuffers_(false),
+        has_warning_(false),
         advanced_features_(0),
         source_(nullptr),
         anonymous_counter_(0),
@@ -1021,6 +1024,7 @@ class Parser : public ParserState {
 
   IDLOptions opts;
   bool uses_flexbuffers_;
+  bool has_warning_;
 
   uint64_t advanced_features_;
 

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -199,6 +199,7 @@ const static FlatCOption options[] = {
     "Used with \"binary\" and \"json\" options, it generates data using "
     "schema-less FlexBuffers." },
   { "", "no-warnings", "", "Inhibit all warnings messages." },
+  { "", "warning-as-errors", "", "Treat all warnings as errors." },
   { "", "cs-global-alias", "",
     "Prepend \"global::\" to all user generated csharp classes and "
     "structs." },
@@ -496,6 +497,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.gen_jvmstatic = true;
       } else if (arg == "--no-warnings") {
         opts.no_warnings = true;
+      } else if (arg == "--warnings-as-errors") {
+        opts.warnings_as_errors = true;
       } else if (arg == "--cpp-std") {
         if (++argi >= argc)
           Error("missing C++ standard specification" + arg, true);

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -144,7 +144,10 @@ void Parser::Message(const std::string &msg) {
 }
 
 void Parser::Warning(const std::string &msg) {
-  if (!opts.no_warnings) Message("warning: " + msg);
+  if (!opts.no_warnings) {
+    Message("warning: " + msg);
+    has_warning_ = true;  // for opts.warnings_as_errors
+  }
 }
 
 CheckedError Parser::Error(const std::string &msg) {
@@ -3443,6 +3446,9 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
     } else {
       ECHECK(ParseDecl(source_filename));
     }
+  }
+  if (opts.warnings_as_errors && has_warning_) {
+    return Error("treating warnings as errors, failed due to above warnings");
   }
   return NoError();
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -2943,6 +2943,25 @@ void StructUnionTest() {
   gadget.Set(fan);
 }
 
+void WarningsAsErrorsTest() {
+  {
+    flatbuffers::IDLOptions opts;
+    opts.warnings_as_errors = false;
+    flatbuffers::Parser parser(opts);
+    TEST_EQ(parser.Parse("table T { THIS_NAME_CAUSES_A_WARNING:string;}\n"
+                         "root_type T;"),
+            true);
+  }
+  {
+    flatbuffers::IDLOptions opts;
+    opts.warnings_as_errors = true;
+    flatbuffers::Parser parser(opts);
+    TEST_EQ(parser.Parse("table T { THIS_NAME_CAUSES_A_WARNING:string;}\n"
+                         "root_type T;"),
+            false);
+  }
+}
+
 void ConformTest() {
   flatbuffers::Parser parser;
   TEST_EQ(parser.Parse("table T { A:int; } enum E:byte { A }"), true);
@@ -4209,6 +4228,7 @@ int FlatBufferTests() {
   FlatbuffersIteratorsTest();
   FixedLengthArraySpanTest();
   StructUnionTest();
+  WarningsAsErrorsTest();
   return 0;
 }
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -2946,7 +2946,7 @@ void StructUnionTest() {
 void WarningsAsErrorsTest() {
   {
     flatbuffers::IDLOptions opts;
-    opts.warnings_as_errors = false;
+    // opts.warnings_as_errors should default to false
     flatbuffers::Parser parser(opts);
     TEST_EQ(parser.Parse("table T { THIS_NAME_CAUSES_A_WARNING:string;}\n"
                          "root_type T;"),


### PR DESCRIPTION
With the option --warnings-as-errors set, flatc will return an error on parsing if any warnings occurred.

Feature requested in #7024.
