### PR TITLE
[Rust] Add length checks to arrays and vectors.

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatbuffers"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2018"
 authors = ["Robert Winslow <hello@rwinslow.com>", "FlatBuffers Maintainers"]
 license = "Apache-2.0"

--- a/rust/flatbuffers/src/array.rs
+++ b/rust/flatbuffers/src/array.rs
@@ -39,7 +39,7 @@ where
 impl<'a, T: 'a, const N: usize> Array<'a, T, N> {
     #[inline(always)]
     pub fn new(buf: &'a [u8]) -> Self {
-        debug_assert!(size_of::<T>() * N == buf.len());
+        assert!(size_of::<T>() * N == buf.len());
 
         Array {
             0: buf,
@@ -59,7 +59,7 @@ impl<'a, T: 'a, const N: usize> Array<'a, T, N> {
 impl<'a, T: Follow<'a> + 'a, const N: usize> Array<'a, T, N> {
     #[inline(always)]
     pub fn get(&self, idx: usize) -> T::Inner {
-        debug_assert!(idx < N);
+        assert!(idx < N);
         let sz = size_of::<T>();
         T::follow(self.0, sz * idx)
     }

--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -84,7 +84,7 @@ impl<'a, T: 'a> Vector<'a, T> {
 impl<'a, T: Follow<'a> + 'a> Vector<'a, T> {
     #[inline(always)]
     pub fn get(&self, idx: usize) -> T::Inner {
-        debug_assert!(idx < self.len() as usize);
+        assert!(idx < self.len() as usize);
         let sz = size_of::<T>();
         debug_assert!(sz > 0);
         T::follow(self.0, self.1 as usize + SIZE_UOFFSET + sz * idx)

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -61,7 +61,8 @@ mod optional_scalars_generated;
 #[path = "../../arrays_test/mod.rs"]
 mod arrays_test_generated;
 
-#[allow(dead_code, unused_imports)]
+// We use incorrect casing to test keywords.
+#[allow(dead_code, unused_imports, non_camel_case_types, non_snake_case)]
 #[path = "../../keyword_test/mod.rs"]
 mod keyword_test_generated;
 


### PR DESCRIPTION
The previous behavior allowed for out of bounds access in
the public API (Fixes #7011).
