### PR TITLE
skip generating reflection.fbs in generate_scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,7 +552,7 @@ if(Python3_Interpreter_FOUND)
   add_custom_command(
     TARGET flatc
     POST_BUILD
-    COMMAND ${Python3_EXECUTABLE} scripts/generate_code.py ${GENERATION_OPTS}
+    COMMAND ${Python3_EXECUTABLE} scripts/generate_code.py ${GENERATION_OPTS} --skip-gen-reflection
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     COMMENT "Running scripts/generate_code.py..."
     VERBATIM)


### PR DESCRIPTION
The generated `reflection_generated.h` is used by `flatc` but is also generated directly after building `flatc`. This change removes the generation of the reflection file when invoked by cmake post build command.