### PR TITLE
remove auto generate code from cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,30 +536,6 @@ function(compile_flatbuffers_schema_to_embedded_binary SRC_FBS OPT)
   register_generated_output(${GEN_BFBS_HEADER})
 endfunction()
 
-# Look if we have python 3.5 installed so that we can run the generate code
-# python script after flatc is built.
-find_package(Python3 3.5 COMPONENTS Interpreter)
-
-if(Python3_Interpreter_FOUND)
-  set(GENERATION_OPTS --flatc "${FLATBUFFERS_FLATC_EXECUTABLE}")
-  if(FLATBUFFERS_BUILD_LEGACY)
-    # Need to set --cpp-std c++-0x options
-    set(GENERATION_OPTS ${GENERATION_OPTS}--cpp-0x)
-  endif()
-  if(FLATBUFFERS_SKIP_MONSTER_EXTRA)
-    set(GENERATION_OPTS ${GENERATION_OPTS} --skip-monster-extra)
-  endif()
-  add_custom_command(
-    TARGET flatc
-    POST_BUILD
-    COMMAND ${Python3_EXECUTABLE} scripts/generate_code.py ${GENERATION_OPTS} --skip-gen-reflection
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    COMMENT "Running scripts/generate_code.py..."
-    VERBATIM)
-else()
-  message("No Python3 interpreter found! Unable to generate files automatically.")
-endif()
-
 if(FLATBUFFERS_BUILD_TESTS)
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/tests" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/samples" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
Addresses: #7090

Removes the automatic running of `scripts/generate_code.py` after `flatc` is built.  We already have [CI checks](https://github.com/google/flatbuffers/blob/433312c55aaece880c4ca040439948a28caa6da5/.github/workflows/build.yml#L156-L169) enabled to catch this, and we shouldn't burden most users of flatbuffers which stuff only developers need to do. 