### PR TITLE
Swift FlatBufferBuilder.sizedByteArray to ByteBuffer.toArray()

### DIFF
--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -388,7 +388,7 @@ public struct ByteBuffer {
   }
 
   /// Returns the written bytes into the ``ByteBuffer``
-  public func toArray() -> [UInt8] {
+    public var underlyingBytes: [UInt8] {
       let cp = capacity &- writerIndex
       let start = memory.advanced(by: writerIndex)
                                 .bindMemory(to: UInt8.self, capacity: cp)

--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -387,6 +387,16 @@ public struct ByteBuffer {
       removing: _writerSize &- removeBytes)
   }
 
+  /// Returns the written bytes into the ``ByteBuffer``
+  public func toArray() -> [UInt8] {
+      let cp = capacity &- writerIndex
+      let start = memory.advanced(by: writerIndex)
+                                .bindMemory(to: UInt8.self, capacity: cp)
+
+      let ptr = UnsafeBufferPointer<UInt8>(start: start, count: cp)
+      return Array(ptr)
+  }
+
   /// SkipPrefix Skips the first 4 bytes in case one of the following
   /// functions are called `getPrefixedSizeCheckedRoot` & `getPrefixedSizeRoot`
   /// which allows us to skip the first 4 bytes instead of recreating the buffer

--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -80,12 +80,7 @@ public struct FlatBufferBuilder {
   /// Should only be used after ``finish(offset:addPrefix:)`` is called
   public var sizedByteArray: [UInt8] {
     assert(finished, "Data shouldn't be called before finish()")
-    let cp = _bb.capacity &- _bb.writerIndex
-    let start = _bb.memory.advanced(by: _bb.writerIndex)
-      .bindMemory(to: UInt8.self, capacity: cp)
-
-    let ptr = UnsafeBufferPointer(start: start, count: cp)
-    return Array(ptr)
+    return _bb.toArray()
   }
 
   /// Returns the original ``ByteBuffer``

--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -80,7 +80,7 @@ public struct FlatBufferBuilder {
   /// Should only be used after ``finish(offset:addPrefix:)`` is called
   public var sizedByteArray: [UInt8] {
     assert(finished, "Data shouldn't be called before finish()")
-    return _bb.toArray()
+    return _bb.underlyingBytes
   }
 
   /// Returns the original ``ByteBuffer``


### PR DESCRIPTION
Moved Swift code from FlatBufferBuilder.sizedByteArray to ByteBuffer.toArray() to allow direct buffer access after serialization via the Object API.