### PR TITLE
rust: Bump thiserror version and remove git dependency

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -20,6 +20,7 @@ serialize = ["serde"]
 smallvec = "1.6.1"
 bitflags = "1.2.1"
 serde = { version = "1.0", optional = true }
-thiserror = { version = "1.0.23", optional = true }
-core2 = { version = "0.3.3", optional = true }
-thiserror_core2 = { git = "https://github.com/antmicro/thiserror-core2.git", branch = "remaining-errors", optional = true }
+thiserror = { version = "1.0.30", optional = true }
+core2 = { version = "0.4.0", optional = true }
+# This version is compliant with mainline 1.0.30
+thiserror_core2 = { version = "2.0.0", default-features = false, optional = true }


### PR DESCRIPTION
Hey,

this bumps up `core2`/`thiserror` versions and removes `git` dependency from the latter.
Continuation to #6989.
