### PR TITLE
Use actions/checkout@v2, which fixes security vulnerability.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         cxx: [g++-10, clang++-12]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: cmake
       run: CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release .
     - name: build
@@ -37,7 +37,7 @@ jobs:
     name: Build Windows 2019 
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
     - name: cmake
@@ -56,7 +56,7 @@ jobs:
     name: Build Windows 2017
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
     - name: cmake
@@ -70,7 +70,7 @@ jobs:
     name: Build Windows 2015
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
     - name: cmake
@@ -92,7 +92,7 @@ jobs:
           #'-p:EnableSpanT=true,UnsafeByteBuffer=true'
           ]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1.9.0
       with: 
@@ -112,7 +112,7 @@ jobs:
     name: Build Mac
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: cmake
       run: cmake -G "Xcode" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_FLATC_EXECUTABLE=_build/Release/flatc .
     - name: build
@@ -139,7 +139,7 @@ jobs:
    name: Build Android (on Linux)
    runs-on: ubuntu-latest
    steps:
-   - uses: actions/checkout@v1
+   - uses: actions/checkout@v2
    - name: set up JDK 1.8
      uses: actions/setup-java@v1
      with:
@@ -160,7 +160,7 @@ jobs:
       matrix:
         cxx: [g++-10, clang++-12]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: cmake
       run: CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles" -DFLATBUFFERS_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release . && make -j4
     - name: Generate
@@ -175,7 +175,7 @@ jobs:
       matrix:
         cxx: [g++-10]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: cmake
       run: CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles" -DFLATBUFFERS_CXX_FLAGS="-Wno-unused-parameter -fno-aligned-new" -DFLATBUFFERS_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release . && make -j4
     - name: Run benchmarks
@@ -190,7 +190,7 @@ jobs:
     name: Build Java
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: test
       working-directory: tests
       run: bash JavaTest.sh
@@ -240,7 +240,7 @@ jobs:
     name: Build Rust
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: test
       working-directory: tests
       run: bash RustTest.sh
@@ -249,7 +249,7 @@ jobs:
     name: Build Python
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: test
       working-directory: tests
       run: bash PythonTest.sh
@@ -258,7 +258,7 @@ jobs:
     name: Build Go
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: flatc
       # FIXME: make test script not rely on flatc
       run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF . && make -j4
@@ -270,7 +270,7 @@ jobs:
     name: Build Swift
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: test
       working-directory: tests/FlatBuffers.Test.Swift
       run: sh SwiftTest.sh
@@ -279,7 +279,7 @@ jobs:
     name: Build TS
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: compile
       run: npm run compile
     - name: test
@@ -290,7 +290,7 @@ jobs:
     name: Build Dart
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable


### PR DESCRIPTION
Simply update the build.yml steps that were using actions/checkout@v1 to use actions/checkout@v2. They should otherwise act exactly the same way.

Fix for issue #6999.
