### PR TITLE
Change Rust generated file defaults

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -633,6 +633,9 @@ struct IDLOptions {
   // If set, implement serde::Serialize for generated Rust types
   bool rust_serialize;
 
+  // If set, generate rust types in individual files with a root module file.
+  bool rust_module_root_file;
+
   // The corresponding language bit will be set if a language is included
   // for code generation.
   unsigned long lang_to_generate;
@@ -698,6 +701,7 @@ struct IDLOptions {
         mini_reflect(IDLOptions::kNone),
         require_explicit_ids(false),
         rust_serialize(false),
+        rust_module_root_file(false),
         lang_to_generate(0),
         set_empty_strings_to_null(true),
         set_empty_vectors_to_null(true) {}

--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -125,12 +125,13 @@ CPP_17_OPTS = NO_INCL_OPTS + [
     "--cpp-static-reflection",
     "--gen-object-api",
 ]
-RUST_OPTS = BASE_OPTS + ["--rust", "--gen-all", "--gen-name-strings"]
+RUST_OPTS = BASE_OPTS + ["--rust", "--gen-all", "--gen-name-strings", "--rust-module-root-file"]
 RUST_SERIALIZE_OPTS = BASE_OPTS + [
     "--rust",
     "--gen-all",
     "--gen-name-strings",
     "--rust-serialize",
+    "--rust-module-root-file",
 ]
 TS_OPTS = ["--ts", "--gen-name-strings"]
 LOBSTER_OPTS = ["--lobster"]

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -185,6 +185,8 @@ const static FlatCOption options[] = {
   { "", "reflect-names", "", "Add minimal type/name reflection." },
   { "", "rust-serialize", "",
     "Implement serde::Serialize on generated Rust types." },
+  {"", "rust-module-root-file", "",
+   "Generate rust code in individual files with a module root file."},
   { "", "root-type", "T", "Select or override the default root_type." },
   { "", "require-explicit-ids", "",
     "When parsing schemas, require explicit ids (id: x)." },
@@ -503,6 +505,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.mini_reflect = IDLOptions::kTypesAndNames;
       } else if (arg == "--rust-serialize") {
         opts.rust_serialize = true;
+      } else if (arg == "--rust-module-root-file") {
+        opts.rust_module_root_file = true;
       } else if (arg == "--require-explicit-ids") {
         opts.require_explicit_ids = true;
       } else if (arg == "--root-type") {

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -194,7 +194,7 @@ bool IsOptionalToBuilder(const FieldDef &field) {
 
 bool GenerateRustModuleRootFile(const Parser &parser,
                                 const std::string &output_dir) {
-  if (parser.opts.one_file) {
+  if (!parser.opts.rust_module_root_file) {
     // Don't generate a root file when generating one file. This isn't an error
     // so return true.
     return true;
@@ -371,7 +371,7 @@ class RustGenerator : public BaseGenerator {
   }
 
   bool generate() {
-    if (parser_.opts.one_file) {
+    if (!parser_.opts.rust_module_root_file) {
       return GenerateOneFile();
     } else {
       return GenerateIndividualFiles();


### PR DESCRIPTION
After #6731, flatc changed its default behavior
for generating rust code to fix some importing issues.
This was a breaking change which invlidated the patch release,
`flatc 2.0.5` (#7081). This PR reverses the default so we can
release a patch update. However, does break Rust users who work at
HEAD.
