### PR TITLE
Fix comment with line orders - Rust should be last.

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -72,8 +72,8 @@ namespace flatbuffers {
 // - Go type.
 // - C# / .Net type.
 // - Python type.
-// - Rust type.
 // - Kotlin type.
+// - Rust type.
 
 // using these macros, we can now write code dealing with types just once, e.g.
 


### PR DESCRIPTION
Comment order is incorrect - Rust should be after Kotlin.

Fix for #6867.
