### PR TITLE
[JS] Browser compatible imports

### DIFF
--- a/ts/builder.ts
+++ b/ts/builder.ts
@@ -1,6 +1,6 @@
-import { ByteBuffer } from "./byte-buffer"
-import { SIZEOF_SHORT, SIZE_PREFIX_LENGTH, SIZEOF_INT, FILE_IDENTIFIER_LENGTH } from "./constants"
-import { Offset, IGeneratedObject } from "./types"
+import { ByteBuffer } from "./byte-buffer.js"
+import { SIZEOF_SHORT, SIZE_PREFIX_LENGTH, SIZEOF_INT, FILE_IDENTIFIER_LENGTH } from "./constants.js"
+import { Offset, IGeneratedObject } from "./types.js"
 
 export class Builder {
     private bb: ByteBuffer

--- a/ts/byte-buffer.ts
+++ b/ts/byte-buffer.ts
@@ -1,7 +1,7 @@
-import { FILE_IDENTIFIER_LENGTH, SIZEOF_INT } from "./constants";
-import { int32, isLittleEndian, float32, float64 } from "./utils";
-import { Offset, Table, IGeneratedObject } from "./types";
-import { Encoding } from "./encoding";
+import { FILE_IDENTIFIER_LENGTH, SIZEOF_INT } from "./constants.js";
+import { int32, isLittleEndian, float32, float64 } from "./utils.js";
+import { Offset, Table, IGeneratedObject } from "./types.js";
+import { Encoding } from "./encoding.js";
 
 export class ByteBuffer {
     private position_ = 0;

--- a/ts/flatbuffers.ts
+++ b/ts/flatbuffers.ts
@@ -1,12 +1,12 @@
-export { SIZEOF_SHORT } from './constants'
-export { SIZEOF_INT } from './constants'
-export { FILE_IDENTIFIER_LENGTH } from './constants'
-export { SIZE_PREFIX_LENGTH } from './constants'
+export { SIZEOF_SHORT } from './constants.js'
+export { SIZEOF_INT } from './constants.js'
+export { FILE_IDENTIFIER_LENGTH } from './constants.js'
+export { SIZE_PREFIX_LENGTH } from './constants.js'
 
-export { Table, Offset } from './types'
+export { Table, Offset } from './types.js'
 
-export { int32, float32, float64, isLittleEndian } from './utils'
+export { int32, float32, float64, isLittleEndian } from './utils.js'
 
-export { Encoding } from './encoding'
-export { Builder } from './builder'
-export { ByteBuffer } from './byte-buffer'
+export { Encoding } from './encoding.js'
+export { Builder } from './builder.js'
+export { ByteBuffer } from './byte-buffer.js'

--- a/ts/flexbuffers.ts
+++ b/ts/flexbuffers.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import { Builder } from './flexbuffers/builder'
-import { toReference } from './flexbuffers/reference'
-export { toReference } from './flexbuffers/reference'
+import { Builder } from './flexbuffers/builder.js'
+import { toReference } from './flexbuffers/reference.js'
+export { toReference } from './flexbuffers/reference.js'
 
 export function builder(): Builder {
     return new Builder();

--- a/ts/flexbuffers/bit-width-util.ts
+++ b/ts/flexbuffers/bit-width-util.ts
@@ -1,4 +1,4 @@
-import { BitWidth } from './bit-width'
+import { BitWidth } from './bit-width.js'
 
 export function toByteWidth(bitWidth: BitWidth): number {
   return 1 << bitWidth;

--- a/ts/flexbuffers/builder.ts
+++ b/ts/flexbuffers/builder.ts
@@ -1,9 +1,9 @@
-import { BitWidth } from './bit-width'
-import { paddingSize, iwidth, uwidth, fwidth, toByteWidth, fromByteWidth } from './bit-width-util'
-import { toUTF8Array } from './flexbuffers-util'
-import { ValueType } from './value-type'
-import { isNumber, isTypedVectorElement, toTypedVector } from './value-type-util'
-import { StackValue } from './stack-value'
+import { BitWidth } from './bit-width.js'
+import { paddingSize, iwidth, uwidth, fwidth, toByteWidth, fromByteWidth } from './bit-width-util.js'
+import { toUTF8Array } from './flexbuffers-util.js'
+import { ValueType } from './value-type.js'
+import { isNumber, isTypedVectorElement, toTypedVector } from './value-type-util.js'
+import { StackValue } from './stack-value.js'
 
 interface StackPointer {
   stackPosition: number,

--- a/ts/flexbuffers/reference-util.ts
+++ b/ts/flexbuffers/reference-util.ts
@@ -1,7 +1,7 @@
-import { BitWidth } from './bit-width'
-import { toByteWidth, fromByteWidth } from './bit-width-util'
-import { toUTF8Array, fromUTF8Array } from './flexbuffers-util'
-import { Reference } from './reference'
+import { BitWidth } from './bit-width.js'
+import { toByteWidth, fromByteWidth } from './bit-width-util.js'
+import { toUTF8Array, fromUTF8Array } from './flexbuffers-util.js'
+import { Reference } from './reference.js'
 
 export function validateOffset(dataView: DataView, offset: number, width: number): void {
   if (dataView.byteLength <= offset + width || (offset & (toByteWidth(width) - 1)) !== 0) {

--- a/ts/flexbuffers/reference.ts
+++ b/ts/flexbuffers/reference.ts
@@ -1,9 +1,9 @@
-import { fromByteWidth } from './bit-width-util'
-import { ValueType } from './value-type'
-import { isNumber, isIndirectNumber, isAVector, fixedTypedVectorElementSize, isFixedTypedVector, isTypedVector, typedVectorElementType, packedType, fixedTypedVectorElementType } from './value-type-util'
-import { indirect, keyForIndex, keyIndex, readFloat, readInt, readUInt, valueForIndexWithKey } from './reference-util'
-import { fromUTF8Array } from './flexbuffers-util';
-import { BitWidth } from './bit-width';
+import { fromByteWidth } from './bit-width-util.js'
+import { ValueType } from './value-type.js'
+import { isNumber, isIndirectNumber, isAVector, fixedTypedVectorElementSize, isFixedTypedVector, isTypedVector, typedVectorElementType, packedType, fixedTypedVectorElementType } from './value-type-util.js'
+import { indirect, keyForIndex, keyIndex, readFloat, readInt, readUInt, valueForIndexWithKey } from './reference-util.js'
+import { fromUTF8Array } from './flexbuffers-util.js';
+import { BitWidth } from './bit-width.js';
 
 export function toReference(buffer: ArrayBuffer): Reference {
   const len = buffer.byteLength;

--- a/ts/flexbuffers/stack-value.ts
+++ b/ts/flexbuffers/stack-value.ts
@@ -1,8 +1,8 @@
-import { Builder } from './builder'
-import { BitWidth } from './bit-width'
-import { paddingSize, uwidth, fromByteWidth } from './bit-width-util'
-import { ValueType } from './value-type'
-import { isInline, packedType } from './value-type-util'
+import { Builder } from './builder.js'
+import { BitWidth } from './bit-width.js'
+import { paddingSize, uwidth, fromByteWidth } from './bit-width-util.js'
+import { ValueType } from './value-type.js'
+import { isInline, packedType } from './value-type-util.js'
 
 export class StackValue {
   constructor(private builder: Builder, public type: ValueType, public width: number, public value: number | boolean | null = null, public offset: number = 0) {

--- a/ts/flexbuffers/value-type-util.ts
+++ b/ts/flexbuffers/value-type-util.ts
@@ -1,4 +1,4 @@
-import { ValueType } from './value-type'
+import { ValueType } from './value-type.js'
 
 export function isInline(value: ValueType): boolean {
   return value === ValueType.BOOL

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -1,5 +1,5 @@
-import { ByteBuffer } from './byte-buffer'
-import { Builder } from './builder'
+import { ByteBuffer } from './byte-buffer.js'
+import { Builder } from './builder.js'
 
 export type Offset = number;
 


### PR DESCRIPTION
Currently it is impossible to import the mjs version in a pure Javascript/Browser environment, because of the missing ".js" suffix inside the import statements.

This can be solved by simply adding the missing ".js" suffixes inside the Typescript files. The Typescript compiler will then pass them through to the transpiled Javascript files.
