### PR TITLE
Nameroverloads

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -160,7 +160,7 @@ class GoGenerator : public BaseGenerator {
   void BeginClass(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "type " + namer_.Type(struct_def.name) + " struct {\n\t";
+    code += "type " + namer_.Type(struct_def) + " struct {\n\t";
 
     // _ is reserved in flatbuffers field names, so no chance of name conflict:
     code += "_tab ";
@@ -171,7 +171,7 @@ class GoGenerator : public BaseGenerator {
   // Construct the name of the type for this enum.
   std::string GetEnumTypeName(const EnumDef &enum_def) {
     return WrapInNameSpaceAndTrack(enum_def.defined_namespace,
-                                   namer_.Type(enum_def.name));
+                                   namer_.Type(enum_def));
   }
 
   // Create a type for the enum values.
@@ -192,7 +192,7 @@ class GoGenerator : public BaseGenerator {
                   size_t max_name_length, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "\t";
-    code += namer_.EnumVariant(enum_def.name, ev.name);
+    code += namer_.EnumVariant(enum_def, ev);
     code += " ";
     code += std::string(max_name_length - ev.name.length(), ' ');
     code += GetEnumTypeName(enum_def);
@@ -219,7 +219,7 @@ class GoGenerator : public BaseGenerator {
                       size_t max_name_length, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "\t";
-    code += namer_.EnumVariant(enum_def.name, ev.name);
+    code += namer_.EnumVariant(enum_def, ev);
     code += ": ";
     code += std::string(max_name_length - ev.name.length(), ' ');
     code += "\"";
@@ -236,7 +236,7 @@ class GoGenerator : public BaseGenerator {
   // Generate String() method on enum type.
   void EnumStringer(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    const std::string enum_type = namer_.Type(enum_def.name);
+    const std::string enum_type = namer_.Type(enum_def);
     code += "func (v " + enum_type + ") String() string {\n";
     code += "\tif s, ok := EnumNames" + enum_type + "[v]; ok {\n";
     code += "\t\treturn s\n";
@@ -250,7 +250,7 @@ class GoGenerator : public BaseGenerator {
   void BeginEnumValues(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "var EnumValues";
-    code += namer_.Type(enum_def.name);
+    code += namer_.Type(enum_def);
     code += " = map[string]" + GetEnumTypeName(enum_def) + "{\n";
   }
 
@@ -262,7 +262,7 @@ class GoGenerator : public BaseGenerator {
     code += ev.name;
     code += "\": ";
     code += std::string(max_name_length - ev.name.length(), ' ');
-    code += namer_.EnumVariant(enum_def.name, ev.name);
+    code += namer_.EnumVariant(enum_def, ev);
     code += ",\n";
   }
 
@@ -277,7 +277,7 @@ class GoGenerator : public BaseGenerator {
                              std::string *code_ptr) {
     std::string &code = *code_ptr;
     const std::string size_prefix[] = { "", "SizePrefixed" };
-    const std::string struct_type = namer_.Type(struct_def.name);
+    const std::string struct_type = namer_.Type(struct_def);
 
     for (int i = 0; i < 2; i++) {
       code += "func Get" + size_prefix[i] + "RootAs" + struct_type;
@@ -336,7 +336,7 @@ class GoGenerator : public BaseGenerator {
     std::string &code = *code_ptr;
 
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name) + "Length(";
+    code += " " + namer_.Function(field) + "Length(";
     code += ") int " + OffsetPrefix(field);
     code += "\t\treturn rcv._tab.VectorLen(o)\n\t}\n";
     code += "\treturn 0\n}\n\n";
@@ -348,7 +348,7 @@ class GoGenerator : public BaseGenerator {
     std::string &code = *code_ptr;
 
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name) + "Bytes(";
+    code += " " + namer_.Function(field) + "Bytes(";
     code += ") []byte " + OffsetPrefix(field);
     code += "\t\treturn rcv._tab.ByteVector(o + rcv._tab.Pos)\n\t}\n";
     code += "\treturn nil\n}\n\n";
@@ -360,7 +360,7 @@ class GoGenerator : public BaseGenerator {
     std::string &code = *code_ptr;
     std::string getter = GenGetter(field.value.type);
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "() " + TypeName(field) + " {\n";
     code += "\treturn " +
             CastToEnum(field.value.type,
@@ -375,7 +375,7 @@ class GoGenerator : public BaseGenerator {
     std::string &code = *code_ptr;
     std::string getter = GenGetter(field.value.type);
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "() " + TypeName(field) + " ";
     code += OffsetPrefix(field);
     if (field.IsScalarOptional()) {
@@ -398,7 +398,7 @@ class GoGenerator : public BaseGenerator {
                               const FieldDef &field, std::string *code_ptr) {
     std::string &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "(obj *" + TypeName(field);
     code += ") *" + TypeName(field);
     code += " {\n";
@@ -417,7 +417,7 @@ class GoGenerator : public BaseGenerator {
                              std::string *code_ptr) {
     std::string &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "(obj *";
     code += TypeName(field);
     code += ") *" + TypeName(field) + " " + OffsetPrefix(field);
@@ -439,7 +439,7 @@ class GoGenerator : public BaseGenerator {
                       std::string *code_ptr) {
     std::string &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "() " + TypeName(field) + " ";
     code += OffsetPrefix(field) + "\t\treturn " + GenGetter(field.value.type);
     code += "(o + rcv._tab.Pos)\n\t}\n\treturn nil\n";
@@ -451,7 +451,7 @@ class GoGenerator : public BaseGenerator {
                      std::string *code_ptr) {
     std::string &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name) + "(";
+    code += " " + namer_.Function(field) + "(";
     code += "obj " + GenTypePointer(field.value.type) + ") bool ";
     code += OffsetPrefix(field);
     code += "\t\t" + GenGetter(field.value.type);
@@ -467,7 +467,7 @@ class GoGenerator : public BaseGenerator {
     auto vectortype = field.value.type.VectorType();
 
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "(obj *" + TypeName(field);
     code += ", j int) bool " + OffsetPrefix(field);
     code += "\t\tx := rcv._tab.Vector(o)\n";
@@ -490,7 +490,7 @@ class GoGenerator : public BaseGenerator {
     auto vectortype = field.value.type.VectorType();
 
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "(j int) " + TypeName(field) + " ";
     code += OffsetPrefix(field);
     code += "\t\ta := rcv._tab.Vector(o)\n";
@@ -538,7 +538,7 @@ class GoGenerator : public BaseGenerator {
       } else {
         std::string &code = *code_ptr;
         code += std::string(", ") + nameprefix;
-        code += namer_.Variable(field.name);
+        code += namer_.Variable(field);
         code += " " + TypeName(field);
       }
     }
@@ -568,7 +568,7 @@ class GoGenerator : public BaseGenerator {
       } else {
         code += "\tbuilder.Prepend" + GenMethod(field) + "(";
         code += CastToBaseType(field.value.type,
-                               nameprefix + namer_.Variable(field.name)) +
+                               nameprefix + namer_.Variable(field)) +
                 ")\n";
       }
     }
@@ -583,7 +583,7 @@ class GoGenerator : public BaseGenerator {
   // Get the value of a table's starting offset.
   void GetStartOfTable(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "func " + namer_.Type(struct_def.name) + "Start";
+    code += "func " + namer_.Type(struct_def) + "Start";
     code += "(builder *flatbuffers.Builder) {\n";
     code += "\tbuilder.StartObject(";
     code += NumToString(struct_def.fields.vec.size());
@@ -594,9 +594,8 @@ class GoGenerator : public BaseGenerator {
   void BuildFieldOfTable(const StructDef &struct_def, const FieldDef &field,
                          const size_t offset, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    const std::string field_var = namer_.Variable(field.name);
-    code += "func " + namer_.Type(struct_def.name) + "Add" +
-            namer_.Function(field.name);
+    const std::string field_var = namer_.Variable(field);
+    code += "func " + namer_.Type(struct_def) + "Add" + namer_.Function(field);
     code += "(builder *flatbuffers.Builder, ";
     code += field_var + " ";
     if (!IsScalar(field.value.type.base_type) && (!struct_def.fixed)) {
@@ -632,8 +631,8 @@ class GoGenerator : public BaseGenerator {
   void BuildVectorOfTable(const StructDef &struct_def, const FieldDef &field,
                           std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "func " + namer_.Type(struct_def.name) + "Start";
-    code += namer_.Function(field.name);
+    code += "func " + namer_.Type(struct_def) + "Start";
+    code += namer_.Function(field);
     code += "Vector(builder *flatbuffers.Builder, numElems int) ";
     code += "flatbuffers.UOffsetT {\n\treturn builder.StartVector(";
     auto vector_type = field.value.type.VectorType();
@@ -647,7 +646,7 @@ class GoGenerator : public BaseGenerator {
   // Get the offset of the end of a table.
   void GetEndOffsetOnTable(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "func " + namer_.Type(struct_def.name) + "End";
+    code += "func " + namer_.Type(struct_def) + "End";
     code += "(builder *flatbuffers.Builder) flatbuffers.UOffsetT ";
     code += "{\n\treturn builder.EndObject()\n}\n";
   }
@@ -655,7 +654,7 @@ class GoGenerator : public BaseGenerator {
   // Generate the receiver for function signatures.
   void GenReceiver(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "func (rcv *" + namer_.Type(struct_def.name) + ")";
+    code += "func (rcv *" + namer_.Type(struct_def) + ")";
   }
 
   // Generate a struct field getter, conditioned on its child type(s).
@@ -708,7 +707,7 @@ class GoGenerator : public BaseGenerator {
     std::string setter =
         "rcv._tab.Mutate" + namer_.Method(GenTypeBasic(field.value.type));
     GenReceiver(struct_def, code_ptr);
-    code += " Mutate" + namer_.Function(field.name);
+    code += " Mutate" + namer_.Function(field);
     code += "(n " + GenTypeGet(field.value.type) + ") bool {\n\treturn " + setter;
     code += "(rcv._tab.Pos+flatbuffers.UOffsetT(";
     code += NumToString(field.value.offset) + "), ";
@@ -722,7 +721,7 @@ class GoGenerator : public BaseGenerator {
     std::string setter = "rcv._tab.Mutate" +
                          namer_.Method(GenTypeBasic(field.value.type)) + "Slot";
     GenReceiver(struct_def, code_ptr);
-    code += " Mutate" + namer_.Function(field.name);
+    code += " Mutate" + namer_.Function(field);
     code += "(n " + GenTypeGet(field.value.type) + ") bool {\n\treturn ";
     code += setter + "(" + NumToString(field.value.offset) + ", ";
     code += CastToBaseType(field.value.type, "n") + ")\n";
@@ -738,7 +737,7 @@ class GoGenerator : public BaseGenerator {
     std::string setter =
         "rcv._tab.Mutate" + namer_.Method(GenTypeBasic(vectortype));
     GenReceiver(struct_def, code_ptr);
-    code += " Mutate" + namer_.Function(field.name);
+    code += " Mutate" + namer_.Function(field);
     code += "(j int, n " + TypeName(field) + ") bool ";
     code += OffsetPrefix(field);
     code += "\t\ta := rcv._tab.Vector(o)\n";
@@ -841,7 +840,7 @@ class GoGenerator : public BaseGenerator {
           field.value.type.enum_def != nullptr &&
           field.value.type.enum_def->is_union)
         continue;
-      code += "\t" + namer_.Field(field.name) + " ";
+      code += "\t" + namer_.Field(field) + " ";
       if (field.IsScalarOptional()) {
         code += "*";
       }
@@ -861,7 +860,7 @@ class GoGenerator : public BaseGenerator {
   void GenNativeUnion(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "type " + NativeName(enum_def) + " struct {\n";
-    code += "\tType " + namer_.Type(enum_def.name) + "\n";
+    code += "\tType " + namer_.Type(enum_def) + "\n";
     code += "\tValue interface{}\n";
     code += "}\n\n";
   }
@@ -877,7 +876,7 @@ class GoGenerator : public BaseGenerator {
          ++it2) {
       const EnumVal &ev = **it2;
       if (ev.IsZero()) continue;
-      code += "\tcase " + namer_.EnumVariant(enum_def.name, ev.name) + ":\n";
+      code += "\tcase " + namer_.EnumVariant(enum_def, ev) + ":\n";
       code += "\t\treturn t.Value.(" + NativeType(ev.union_type) +
               ").Pack(builder)\n";
     }
@@ -889,7 +888,7 @@ class GoGenerator : public BaseGenerator {
   void GenNativeUnionUnPack(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "func (rcv " + namer_.Type(enum_def.name) +
+    code += "func (rcv " + namer_.Type(enum_def) +
             ") UnPack(table flatbuffers.Table) *" + NativeName(enum_def) +
             " {\n";
     code += "\tswitch rcv {\n";
@@ -898,13 +897,13 @@ class GoGenerator : public BaseGenerator {
          ++it2) {
       const EnumVal &ev = **it2;
       if (ev.IsZero()) continue;
-      code += "\tcase " + namer_.EnumVariant(enum_def.name, ev.name) + ":\n";
+      code += "\tcase " + namer_.EnumVariant(enum_def, ev) + ":\n";
       code += "\t\tx := " + ev.union_type.struct_def->name + "{_tab: table}\n";
 
       code += "\t\treturn &" +
               WrapInNameSpaceAndTrack(enum_def.defined_namespace,
                                       NativeName(enum_def)) +
-              "{ Type: " + namer_.EnumVariant(enum_def.name, ev.name) +
+              "{ Type: " + namer_.EnumVariant(enum_def, ev) +
               ", Value: x.UnPack() }\n";
     }
     code += "\t}\n";
@@ -914,7 +913,7 @@ class GoGenerator : public BaseGenerator {
 
   void GenNativeTablePack(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    const std::string struct_type = namer_.Type(struct_def.name);
+    const std::string struct_type = namer_.Type(struct_def);
 
     code += "func (t *" + NativeName(struct_def) +
             ") Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {\n";
@@ -925,8 +924,8 @@ class GoGenerator : public BaseGenerator {
       if (field.deprecated) continue;
       if (IsScalar(field.value.type.base_type)) continue;
 
-      const std::string field_field = namer_.Field(field.name);
-      const std::string field_var = namer_.Variable(field.name);
+      const std::string field_field = namer_.Field(field);
+      const std::string field_var = namer_.Variable(field);
       const std::string offset = field_var + "Offset";
 
       if (IsString(field.value.type)) {
@@ -962,7 +961,7 @@ class GoGenerator : public BaseGenerator {
                   "[j].Pack(builder)\n";
           code += "\t\t}\n";
         }
-        code += "\t\t" + struct_type + "Start" + namer_.Function(field.name) +
+        code += "\t\t" + struct_type + "Start" + namer_.Function(field) +
                 "Vector(builder, " + length + ")\n";
         code += "\t\tfor j := " + length + " - 1; j >= 0; j-- {\n";
         if (IsScalar(field.value.type.element)) {
@@ -996,9 +995,9 @@ class GoGenerator : public BaseGenerator {
          it != struct_def.fields.vec.end(); ++it) {
       const FieldDef &field = **it;
       if (field.deprecated) continue;
-      const std::string field_field = namer_.Field(field.name);
-      const std::string field_fn = namer_.Function(field.name);
-      const std::string offset = namer_.Variable(field.name) + "Offset";
+      const std::string field_field = namer_.Field(field);
+      const std::string field_fn = namer_.Function(field);
+      const std::string offset = namer_.Variable(field) + "Offset";
 
       if (IsScalar(field.value.type.base_type)) {
         std::string prefix;
@@ -1037,7 +1036,7 @@ class GoGenerator : public BaseGenerator {
   void GenNativeTableUnPack(const StructDef &struct_def,
                             std::string *code_ptr) {
     std::string &code = *code_ptr;
-    const std::string struct_type = namer_.Type(struct_def.name);
+    const std::string struct_type = namer_.Type(struct_def);
 
     code += "func (rcv *" + struct_type + ") UnPackTo(t *" +
             NativeName(struct_def) + ") {\n";
@@ -1045,8 +1044,8 @@ class GoGenerator : public BaseGenerator {
          it != struct_def.fields.vec.end(); ++it) {
       const FieldDef &field = **it;
       if (field.deprecated) continue;
-      const std::string field_field = namer_.Field(field.name);
-      const std::string field_var = namer_.Variable(field.name);
+      const std::string field_field = namer_.Field(field);
+      const std::string field_var = namer_.Variable(field);
       const std::string length = field_var + "Length";
       if (IsScalar(field.value.type.base_type)) {
         if (field.value.type.enum_def != nullptr &&
@@ -1089,8 +1088,8 @@ class GoGenerator : public BaseGenerator {
       } else if (field.value.type.base_type == BASE_TYPE_UNION) {
         const std::string field_table = field_var + "Table";
         code += "\t" + field_table + " := flatbuffers.Table{}\n";
-        code += "\tif rcv." + namer_.Method(field.name) + "(&" + field_table +
-                ") {\n";
+        code +=
+            "\tif rcv." + namer_.Method(field) + "(&" + field_table + ") {\n";
         code += "\t\tt." + field_field + " = rcv." +
                 namer_.Method(field.name + UnionTypeFieldSuffix()) +
                 "().UnPack(" + field_table + ")\n";
@@ -1116,7 +1115,7 @@ class GoGenerator : public BaseGenerator {
     code += "func (t *" + NativeName(struct_def) +
             ") Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {\n";
     code += "\tif t == nil { return 0 }\n";
-    code += "\treturn Create" + namer_.Type(struct_def.name) + "(builder";
+    code += "\treturn Create" + namer_.Type(struct_def) + "(builder";
     StructPackArgs(struct_def, "", code_ptr);
     code += ")\n";
     code += "}\n";
@@ -1130,10 +1129,10 @@ class GoGenerator : public BaseGenerator {
       const FieldDef &field = **it;
       if (field.value.type.base_type == BASE_TYPE_STRUCT) {
         StructPackArgs(*field.value.type.struct_def,
-                       (nameprefix + namer_.Field(field.name) + ".").c_str(),
+                       (nameprefix + namer_.Field(field) + ".").c_str(),
                        code_ptr);
       } else {
-        code += std::string(", t.") + nameprefix + namer_.Field(field.name);
+        code += std::string(", t.") + nameprefix + namer_.Field(field);
       }
     }
   }
@@ -1142,22 +1141,22 @@ class GoGenerator : public BaseGenerator {
                              std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "func (rcv *" + namer_.Type(struct_def.name) + ") UnPackTo(t *" +
+    code += "func (rcv *" + namer_.Type(struct_def) + ") UnPackTo(t *" +
             NativeName(struct_def) + ") {\n";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
       const FieldDef &field = **it;
       if (field.value.type.base_type == BASE_TYPE_STRUCT) {
-        code += "\tt." + namer_.Field(field.name) + " = rcv." +
-                namer_.Method(field.name) + "(nil).UnPack()\n";
+        code += "\tt." + namer_.Field(field) + " = rcv." +
+                namer_.Method(field) + "(nil).UnPack()\n";
       } else {
-        code += "\tt." + namer_.Field(field.name) + " = rcv." +
-                namer_.Method(field.name) + "()\n";
+        code += "\tt." + namer_.Field(field) + " = rcv." +
+                namer_.Method(field) + "()\n";
       }
     }
     code += "}\n\n";
 
-    code += "func (rcv *" + namer_.Type(struct_def.name) + ") UnPack() *" +
+    code += "func (rcv *" + namer_.Type(struct_def) + ") UnPack() *" +
             NativeName(struct_def) + " {\n";
     code += "\tif rcv == nil { return nil }\n";
     code += "\tt := &" + NativeName(struct_def) + "{}\n";
@@ -1285,11 +1284,11 @@ class GoGenerator : public BaseGenerator {
   }
 
   std::string NativeName(const StructDef &struct_def) const {
-    return namer_.ObjectType(struct_def.name);
+    return namer_.ObjectType(struct_def);
   }
 
   std::string NativeName(const EnumDef &enum_def) const {
-    return namer_.ObjectType(enum_def.name);
+    return namer_.ObjectType(enum_def);
   }
 
   std::string NativeType(const Type &type) {
@@ -1366,20 +1365,19 @@ class GoGenerator : public BaseGenerator {
     while (code.length() > 2 && code.substr(code.length() - 2) == "\n\n") {
       code.pop_back();
     }
-    std::string filename = namer_.Directories(ns.components) +
-                           namer_.File(def.name, SkipFile::Suffix);
+    std::string filename =
+        namer_.Directories(ns) + namer_.File(def, SkipFile::Suffix);
     return SaveFile(filename.c_str(), code, false);
   }
 
   // Create the full name of the imported namespace (format: A__B__C).
   std::string NamespaceImportName(const Namespace *ns) const {
-    return namer_.Namespace(ns->components);
+    return namer_.Namespace(*ns);
   }
 
   // Create the full path for the imported namespace (format: A/B/C).
   std::string NamespaceImportPath(const Namespace *ns) const {
-    return namer_.Directories(ns->components,
-                              SkipDir::OutputPathAndTrailingPathSeparator);
+    return namer_.Directories(*ns, SkipDir::OutputPathAndTrailingPathSeparator);
   }
 
   // Ensure that a type is prefixed with its go package import name if it is

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -88,7 +88,7 @@ class PythonGenerator : public BaseGenerator {
   // Begin a class declaration.
   void BeginClass(const StructDef &struct_def, std::string *code_ptr) const {
     auto &code = *code_ptr;
-    code += "class " + namer_.Type(struct_def.name) + "(object):\n";
+    code += "class " + namer_.Type(struct_def) + "(object):\n";
     code += Indent + "__slots__ = ['_tab']";
     code += "\n\n";
   }
@@ -96,7 +96,7 @@ class PythonGenerator : public BaseGenerator {
   // Begin enum code with a class declaration.
   void BeginEnum(const EnumDef &enum_def, std::string *code_ptr) const {
     auto &code = *code_ptr;
-    code += "class " + namer_.Type(enum_def.name) + "(object):\n";
+    code += "class " + namer_.Type(enum_def) + "(object):\n";
   }
 
   // Starts a new line and then indents.
@@ -109,7 +109,7 @@ class PythonGenerator : public BaseGenerator {
                   std::string *code_ptr) const {
     auto &code = *code_ptr;
     code += Indent;
-    code += namer_.Variant(ev.name);
+    code += namer_.Variant(ev);
     code += " = ";
     code += enum_def.ToString(ev) + "\n";
   }
@@ -118,7 +118,7 @@ class PythonGenerator : public BaseGenerator {
   void NewRootTypeFromBuffer(const StructDef &struct_def,
                              std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const std::string struct_type = namer_.Type(struct_def.name);
+    const std::string struct_type = namer_.Type(struct_def);
 
     code += Indent + "@classmethod\n";
     code += Indent + "def GetRootAs";
@@ -158,7 +158,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
 
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name) + "Length(self";
+    code += namer_.Method(field) + "Length(self";
     code += "):" + OffsetPrefix(field);
     code += Indent + Indent + Indent + "return self._tab.VectorLen(o)\n";
     code += Indent + Indent + "return 0\n\n";
@@ -170,7 +170,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
 
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name) + "IsNone(self";
+    code += namer_.Method(field) + "IsNone(self";
     code += "):";
     code += GenIndents(2) +
             "o = flatbuffers.number_types.UOffsetTFlags.py_type" +
@@ -186,7 +186,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
     std::string getter = GenGetter(field.value.type);
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self): return " + getter;
     code += "self._tab.Pos + flatbuffers.number_types.UOffsetTFlags.py_type(";
     code += NumToString(field.value.offset) + "))\n";
@@ -198,7 +198,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
     std::string getter = GenGetter(field.value.type);
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self):";
     code += OffsetPrefix(field);
     getter += "o + self._tab.Pos)";
@@ -223,7 +223,7 @@ class PythonGenerator : public BaseGenerator {
                               std::string *code_ptr) const {
     auto &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self, obj):\n";
     code += Indent + Indent + "obj.Init(self._tab.Bytes, self._tab.Pos + ";
     code += NumToString(field.value.offset) + ")";
@@ -236,7 +236,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
     const auto vec_type = field.value.type.VectorType();
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     if (IsStruct(vec_type)) {
       code += "(self, obj, i):\n";
       code += Indent + Indent + "obj.Init(self._tab.Bytes, self._tab.Pos + ";
@@ -260,7 +260,7 @@ class PythonGenerator : public BaseGenerator {
                              std::string *code_ptr) const {
     auto &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self):";
     code += OffsetPrefix(field);
     if (field.value.type.struct_def->fixed) {
@@ -285,7 +285,7 @@ class PythonGenerator : public BaseGenerator {
                       std::string *code_ptr) const {
     auto &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self):";
     code += OffsetPrefix(field);
     code += Indent + Indent + Indent + "return " + GenGetter(field.value.type);
@@ -298,7 +298,7 @@ class PythonGenerator : public BaseGenerator {
                      std::string *code_ptr) const {
     auto &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name) + "(self):";
+    code += namer_.Method(field) + "(self):";
     code += OffsetPrefix(field);
 
     // TODO(rw): this works and is not the good way to it:
@@ -345,7 +345,7 @@ class PythonGenerator : public BaseGenerator {
     auto vectortype = field.value.type.VectorType();
 
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self, j):" + OffsetPrefix(field);
     code += Indent + Indent + Indent + "x = self._tab.Vector(o)\n";
     code += Indent + Indent + Indent;
@@ -374,7 +374,7 @@ class PythonGenerator : public BaseGenerator {
     auto vectortype = field.value.type.VectorType();
 
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self, j):";
     code += OffsetPrefix(field);
     code += Indent + Indent + Indent + "a = self._tab.Vector(o)\n";
@@ -403,7 +403,7 @@ class PythonGenerator : public BaseGenerator {
     if (!(IsScalar(vectortype.base_type))) { return; }
 
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name) + "AsNumpy(self):";
+    code += namer_.Method(field) + "AsNumpy(self):";
     code += OffsetPrefix(field);
 
     code += Indent + Indent + Indent;
@@ -445,7 +445,7 @@ class PythonGenerator : public BaseGenerator {
 
     auto &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name) + "NestedRoot(self):";
+    code += namer_.Method(field) + "NestedRoot(self):";
 
     code += OffsetPrefix(field);
 
@@ -464,7 +464,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
 
     code += "\n";
-    code += "def Create" + namer_.Type(struct_def.name);
+    code += "def Create" + namer_.Type(struct_def);
     code += "(builder";
   }
 
@@ -487,14 +487,14 @@ class PythonGenerator : public BaseGenerator {
         // a nested struct, prefix the name with the field name.
         auto subprefix = nameprefix;
         if (has_field_name) {
-          subprefix += namer_.Field(field.name) + fieldname_suffix;
+          subprefix += namer_.Field(field) + fieldname_suffix;
         }
         StructBuilderArgs(*field.value.type.struct_def, subprefix, namesuffix,
                           has_field_name, fieldname_suffix, code_ptr);
       } else {
         auto &code = *code_ptr;
         code += std::string(", ") + nameprefix;
-        if (has_field_name) { code += namer_.Field(field.name); }
+        if (has_field_name) { code += namer_.Field(field); }
         code += namesuffix;
       }
     }
@@ -526,10 +526,9 @@ class PythonGenerator : public BaseGenerator {
         code +=
             indent + "    builder.Pad(" + NumToString(field.padding) + ")\n";
       if (IsStruct(field_type)) {
-        StructBuilderBody(
-            *field_type.struct_def,
-            (nameprefix + (namer_.Field(field.name) + "_")).c_str(), code_ptr,
-            index, in_array);
+        StructBuilderBody(*field_type.struct_def,
+                          (nameprefix + (namer_.Field(field) + "_")).c_str(),
+                          code_ptr, index, in_array);
       } else {
         const auto index_var = "_idx" + NumToString(index);
         if (IsArray(field_type)) {
@@ -539,14 +538,13 @@ class PythonGenerator : public BaseGenerator {
           in_array = true;
         }
         if (IsStruct(type)) {
-          StructBuilderBody(
-              *field_type.struct_def,
-              (nameprefix + (namer_.Field(field.name) + "_")).c_str(), code_ptr,
-              index + 1, in_array);
+          StructBuilderBody(*field_type.struct_def,
+                            (nameprefix + (namer_.Field(field) + "_")).c_str(),
+                            code_ptr, index + 1, in_array);
         } else {
           code += IsArray(field_type) ? "    " : "";
           code += indent + "    builder.Prepend" + GenMethod(field) + "(";
-          code += nameprefix + namer_.Variable(field.name);
+          code += nameprefix + namer_.Variable(field);
           size_t array_cnt = index + (IsArray(field_type) ? 1 : 0);
           for (size_t i = 0; in_array && i < array_cnt; i++) {
             code += "[_idx" + NumToString(i) + "-1]";
@@ -566,7 +564,7 @@ class PythonGenerator : public BaseGenerator {
   void GetStartOfTable(const StructDef &struct_def,
                        std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto struct_type = namer_.Type(struct_def);
     // Generate method with struct name.
     code += "def " + struct_type + "Start(builder): ";
     code += "builder.StartObject(";
@@ -584,11 +582,11 @@ class PythonGenerator : public BaseGenerator {
   void BuildFieldOfTable(const StructDef &struct_def, const FieldDef &field,
                          const size_t offset, std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const std::string field_var = namer_.Variable(field.name);
-    const std::string field_method = namer_.Method(field.name);
+    const std::string field_var = namer_.Variable(field);
+    const std::string field_method = namer_.Method(field);
 
     // Generate method with struct name.
-    code += "def " + namer_.Type(struct_def.name) + "Add" + field_method;
+    code += "def " + namer_.Type(struct_def) + "Add" + field_method;
     code += "(builder, ";
     code += field_var;
     code += "): ";
@@ -610,8 +608,8 @@ class PythonGenerator : public BaseGenerator {
     if (!parser_.opts.one_file) {
       // Generate method without struct name.
       code += "def Add" + field_method + "(builder, " + field_var + "):\n";
-      code += Indent + "return " + namer_.Type(struct_def.name) + "Add" +
-              field_method;
+      code +=
+          Indent + "return " + namer_.Type(struct_def) + "Add" + field_method;
       code += "(builder, ";
       code += field_var;
       code += ")\n";
@@ -622,8 +620,8 @@ class PythonGenerator : public BaseGenerator {
   void BuildVectorOfTable(const StructDef &struct_def, const FieldDef &field,
                           std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const std::string struct_type = namer_.Type(struct_def.name);
-    const std::string field_method = namer_.Method(field.name);
+    const std::string struct_type = namer_.Type(struct_def);
+    const std::string field_method = namer_.Method(field);
 
     // Generate method with struct name.
     code += "def " + struct_type + "Start" + field_method;
@@ -653,8 +651,8 @@ class PythonGenerator : public BaseGenerator {
     if (!nested) { return; }  // There is no nested flatbuffer.
 
     auto &code = *code_ptr;
-    const std::string field_method = namer_.Method(field.name);
-    const std::string struct_type = namer_.Type(struct_def.name);
+    const std::string field_method = namer_.Method(field);
+    const std::string struct_type = namer_.Type(struct_def);
 
     // Generate method with struct and field name.
     code += "def " + struct_type + "Make" + field_method;
@@ -685,22 +683,21 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
 
     // Generate method with struct name.
-    code += "def " + namer_.Type(struct_def.name) + "End";
+    code += "def " + namer_.Type(struct_def) + "End";
     code += "(builder): ";
     code += "return builder.EndObject()\n";
 
     if (!parser_.opts.one_file) {
       // Generate method without struct name.
       code += "def End(builder):\n";
-      code +=
-          Indent + "return " + namer_.Type(struct_def.name) + "End(builder)";
+      code += Indent + "return " + namer_.Type(struct_def) + "End(builder)";
     }
   }
 
   // Generate the receiver for function signatures.
   void GenReceiver(const StructDef &struct_def, std::string *code_ptr) const {
     auto &code = *code_ptr;
-    code += Indent + "# " + namer_.Type(struct_def.name) + "\n";
+    code += Indent + "# " + namer_.Type(struct_def) + "\n";
     code += Indent + "def ";
   }
 
@@ -795,7 +792,7 @@ class PythonGenerator : public BaseGenerator {
     }
 
     code += Indent + "@classmethod\n";
-    code += Indent + "def " + namer_.Type(struct_def.name);
+    code += Indent + "def " + namer_.Type(struct_def);
     code += "BufferHasIdentifier(cls, buf, offset, size_prefixed=False):";
     code += "\n";
     code += Indent + Indent;
@@ -846,7 +843,7 @@ class PythonGenerator : public BaseGenerator {
   void GenReceiverForObjectAPI(const StructDef &struct_def,
                                std::string *code_ptr) const {
     auto &code = *code_ptr;
-    code += GenIndents(1) + "# " + namer_.ObjectType(struct_def.name);
+    code += GenIndents(1) + "# " + namer_.ObjectType(struct_def);
     code += GenIndents(1) + "def ";
   }
 
@@ -854,7 +851,7 @@ class PythonGenerator : public BaseGenerator {
                               std::string *code_ptr) const {
     auto &code = *code_ptr;
     code += "\n";
-    code += "class " + namer_.ObjectType(struct_def.name) + "(object):";
+    code += "class " + namer_.ObjectType(struct_def) + "(object):";
     code += "\n";
   }
 
@@ -907,7 +904,7 @@ class PythonGenerator : public BaseGenerator {
       std::string field_type;
       switch (ev.union_type.base_type) {
         case BASE_TYPE_STRUCT:
-          field_type = namer_.ObjectType(ev.union_type.struct_def->name);
+          field_type = namer_.ObjectType(*ev.union_type.struct_def);
           if (parser_.opts.include_dependence_headers) {
             auto package_reference = GenPackageReference(ev.union_type);
             field_type = package_reference + "." + field_type;
@@ -939,7 +936,7 @@ class PythonGenerator : public BaseGenerator {
     import_typing_list->insert("Optional");
     auto &output = *out_ptr;
     const Type &type = field.value.type;
-    const std::string object_type = namer_.ObjectType(type.struct_def->name);
+    const std::string object_type = namer_.ObjectType(*type.struct_def);
     if (parser_.opts.include_dependence_headers) {
       auto package_reference = GenPackageReference(type);
       output = package_reference + "." + object_type + "]";
@@ -959,7 +956,7 @@ class PythonGenerator : public BaseGenerator {
     const BaseType base_type = vector_type.base_type;
     if (base_type == BASE_TYPE_STRUCT) {
       const std::string object_type =
-          namer_.ObjectType(GenTypeGet(vector_type));
+          namer_.ObjectType(*vector_type.struct_def);
       field_type = object_type + "]";
       if (parser_.opts.include_dependence_headers) {
         auto package_reference = GenPackageReference(vector_type);
@@ -1007,7 +1004,7 @@ class PythonGenerator : public BaseGenerator {
 
       const auto default_value = GetDefaultValue(field);
       // Wrties the init statement.
-      const auto field_field = namer_.Field(field.name);
+      const auto field_field = namer_.Field(field);
       code += GenIndents(2) + "self." + field_field + " = " + default_value +
               "  # type: " + field_type;
     }
@@ -1052,8 +1049,8 @@ class PythonGenerator : public BaseGenerator {
   void InitializeFromBuf(const StructDef &struct_def,
                          std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto struct_var = namer_.Variable(struct_def.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto struct_var = namer_.Variable(struct_def);
+    const auto struct_type = namer_.Type(struct_def);
 
     code += GenIndents(1) + "@classmethod";
     code += GenIndents(1) + "def InitFromBuf(cls, buf, pos):";
@@ -1066,8 +1063,8 @@ class PythonGenerator : public BaseGenerator {
   void InitializeFromObjForObject(const StructDef &struct_def,
                                   std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto struct_var = namer_.Variable(struct_def.name);
-    const auto struct_object = namer_.ObjectType(struct_def.name);
+    const auto struct_var = namer_.Variable(struct_def);
+    const auto struct_object = namer_.ObjectType(struct_def);
 
     code += GenIndents(1) + "@classmethod";
     code += GenIndents(1) + "def InitFromObj(cls, " + struct_var + "):";
@@ -1080,9 +1077,9 @@ class PythonGenerator : public BaseGenerator {
   void GenUnPackForStruct(const StructDef &struct_def, const FieldDef &field,
                           std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto struct_var = namer_.Variable(struct_def.name);
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
+    const auto struct_var = namer_.Variable(struct_def);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
     auto field_type = TypeName(field);
 
     if (parser_.opts.include_dependence_headers) {
@@ -1108,11 +1105,11 @@ class PythonGenerator : public BaseGenerator {
   void GenUnPackForUnion(const StructDef &struct_def, const FieldDef &field,
                          std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_var = namer_.Variable(struct_def);
     const EnumDef &enum_def = *field.value.type.enum_def;
-    auto union_type = namer_.Namespace(enum_def.name);
+    auto union_type = namer_.Type(enum_def);
 
     if (parser_.opts.include_dependence_headers) {
       union_type = GenPackageReference(enum_def) + "." + union_type;
@@ -1126,9 +1123,9 @@ class PythonGenerator : public BaseGenerator {
                                 const FieldDef &field,
                                 std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_var = namer_.Variable(struct_def);
 
     code += GenIndents(2) + "if not " + struct_var + "." + field_method +
             "IsNone():";
@@ -1160,9 +1157,9 @@ class PythonGenerator : public BaseGenerator {
                                       std::string *code_ptr,
                                       int indents) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_var = namer_.Variable(struct_def);
 
     code += GenIndents(indents) + "self." + field_field + " = []";
     code += GenIndents(indents) + "for i in range(" + struct_var + "." +
@@ -1175,9 +1172,9 @@ class PythonGenerator : public BaseGenerator {
                                 const FieldDef &field,
                                 std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_var = namer_.Variable(struct_def);
 
     code += GenIndents(2) + "if not " + struct_var + "." + field_method +
             "IsNone():";
@@ -1200,9 +1197,9 @@ class PythonGenerator : public BaseGenerator {
   void GenUnPackForScalar(const StructDef &struct_def, const FieldDef &field,
                           std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_var = namer_.Variable(struct_def);
 
     code += GenIndents(2) + "self." + field_field + " = " + struct_var + "." +
             field_method + "()";
@@ -1248,7 +1245,7 @@ class PythonGenerator : public BaseGenerator {
 
     // Writes import statements and code into the generated file.
     auto &code_base = *code_ptr;
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto struct_var = namer_.Variable(struct_def);
 
     GenReceiverForObjectAPI(struct_def, code_ptr);
     code_base += "_UnPack(self, " + struct_var + "):";
@@ -1269,7 +1266,7 @@ class PythonGenerator : public BaseGenerator {
   void GenPackForStruct(const StructDef &struct_def,
                         std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto struct_fn = namer_.Function(struct_def.name);
+    const auto struct_fn = namer_.Function(struct_def);
 
     GenReceiverForObjectAPI(struct_def, code_ptr);
     code += "Pack(self, builder):";
@@ -1289,9 +1286,9 @@ class PythonGenerator : public BaseGenerator {
                                    std::string *code_ptr) const {
     auto &code_prefix = *code_prefix_ptr;
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto struct_type = namer_.Type(struct_def.name);
-    const auto field_method = namer_.Method(field.name);
+    const auto field_field = namer_.Field(field);
+    const auto struct_type = namer_.Type(struct_def);
+    const auto field_method = namer_.Method(field);
 
     // Creates the field.
     code_prefix += GenIndents(2) + "if self." + field_field + " is not None:";
@@ -1332,9 +1329,9 @@ class PythonGenerator : public BaseGenerator {
                                          std::string *code_ptr,
                                          int indents) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_type = namer_.Type(struct_def);
     const auto vectortype = field.value.type.VectorType();
 
     code += GenIndents(indents) + struct_type + "Start" + field_method +
@@ -1368,9 +1365,9 @@ class PythonGenerator : public BaseGenerator {
                                    std::string *code_ptr) const {
     auto &code = *code_ptr;
     auto &code_prefix = *code_prefix_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_type = namer_.Type(struct_def);
 
     // Adds the field into the struct.
     code += GenIndents(2) + "if self." + field_field + " is not None:";
@@ -1411,9 +1408,9 @@ class PythonGenerator : public BaseGenerator {
                              std::string *code_ptr) const {
     auto &code_prefix = *code_prefix_ptr;
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_type = namer_.Type(struct_def);
 
     if (field.value.type.struct_def->fixed) {
       // Pure struct fields need to be created along with their parent
@@ -1438,9 +1435,9 @@ class PythonGenerator : public BaseGenerator {
                             std::string *code_ptr) const {
     auto &code_prefix = *code_prefix_ptr;
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_type = namer_.Type(struct_def);
 
     // TODO(luwa): TypeT should be moved under the None check as well.
     code_prefix += GenIndents(2) + "if self." + field_field + " is not None:";
@@ -1455,8 +1452,8 @@ class PythonGenerator : public BaseGenerator {
                        std::string *code_ptr) const {
     auto &code_base = *code_ptr;
     std::string code, code_prefix;
-    const auto struct_var = namer_.Variable(struct_def.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto struct_var = namer_.Variable(struct_def);
+    const auto struct_type = namer_.Type(struct_def);
 
     GenReceiverForObjectAPI(struct_def, code_ptr);
     code_base += "Pack(self, builder):";
@@ -1466,8 +1463,8 @@ class PythonGenerator : public BaseGenerator {
       auto &field = **it;
       if (field.deprecated) continue;
 
-      const auto field_method = namer_.Method(field.name);
-      const auto field_field = namer_.Field(field.name);
+      const auto field_method = namer_.Method(field);
+      const auto field_field = namer_.Field(field);
 
       switch (field.value.type.base_type) {
         case BASE_TYPE_STRUCT: {
@@ -1555,9 +1552,9 @@ class PythonGenerator : public BaseGenerator {
   void GenUnionCreatorForStruct(const EnumDef &enum_def, const EnumVal &ev,
                                 std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto union_type = namer_.Type(enum_def.name);
-    const auto variant = namer_.Variant(ev.name);
-    auto field_type = namer_.ObjectType(GenTypeGet(ev.union_type));
+    const auto union_type = namer_.Type(enum_def);
+    const auto variant = namer_.Variant(ev);
+    auto field_type = namer_.ObjectType(*ev.union_type.struct_def);
 
     code += GenIndents(1) + "if unionType == " + union_type + "()." +
             variant + ":";
@@ -1573,8 +1570,8 @@ class PythonGenerator : public BaseGenerator {
   void GenUnionCreatorForString(const EnumDef &enum_def, const EnumVal &ev,
                                 std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto union_type = namer_.Type(enum_def.name);
-    const auto variant = namer_.Variant(ev.name);
+    const auto union_type = namer_.Type(enum_def);
+    const auto variant = namer_.Variant(ev);
 
     code += GenIndents(1) + "if unionType == " + union_type + "()." +
             variant + ":";
@@ -1588,7 +1585,7 @@ class PythonGenerator : public BaseGenerator {
     if (enum_def.generated) return;
 
     auto &code = *code_ptr;
-    const auto enum_fn = namer_.Function(enum_def.name);
+    const auto enum_fn = namer_.Function(enum_def);
 
     code += "\n";
     code += "def " + enum_fn + "Creator(unionType, table):";
@@ -1721,7 +1718,7 @@ class PythonGenerator : public BaseGenerator {
       if (parser_.opts.one_file && !enumcode.empty()) {
         *one_file_code += enumcode + "\n\n";
       } else {
-        if (!SaveType(namer_.File(enum_def.name, SkipFile::Suffix),
+        if (!SaveType(namer_.File(enum_def, SkipFile::Suffix),
                       *enum_def.defined_namespace, enumcode, false))
           return false;
       }
@@ -1742,7 +1739,7 @@ class PythonGenerator : public BaseGenerator {
       if (parser_.opts.one_file && !declcode.empty()) {
         *one_file_code += declcode + "\n\n";
       } else {
-        if (!SaveType(namer_.File(struct_def.name, SkipFile::Suffix),
+        if (!SaveType(namer_.File(struct_def, SkipFile::Suffix),
                       *struct_def.defined_namespace, declcode, true))
           return false;
       }

--- a/src/namer.h
+++ b/src/namer.h
@@ -136,10 +136,6 @@ class Namer {
 
   std::string Function(const Definition &s) const { return Function(s.name); }
 
-  std::string Field(const std::string &s) const {
-    return Format(s, config_.fields);
-  }
-
   std::string Field(const FieldDef &s) const { return Field(s.name); }
 
   std::string Variable(const FieldDef &s) const { return Variable(s.name); }
@@ -232,8 +228,16 @@ class Namer {
     }
   }
 
+  // Legacy fields do not really follow the usual config and should be
+  // considered for deprecation.
+
   std::string LegacyRustNativeVariant(const EnumVal &v) const {
     return ConvertCase(EscapeKeyword(v.name), Case::kUpperCamel);
+  }
+
+  std::string LegacyRustFieldOffsetName(const FieldDef& field) const {
+
+    return "VT_" + ConvertCase(EscapeKeyword(field.name), Case::kAllUpper);
   }
 
  private:
@@ -243,6 +247,10 @@ class Namer {
 
   std::string ObjectType(const std::string &s) const {
     return config_.object_prefix + Type(s) + config_.object_suffix;
+  }
+
+  std::string Field(const std::string &s) const {
+    return Format(s, config_.fields);
   }
 
   std::string Variable(const std::string &s) const {

--- a/src/namer.h
+++ b/src/namer.h
@@ -181,6 +181,11 @@ class Namer {
     return Type(def.name);
   }
 
+  std::string NamespacedType(const std::vector<std::string> &ns,
+                             const std::string &s) const {
+    return Namespace(ns) + config_.namespace_seperator + Type(s);
+  }
+
   // Returns `filename` with the right casing, suffix, and extension.
   std::string File(const std::string &filename,
                    SkipFile skips = SkipFile::None) const {
@@ -246,11 +251,6 @@ class Namer {
 
   std::string Variant(const std::string &s) const {
     return Format(s, config_.variants);
-  }
-
-  std::string NamespacedType(const std::vector<std::string> &ns,
-                             const std::string &s) const {
-    return Namespace(ns) + config_.namespace_seperator + Type(s);
   }
 
   std::string Format(const std::string &s, Case casing) const {

--- a/src/namer.h
+++ b/src/namer.h
@@ -112,8 +112,14 @@ class Namer {
   Namer(Config config, std::set<std::string> keywords)
       : config_(config), keywords_(std::move(keywords)) {}
 
-  std::string Type(const std::string &s) const {
-    return Format(s, config_.types);
+  // Types are always structs or enums so we can only expose these two
+  // overloads.
+  std::string Type(const StructDef &d) const { return Type(d.name); }
+
+  std::string Type(const EnumDef &d) const { return Type(d.name); }
+
+  template<typename T> std::string Method(const T &s) const {
+    return Method(s.name);
   }
 
   std::string Method(const std::string &s) const {
@@ -124,29 +130,31 @@ class Namer {
     return Format(s, config_.constants);
   }
 
+  std::string Function(const Definition &s) const { return Function(s.name); }
+
   std::string Function(const std::string &s) const {
     return Format(s, config_.functions);
   }
 
+  std::string Field(const FieldDef &s) const { return Field(s.name); }
   std::string Field(const std::string &s) const {
     return Format(s, config_.fields);
   }
 
-  std::string Variable(const std::string &s) const {
-    return Format(s, config_.variables);
-  }
+  std::string Variable(const FieldDef &s) const { return Variable(s.name); }
 
-  std::string Variant(const std::string &s) const {
-    return Format(s, config_.variants);
-  }
+  std::string Variable(const StructDef &s) const { return Variable(s.name); }
 
-  std::string EnumVariant(const std::string &e, const std::string v) const {
+  std::string Variant(const EnumVal &s) const { return Variant(s.name); }
+
+  std::string EnumVariant(const EnumDef &e, const EnumVal &v) const {
     return Type(e) + config_.enum_variant_seperator + Variant(v);
   }
 
-  std::string ObjectType(const std::string &s) const {
-    return config_.object_prefix + Type(s) + config_.object_suffix;
+  std::string ObjectType(const StructDef &d) const {
+    return ObjectType(d.name);
   }
+  std::string ObjectType(const EnumDef &d) const { return ObjectType(d.name); }
 
   std::string Namespace(const std::string &s) const {
     return Format(s, config_.namespaces);
@@ -161,9 +169,19 @@ class Namer {
     return result;
   }
 
+  std::string Namespace(const struct Namespace &ns) const {
+    return Namespace(ns.components);
+  }
+
   std::string NamespacedType(const std::vector<std::string> &ns,
                              const std::string &s) const {
     return Namespace(ns) + config_.namespace_seperator + Type(s);
+  }
+  std::string NamespacedType(const Definition &def) const {
+    if (def.defined_namespace != nullptr) {
+      return NamespacedType(def.defined_namespace->components, def.name);
+    }
+    return Type(def.name);
   }
 
   // Returns `filename` with the right casing, suffix, and extension.
@@ -175,6 +193,11 @@ class Namer {
            (skip_suffix ? "" : config_.filename_suffix) +
            (skip_ext ? "" : config_.filename_extension);
   }
+  template<typename T>
+  std::string File(const T &f, SkipFile skips = SkipFile::None) const {
+    return File(f.name, skips);
+  }
+
   // Formats `directories` prefixed with the output_path and joined with the
   // right seperator. Output path prefixing and the trailing separator may be
   // skiped using `skips`.
@@ -194,6 +217,11 @@ class Namer {
     return result;
   }
 
+  std::string Directories(const struct Namespace &ns,
+                          SkipDir skips = SkipDir::None) const {
+    return Directories(ns.components, skips);
+  }
+
   std::string EscapeKeyword(const std::string &name) const {
     if (keywords_.find(name) == keywords_.end()) {
       return name;
@@ -202,7 +230,27 @@ class Namer {
     }
   }
 
+  std::string LegacyRustNativeVariant(const EnumVal &v) const {
+    return ConvertCase(EscapeKeyword(v.name), Case::kUpperCamel);
+  }
+
  private:
+  std::string Type(const std::string &s) const {
+    return Format(s, config_.types);
+  }
+
+  std::string ObjectType(const std::string &s) const {
+    return config_.object_prefix + Type(s) + config_.object_suffix;
+  }
+
+  std::string Variable(const std::string &s) const {
+    return Format(s, config_.variables);
+  }
+
+  std::string Variant(const std::string &s) const {
+    return Format(s, config_.variants);
+  }
+
   std::string Format(const std::string &s, Case casing) const {
     // NOTE: If you need to escape keywords after converting case, which would
     // make more sense than this, make it a config option.

--- a/src/namer.h
+++ b/src/namer.h
@@ -130,16 +130,17 @@ class Namer {
     return Format(s, config_.constants);
   }
 
-  std::string Function(const Definition &s) const { return Function(s.name); }
-
   std::string Function(const std::string &s) const {
     return Format(s, config_.functions);
   }
 
-  std::string Field(const FieldDef &s) const { return Field(s.name); }
+  std::string Function(const Definition &s) const { return Function(s.name); }
+
   std::string Field(const std::string &s) const {
     return Format(s, config_.fields);
   }
+
+  std::string Field(const FieldDef &s) const { return Field(s.name); }
 
   std::string Variable(const FieldDef &s) const { return Variable(s.name); }
 
@@ -173,10 +174,6 @@ class Namer {
     return Namespace(ns.components);
   }
 
-  std::string NamespacedType(const std::vector<std::string> &ns,
-                             const std::string &s) const {
-    return Namespace(ns) + config_.namespace_seperator + Type(s);
-  }
   std::string NamespacedType(const Definition &def) const {
     if (def.defined_namespace != nullptr) {
       return NamespacedType(def.defined_namespace->components, def.name);
@@ -249,6 +246,11 @@ class Namer {
 
   std::string Variant(const std::string &s) const {
     return Format(s, config_.variants);
+  }
+
+  std::string NamespacedType(const std::vector<std::string> &ns,
+                             const std::string &s) const {
+    return Namespace(ns) + config_.namespace_seperator + Type(s);
   }
 
   std::string Format(const std::string &s, Case casing) const {


### PR DESCRIPTION
This PR defines and applies overloads to `Namer` as per #7142. 

This allows (and in some cases forces) callers to use types such as `StructDef`, `EnumDef`, or `EnumVal` instead of `std::string`.  The latter required callers to type `.name` a lot. In addition to being more succinct, these overloads are more type safe as there are some methods, e.g. `Namer::Type` which we cannot expect to be called with some sources of strings, e.g. `FieldDef::name`. Accordingly, I tried to make the string-y implementations behind the overloads private when it makes sense.