### PR TITLE
[ts] Builder incorrectly serializing empty strings

### DIFF
--- a/ts/builder.ts
+++ b/ts/builder.ts
@@ -523,7 +523,6 @@ export class Builder {
      * @return The offset in the buffer where the encoded string starts
      */
     createString(s: string | Uint8Array): Offset {
-      if (!s) { return 0 }
       let utf8: string | Uint8Array | number[];
       if (s instanceof Uint8Array) {
         utf8 = s;

--- a/ts/builder.ts
+++ b/ts/builder.ts
@@ -522,7 +522,11 @@ export class Builder {
      * @param s The string to encode
      * @return The offset in the buffer where the encoded string starts
      */
-    createString(s: string | Uint8Array): Offset {
+    createString(s: string | Uint8Array | null | undefined): Offset {
+      if (s === null || s === undefined) {
+        return 0;
+      }
+
       let utf8: string | Uint8Array | number[];
       if (s instanceof Uint8Array) {
         utf8 = s;


### PR DESCRIPTION
The builder was returning an offset of zero for empty strings. This is
leading to flatbuffers which fail verification in other languages, such
as Rust.