### PR TITLE
Fix missing 'break'

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -424,7 +424,7 @@ std::string ConvertCase(const std::string &input, Case output_case,
     case Case::kUpperCamel:
       return ConvertCase(CamelToSnake(input), output_case);
     case Case::kDasher: return ConvertCase(DasherToSnake(input), output_case);
-    case Case::kKeep: printf("WARNING: Converting from kKeep case.\n");
+    case Case::kKeep: printf("WARNING: Converting from kKeep case.\n"); break;
     default:
     case Case::kSnake:
     case Case::kScreamingSnake:


### PR DESCRIPTION
I forgot to add a `break;` statement when adding a warning in #7144 which broke master :(