### PR TITLE
Trigger fuzzing CI only on relevant changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,13 @@
 name: CIFuzz
-on: [pull_request]
+on: 
+  pull_request:
+    branches:
+      - master
+    paths:
+      - include/**
+      - src/**
+      - tests/**.cpp
+      - tests/**.h
 jobs:
  Fuzzing:
    runs-on: ubuntu-latest


### PR DESCRIPTION
Fuzzing CI takes too long to run on every pull request, especially if the change has no effect on the fuzzer, which is only for C++ at the moment.