### PR TITLE
import type to avoid circular dependency TS

### DIFF
--- a/ts/flexbuffers/reference-util.ts
+++ b/ts/flexbuffers/reference-util.ts
@@ -1,7 +1,7 @@
 import { BitWidth } from './bit-width'
 import { toByteWidth, fromByteWidth } from './bit-width-util'
 import { toUTF8Array, fromUTF8Array } from './flexbuffers-util'
-import { Reference } from './reference'
+import type { Reference } from './reference'
 
 export function validateOffset(dataView: DataView, offset: number, width: number): void {
   if (dataView.byteLength <= offset + width || (offset & (toByteWidth(width) - 1)) !== 0) {


### PR DESCRIPTION
This was the suggested fix: https://stackoverflow.com/questions/24444436/circular-type-references-in-typescript

Fixes: #7065 
