### PR TITLE
Namersw

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -160,7 +160,7 @@ class GoGenerator : public BaseGenerator {
   void BeginClass(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "type " + namer_.Type(struct_def.name) + " struct {\n\t";
+    code += "type " + namer_.Type(struct_def) + " struct {\n\t";
 
     // _ is reserved in flatbuffers field names, so no chance of name conflict:
     code += "_tab ";
@@ -171,7 +171,7 @@ class GoGenerator : public BaseGenerator {
   // Construct the name of the type for this enum.
   std::string GetEnumTypeName(const EnumDef &enum_def) {
     return WrapInNameSpaceAndTrack(enum_def.defined_namespace,
-                                   namer_.Type(enum_def.name));
+                                   namer_.Type(enum_def));
   }
 
   // Create a type for the enum values.
@@ -192,7 +192,7 @@ class GoGenerator : public BaseGenerator {
                   size_t max_name_length, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "\t";
-    code += namer_.EnumVariant(enum_def.name, ev.name);
+    code += namer_.EnumVariant(enum_def, ev);
     code += " ";
     code += std::string(max_name_length - ev.name.length(), ' ');
     code += GetEnumTypeName(enum_def);
@@ -219,7 +219,7 @@ class GoGenerator : public BaseGenerator {
                       size_t max_name_length, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "\t";
-    code += namer_.EnumVariant(enum_def.name, ev.name);
+    code += namer_.EnumVariant(enum_def, ev);
     code += ": ";
     code += std::string(max_name_length - ev.name.length(), ' ');
     code += "\"";
@@ -236,7 +236,7 @@ class GoGenerator : public BaseGenerator {
   // Generate String() method on enum type.
   void EnumStringer(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    const std::string enum_type = namer_.Type(enum_def.name);
+    const std::string enum_type = namer_.Type(enum_def);
     code += "func (v " + enum_type + ") String() string {\n";
     code += "\tif s, ok := EnumNames" + enum_type + "[v]; ok {\n";
     code += "\t\treturn s\n";
@@ -250,7 +250,7 @@ class GoGenerator : public BaseGenerator {
   void BeginEnumValues(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "var EnumValues";
-    code += namer_.Type(enum_def.name);
+    code += namer_.Type(enum_def);
     code += " = map[string]" + GetEnumTypeName(enum_def) + "{\n";
   }
 
@@ -262,7 +262,7 @@ class GoGenerator : public BaseGenerator {
     code += ev.name;
     code += "\": ";
     code += std::string(max_name_length - ev.name.length(), ' ');
-    code += namer_.EnumVariant(enum_def.name, ev.name);
+    code += namer_.EnumVariant(enum_def, ev);
     code += ",\n";
   }
 
@@ -277,7 +277,7 @@ class GoGenerator : public BaseGenerator {
                              std::string *code_ptr) {
     std::string &code = *code_ptr;
     const std::string size_prefix[] = { "", "SizePrefixed" };
-    const std::string struct_type = namer_.Type(struct_def.name);
+    const std::string struct_type = namer_.Type(struct_def);
 
     for (int i = 0; i < 2; i++) {
       code += "func Get" + size_prefix[i] + "RootAs" + struct_type;
@@ -336,7 +336,7 @@ class GoGenerator : public BaseGenerator {
     std::string &code = *code_ptr;
 
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name) + "Length(";
+    code += " " + namer_.Function(field) + "Length(";
     code += ") int " + OffsetPrefix(field);
     code += "\t\treturn rcv._tab.VectorLen(o)\n\t}\n";
     code += "\treturn 0\n}\n\n";
@@ -348,7 +348,7 @@ class GoGenerator : public BaseGenerator {
     std::string &code = *code_ptr;
 
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name) + "Bytes(";
+    code += " " + namer_.Function(field) + "Bytes(";
     code += ") []byte " + OffsetPrefix(field);
     code += "\t\treturn rcv._tab.ByteVector(o + rcv._tab.Pos)\n\t}\n";
     code += "\treturn nil\n}\n\n";
@@ -360,7 +360,7 @@ class GoGenerator : public BaseGenerator {
     std::string &code = *code_ptr;
     std::string getter = GenGetter(field.value.type);
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "() " + TypeName(field) + " {\n";
     code += "\treturn " +
             CastToEnum(field.value.type,
@@ -375,7 +375,7 @@ class GoGenerator : public BaseGenerator {
     std::string &code = *code_ptr;
     std::string getter = GenGetter(field.value.type);
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "() " + TypeName(field) + " ";
     code += OffsetPrefix(field);
     if (field.IsScalarOptional()) {
@@ -398,7 +398,7 @@ class GoGenerator : public BaseGenerator {
                               const FieldDef &field, std::string *code_ptr) {
     std::string &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "(obj *" + TypeName(field);
     code += ") *" + TypeName(field);
     code += " {\n";
@@ -417,7 +417,7 @@ class GoGenerator : public BaseGenerator {
                              std::string *code_ptr) {
     std::string &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "(obj *";
     code += TypeName(field);
     code += ") *" + TypeName(field) + " " + OffsetPrefix(field);
@@ -439,7 +439,7 @@ class GoGenerator : public BaseGenerator {
                       std::string *code_ptr) {
     std::string &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "() " + TypeName(field) + " ";
     code += OffsetPrefix(field) + "\t\treturn " + GenGetter(field.value.type);
     code += "(o + rcv._tab.Pos)\n\t}\n\treturn nil\n";
@@ -451,7 +451,7 @@ class GoGenerator : public BaseGenerator {
                      std::string *code_ptr) {
     std::string &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name) + "(";
+    code += " " + namer_.Function(field) + "(";
     code += "obj " + GenTypePointer(field.value.type) + ") bool ";
     code += OffsetPrefix(field);
     code += "\t\t" + GenGetter(field.value.type);
@@ -467,7 +467,7 @@ class GoGenerator : public BaseGenerator {
     auto vectortype = field.value.type.VectorType();
 
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "(obj *" + TypeName(field);
     code += ", j int) bool " + OffsetPrefix(field);
     code += "\t\tx := rcv._tab.Vector(o)\n";
@@ -490,7 +490,7 @@ class GoGenerator : public BaseGenerator {
     auto vectortype = field.value.type.VectorType();
 
     GenReceiver(struct_def, code_ptr);
-    code += " " + namer_.Function(field.name);
+    code += " " + namer_.Function(field);
     code += "(j int) " + TypeName(field) + " ";
     code += OffsetPrefix(field);
     code += "\t\ta := rcv._tab.Vector(o)\n";
@@ -538,7 +538,7 @@ class GoGenerator : public BaseGenerator {
       } else {
         std::string &code = *code_ptr;
         code += std::string(", ") + nameprefix;
-        code += namer_.Variable(field.name);
+        code += namer_.Variable(field);
         code += " " + TypeName(field);
       }
     }
@@ -568,7 +568,7 @@ class GoGenerator : public BaseGenerator {
       } else {
         code += "\tbuilder.Prepend" + GenMethod(field) + "(";
         code += CastToBaseType(field.value.type,
-                               nameprefix + namer_.Variable(field.name)) +
+                               nameprefix + namer_.Variable(field)) +
                 ")\n";
       }
     }
@@ -583,7 +583,7 @@ class GoGenerator : public BaseGenerator {
   // Get the value of a table's starting offset.
   void GetStartOfTable(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "func " + namer_.Type(struct_def.name) + "Start";
+    code += "func " + namer_.Type(struct_def) + "Start";
     code += "(builder *flatbuffers.Builder) {\n";
     code += "\tbuilder.StartObject(";
     code += NumToString(struct_def.fields.vec.size());
@@ -594,9 +594,8 @@ class GoGenerator : public BaseGenerator {
   void BuildFieldOfTable(const StructDef &struct_def, const FieldDef &field,
                          const size_t offset, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    const std::string field_var = namer_.Variable(field.name);
-    code += "func " + namer_.Type(struct_def.name) + "Add" +
-            namer_.Function(field.name);
+    const std::string field_var = namer_.Variable(field);
+    code += "func " + namer_.Type(struct_def) + "Add" + namer_.Function(field);
     code += "(builder *flatbuffers.Builder, ";
     code += field_var + " ";
     if (!IsScalar(field.value.type.base_type) && (!struct_def.fixed)) {
@@ -632,8 +631,8 @@ class GoGenerator : public BaseGenerator {
   void BuildVectorOfTable(const StructDef &struct_def, const FieldDef &field,
                           std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "func " + namer_.Type(struct_def.name) + "Start";
-    code += namer_.Function(field.name);
+    code += "func " + namer_.Type(struct_def) + "Start";
+    code += namer_.Function(field);
     code += "Vector(builder *flatbuffers.Builder, numElems int) ";
     code += "flatbuffers.UOffsetT {\n\treturn builder.StartVector(";
     auto vector_type = field.value.type.VectorType();
@@ -647,7 +646,7 @@ class GoGenerator : public BaseGenerator {
   // Get the offset of the end of a table.
   void GetEndOffsetOnTable(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "func " + namer_.Type(struct_def.name) + "End";
+    code += "func " + namer_.Type(struct_def) + "End";
     code += "(builder *flatbuffers.Builder) flatbuffers.UOffsetT ";
     code += "{\n\treturn builder.EndObject()\n}\n";
   }
@@ -655,7 +654,7 @@ class GoGenerator : public BaseGenerator {
   // Generate the receiver for function signatures.
   void GenReceiver(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "func (rcv *" + namer_.Type(struct_def.name) + ")";
+    code += "func (rcv *" + namer_.Type(struct_def) + ")";
   }
 
   // Generate a struct field getter, conditioned on its child type(s).
@@ -708,7 +707,7 @@ class GoGenerator : public BaseGenerator {
     std::string setter =
         "rcv._tab.Mutate" + namer_.Method(GenTypeBasic(field.value.type));
     GenReceiver(struct_def, code_ptr);
-    code += " Mutate" + namer_.Function(field.name);
+    code += " Mutate" + namer_.Function(field);
     code += "(n " + GenTypeGet(field.value.type) + ") bool {\n\treturn " + setter;
     code += "(rcv._tab.Pos+flatbuffers.UOffsetT(";
     code += NumToString(field.value.offset) + "), ";
@@ -722,7 +721,7 @@ class GoGenerator : public BaseGenerator {
     std::string setter = "rcv._tab.Mutate" +
                          namer_.Method(GenTypeBasic(field.value.type)) + "Slot";
     GenReceiver(struct_def, code_ptr);
-    code += " Mutate" + namer_.Function(field.name);
+    code += " Mutate" + namer_.Function(field);
     code += "(n " + GenTypeGet(field.value.type) + ") bool {\n\treturn ";
     code += setter + "(" + NumToString(field.value.offset) + ", ";
     code += CastToBaseType(field.value.type, "n") + ")\n";
@@ -738,7 +737,7 @@ class GoGenerator : public BaseGenerator {
     std::string setter =
         "rcv._tab.Mutate" + namer_.Method(GenTypeBasic(vectortype));
     GenReceiver(struct_def, code_ptr);
-    code += " Mutate" + namer_.Function(field.name);
+    code += " Mutate" + namer_.Function(field);
     code += "(j int, n " + TypeName(field) + ") bool ";
     code += OffsetPrefix(field);
     code += "\t\ta := rcv._tab.Vector(o)\n";
@@ -841,7 +840,7 @@ class GoGenerator : public BaseGenerator {
           field.value.type.enum_def != nullptr &&
           field.value.type.enum_def->is_union)
         continue;
-      code += "\t" + namer_.Field(field.name) + " ";
+      code += "\t" + namer_.Field(field) + " ";
       if (field.IsScalarOptional()) {
         code += "*";
       }
@@ -861,7 +860,7 @@ class GoGenerator : public BaseGenerator {
   void GenNativeUnion(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "type " + NativeName(enum_def) + " struct {\n";
-    code += "\tType " + namer_.Type(enum_def.name) + "\n";
+    code += "\tType " + namer_.Type(enum_def) + "\n";
     code += "\tValue interface{}\n";
     code += "}\n\n";
   }
@@ -877,7 +876,7 @@ class GoGenerator : public BaseGenerator {
          ++it2) {
       const EnumVal &ev = **it2;
       if (ev.IsZero()) continue;
-      code += "\tcase " + namer_.EnumVariant(enum_def.name, ev.name) + ":\n";
+      code += "\tcase " + namer_.EnumVariant(enum_def, ev) + ":\n";
       code += "\t\treturn t.Value.(" + NativeType(ev.union_type) +
               ").Pack(builder)\n";
     }
@@ -889,7 +888,7 @@ class GoGenerator : public BaseGenerator {
   void GenNativeUnionUnPack(const EnumDef &enum_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "func (rcv " + namer_.Type(enum_def.name) +
+    code += "func (rcv " + namer_.Type(enum_def) +
             ") UnPack(table flatbuffers.Table) *" + NativeName(enum_def) +
             " {\n";
     code += "\tswitch rcv {\n";
@@ -898,13 +897,13 @@ class GoGenerator : public BaseGenerator {
          ++it2) {
       const EnumVal &ev = **it2;
       if (ev.IsZero()) continue;
-      code += "\tcase " + namer_.EnumVariant(enum_def.name, ev.name) + ":\n";
+      code += "\tcase " + namer_.EnumVariant(enum_def, ev) + ":\n";
       code += "\t\tx := " + ev.union_type.struct_def->name + "{_tab: table}\n";
 
       code += "\t\treturn &" +
               WrapInNameSpaceAndTrack(enum_def.defined_namespace,
                                       NativeName(enum_def)) +
-              "{ Type: " + namer_.EnumVariant(enum_def.name, ev.name) +
+              "{ Type: " + namer_.EnumVariant(enum_def, ev) +
               ", Value: x.UnPack() }\n";
     }
     code += "\t}\n";
@@ -914,7 +913,7 @@ class GoGenerator : public BaseGenerator {
 
   void GenNativeTablePack(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    const std::string struct_type = namer_.Type(struct_def.name);
+    const std::string struct_type = namer_.Type(struct_def);
 
     code += "func (t *" + NativeName(struct_def) +
             ") Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {\n";
@@ -925,8 +924,8 @@ class GoGenerator : public BaseGenerator {
       if (field.deprecated) continue;
       if (IsScalar(field.value.type.base_type)) continue;
 
-      const std::string field_field = namer_.Field(field.name);
-      const std::string field_var = namer_.Variable(field.name);
+      const std::string field_field = namer_.Field(field);
+      const std::string field_var = namer_.Variable(field);
       const std::string offset = field_var + "Offset";
 
       if (IsString(field.value.type)) {
@@ -962,7 +961,7 @@ class GoGenerator : public BaseGenerator {
                   "[j].Pack(builder)\n";
           code += "\t\t}\n";
         }
-        code += "\t\t" + struct_type + "Start" + namer_.Function(field.name) +
+        code += "\t\t" + struct_type + "Start" + namer_.Function(field) +
                 "Vector(builder, " + length + ")\n";
         code += "\t\tfor j := " + length + " - 1; j >= 0; j-- {\n";
         if (IsScalar(field.value.type.element)) {
@@ -996,9 +995,9 @@ class GoGenerator : public BaseGenerator {
          it != struct_def.fields.vec.end(); ++it) {
       const FieldDef &field = **it;
       if (field.deprecated) continue;
-      const std::string field_field = namer_.Field(field.name);
-      const std::string field_fn = namer_.Function(field.name);
-      const std::string offset = namer_.Variable(field.name) + "Offset";
+      const std::string field_field = namer_.Field(field);
+      const std::string field_fn = namer_.Function(field);
+      const std::string offset = namer_.Variable(field) + "Offset";
 
       if (IsScalar(field.value.type.base_type)) {
         std::string prefix;
@@ -1037,7 +1036,7 @@ class GoGenerator : public BaseGenerator {
   void GenNativeTableUnPack(const StructDef &struct_def,
                             std::string *code_ptr) {
     std::string &code = *code_ptr;
-    const std::string struct_type = namer_.Type(struct_def.name);
+    const std::string struct_type = namer_.Type(struct_def);
 
     code += "func (rcv *" + struct_type + ") UnPackTo(t *" +
             NativeName(struct_def) + ") {\n";
@@ -1045,8 +1044,8 @@ class GoGenerator : public BaseGenerator {
          it != struct_def.fields.vec.end(); ++it) {
       const FieldDef &field = **it;
       if (field.deprecated) continue;
-      const std::string field_field = namer_.Field(field.name);
-      const std::string field_var = namer_.Variable(field.name);
+      const std::string field_field = namer_.Field(field);
+      const std::string field_var = namer_.Variable(field);
       const std::string length = field_var + "Length";
       if (IsScalar(field.value.type.base_type)) {
         if (field.value.type.enum_def != nullptr &&
@@ -1089,8 +1088,8 @@ class GoGenerator : public BaseGenerator {
       } else if (field.value.type.base_type == BASE_TYPE_UNION) {
         const std::string field_table = field_var + "Table";
         code += "\t" + field_table + " := flatbuffers.Table{}\n";
-        code += "\tif rcv." + namer_.Method(field.name) + "(&" + field_table +
-                ") {\n";
+        code +=
+            "\tif rcv." + namer_.Method(field) + "(&" + field_table + ") {\n";
         code += "\t\tt." + field_field + " = rcv." +
                 namer_.Method(field.name + UnionTypeFieldSuffix()) +
                 "().UnPack(" + field_table + ")\n";
@@ -1116,7 +1115,7 @@ class GoGenerator : public BaseGenerator {
     code += "func (t *" + NativeName(struct_def) +
             ") Pack(builder *flatbuffers.Builder) flatbuffers.UOffsetT {\n";
     code += "\tif t == nil { return 0 }\n";
-    code += "\treturn Create" + namer_.Type(struct_def.name) + "(builder";
+    code += "\treturn Create" + namer_.Type(struct_def) + "(builder";
     StructPackArgs(struct_def, "", code_ptr);
     code += ")\n";
     code += "}\n";
@@ -1130,10 +1129,10 @@ class GoGenerator : public BaseGenerator {
       const FieldDef &field = **it;
       if (field.value.type.base_type == BASE_TYPE_STRUCT) {
         StructPackArgs(*field.value.type.struct_def,
-                       (nameprefix + namer_.Field(field.name) + ".").c_str(),
+                       (nameprefix + namer_.Field(field) + ".").c_str(),
                        code_ptr);
       } else {
-        code += std::string(", t.") + nameprefix + namer_.Field(field.name);
+        code += std::string(", t.") + nameprefix + namer_.Field(field);
       }
     }
   }
@@ -1142,22 +1141,22 @@ class GoGenerator : public BaseGenerator {
                              std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += "func (rcv *" + namer_.Type(struct_def.name) + ") UnPackTo(t *" +
+    code += "func (rcv *" + namer_.Type(struct_def) + ") UnPackTo(t *" +
             NativeName(struct_def) + ") {\n";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
       const FieldDef &field = **it;
       if (field.value.type.base_type == BASE_TYPE_STRUCT) {
-        code += "\tt." + namer_.Field(field.name) + " = rcv." +
-                namer_.Method(field.name) + "(nil).UnPack()\n";
+        code += "\tt." + namer_.Field(field) + " = rcv." +
+                namer_.Method(field) + "(nil).UnPack()\n";
       } else {
-        code += "\tt." + namer_.Field(field.name) + " = rcv." +
-                namer_.Method(field.name) + "()\n";
+        code += "\tt." + namer_.Field(field) + " = rcv." +
+                namer_.Method(field) + "()\n";
       }
     }
     code += "}\n\n";
 
-    code += "func (rcv *" + namer_.Type(struct_def.name) + ") UnPack() *" +
+    code += "func (rcv *" + namer_.Type(struct_def) + ") UnPack() *" +
             NativeName(struct_def) + " {\n";
     code += "\tif rcv == nil { return nil }\n";
     code += "\tt := &" + NativeName(struct_def) + "{}\n";
@@ -1285,11 +1284,11 @@ class GoGenerator : public BaseGenerator {
   }
 
   std::string NativeName(const StructDef &struct_def) const {
-    return namer_.ObjectType(struct_def.name);
+    return namer_.ObjectType(struct_def);
   }
 
   std::string NativeName(const EnumDef &enum_def) const {
-    return namer_.ObjectType(enum_def.name);
+    return namer_.ObjectType(enum_def);
   }
 
   std::string NativeType(const Type &type) {
@@ -1366,20 +1365,19 @@ class GoGenerator : public BaseGenerator {
     while (code.length() > 2 && code.substr(code.length() - 2) == "\n\n") {
       code.pop_back();
     }
-    std::string filename = namer_.Directories(ns.components) +
-                           namer_.File(def.name, SkipFile::Suffix);
+    std::string filename =
+        namer_.Directories(ns) + namer_.File(def, SkipFile::Suffix);
     return SaveFile(filename.c_str(), code, false);
   }
 
   // Create the full name of the imported namespace (format: A__B__C).
   std::string NamespaceImportName(const Namespace *ns) const {
-    return namer_.Namespace(ns->components);
+    return namer_.Namespace(*ns);
   }
 
   // Create the full path for the imported namespace (format: A/B/C).
   std::string NamespaceImportPath(const Namespace *ns) const {
-    return namer_.Directories(ns->components,
-                              SkipDir::OutputPathAndTrailingPathSeparator);
+    return namer_.Directories(*ns, SkipDir::OutputPathAndTrailingPathSeparator);
   }
 
   // Ensure that a type is prefixed with its go package import name if it is

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -61,6 +61,7 @@ Namer::Config GoDefaultConfig() {
            /*variables=*/Case::kLowerCamel,
            /*variants=*/Case::kKeep,
            /*enum_variant_seperator=*/"",  // I.e. Concatenate.
+           /*escape_keywords=*/Namer::Config::Escape::BeforeConvertingCase,
            /*namespaces=*/Case::kKeep,
            /*namespace_seperator=*/"__",
            /*object_prefix=*/"",

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -49,6 +49,7 @@ Namer::Config PythonDefaultConfig() {
            /*variable=*/Case::kLowerCamel,
            /*variants=*/Case::kKeep,
            /*enum_variant_seperator=*/".",
+           /*escape_keywords=*/Namer::Config::Escape::BeforeConvertingCase,
            /*namespaces=*/Case::kKeep,  // Packages in python.
            /*namespace_seperator=*/".",
            /*object_prefix=*/"",

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -88,7 +88,7 @@ class PythonGenerator : public BaseGenerator {
   // Begin a class declaration.
   void BeginClass(const StructDef &struct_def, std::string *code_ptr) const {
     auto &code = *code_ptr;
-    code += "class " + namer_.Type(struct_def.name) + "(object):\n";
+    code += "class " + namer_.Type(struct_def) + "(object):\n";
     code += Indent + "__slots__ = ['_tab']";
     code += "\n\n";
   }
@@ -96,7 +96,7 @@ class PythonGenerator : public BaseGenerator {
   // Begin enum code with a class declaration.
   void BeginEnum(const EnumDef &enum_def, std::string *code_ptr) const {
     auto &code = *code_ptr;
-    code += "class " + namer_.Type(enum_def.name) + "(object):\n";
+    code += "class " + namer_.Type(enum_def) + "(object):\n";
   }
 
   // Starts a new line and then indents.
@@ -109,7 +109,7 @@ class PythonGenerator : public BaseGenerator {
                   std::string *code_ptr) const {
     auto &code = *code_ptr;
     code += Indent;
-    code += namer_.Variant(ev.name);
+    code += namer_.Variant(ev);
     code += " = ";
     code += enum_def.ToString(ev) + "\n";
   }
@@ -118,7 +118,7 @@ class PythonGenerator : public BaseGenerator {
   void NewRootTypeFromBuffer(const StructDef &struct_def,
                              std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const std::string struct_type = namer_.Type(struct_def.name);
+    const std::string struct_type = namer_.Type(struct_def);
 
     code += Indent + "@classmethod\n";
     code += Indent + "def GetRootAs";
@@ -158,7 +158,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
 
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name) + "Length(self";
+    code += namer_.Method(field) + "Length(self";
     code += "):" + OffsetPrefix(field);
     code += Indent + Indent + Indent + "return self._tab.VectorLen(o)\n";
     code += Indent + Indent + "return 0\n\n";
@@ -170,7 +170,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
 
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name) + "IsNone(self";
+    code += namer_.Method(field) + "IsNone(self";
     code += "):";
     code += GenIndents(2) +
             "o = flatbuffers.number_types.UOffsetTFlags.py_type" +
@@ -186,7 +186,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
     std::string getter = GenGetter(field.value.type);
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self): return " + getter;
     code += "self._tab.Pos + flatbuffers.number_types.UOffsetTFlags.py_type(";
     code += NumToString(field.value.offset) + "))\n";
@@ -198,7 +198,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
     std::string getter = GenGetter(field.value.type);
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self):";
     code += OffsetPrefix(field);
     getter += "o + self._tab.Pos)";
@@ -223,7 +223,7 @@ class PythonGenerator : public BaseGenerator {
                               std::string *code_ptr) const {
     auto &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self, obj):\n";
     code += Indent + Indent + "obj.Init(self._tab.Bytes, self._tab.Pos + ";
     code += NumToString(field.value.offset) + ")";
@@ -236,7 +236,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
     const auto vec_type = field.value.type.VectorType();
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     if (IsStruct(vec_type)) {
       code += "(self, obj, i):\n";
       code += Indent + Indent + "obj.Init(self._tab.Bytes, self._tab.Pos + ";
@@ -260,7 +260,7 @@ class PythonGenerator : public BaseGenerator {
                              std::string *code_ptr) const {
     auto &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self):";
     code += OffsetPrefix(field);
     if (field.value.type.struct_def->fixed) {
@@ -285,7 +285,7 @@ class PythonGenerator : public BaseGenerator {
                       std::string *code_ptr) const {
     auto &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self):";
     code += OffsetPrefix(field);
     code += Indent + Indent + Indent + "return " + GenGetter(field.value.type);
@@ -298,7 +298,7 @@ class PythonGenerator : public BaseGenerator {
                      std::string *code_ptr) const {
     auto &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name) + "(self):";
+    code += namer_.Method(field) + "(self):";
     code += OffsetPrefix(field);
 
     // TODO(rw): this works and is not the good way to it:
@@ -345,7 +345,7 @@ class PythonGenerator : public BaseGenerator {
     auto vectortype = field.value.type.VectorType();
 
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self, j):" + OffsetPrefix(field);
     code += Indent + Indent + Indent + "x = self._tab.Vector(o)\n";
     code += Indent + Indent + Indent;
@@ -374,7 +374,7 @@ class PythonGenerator : public BaseGenerator {
     auto vectortype = field.value.type.VectorType();
 
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name);
+    code += namer_.Method(field);
     code += "(self, j):";
     code += OffsetPrefix(field);
     code += Indent + Indent + Indent + "a = self._tab.Vector(o)\n";
@@ -403,7 +403,7 @@ class PythonGenerator : public BaseGenerator {
     if (!(IsScalar(vectortype.base_type))) { return; }
 
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name) + "AsNumpy(self):";
+    code += namer_.Method(field) + "AsNumpy(self):";
     code += OffsetPrefix(field);
 
     code += Indent + Indent + Indent;
@@ -445,7 +445,7 @@ class PythonGenerator : public BaseGenerator {
 
     auto &code = *code_ptr;
     GenReceiver(struct_def, code_ptr);
-    code += namer_.Method(field.name) + "NestedRoot(self):";
+    code += namer_.Method(field) + "NestedRoot(self):";
 
     code += OffsetPrefix(field);
 
@@ -464,7 +464,7 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
 
     code += "\n";
-    code += "def Create" + namer_.Type(struct_def.name);
+    code += "def Create" + namer_.Type(struct_def);
     code += "(builder";
   }
 
@@ -487,14 +487,14 @@ class PythonGenerator : public BaseGenerator {
         // a nested struct, prefix the name with the field name.
         auto subprefix = nameprefix;
         if (has_field_name) {
-          subprefix += namer_.Field(field.name) + fieldname_suffix;
+          subprefix += namer_.Field(field) + fieldname_suffix;
         }
         StructBuilderArgs(*field.value.type.struct_def, subprefix, namesuffix,
                           has_field_name, fieldname_suffix, code_ptr);
       } else {
         auto &code = *code_ptr;
         code += std::string(", ") + nameprefix;
-        if (has_field_name) { code += namer_.Field(field.name); }
+        if (has_field_name) { code += namer_.Field(field); }
         code += namesuffix;
       }
     }
@@ -526,10 +526,9 @@ class PythonGenerator : public BaseGenerator {
         code +=
             indent + "    builder.Pad(" + NumToString(field.padding) + ")\n";
       if (IsStruct(field_type)) {
-        StructBuilderBody(
-            *field_type.struct_def,
-            (nameprefix + (namer_.Field(field.name) + "_")).c_str(), code_ptr,
-            index, in_array);
+        StructBuilderBody(*field_type.struct_def,
+                          (nameprefix + (namer_.Field(field) + "_")).c_str(),
+                          code_ptr, index, in_array);
       } else {
         const auto index_var = "_idx" + NumToString(index);
         if (IsArray(field_type)) {
@@ -539,14 +538,13 @@ class PythonGenerator : public BaseGenerator {
           in_array = true;
         }
         if (IsStruct(type)) {
-          StructBuilderBody(
-              *field_type.struct_def,
-              (nameprefix + (namer_.Field(field.name) + "_")).c_str(), code_ptr,
-              index + 1, in_array);
+          StructBuilderBody(*field_type.struct_def,
+                            (nameprefix + (namer_.Field(field) + "_")).c_str(),
+                            code_ptr, index + 1, in_array);
         } else {
           code += IsArray(field_type) ? "    " : "";
           code += indent + "    builder.Prepend" + GenMethod(field) + "(";
-          code += nameprefix + namer_.Variable(field.name);
+          code += nameprefix + namer_.Variable(field);
           size_t array_cnt = index + (IsArray(field_type) ? 1 : 0);
           for (size_t i = 0; in_array && i < array_cnt; i++) {
             code += "[_idx" + NumToString(i) + "-1]";
@@ -566,7 +564,7 @@ class PythonGenerator : public BaseGenerator {
   void GetStartOfTable(const StructDef &struct_def,
                        std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto struct_type = namer_.Type(struct_def);
     // Generate method with struct name.
     code += "def " + struct_type + "Start(builder): ";
     code += "builder.StartObject(";
@@ -584,11 +582,11 @@ class PythonGenerator : public BaseGenerator {
   void BuildFieldOfTable(const StructDef &struct_def, const FieldDef &field,
                          const size_t offset, std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const std::string field_var = namer_.Variable(field.name);
-    const std::string field_method = namer_.Method(field.name);
+    const std::string field_var = namer_.Variable(field);
+    const std::string field_method = namer_.Method(field);
 
     // Generate method with struct name.
-    code += "def " + namer_.Type(struct_def.name) + "Add" + field_method;
+    code += "def " + namer_.Type(struct_def) + "Add" + field_method;
     code += "(builder, ";
     code += field_var;
     code += "): ";
@@ -610,8 +608,8 @@ class PythonGenerator : public BaseGenerator {
     if (!parser_.opts.one_file) {
       // Generate method without struct name.
       code += "def Add" + field_method + "(builder, " + field_var + "):\n";
-      code += Indent + "return " + namer_.Type(struct_def.name) + "Add" +
-              field_method;
+      code +=
+          Indent + "return " + namer_.Type(struct_def) + "Add" + field_method;
       code += "(builder, ";
       code += field_var;
       code += ")\n";
@@ -622,8 +620,8 @@ class PythonGenerator : public BaseGenerator {
   void BuildVectorOfTable(const StructDef &struct_def, const FieldDef &field,
                           std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const std::string struct_type = namer_.Type(struct_def.name);
-    const std::string field_method = namer_.Method(field.name);
+    const std::string struct_type = namer_.Type(struct_def);
+    const std::string field_method = namer_.Method(field);
 
     // Generate method with struct name.
     code += "def " + struct_type + "Start" + field_method;
@@ -653,8 +651,8 @@ class PythonGenerator : public BaseGenerator {
     if (!nested) { return; }  // There is no nested flatbuffer.
 
     auto &code = *code_ptr;
-    const std::string field_method = namer_.Method(field.name);
-    const std::string struct_type = namer_.Type(struct_def.name);
+    const std::string field_method = namer_.Method(field);
+    const std::string struct_type = namer_.Type(struct_def);
 
     // Generate method with struct and field name.
     code += "def " + struct_type + "Make" + field_method;
@@ -685,22 +683,21 @@ class PythonGenerator : public BaseGenerator {
     auto &code = *code_ptr;
 
     // Generate method with struct name.
-    code += "def " + namer_.Type(struct_def.name) + "End";
+    code += "def " + namer_.Type(struct_def) + "End";
     code += "(builder): ";
     code += "return builder.EndObject()\n";
 
     if (!parser_.opts.one_file) {
       // Generate method without struct name.
       code += "def End(builder):\n";
-      code +=
-          Indent + "return " + namer_.Type(struct_def.name) + "End(builder)";
+      code += Indent + "return " + namer_.Type(struct_def) + "End(builder)";
     }
   }
 
   // Generate the receiver for function signatures.
   void GenReceiver(const StructDef &struct_def, std::string *code_ptr) const {
     auto &code = *code_ptr;
-    code += Indent + "# " + namer_.Type(struct_def.name) + "\n";
+    code += Indent + "# " + namer_.Type(struct_def) + "\n";
     code += Indent + "def ";
   }
 
@@ -795,7 +792,7 @@ class PythonGenerator : public BaseGenerator {
     }
 
     code += Indent + "@classmethod\n";
-    code += Indent + "def " + namer_.Type(struct_def.name);
+    code += Indent + "def " + namer_.Type(struct_def);
     code += "BufferHasIdentifier(cls, buf, offset, size_prefixed=False):";
     code += "\n";
     code += Indent + Indent;
@@ -846,7 +843,7 @@ class PythonGenerator : public BaseGenerator {
   void GenReceiverForObjectAPI(const StructDef &struct_def,
                                std::string *code_ptr) const {
     auto &code = *code_ptr;
-    code += GenIndents(1) + "# " + namer_.ObjectType(struct_def.name);
+    code += GenIndents(1) + "# " + namer_.ObjectType(struct_def);
     code += GenIndents(1) + "def ";
   }
 
@@ -854,7 +851,7 @@ class PythonGenerator : public BaseGenerator {
                               std::string *code_ptr) const {
     auto &code = *code_ptr;
     code += "\n";
-    code += "class " + namer_.ObjectType(struct_def.name) + "(object):";
+    code += "class " + namer_.ObjectType(struct_def) + "(object):";
     code += "\n";
   }
 
@@ -907,7 +904,7 @@ class PythonGenerator : public BaseGenerator {
       std::string field_type;
       switch (ev.union_type.base_type) {
         case BASE_TYPE_STRUCT:
-          field_type = namer_.ObjectType(ev.union_type.struct_def->name);
+          field_type = namer_.ObjectType(*ev.union_type.struct_def);
           if (parser_.opts.include_dependence_headers) {
             auto package_reference = GenPackageReference(ev.union_type);
             field_type = package_reference + "." + field_type;
@@ -939,7 +936,7 @@ class PythonGenerator : public BaseGenerator {
     import_typing_list->insert("Optional");
     auto &output = *out_ptr;
     const Type &type = field.value.type;
-    const std::string object_type = namer_.ObjectType(type.struct_def->name);
+    const std::string object_type = namer_.ObjectType(*type.struct_def);
     if (parser_.opts.include_dependence_headers) {
       auto package_reference = GenPackageReference(type);
       output = package_reference + "." + object_type + "]";
@@ -959,7 +956,7 @@ class PythonGenerator : public BaseGenerator {
     const BaseType base_type = vector_type.base_type;
     if (base_type == BASE_TYPE_STRUCT) {
       const std::string object_type =
-          namer_.ObjectType(GenTypeGet(vector_type));
+          namer_.ObjectType(*vector_type.struct_def);
       field_type = object_type + "]";
       if (parser_.opts.include_dependence_headers) {
         auto package_reference = GenPackageReference(vector_type);
@@ -1007,7 +1004,7 @@ class PythonGenerator : public BaseGenerator {
 
       const auto default_value = GetDefaultValue(field);
       // Wrties the init statement.
-      const auto field_field = namer_.Field(field.name);
+      const auto field_field = namer_.Field(field);
       code += GenIndents(2) + "self." + field_field + " = " + default_value +
               "  # type: " + field_type;
     }
@@ -1052,8 +1049,8 @@ class PythonGenerator : public BaseGenerator {
   void InitializeFromBuf(const StructDef &struct_def,
                          std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto struct_var = namer_.Variable(struct_def.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto struct_var = namer_.Variable(struct_def);
+    const auto struct_type = namer_.Type(struct_def);
 
     code += GenIndents(1) + "@classmethod";
     code += GenIndents(1) + "def InitFromBuf(cls, buf, pos):";
@@ -1066,8 +1063,8 @@ class PythonGenerator : public BaseGenerator {
   void InitializeFromObjForObject(const StructDef &struct_def,
                                   std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto struct_var = namer_.Variable(struct_def.name);
-    const auto struct_object = namer_.ObjectType(struct_def.name);
+    const auto struct_var = namer_.Variable(struct_def);
+    const auto struct_object = namer_.ObjectType(struct_def);
 
     code += GenIndents(1) + "@classmethod";
     code += GenIndents(1) + "def InitFromObj(cls, " + struct_var + "):";
@@ -1080,9 +1077,9 @@ class PythonGenerator : public BaseGenerator {
   void GenUnPackForStruct(const StructDef &struct_def, const FieldDef &field,
                           std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto struct_var = namer_.Variable(struct_def.name);
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
+    const auto struct_var = namer_.Variable(struct_def);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
     auto field_type = TypeName(field);
 
     if (parser_.opts.include_dependence_headers) {
@@ -1108,11 +1105,11 @@ class PythonGenerator : public BaseGenerator {
   void GenUnPackForUnion(const StructDef &struct_def, const FieldDef &field,
                          std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_var = namer_.Variable(struct_def);
     const EnumDef &enum_def = *field.value.type.enum_def;
-    auto union_type = namer_.Namespace(enum_def.name);
+    auto union_type = namer_.Type(enum_def);
 
     if (parser_.opts.include_dependence_headers) {
       union_type = GenPackageReference(enum_def) + "." + union_type;
@@ -1126,9 +1123,9 @@ class PythonGenerator : public BaseGenerator {
                                 const FieldDef &field,
                                 std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_var = namer_.Variable(struct_def);
 
     code += GenIndents(2) + "if not " + struct_var + "." + field_method +
             "IsNone():";
@@ -1160,9 +1157,9 @@ class PythonGenerator : public BaseGenerator {
                                       std::string *code_ptr,
                                       int indents) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_var = namer_.Variable(struct_def);
 
     code += GenIndents(indents) + "self." + field_field + " = []";
     code += GenIndents(indents) + "for i in range(" + struct_var + "." +
@@ -1175,9 +1172,9 @@ class PythonGenerator : public BaseGenerator {
                                 const FieldDef &field,
                                 std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_var = namer_.Variable(struct_def);
 
     code += GenIndents(2) + "if not " + struct_var + "." + field_method +
             "IsNone():";
@@ -1200,9 +1197,9 @@ class PythonGenerator : public BaseGenerator {
   void GenUnPackForScalar(const StructDef &struct_def, const FieldDef &field,
                           std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_var = namer_.Variable(struct_def);
 
     code += GenIndents(2) + "self." + field_field + " = " + struct_var + "." +
             field_method + "()";
@@ -1248,7 +1245,7 @@ class PythonGenerator : public BaseGenerator {
 
     // Writes import statements and code into the generated file.
     auto &code_base = *code_ptr;
-    const auto struct_var = namer_.Variable(struct_def.name);
+    const auto struct_var = namer_.Variable(struct_def);
 
     GenReceiverForObjectAPI(struct_def, code_ptr);
     code_base += "_UnPack(self, " + struct_var + "):";
@@ -1269,7 +1266,7 @@ class PythonGenerator : public BaseGenerator {
   void GenPackForStruct(const StructDef &struct_def,
                         std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto struct_fn = namer_.Function(struct_def.name);
+    const auto struct_fn = namer_.Function(struct_def);
 
     GenReceiverForObjectAPI(struct_def, code_ptr);
     code += "Pack(self, builder):";
@@ -1289,9 +1286,9 @@ class PythonGenerator : public BaseGenerator {
                                    std::string *code_ptr) const {
     auto &code_prefix = *code_prefix_ptr;
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto struct_type = namer_.Type(struct_def.name);
-    const auto field_method = namer_.Method(field.name);
+    const auto field_field = namer_.Field(field);
+    const auto struct_type = namer_.Type(struct_def);
+    const auto field_method = namer_.Method(field);
 
     // Creates the field.
     code_prefix += GenIndents(2) + "if self." + field_field + " is not None:";
@@ -1332,9 +1329,9 @@ class PythonGenerator : public BaseGenerator {
                                          std::string *code_ptr,
                                          int indents) const {
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_type = namer_.Type(struct_def);
     const auto vectortype = field.value.type.VectorType();
 
     code += GenIndents(indents) + struct_type + "Start" + field_method +
@@ -1368,9 +1365,9 @@ class PythonGenerator : public BaseGenerator {
                                    std::string *code_ptr) const {
     auto &code = *code_ptr;
     auto &code_prefix = *code_prefix_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_type = namer_.Type(struct_def);
 
     // Adds the field into the struct.
     code += GenIndents(2) + "if self." + field_field + " is not None:";
@@ -1411,9 +1408,9 @@ class PythonGenerator : public BaseGenerator {
                              std::string *code_ptr) const {
     auto &code_prefix = *code_prefix_ptr;
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_type = namer_.Type(struct_def);
 
     if (field.value.type.struct_def->fixed) {
       // Pure struct fields need to be created along with their parent
@@ -1438,9 +1435,9 @@ class PythonGenerator : public BaseGenerator {
                             std::string *code_ptr) const {
     auto &code_prefix = *code_prefix_ptr;
     auto &code = *code_ptr;
-    const auto field_field = namer_.Field(field.name);
-    const auto field_method = namer_.Method(field.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto field_field = namer_.Field(field);
+    const auto field_method = namer_.Method(field);
+    const auto struct_type = namer_.Type(struct_def);
 
     // TODO(luwa): TypeT should be moved under the None check as well.
     code_prefix += GenIndents(2) + "if self." + field_field + " is not None:";
@@ -1455,8 +1452,8 @@ class PythonGenerator : public BaseGenerator {
                        std::string *code_ptr) const {
     auto &code_base = *code_ptr;
     std::string code, code_prefix;
-    const auto struct_var = namer_.Variable(struct_def.name);
-    const auto struct_type = namer_.Type(struct_def.name);
+    const auto struct_var = namer_.Variable(struct_def);
+    const auto struct_type = namer_.Type(struct_def);
 
     GenReceiverForObjectAPI(struct_def, code_ptr);
     code_base += "Pack(self, builder):";
@@ -1466,8 +1463,8 @@ class PythonGenerator : public BaseGenerator {
       auto &field = **it;
       if (field.deprecated) continue;
 
-      const auto field_method = namer_.Method(field.name);
-      const auto field_field = namer_.Field(field.name);
+      const auto field_method = namer_.Method(field);
+      const auto field_field = namer_.Field(field);
 
       switch (field.value.type.base_type) {
         case BASE_TYPE_STRUCT: {
@@ -1555,9 +1552,9 @@ class PythonGenerator : public BaseGenerator {
   void GenUnionCreatorForStruct(const EnumDef &enum_def, const EnumVal &ev,
                                 std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto union_type = namer_.Type(enum_def.name);
-    const auto variant = namer_.Variant(ev.name);
-    auto field_type = namer_.ObjectType(GenTypeGet(ev.union_type));
+    const auto union_type = namer_.Type(enum_def);
+    const auto variant = namer_.Variant(ev);
+    auto field_type = namer_.ObjectType(*ev.union_type.struct_def);
 
     code += GenIndents(1) + "if unionType == " + union_type + "()." +
             variant + ":";
@@ -1573,8 +1570,8 @@ class PythonGenerator : public BaseGenerator {
   void GenUnionCreatorForString(const EnumDef &enum_def, const EnumVal &ev,
                                 std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto union_type = namer_.Type(enum_def.name);
-    const auto variant = namer_.Variant(ev.name);
+    const auto union_type = namer_.Type(enum_def);
+    const auto variant = namer_.Variant(ev);
 
     code += GenIndents(1) + "if unionType == " + union_type + "()." +
             variant + ":";
@@ -1588,7 +1585,7 @@ class PythonGenerator : public BaseGenerator {
     if (enum_def.generated) return;
 
     auto &code = *code_ptr;
-    const auto enum_fn = namer_.Function(enum_def.name);
+    const auto enum_fn = namer_.Function(enum_def);
 
     code += "\n";
     code += "def " + enum_fn + "Creator(unionType, table):";
@@ -1721,7 +1718,7 @@ class PythonGenerator : public BaseGenerator {
       if (parser_.opts.one_file && !enumcode.empty()) {
         *one_file_code += enumcode + "\n\n";
       } else {
-        if (!SaveType(namer_.File(enum_def.name, SkipFile::Suffix),
+        if (!SaveType(namer_.File(enum_def, SkipFile::Suffix),
                       *enum_def.defined_namespace, enumcode, false))
           return false;
       }
@@ -1742,7 +1739,7 @@ class PythonGenerator : public BaseGenerator {
       if (parser_.opts.one_file && !declcode.empty()) {
         *one_file_code += declcode + "\n\n";
       } else {
-        if (!SaveType(namer_.File(struct_def.name, SkipFile::Suffix),
+        if (!SaveType(namer_.File(struct_def, SkipFile::Suffix),
                       *struct_def.defined_namespace, declcode, true))
           return false;
       }

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -37,6 +37,7 @@ Namer::Config RustDefaultConfig() {
            /*variables=*/Case::kUnknown,  // Unused.
            /*variants=*/Case::kKeep,
            /*enum_variant_seperator=*/"::",
+           /*escape_keywords=*/Namer::Config::Escape::BeforeConvertingCase,
            /*namespaces=*/Case::kSnake,
            /*namespace_seperator=*/"::",
            /*object_prefix=*/"",

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -143,7 +143,8 @@ class SwiftGenerator : public BaseGenerator {
 
   // Generates the reader for swift
   void GenStructReader(const StructDef &struct_def) {
-    const bool is_private_access = struct_def.attributes.Lookup("private");
+    const bool is_private_access =
+        struct_def.attributes.Lookup("private") != nullptr;
     code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");
     GenComment(struct_def.doc_comment);
     code_.SetValue("STRUCTNAME", namer_.NamespacedType(struct_def));
@@ -300,7 +301,8 @@ class SwiftGenerator : public BaseGenerator {
 
   // Generates the create function for swift
   void GenStructWriter(const StructDef &struct_def) {
-    const bool is_private_access = struct_def.attributes.Lookup("private");
+    const bool is_private_access =
+        struct_def.attributes.Lookup("private") != nullptr;
     code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");
     code_.SetValue("STRUCTNAME", namer_.NamespacedType(struct_def));
     code_.SetValue("SHORT_STRUCTNAME", namer_.Method(struct_def));
@@ -368,7 +370,8 @@ class SwiftGenerator : public BaseGenerator {
 
   // Generates the reader for swift
   void GenTable(const StructDef &struct_def) {
-    const bool is_private_access = struct_def.attributes.Lookup("private");
+    const bool is_private_access =
+        struct_def.attributes.Lookup("private") != nullptr;
     code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");
     GenObjectHeader(struct_def);
     GenTableAccessors(struct_def);

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -1451,8 +1451,8 @@ class SwiftGenerator : public BaseGenerator {
 
     switch (field.value.type.base_type) {
       case BASE_TYPE_STRUCT: {
-        const auto type = GenType(field.value.type, true);
-        code_.SetValue("VALUETYPE", type);
+        const auto objtype = GenType(field.value.type, true);
+        code_.SetValue("VALUETYPE", objtype);
         const auto optional =
             (field.value.type.struct_def && field.value.type.struct_def->fixed);
         std::string question_mark =
@@ -1460,7 +1460,7 @@ class SwiftGenerator : public BaseGenerator {
 
         code_ +=
             "{{ACCESS_TYPE}} var {{FIELDVAR}}: {{VALUETYPE}}" + question_mark;
-        base_constructor.push_back("" + field_var + " = " + type + "()");
+        base_constructor.push_back("" + field_var + " = " + objtype + "()");
 
         if (field.value.type.struct_def->fixed) {
           buffer_constructor.push_back("" + field_var + " = _t." + field_field);

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -38,7 +38,7 @@ Namer::Config SwiftDefaultConfig() {
            /*enum_variant_seperator=*/".",
            /*escape_keywords=*/Namer::Config::Escape::AfterConvertingCase,
            /*namespaces=*/Case::kKeep,
-           /*namespace_seperator=*/"__",
+           /*namespace_seperator=*/"_",
            /*object_prefix=*/"",
            /*object_suffix=*/"T",
            /*keyword_prefix=*/"",
@@ -72,7 +72,7 @@ inline std::string GenIndirect(const std::string &reading) {
 }
 
 inline std::string GenArrayMainBody(const std::string &optional) {
-  return "{{ACCESS_TYPE}} func {{VALUENAME}}(at index: Int32) -> "
+  return "{{ACCESS_TYPE}} func {{FIELDMETHOD}}(at index: Int32) -> "
          "{{VALUETYPE}}" +
          optional + " { ";
 }
@@ -143,10 +143,10 @@ class SwiftGenerator : public BaseGenerator {
 
   // Generates the reader for swift
   void GenStructReader(const StructDef &struct_def) {
-    auto is_private_access = struct_def.attributes.Lookup("private");
+    const bool is_private_access = struct_def.attributes.Lookup("private");
     code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");
     GenComment(struct_def.doc_comment);
-    code_.SetValue("STRUCTNAME", NameWrappedInNameSpace(struct_def));
+    code_.SetValue("STRUCTNAME", namer_.NamespacedType(struct_def));
     code_ +=
         "{{ACCESS_TYPE}} struct {{STRUCTNAME}}: NativeStruct, Verifiable, "
         "FlatbuffersInitializable\\";
@@ -163,14 +163,14 @@ class SwiftGenerator : public BaseGenerator {
 
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
 
       if (!constructor.empty()) constructor += ", ";
 
-      auto name = namer_.Variable(field.name);
-      auto type = GenType(field.value.type);
-      code_.SetValue("VALUENAME", name);
+      const auto name = namer_.Variable(field);
+      const auto type = GenType(field.value.type);
+      code_.SetValue("FIELDVAR", name);
       if (IsEnum(field.value.type)) {
         code_.SetValue("BASEVALUE", GenTypeBasic(field.value.type, false));
       }
@@ -178,12 +178,13 @@ class SwiftGenerator : public BaseGenerator {
       GenComment(field.doc_comment);
       std::string valueType =
           IsEnum(field.value.type) ? "{{BASEVALUE}}" : "{{VALUETYPE}}";
-      code_ += "private var _{{VALUENAME}}: " + valueType;
-      auto accessing_value = IsEnum(field.value.type) ? ".value" : "";
-      auto is_bool = IsBool(field.value.type.base_type);
-      auto base_value = IsStruct(field.value.type) ? (type + "()")
-        : is_bool ? ("0" == field.value.constant ? "false" : "true")
-        : field.value.constant;
+      code_ += "private var _{{FIELDVAR}}: " + valueType;
+      const auto accessing_value = IsEnum(field.value.type) ? ".value" : "";
+      const auto is_bool = IsBool(field.value.type.base_type);
+      const auto base_value =
+          IsStruct(field.value.type) ? (type + "()")
+          : is_bool ? ("0" == field.value.constant ? "false" : "true")
+                    : field.value.constant;
 
       main_constructor.push_back("_" + name + " = " + name + accessing_value);
       base_constructor.push_back("_" + name + " = " + base_value);
@@ -201,18 +202,16 @@ class SwiftGenerator : public BaseGenerator {
 
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
-      auto name = namer_.Variable(field.name);
-      auto type = GenType(field.value.type);
-      code_.SetValue("VALUENAME", name);
-      code_.SetValue("VALUETYPE", type);
+      code_.SetValue("FIELDVAR", namer_.Variable(field));
+      code_.SetValue("VALUETYPE", GenType(field.value.type));
       GenComment(field.doc_comment);
       if (!IsEnum(field.value.type)) {
-        code_ += GenReaderMainBody() + "_{{VALUENAME}} }";
+        code_ += GenReaderMainBody() + "_{{FIELDVAR}} }";
       } else if (IsEnum(field.value.type)) {
         code_ +=
-            GenReaderMainBody() + "{{VALUETYPE}}(rawValue: _{{VALUENAME}})! }";
+            GenReaderMainBody() + "{{VALUETYPE}}(rawValue: _{{FIELDVAR}})! }";
       }
     }
     code_ += "";
@@ -235,22 +234,21 @@ class SwiftGenerator : public BaseGenerator {
     code_ += "let {{ACCESS}} = Struct(bb: bb, position: o)";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
-      auto name = namer_.Variable(field.name);
-      auto type = field.value.type;
-      code_.SetValue("VALUENAME", name);
+      const auto type = field.value.type;
+      code_.SetValue("FIELDVAR", namer_.Variable(field));
       code_.SetValue("VALUETYPE", GenType(type));
       code_.SetValue("OFFSET", NumToString(field.value.offset));
       if (IsScalar(type.base_type)) {
         if (IsEnum(type))
           code_.SetValue("VALUETYPE", GenTypeBasic(field.value.type, false));
         code_ +=
-            "_{{VALUENAME}} = {{ACCESS}}.readBuffer(of: {{VALUETYPE}}.self, "
+            "_{{FIELDVAR}} = {{ACCESS}}.readBuffer(of: {{VALUETYPE}}.self, "
             "at: {{OFFSET}})";
       } else {
         code_ +=
-            "_{{VALUENAME}} = {{VALUETYPE}}({{ACCESS}}.bb, o: "
+            "_{{FIELDVAR}} = {{VALUETYPE}}({{ACCESS}}.bb, o: "
             "{{ACCESS}}.postion + {{OFFSET}})";
       }
     }
@@ -263,11 +261,11 @@ class SwiftGenerator : public BaseGenerator {
 
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
-      auto offset = NumToString(field.value.offset);
-      auto type = GenType(field.value.type);
-      code_.SetValue("VALUENAME", namer_.Variable(field.name));
+      const auto offset = NumToString(field.value.offset);
+      const auto type = GenType(field.value.type);
+      code_.SetValue("FIELDVAR", namer_.Variable(field));
       if (IsEnum(field.value.type)) {
         code_.SetValue("BASEVALUE", GenTypeBasic(field.value.type, false));
       }
@@ -291,7 +289,7 @@ class SwiftGenerator : public BaseGenerator {
     }
 
     if (parser_.opts.generate_object_based_api) {
-      GenerateObjectAPIExtensionHeader(NameWrappedInNameSpace(struct_def));
+      GenerateObjectAPIExtensionHeader(namer_.NamespacedType(struct_def));
       code_ += "return builder.create(struct: obj)";
       Outdent();
       code_ += "}";
@@ -302,10 +300,10 @@ class SwiftGenerator : public BaseGenerator {
 
   // Generates the create function for swift
   void GenStructWriter(const StructDef &struct_def) {
-    auto is_private_access = struct_def.attributes.Lookup("private");
+    const bool is_private_access = struct_def.attributes.Lookup("private");
     code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");
-    code_.SetValue("STRUCTNAME", NameWrappedInNameSpace(struct_def));
-    code_.SetValue("SHORT_STRUCTNAME", namer_.Method(struct_def.name));
+    code_.SetValue("STRUCTNAME", namer_.NamespacedType(struct_def));
+    code_.SetValue("SHORT_STRUCTNAME", namer_.Method(struct_def));
     code_ += "extension {{STRUCTNAME}} {";
     Indent();
     code_ += "@discardableResult";
@@ -335,7 +333,7 @@ class SwiftGenerator : public BaseGenerator {
     auto &code = *code_ptr;
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
       const auto &field_type = field.value.type;
       if (IsStruct(field.value.type)) {
@@ -343,15 +341,15 @@ class SwiftGenerator : public BaseGenerator {
             *field_type.struct_def, code_ptr, (nameprefix + field.name),
             (object_name + "." + field.name), obj_api_named, is_obj_api);
       } else {
-        auto field_var = namer_.Variable(field.name);
-        auto field_field = namer_.Field(field.name);
-        auto type = GenType(field.value.type);
+        const auto field_var = namer_.Variable(field);
+        const auto field_field = namer_.Field(field);
+        const auto type = GenType(field.value.type);
         if (!is_obj_api) {
           code += nameprefix + field_var + ": " + type;
           if (!IsEnum(field.value.type)) {
             code += " = ";
-            auto is_bool = IsBool(field.value.type.base_type);
-            auto constant =
+            const auto is_bool = IsBool(field.value.type.base_type);
+            const auto constant =
                 is_bool ? ("0" == field.value.constant ? "false" : "true")
                         : field.value.constant;
             code += constant;
@@ -370,7 +368,7 @@ class SwiftGenerator : public BaseGenerator {
 
   // Generates the reader for swift
   void GenTable(const StructDef &struct_def) {
-    auto is_private_access = struct_def.attributes.Lookup("private");
+    const bool is_private_access = struct_def.attributes.Lookup("private");
     code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");
     GenObjectHeader(struct_def);
     GenTableAccessors(struct_def);
@@ -395,7 +393,7 @@ class SwiftGenerator : public BaseGenerator {
            it != struct_def.fields.vec.end(); ++it) {
         const auto &field = **it;
         if (field.deprecated) { continue; }
-        code_.SetValue("OFFSET_NAME", namer_.Variable(field.name));
+        code_.SetValue("OFFSET_NAME", namer_.Variable(field));
         code_.SetValue("OFFSET_VALUE", NumToString(field.value.offset));
         code_ += "case {{OFFSET_NAME}} = {{OFFSET_VALUE}}";
       }
@@ -410,8 +408,8 @@ class SwiftGenerator : public BaseGenerator {
   void GenObjectHeader(const StructDef &struct_def) {
     GenComment(struct_def.doc_comment);
 
-    code_.SetValue("SHORT_STRUCTNAME", namer_.Type(struct_def.name));
-    code_.SetValue("STRUCTNAME", NameWrappedInNameSpace(struct_def));
+    code_.SetValue("SHORT_STRUCTNAME", namer_.Type(struct_def));
+    code_.SetValue("STRUCTNAME", namer_.NamespacedType(struct_def));
     code_.SetValue("OBJECTTYPE", struct_def.fixed ? "Struct" : "Table");
     code_.SetValue("MUTABLE", struct_def.fixed ? Mutable() : "");
     code_ +=
@@ -455,7 +453,7 @@ class SwiftGenerator : public BaseGenerator {
     std::vector<std::string> require_fields;
     std::vector<std::string> create_func_body;
     std::vector<std::string> create_func_header;
-    auto should_generate_create = struct_def.fields.vec.size() != 0;
+    const auto should_generate_create = struct_def.fields.vec.size() != 0;
 
     code_.SetValue("NUMBEROFFIELDS", NumToString(struct_def.fields.vec.size()));
     code_ +=
@@ -515,14 +513,12 @@ class SwiftGenerator : public BaseGenerator {
     std::string spacing = "";
 
     if (key_field != nullptr && !struct_def.fixed && struct_def.has_key) {
-      code_.SetValue("VALUENAME", NameWrappedInNameSpace(struct_def));
-      code_.SetValue("SHORT_VALUENAME", namer_.Type(struct_def.name));
       code_.SetValue("VOFFSET", NumToString(key_field->value.offset));
 
-      code_ +=
-          "{{ACCESS_TYPE}} static func "
-          "sortVectorOf{{SHORT_VALUENAME}}(offsets:[Offset], "
-          "_ fbb: inout FlatBufferBuilder) -> Offset {";
+      code_ += "{{ACCESS_TYPE}} static func " +
+               namer_.Method("sort_vector_of_" + struct_def.name) +
+               "(offsets:[Offset], "
+               "_ fbb: inout FlatBufferBuilder) -> Offset {";
       Indent();
       code_ += spacing + "var off = offsets";
       code_ +=
@@ -533,7 +529,7 @@ class SwiftGenerator : public BaseGenerator {
       code_ += spacing + "return fbb.createVector(ofOffsets: off)";
       Outdent();
       code_ += "}";
-      GenLookup(*key_field);
+      GenLookup(*key_field, namer_.NamespacedType(struct_def));
     }
   }
 
@@ -543,43 +539,44 @@ class SwiftGenerator : public BaseGenerator {
     std::string builder_string = ", _ fbb: inout FlatBufferBuilder) { ";
     auto &create_func_body = *create_body;
     auto &create_func_header = *create_header;
-    // DO NOT SUBMIT: Overloaded kind of name.
-    auto name = namer_.Field(field.name);
-    auto type = GenType(field.value.type);
-    auto opt_scalar =
+    const auto field_field = namer_.Field(field);
+    const auto field_var = namer_.Variable(field);
+    const auto type = GenType(field.value.type);
+    const auto opt_scalar =
         field.IsOptional() && IsScalar(field.value.type.base_type);
-    auto nullable_type = opt_scalar ? type + "?" : type;
-    code_.SetValue("VALUENAME", namer_.Variable(field.name));
+    const auto nullable_type = opt_scalar ? type + "?" : type;
+    code_.SetValue("FIELDVAR", namer_.Variable(field));
     code_.SetValue("VALUETYPE", nullable_type);
-    code_.SetValue("OFFSET", namer_.Field(field.name));
+    code_.SetValue("OFFSET", namer_.Field(field));
     code_.SetValue("CONSTANT", field.value.constant);
     std::string check_if_vector =
         (IsVector(field.value.type) || IsArray(field.value.type)) ? "VectorOf("
                                                                   : "(";
-    auto body = "add" + check_if_vector + name + ": ";
+    const auto body = "add" + check_if_vector + field_field + ": ";
     code_ += "{{ACCESS_TYPE}} static func " + body + "\\";
 
-    create_func_body.push_back("{{STRUCTNAME}}." + body + name + ", &fbb)");
+    create_func_body.push_back("{{STRUCTNAME}}." + body + field_field +
+                               ", &fbb)");
 
     if (IsScalar(field.value.type.base_type) &&
         !IsBool(field.value.type.base_type)) {
-      std::string is_enum = IsEnum(field.value.type) ? ".rawValue" : "";
-      std::string optional_enum =
+      const std::string is_enum = IsEnum(field.value.type) ? ".rawValue" : "";
+      const std::string optional_enum =
           IsEnum(field.value.type) ? ("?" + is_enum) : "";
       code_ +=
-          "{{VALUETYPE}}" + builder_string + "fbb.add(element: {{VALUENAME}}\\";
+          "{{VALUETYPE}}" + builder_string + "fbb.add(element: {{FIELDVAR}}\\";
 
       code_ += field.IsOptional() ? (optional_enum + "\\")
                                   : (is_enum + ", def: {{CONSTANT}}\\");
 
       code_ += ", at: {{TABLEOFFSET}}.{{OFFSET}}.p) }";
 
-      auto default_value =
+      const auto default_value =
           IsEnum(field.value.type)
               ? (field.IsOptional() ? "nil" : GenEnumDefaultValue(field))
               : field.value.constant;
       create_func_header.push_back(
-          "" + name + ": " + nullable_type + " = " +
+          "" + field_field + ": " + nullable_type + " = " +
           (field.IsOptional() ? "nil" : default_value));
       return;
     }
@@ -590,48 +587,48 @@ class SwiftGenerator : public BaseGenerator {
 
       code_.SetValue("CONSTANT", default_value);
       code_.SetValue("VALUETYPE", field.IsOptional() ? "Bool?" : "Bool");
-      code_ += "{{VALUETYPE}}" + builder_string +
-               "fbb.add(element: {{VALUENAME}},\\";
+      code_ +=
+          "{{VALUETYPE}}" + builder_string + "fbb.add(element: {{FIELDVAR}},\\";
       code_ += field.IsOptional() ? "\\" : " def: {{CONSTANT}},";
       code_ += " at: {{TABLEOFFSET}}.{{OFFSET}}.p) }";
       create_func_header.push_back(
-          name + ": " + nullable_type + " = " +
+          field_var + ": " + nullable_type + " = " +
           (field.IsOptional() ? "nil" : default_value));
       return;
     }
 
     if (IsStruct(field.value.type)) {
-      auto create_struct =
-          "guard let {{VALUENAME}} = {{VALUENAME}} else { return };"
-          " fbb.create(struct: {{VALUENAME}}, position: "
+      const auto create_struct =
+          "guard let {{FIELDVAR}} = {{FIELDVAR}} else { return };"
+          " fbb.create(struct: {{FIELDVAR}}, position: "
           "{{TABLEOFFSET}}.{{OFFSET}}.p) }";
       code_ += type + "?" + builder_string + create_struct;
       /// Optional hard coded since structs are always optional
-      create_func_header.push_back(name + ": " + type + "? = nil");
+      create_func_header.push_back(field_var + ": " + type + "? = nil");
       return;
     }
 
-    auto camel_case_name =
-        ConvertCase(name, Case::kLowerCamel) +
+    const auto arg_label =
+        namer_.Variable(field) +
         (IsVector(field.value.type) || IsArray(field.value.type)
              ? "VectorOffset"
              : "Offset");
-    create_func_header.push_back(camel_case_name + " " + name + ": " +
+    create_func_header.push_back(arg_label + " " + field_var + ": " +
                                  "Offset = Offset()");
-    auto reader_type =
+    const auto reader_type =
         IsStruct(field.value.type) && field.value.type.struct_def->fixed
             ? "structOffset: {{TABLEOFFSET}}.{{OFFSET}}.p) }"
-            : "offset: {{VALUENAME}}, at: {{TABLEOFFSET}}.{{OFFSET}}.p) }";
+            : "offset: {{FIELDVAR}}, at: {{TABLEOFFSET}}.{{OFFSET}}.p) }";
     code_ += "Offset" + builder_string + "fbb.add(" + reader_type;
 
-    auto vectortype = field.value.type.VectorType();
+    const auto vectortype = field.value.type.VectorType();
 
     if ((vectortype.base_type == BASE_TYPE_STRUCT &&
          field.value.type.struct_def->fixed) &&
         (IsVector(field.value.type) || IsArray(field.value.type))) {
-      auto field_name = NameWrappedInNameSpace(*vectortype.struct_def);
-      code_ += "public static func startVectorOf" +
-               ConvertCase(name, Case::kUpperCamel) +
+      const auto field_name = namer_.NamespacedType(*vectortype.struct_def);
+      code_ += "public static func " +
+               namer_.Method("start_vector_of_" + field_var) +
                "(_ size: Int, in builder: inout "
                "FlatBufferBuilder) {";
       Indent();
@@ -646,17 +643,18 @@ class SwiftGenerator : public BaseGenerator {
   void GenTableReader(const StructDef &struct_def) {
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
       GenTableReaderFields(field);
     }
   }
 
   void GenTableReaderFields(const FieldDef &field) {
-    auto offset = NumToString(field.value.offset);
-    auto name = namer_.Field(field.name);
-    auto type = GenType(field.value.type);
-    code_.SetValue("VALUENAME", namer_.Variable(field.name));
+    const auto offset = NumToString(field.value.offset);
+    const auto field_field = namer_.Field(field);
+    const auto type = GenType(field.value.type);
+    code_.SetValue("FIELDVAR", namer_.Variable(field));
+    code_.SetValue("FIELDMETHOD", namer_.Method(field));
     code_.SetValue("VALUETYPE", type);
     code_.SetValue("OFFSET", namer_.Constant(field.name));
     code_.SetValue("CONSTANT", field.value.constant);
@@ -664,7 +662,7 @@ class SwiftGenerator : public BaseGenerator {
         field.IsOptional() && IsScalar(field.value.type.base_type);
     std::string def_Val = opt_scalar ? "nil" : "{{CONSTANT}}";
     std::string optional = opt_scalar ? "?" : "";
-    auto const_string = "return o == 0 ? " + def_Val + " : ";
+    const auto const_string = "return o == 0 ? " + def_Val + " : ";
     GenComment(field.doc_comment);
     if (IsScalar(field.value.type.base_type) && !IsEnum(field.value.type) &&
         !IsBool(field.value.type.base_type)) {
@@ -689,7 +687,7 @@ class SwiftGenerator : public BaseGenerator {
     }
 
     if (IsEnum(field.value.type)) {
-      auto default_value =
+      const auto default_value =
           field.IsOptional() ? "nil" : GenEnumDefaultValue(field);
       code_.SetValue("BASEVALUE", GenTypeBasic(field.value.type, false));
       code_ += GenReaderMainBody(optional) + "\\";
@@ -700,16 +698,15 @@ class SwiftGenerator : public BaseGenerator {
       return;
     }
 
-    std::string is_required = field.IsRequired() ? "!" : "?";
-    auto required_reader = field.IsRequired() ? "return " : const_string;
+    const std::string is_required = field.IsRequired() ? "!" : "?";
+    const auto required_reader = field.IsRequired() ? "return " : const_string;
 
     if (IsStruct(field.value.type) && field.value.type.struct_def->fixed) {
       code_.SetValue("VALUETYPE", GenType(field.value.type));
       code_.SetValue("CONSTANT", "nil");
       code_ += GenReaderMainBody(is_required) + GenOffset() + required_reader +
                "{{ACCESS}}.readBuffer(of: {{VALUETYPE}}.self, at: o) }";
-      code_.SetValue("VALUENAME",
-                     "mutable" + ConvertCase(name, Case::kUpperCamel));
+      code_.SetValue("FIELDVAR", namer_.Variable("mutable_" + field_field));
       code_.SetValue("VALUETYPE", GenType(field.value.type) + Mutable());
       code_.SetValue("CONSTANT", "nil");
       code_ += GenReaderMainBody(is_required) + GenOffset() + required_reader +
@@ -726,12 +723,12 @@ class SwiftGenerator : public BaseGenerator {
         break;
 
       case BASE_TYPE_STRING: {
-        auto default_string = "\"" + field.value.constant + "\"";
+        const auto default_string = "\"" + field.value.constant + "\"";
         code_.SetValue("VALUETYPE", GenType(field.value.type));
         code_.SetValue("CONSTANT", field.IsDefault() ? default_string : "nil");
         code_ += GenReaderMainBody(is_required) + GenOffset() +
                  required_reader + "{{ACCESS}}.string(at: o) }";
-        code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}SegmentArray: [UInt8]" +
+        code_ += "{{ACCESS_TYPE}} var {{FIELDVAR}}SegmentArray: [UInt8]" +
                  is_required +
                  " { return "
                  "{{ACCESS}}.getVector(at: {{TABLEOFFSET}}.{{OFFSET}}.v) }";
@@ -742,7 +739,7 @@ class SwiftGenerator : public BaseGenerator {
       case BASE_TYPE_UNION:
         code_.SetValue("CONSTANT", "nil");
         code_ +=
-            "{{ACCESS_TYPE}} func {{VALUENAME}}<T: "
+            "{{ACCESS_TYPE}} func {{FIELDVAR}}<T: "
             "FlatbuffersInitializable>(type: "
             "T.Type) -> T" +
             is_required + " { " + GenOffset() + required_reader +
@@ -754,20 +751,19 @@ class SwiftGenerator : public BaseGenerator {
 
   void GenTableReaderVectorFields(const FieldDef &field) {
     std::string const_string = "return o == 0 ? {{CONSTANT}} : ";
-    auto vectortype = field.value.type.VectorType();
+    const auto vectortype = field.value.type.VectorType();
     code_.SetValue("SIZE", NumToString(InlineSize(vectortype)));
-    code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}Count: Int32 { " + GenOffset() +
+    code_ += "{{ACCESS_TYPE}} var {{FIELDVAR}}Count: Int32 { " + GenOffset() +
              "return o == 0 ? 0 : {{ACCESS}}.vector(count: o) }";
-    code_.SetValue("CONSTANT",
-                   IsScalar(vectortype.base_type) == true ? "0" : "nil");
-    auto nullable = IsScalar(vectortype.base_type) == true ? "" : "?";
-    nullable = IsEnum(vectortype) == true ? "?" : nullable;
+    code_.SetValue("CONSTANT", IsScalar(vectortype.base_type) ? "0" : "nil");
+    const auto nullable =
+        IsScalar(vectortype.base_type) && !IsEnum(vectortype) ? "" : "?";
 
     if (vectortype.base_type != BASE_TYPE_UNION) {
       code_ += GenArrayMainBody(nullable) + GenOffset() + "\\";
     } else {
       code_ +=
-          "{{ACCESS_TYPE}} func {{VALUENAME}}<T: FlatbuffersInitializable>(at "
+          "{{ACCESS_TYPE}} func {{FIELDVAR}}<T: FlatbuffersInitializable>(at "
           "index: "
           "Int32, type: T.Type) -> T? { " +
           GenOffset() + "\\";
@@ -786,7 +782,7 @@ class SwiftGenerator : public BaseGenerator {
           "{{ACCESS}}.directRead(of: {{VALUETYPE}}.self, offset: "
           "{{ACCESS}}.vector(at: o) + index * {{SIZE}}) }";
       code_ +=
-          "{{ACCESS_TYPE}} var {{VALUENAME}}: [{{VALUETYPE}}] { return "
+          "{{ACCESS_TYPE}} var {{FIELDVAR}}: [{{VALUETYPE}}] { return "
           "{{ACCESS}}.getVector(at: {{TABLEOFFSET}}.{{OFFSET}}.v) ?? [] }";
       if (parser_.opts.mutable_buffer) code_ += GenMutateArray();
       return;
@@ -797,8 +793,7 @@ class SwiftGenerator : public BaseGenerator {
       code_ +=
           "{{ACCESS}}.directRead(of: {{VALUETYPE}}.self, offset: "
           "{{ACCESS}}.vector(at: o) + index * {{SIZE}}) }";
-      code_.SetValue("VALUENAME",
-                     "mutable" + ConvertCase(namer_.Field(field.name), Case::kUpperCamel));
+      code_.SetValue("FIELDMETHOD", namer_.Method("mutable_" + field.name));
       code_.SetValue("VALUETYPE", GenType(field.value.type) + Mutable());
       code_ += GenArrayMainBody(nullable) + GenOffset() + const_string +
                GenConstructor("{{ACCESS}}.vector(at: o) + index * {{SIZE}}");
@@ -833,10 +828,10 @@ class SwiftGenerator : public BaseGenerator {
       code_ += GenConstructor(
           "{{ACCESS}}.indirect({{ACCESS}}.vector(at: o) + index * "
           "{{SIZE}})");
-      auto &sd = *field.value.type.struct_def;
-      auto &fields = sd.fields.vec;
+      const auto &sd = *field.value.type.struct_def;
+      const auto &fields = sd.fields.vec;
       for (auto kit = fields.begin(); kit != fields.end(); ++kit) {
-        auto &key_field = **kit;
+        const auto &key_field = **kit;
         if (key_field.key) {
           GenByKeyFunctions(key_field);
           break;
@@ -850,12 +845,12 @@ class SwiftGenerator : public BaseGenerator {
     Indent();
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
 
       code_.SetValue("RAWVALUENAME", field.name);
-      code_.SetValue("VALUENAME", namer_.Variable(field.name));
-      code_ += "case {{VALUENAME}} = \"{{RAWVALUENAME}}\"";
+      code_.SetValue("FIELDVAR", namer_.Variable(field));
+      code_ += "case {{FIELDVAR}} = \"{{RAWVALUENAME}}\"";
     }
     Outdent();
     code_ += "}";
@@ -863,8 +858,8 @@ class SwiftGenerator : public BaseGenerator {
 
   void GenerateEncoderUnionBody(const FieldDef &field) {
     EnumDef &union_def = *field.value.type.enum_def;
-    auto is_vector = field.value.type.base_type == BASE_TYPE_VECTOR ||
-                     field.value.type.base_type == BASE_TYPE_ARRAY;
+    const auto is_vector = field.value.type.base_type == BASE_TYPE_VECTOR ||
+                           field.value.type.base_type == BASE_TYPE_ARRAY;
     if (field.value.type.base_type == BASE_TYPE_UTYPE ||
         (is_vector &&
          field.value.type.VectorType().base_type == BASE_TYPE_UTYPE))
@@ -872,28 +867,25 @@ class SwiftGenerator : public BaseGenerator {
     if (is_vector) {
       code_ +=
           "var enumsEncoder = container.nestedUnkeyedContainer(forKey: "
-          ".{{VALUENAME}}Type)";
+          ".{{FIELDVAR}}Type)";
       code_ +=
           "var contentEncoder = container.nestedUnkeyedContainer(forKey: "
-          ".{{VALUENAME}})";
-      code_ += "for index in 0..<{{VALUENAME}}Count {";
+          ".{{FIELDVAR}})";
+      code_ += "for index in 0..<{{FIELDVAR}}Count {";
       Indent();
-      code_ +=
-          "guard let type = {{VALUENAME}}Type(at: index) else { continue }";
+      code_ += "guard let type = {{FIELDVAR}}Type(at: index) else { continue }";
       code_ += "try enumsEncoder.encode(type)";
       code_ += "switch type {";
       for (auto it = union_def.Vals().begin(); it != union_def.Vals().end();
            ++it) {
         const auto &ev = **it;
-
-        auto name = namer_.LegacySwiftVariant(ev);
-        auto type = GenType(ev.union_type);
-        code_.SetValue("KEY", name);
+        const auto type = GenType(ev.union_type);
+        code_.SetValue("KEY", namer_.LegacySwiftVariant(ev));
         code_.SetValue("VALUETYPE", type);
         if (ev.union_type.base_type == BASE_TYPE_NONE) { continue; }
         code_ += "case .{{KEY}}:";
         Indent();
-        code_ += "let _v = {{VALUENAME}}(at: index, type: {{VALUETYPE}}.self)";
+        code_ += "let _v = {{FIELDVAR}}(at: index, type: {{VALUETYPE}}.self)";
         code_ += "try contentEncoder.encode(_v)";
         Outdent();
       }
@@ -904,20 +896,18 @@ class SwiftGenerator : public BaseGenerator {
       return;
     }
 
-    code_ += "switch {{VALUENAME}}Type {";
+    code_ += "switch {{FIELDVAR}}Type {";
     for (auto it = union_def.Vals().begin(); it != union_def.Vals().end();
          ++it) {
       const auto &ev = **it;
-
-      auto name = namer_.LegacySwiftVariant(ev);
-      auto type = GenType(ev.union_type);
-      code_.SetValue("KEY", name);
+      const auto type = GenType(ev.union_type);
+      code_.SetValue("KEY", namer_.LegacySwiftVariant(ev));
       code_.SetValue("VALUETYPE", type);
       if (ev.union_type.base_type == BASE_TYPE_NONE) { continue; }
       code_ += "case .{{KEY}}:";
       Indent();
-      code_ += "let _v = {{VALUENAME}}(type: {{VALUETYPE}}.self)";
-      code_ += "try container.encodeIfPresent(_v, forKey: .{{VALUENAME}})";
+      code_ += "let _v = {{FIELDVAR}}(type: {{VALUETYPE}}.self)";
+      code_ += "try container.encodeIfPresent(_v, forKey: .{{FIELDVAR}})";
       Outdent();
     }
     code_ += "default: break;";
@@ -928,33 +918,31 @@ class SwiftGenerator : public BaseGenerator {
     code_ += "var container = encoder.container(keyedBy: CodingKeys.self)";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
-      auto name = namer_.Variable(field.name);
-      auto type = field.value.type;
+      const auto type = field.value.type;
 
-      auto is_non_union_vector =
+      const auto is_non_union_vector =
           (field.value.type.base_type == BASE_TYPE_ARRAY ||
            field.value.type.base_type == BASE_TYPE_VECTOR) &&
           field.value.type.VectorType().base_type != BASE_TYPE_UTYPE;
 
-      code_.SetValue("RAWVALUENAME", field.name);
-      code_.SetValue("VALUENAME", name);
+      code_.SetValue("FIELDVAR", namer_.Variable(field));
       code_.SetValue("CONSTANT", field.value.constant);
       bool should_indent = true;
       if (is_non_union_vector) {
-        code_ += "if {{VALUENAME}}Count > 0 {";
+        code_ += "if {{FIELDVAR}}Count > 0 {";
       } else if (IsEnum(type) && !field.IsOptional()) {
         code_.SetValue("CONSTANT", GenEnumDefaultValue(field));
-        code_ += "if {{VALUENAME}} != {{CONSTANT}} {";
+        code_ += "if {{FIELDVAR}} != {{CONSTANT}} {";
       } else if (IsScalar(type.base_type) && !IsEnum(type) &&
                  !IsBool(type.base_type) && !field.IsOptional()) {
-        code_ += "if {{VALUENAME}} != {{CONSTANT}} {";
+        code_ += "if {{FIELDVAR}} != {{CONSTANT}} {";
       } else if (IsBool(type.base_type) && !field.IsOptional()) {
         std::string default_value =
             "0" == field.value.constant ? "false" : "true";
         code_.SetValue("CONSTANT", default_value);
-        code_ += "if {{VALUENAME}} != {{CONSTANT}} {";
+        code_ += "if {{FIELDVAR}} != {{CONSTANT}} {";
       } else {
         should_indent = false;
       }
@@ -967,17 +955,17 @@ class SwiftGenerator : public BaseGenerator {
                   IsEnum(type.VectorType()))) {
         code_ +=
             "var contentEncoder = container.nestedUnkeyedContainer(forKey: "
-            ".{{VALUENAME}})";
-        code_ += "for index in 0..<{{VALUENAME}}Count {";
+            ".{{FIELDVAR}})";
+        code_ += "for index in 0..<{{FIELDVAR}}Count {";
         Indent();
-        code_ += "guard let type = {{VALUENAME}}(at: index) else { continue }";
+        code_ += "guard let type = {{FIELDVAR}}(at: index) else { continue }";
         code_ += "try contentEncoder.encode(type)";
         Outdent();
         code_ += "}";
       } else {
         code_ +=
-            "try container.encodeIfPresent({{VALUENAME}}, forKey: "
-            ".{{VALUENAME}})";
+            "try container.encodeIfPresent({{FIELDVAR}}, forKey: "
+            ".{{FIELDVAR}})";
       }
       if (should_indent) Outdent();
 
@@ -1012,13 +1000,13 @@ class SwiftGenerator : public BaseGenerator {
     code_ += "var _v = try verifier.visitTable(at: position)";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
-      auto offset = NumToString(field.value.offset);
+      const auto offset = NumToString(field.value.offset);
 
-      code_.SetValue("VALUENAME", namer_.Variable(field.name));
+      code_.SetValue("FIELDVAR", namer_.Variable(field));
       code_.SetValue("VALUETYPE", GenerateVerifierType(field));
-      code_.SetValue("OFFSET", namer_.Field(field.name));
+      code_.SetValue("OFFSET", namer_.Field(field));
       code_.SetValue("ISREQUIRED", field.IsRequired() ? "true" : "false");
 
       if (IsUnion(field.value.type)) {
@@ -1028,7 +1016,7 @@ class SwiftGenerator : public BaseGenerator {
 
       code_ +=
           "try _v.visit(field: {{TABLEOFFSET}}.{{OFFSET}}.p, fieldName: "
-          "\"{{VALUENAME}}\", required: {{ISREQUIRED}}, type: "
+          "\"{{FIELDVAR}}\", required: {{ISREQUIRED}}, type: "
           "{{VALUETYPE}}.self)";
     }
     code_ += "_v.finish()";
@@ -1037,28 +1025,27 @@ class SwiftGenerator : public BaseGenerator {
   }
 
   void GenerateUnionTypeVerifier(const FieldDef &field) {
-    auto is_vector = IsVector(field.value.type) || IsArray(field.value.type);
+    const auto is_vector =
+        IsVector(field.value.type) || IsArray(field.value.type);
     if (field.value.type.base_type == BASE_TYPE_UTYPE ||
         (is_vector &&
          field.value.type.VectorType().base_type == BASE_TYPE_UTYPE))
       return;
     EnumDef &union_def = *field.value.type.enum_def;
-    code_.SetValue("VALUETYPE", NameWrappedInNameSpace(union_def));
+    code_.SetValue("VALUETYPE", namer_.NamespacedType(union_def));
     code_.SetValue("FUNCTION_NAME", is_vector ? "visitUnionVector" : "visit");
     code_ +=
         "try _v.{{FUNCTION_NAME}}(unionKey: {{TABLEOFFSET}}.{{OFFSET}}Type.p, "
         "unionField: {{TABLEOFFSET}}.{{OFFSET}}.p, unionKeyName: "
-        "\"{{VALUENAME}}Type\", fieldName: \"{{VALUENAME}}\", required: "
+        "\"{{FIELDVAR}}Type\", fieldName: \"{{FIELDVAR}}\", required: "
         "{{ISREQUIRED}}, completion: { (verifier, key: {{VALUETYPE}}, pos) in";
     Indent();
     code_ += "switch key {";
     for (auto it = union_def.Vals().begin(); it != union_def.Vals().end();
          ++it) {
       const auto &ev = **it;
-
-      auto name = namer_.LegacySwiftVariant(ev);
-      auto type = GenType(ev.union_type);
-      code_.SetValue("KEY", name);
+      const auto type = GenType(ev.union_type);
+      code_.SetValue("KEY", namer_.LegacySwiftVariant(ev));
       code_.SetValue("VALUETYPE", type);
       code_ += "case .{{KEY}}:";
       Indent();
@@ -1084,11 +1071,11 @@ class SwiftGenerator : public BaseGenerator {
   }
 
   std::string GenerateVerifierType(const FieldDef &field) {
-    auto type = field.value.type;
-    auto is_vector = IsVector(type) || IsArray(type);
+    const auto type = field.value.type;
+    const auto is_vector = IsVector(type) || IsArray(type);
 
     if (is_vector) {
-      auto vector_type = field.value.type.VectorType();
+      const auto vector_type = field.value.type.VectorType();
       return "ForwardOffset<Vector<" +
              GenerateNestedVerifierTypes(vector_type) + ", " +
              GenType(vector_type) + ">>";
@@ -1098,7 +1085,7 @@ class SwiftGenerator : public BaseGenerator {
   }
 
   std::string GenerateNestedVerifierTypes(const Type &type) {
-    auto string_type = GenType(type);
+    const auto string_type = GenType(type);
 
     if (IsScalar(type.base_type)) { return string_type; }
 
@@ -1112,7 +1099,7 @@ class SwiftGenerator : public BaseGenerator {
   void GenByKeyFunctions(const FieldDef &key_field) {
     code_.SetValue("TYPE", GenType(key_field.value.type));
     code_ +=
-        "{{ACCESS_TYPE}} func {{VALUENAME}}By(key: {{TYPE}}) -> {{VALUETYPE}}? "
+        "{{ACCESS_TYPE}} func {{FIELDVAR}}By(key: {{TYPE}}) -> {{VALUETYPE}}? "
         "{ \\";
     code_ += GenOffset() +
              "return o == 0 ? nil : {{VALUETYPE}}.lookupByKey(vector: "
@@ -1121,11 +1108,11 @@ class SwiftGenerator : public BaseGenerator {
 
   void GenEnum(const EnumDef &enum_def) {
     if (enum_def.generated) return;
-    auto is_private_access = enum_def.attributes.Lookup("private");
+    const auto is_private_access = enum_def.attributes.Lookup("private");
     code_.SetValue("ENUM_TYPE",
                    enum_def.is_union ? "UnionEnum" : "Enum, Verifiable");
     code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");
-    code_.SetValue("ENUM_NAME", NameWrappedInNameSpace(enum_def));
+    code_.SetValue("ENUM_NAME", namer_.NamespacedType(enum_def));
     code_.SetValue("BASE_TYPE", GenTypeBasic(enum_def.underlying_type, false));
     GenComment(enum_def.doc_comment);
     code_ +=
@@ -1148,8 +1135,7 @@ class SwiftGenerator : public BaseGenerator {
         "{{ACCESS_TYPE}} var value: {{BASE_TYPE}} { return self.rawValue }";
     for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
       const auto &ev = **it;
-      auto name = namer_.LegacySwiftVariant(ev);
-      code_.SetValue("KEY", name);
+      code_.SetValue("KEY", namer_.LegacySwiftVariant(ev));
       code_.SetValue("VALUE", enum_def.ToString(ev));
       GenComment(ev.doc_comment);
       code_ += "case {{KEY}} = {{VALUE}}";
@@ -1194,8 +1180,7 @@ class SwiftGenerator : public BaseGenerator {
     code_ += "switch self {";
     for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
       const auto &ev = **it;
-      auto name = namer_.LegacySwiftVariant(ev);
-      code_.SetValue("KEY", name);
+      code_.SetValue("KEY", namer_.LegacySwiftVariant(ev));
       code_.SetValue("RAWKEY", ev.name);
       code_ += "case .{{KEY}}: try container.encode(\"{{RAWKEY}}\")";
     }
@@ -1208,18 +1193,18 @@ class SwiftGenerator : public BaseGenerator {
 
   // MARK: - Object API
 
-  void GenerateObjectAPIExtensionHeader(std::string name) {
+  void GenerateObjectAPIExtensionHeader(std::string type_name) {
     code_ += "\n";
-    code_ += "{{ACCESS_TYPE}} mutating func unpack() -> " + name + " {";
+    code_ += "{{ACCESS_TYPE}} mutating func unpack() -> " + type_name + " {";
     Indent();
-    code_ += "return " + name + "(&self)";
+    code_ += "return " + type_name + "(&self)";
     Outdent();
     code_ += "}";
     code_ +=
         "{{ACCESS_TYPE}} static func pack(_ builder: inout FlatBufferBuilder, "
         "obj: "
         "inout " +
-        name + "?) -> Offset {";
+        type_name + "?) -> Offset {";
     Indent();
     code_ += "guard var obj = obj else { return Offset() }";
     code_ += "return pack(&builder, obj: &obj)";
@@ -1230,7 +1215,7 @@ class SwiftGenerator : public BaseGenerator {
         "{{ACCESS_TYPE}} static func pack(_ builder: inout FlatBufferBuilder, "
         "obj: "
         "inout " +
-        name + ") -> Offset {";
+        type_name + ") -> Offset {";
     Indent();
   }
 
@@ -1240,40 +1225,39 @@ class SwiftGenerator : public BaseGenerator {
     Indent();
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
 
-      auto name = namer_.Variable(field.name);
-      auto type = GenType(field.value.type);
-      code_.SetValue("VALUENAME", name);
+      const auto type = GenType(field.value.type);
+      code_.SetValue("FIELDVAR", namer_.Variable(field));
       if (IsStruct(field.value.type)) {
-        code_ += "var _v{{VALUENAME}} = _t.{{VALUENAME}}";
-        code_ += "_{{VALUENAME}} = _v{{VALUENAME}}.unpack()";
+        code_ += "var _v{{FIELDVAR}} = _t.{{FIELDVAR}}";
+        code_ += "_{{FIELDVAR}} = _v{{FIELDVAR}}.unpack()";
         continue;
       }
       std::string is_enum = IsEnum(field.value.type) ? ".value" : "";
-      code_ += "_{{VALUENAME}} = _t.{{VALUENAME}}" + is_enum;
+      code_ += "_{{FIELDVAR}} = _t.{{FIELDVAR}}" + is_enum;
     }
     Outdent();
     code_ += "}\n";
   }
 
   void GenObjectAPI(const StructDef &struct_def) {
-    code_ += "{{ACCESS_TYPE}} class " + ObjectAPIName("{{STRUCTNAME}}") +
-             ": NativeObject {\n";
+    code_ += "{{ACCESS_TYPE}} class " +
+             namer_.NamespacedObjectType(struct_def) + ": NativeObject {\n";
     std::vector<std::string> buffer_constructor;
     std::vector<std::string> base_constructor;
     Indent();
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
       BuildObjectAPIConstructorBody(field, struct_def.fixed, buffer_constructor,
                                     base_constructor);
     }
     code_ += "";
     BuildObjectConstructor(buffer_constructor,
-                           "_ _t: inout " + NameWrappedInNameSpace(struct_def));
+                           "_ _t: inout " + namer_.NamespacedType(struct_def));
     BuildObjectConstructor(base_constructor);
     if (!struct_def.fixed)
       code_ +=
@@ -1285,35 +1269,37 @@ class SwiftGenerator : public BaseGenerator {
   }
 
   void GenerateObjectAPITableExtension(const StructDef &struct_def) {
-    GenerateObjectAPIExtensionHeader(ObjectAPIName("{{STRUCTNAME}}"));
+    GenerateObjectAPIExtensionHeader(namer_.NamespacedObjectType(struct_def));
     std::vector<std::string> unpack_body;
     std::string builder = ", &builder)";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
-      auto name = namer_.Variable(field.name);
-      auto type = GenType(field.value.type);
+      const auto field_var = namer_.Variable(field);
+      const auto field_field = namer_.Field(field);
+      const auto field_method = namer_.Method(field);
+      const auto type = GenType(field.value.type);
       std::string check_if_vector =
           (IsVector(field.value.type) || IsArray(field.value.type))
               ? "VectorOf("
               : "(";
-      std::string body = "add" + check_if_vector + name + ": ";
+      std::string body = "add" + check_if_vector + field_method + ": ";
       switch (field.value.type.base_type) {
         case BASE_TYPE_ARRAY: FLATBUFFERS_FALLTHROUGH();
         case BASE_TYPE_VECTOR: {
-          GenerateVectorObjectAPITableExtension(field, name, type);
-          unpack_body.push_back("{{STRUCTNAME}}." + body + "__" + name +
+          GenerateVectorObjectAPITableExtension(field);
+          unpack_body.push_back("{{STRUCTNAME}}." + body + "__" + field_var +
                                 builder);
           break;
         }
         case BASE_TYPE_UNION: {
-          code_ += "let __" + name + " = obj." + name +
+          code_ += "let __" + field_var + " = obj." + field_var +
                    "?.pack(builder: &builder) ?? Offset()";
-          unpack_body.push_back("if let o = obj." + name + "?.type {");
-          unpack_body.push_back("  {{STRUCTNAME}}.add(" + name + "Type: o" +
-                                builder);
-          unpack_body.push_back("  {{STRUCTNAME}}." + body + "__" + name +
+          unpack_body.push_back("if let o = obj." + field_var + "?.type {");
+          unpack_body.push_back("  {{STRUCTNAME}}.add(" + field_var +
+                                "Type: o" + builder);
+          unpack_body.push_back("  {{STRUCTNAME}}." + body + "__" + field_var +
                                 builder);
           unpack_body.push_back("}\n");
           break;
@@ -1327,31 +1313,31 @@ class SwiftGenerator : public BaseGenerator {
             GenerateStructArgs(*field.value.type.struct_def, &code, "", "",
                                "$0", true);
             code = code.substr(0, code.size() - 2);
-            unpack_body.push_back("{{STRUCTNAME}}." + body + "obj." + name +
-                                  builder);
+            unpack_body.push_back("{{STRUCTNAME}}." + body + "obj." +
+                                  field_field + builder);
           } else {
-            code_ += "let __" + name + " = " + type +
-                     ".pack(&builder, obj: &obj." + name + ")";
-            unpack_body.push_back("{{STRUCTNAME}}." + body + "__" + name +
+            code_ += "let __" + field_var + " = " + type +
+                     ".pack(&builder, obj: &obj." + field_field + ")";
+            unpack_body.push_back("{{STRUCTNAME}}." + body + "__" + field_var +
                                   builder);
           }
           break;
         }
         case BASE_TYPE_STRING: {
-          unpack_body.push_back("{{STRUCTNAME}}." + body + "__" + name +
+          unpack_body.push_back("{{STRUCTNAME}}." + body + "__" + field_var +
                                 builder);
           if (field.IsRequired()) {
-            code_ +=
-                "let __" + name + " = builder.create(string: obj." + name + ")";
+            code_ += "let __" + field_var + " = builder.create(string: obj." +
+                     field_field + ")";
           } else {
-            BuildingOptionalObjects(name, "builder.create(string: s)");
+            BuildingOptionalObjects(field_field, "builder.create(string: s)");
           }
           break;
         }
         case BASE_TYPE_UTYPE: break;
         default:
-          unpack_body.push_back("{{STRUCTNAME}}." + body + "obj." + name +
-                                builder);
+          unpack_body.push_back("{{STRUCTNAME}}." + body + "obj." +
+                                field_field + builder);
       }
     }
     code_ += "let __root = {{STRUCTNAME}}.start{{SHORT_STRUCTNAME}}(&builder)";
@@ -1364,64 +1350,64 @@ class SwiftGenerator : public BaseGenerator {
     code_ += "}";
   }
 
-  void GenerateVectorObjectAPITableExtension(const FieldDef &field,
-                                             const std::string &name,
-                                             const std::string &type) {
-    auto vectortype = field.value.type.VectorType();
+  void GenerateVectorObjectAPITableExtension(const FieldDef &field_def) {
+    const Type &field_type = field_def.value.type;
+    const auto type = GenType(field_type);
+    const auto var = namer_.Variable(field_def);
+    const auto field = namer_.Field(field_def);
+
+    const auto vectortype = field_type.VectorType();
     switch (vectortype.base_type) {
       case BASE_TYPE_UNION: {
-        code_ += "var __" + name + "__: [Offset] = []";
-        code_ += "for i in obj." + name + " {";
+        code_ += "var __" + var + "__: [Offset] = []";
+        code_ += "for i in obj." + var + " {";
         Indent();
         code_ += "guard let off = i?.pack(builder: &builder) else { continue }";
-        code_ += "__" + name + "__.append(off)";
+        code_ += "__" + var + "__.append(off)";
         Outdent();
         code_ += "}";
-        code_ += "let __" + name + " = builder.createVector(ofOffsets: __" +
-                 name + "__)";
-        code_ += "let __" + name + "Type = builder.createVector(obj." + name +
+        code_ += "let __" + var + " = builder.createVector(ofOffsets: __" +
+                 var + "__)";
+        code_ += "let __" + var + "Type = builder.createVector(obj." + field +
                  ".compactMap { $0?.type })";
         break;
       }
       case BASE_TYPE_UTYPE: break;
       case BASE_TYPE_STRUCT: {
-        if (field.value.type.struct_def &&
-            !field.value.type.struct_def->fixed) {
-          code_ += "var __" + name + "__: [Offset] = []";
-          code_ += "for var i in obj." + name + " {";
+        if (field_type.struct_def && !field_type.struct_def->fixed) {
+          code_ += "var __" + var + "__: [Offset] = []";
+          code_ += "for var i in obj." + var + " {";
           Indent();
           code_ +=
-              "__" + name + "__.append(" + type + ".pack(&builder, obj: &i))";
+              "__" + var + "__.append(" + type + ".pack(&builder, obj: &i))";
           Outdent();
           code_ += "}";
-          code_ += "let __" + name + " = builder.createVector(ofOffsets: __" +
-                   name + "__)";
+          code_ += "let __" + var + " = builder.createVector(ofOffsets: __" +
+                   var + "__)";
         } else {
-          code_ += "{{STRUCTNAME}}.startVectorOf" +
-                   ConvertCase(name, Case::kUpperCamel) + "(obj." + name +
-                   ".count, in: &builder)";
+          code_ += "{{STRUCTNAME}}." + namer_.Method("start_vector_of_" + var) +
+                   "(obj." + field + ".count, in: &builder)";
           std::string code;
-          GenerateStructArgs(*field.value.type.struct_def, &code, "", "", "_o",
-                             true);
+          GenerateStructArgs(*field_type.struct_def, &code, "", "", "_o", true);
           code = code.substr(0, code.size() - 2);
-          code_ += "for i in obj." + name + " {";
+          code_ += "for i in obj." + field + " {";
           Indent();
           code_ += "guard let _o = i else { continue }";
           code_ += "builder.create(struct: _o)";
           Outdent();
           code_ += "}";
-          code_ += "let __" + name + " = builder.endVector(len: obj." + name +
+          code_ += "let __" + var + " = builder.endVector(len: obj." + field +
                    ".count)";
         }
         break;
       }
       case BASE_TYPE_STRING: {
-        code_ += "let __" + name + " = builder.createVector(ofStrings: obj." +
-                 name + ".compactMap({ $0 }) )";
+        code_ += "let __" + var + " = builder.createVector(ofStrings: obj." +
+                 var + ".compactMap({ $0 }) )";
         break;
       }
       default: {
-        code_ += "let __" + name + " = builder.createVector(obj." + name + ")";
+        code_ += "let __" + var + " = builder.createVector(obj." + field + ")";
         break;
       }
     }
@@ -1456,120 +1442,125 @@ class SwiftGenerator : public BaseGenerator {
       const FieldDef &field, bool is_fixed,
       std::vector<std::string> &buffer_constructor,
       std::vector<std::string> &base_constructor) {
-    auto name = namer_.Field(field.name);
-    auto type = GenType(field.value.type);
-    code_.SetValue("VALUENAME", name);
+    const auto field_field = namer_.Field(field);
+    const auto field_var = namer_.Variable(field);
+    const auto type = GenType(field.value.type);
+    code_.SetValue("FIELDVAR", field_field);
     code_.SetValue("VALUETYPE", type);
     std::string is_required = field.IsRequired() ? "" : "?";
 
     switch (field.value.type.base_type) {
       case BASE_TYPE_STRUCT: {
-        type = GenType(field.value.type, true);
+        const auto type = GenType(field.value.type, true);
         code_.SetValue("VALUETYPE", type);
-        auto optional =
+        const auto optional =
             (field.value.type.struct_def && field.value.type.struct_def->fixed);
         std::string question_mark =
             (field.IsRequired() || (optional && is_fixed) ? "" : "?");
 
         code_ +=
-            "{{ACCESS_TYPE}} var {{VALUENAME}}: {{VALUETYPE}}" + question_mark;
-        base_constructor.push_back("" + name + " = " + type + "()");
+            "{{ACCESS_TYPE}} var {{FIELDVAR}}: {{VALUETYPE}}" + question_mark;
+        base_constructor.push_back("" + field_var + " = " + type + "()");
 
         if (field.value.type.struct_def->fixed) {
-          buffer_constructor.push_back("" + name + " = _t." + name);
+          buffer_constructor.push_back("" + field_var + " = _t." + field_field);
         } else {
-          buffer_constructor.push_back("var __" + name + " = _t." + name);
+          buffer_constructor.push_back("var __" + field_var + " = _t." +
+                                       field_field);
           buffer_constructor.push_back(
-              "" + name + " = __" + name +
+              "" + field_var + " = __" + field_var +
               (field.IsRequired() ? "!" : question_mark) + ".unpack()");
         }
         break;
       }
       case BASE_TYPE_ARRAY: FLATBUFFERS_FALLTHROUGH();
       case BASE_TYPE_VECTOR: {
-        BuildObjectAPIConstructorBodyVectors(field, name, buffer_constructor,
+        BuildObjectAPIConstructorBodyVectors(field, buffer_constructor,
                                              base_constructor, "    ");
         break;
       }
       case BASE_TYPE_STRING: {
-        code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: String" + is_required;
-        buffer_constructor.push_back(name + " = _t." + name);
+        code_ += "{{ACCESS_TYPE}} var {{FIELDVAR}}: String" + is_required;
+        buffer_constructor.push_back(field_var + " = _t." + field_field);
 
         if (field.IsRequired()) {
           std::string default_value =
               field.IsDefault() ? field.value.constant : "";
-          base_constructor.push_back(name + " = \"" + default_value + "\"");
+          base_constructor.push_back(field_var + " = \"" + default_value +
+                                     "\"");
           break;
         }
         if (field.IsDefault() && !field.IsRequired()) {
           std::string value = field.IsDefault() ? field.value.constant : "nil";
-          base_constructor.push_back(name + " = \"" + value + "\"");
+          base_constructor.push_back(field_var + " = \"" + value + "\"");
         }
         break;
       }
       case BASE_TYPE_UTYPE: break;
       case BASE_TYPE_UNION: {
-        BuildUnionEnumSwitchCase(*field.value.type.enum_def, name,
+        BuildUnionEnumSwitchCase(*field.value.type.enum_def, field_var,
                                  buffer_constructor);
         break;
       }
       default: {
-        buffer_constructor.push_back(name + " = _t." + name);
+        buffer_constructor.push_back(field_var + " = _t." + field_field);
         std::string nullable = field.IsOptional() ? "?" : "";
         if (IsScalar(field.value.type.base_type) &&
             !IsBool(field.value.type.base_type) && !IsEnum(field.value.type)) {
-          code_ +=
-              "{{ACCESS_TYPE}} var {{VALUENAME}}: {{VALUETYPE}}" + nullable;
+          code_ += "{{ACCESS_TYPE}} var {{FIELDVAR}}: {{VALUETYPE}}" + nullable;
           if (!field.IsOptional())
-            base_constructor.push_back(name + " = " + field.value.constant);
+            base_constructor.push_back(field_var + " = " +
+                                       field.value.constant);
           break;
         }
 
         if (IsEnum(field.value.type)) {
-          auto default_value = IsEnum(field.value.type)
-                                   ? GenEnumDefaultValue(field)
-                                   : field.value.constant;
-          code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: {{VALUETYPE}}";
-          base_constructor.push_back(name + " = " + default_value);
+          const auto default_value = IsEnum(field.value.type)
+                                         ? GenEnumDefaultValue(field)
+                                         : field.value.constant;
+          code_ += "{{ACCESS_TYPE}} var {{FIELDVAR}}: {{VALUETYPE}}";
+          base_constructor.push_back(field_var + " = " + default_value);
           break;
         }
 
         if (IsBool(field.value.type.base_type)) {
-          code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: Bool" + nullable;
+          code_ += "{{ACCESS_TYPE}} var {{FIELDVAR}}: Bool" + nullable;
           std::string default_value =
               "0" == field.value.constant ? "false" : "true";
           if (!field.IsOptional())
-            base_constructor.push_back(name + " = " + default_value);
+            base_constructor.push_back(field_var + " = " + default_value);
         }
       }
     }
   }
 
   void BuildObjectAPIConstructorBodyVectors(
-      const FieldDef &field, const std::string &name,
-      std::vector<std::string> &buffer_constructor,
+      const FieldDef &field, std::vector<std::string> &buffer_constructor,
       std::vector<std::string> &base_constructor,
       const std::string &indentation) {
-    auto vectortype = field.value.type.VectorType();
+    const auto vectortype = field.value.type.VectorType();
+    const auto field_var = namer_.Field(field);
+    const auto field_field = namer_.Field(field);
 
     if (vectortype.base_type != BASE_TYPE_UTYPE) {
-      buffer_constructor.push_back(name + " = []");
-      buffer_constructor.push_back("for index in 0..<_t." + name + "Count {");
-      base_constructor.push_back(name + " = []");
+      buffer_constructor.push_back(field_var + " = []");
+      buffer_constructor.push_back("for index in 0..<_t." + field_field +
+                                   "Count {");
+      base_constructor.push_back(field_var + " = []");
     }
 
     switch (vectortype.base_type) {
       case BASE_TYPE_STRUCT: {
         code_.SetValue("VALUETYPE", GenType(vectortype, true));
-        code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: [{{VALUETYPE}}?]";
+        code_ += "{{ACCESS_TYPE}} var {{FIELDVAR}}: [{{VALUETYPE}}?]";
         if (!vectortype.struct_def->fixed) {
-          buffer_constructor.push_back(indentation + "var __v_ = _t." + name +
-                                       "(at: index)");
-          buffer_constructor.push_back(indentation + name +
+          buffer_constructor.push_back(indentation + "var __v_ = _t." +
+                                       field_field + "(at: index)");
+          buffer_constructor.push_back(indentation + field_var +
                                        ".append(__v_?.unpack())");
         } else {
-          buffer_constructor.push_back(indentation + name + ".append(_t." +
-                                       name + "(at: index))");
+          buffer_constructor.push_back(indentation + field_var + ".append(_t." +
+                                       field_var + "(at: index))");
         }
         break;
       }
@@ -1578,7 +1569,7 @@ class SwiftGenerator : public BaseGenerator {
         break;
       }
       case BASE_TYPE_UNION: {
-        BuildUnionEnumSwitchCase(*field.value.type.enum_def, name,
+        BuildUnionEnumSwitchCase(*field.value.type.enum_def, field_var,
                                  buffer_constructor, indentation, true);
         break;
       }
@@ -1587,18 +1578,18 @@ class SwiftGenerator : public BaseGenerator {
         code_.SetValue(
             "VALUETYPE",
             (IsString(vectortype) ? "String?" : GenType(vectortype)));
-        code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: [{{VALUETYPE}}]";
+        code_ += "{{ACCESS_TYPE}} var {{FIELDVAR}}: [{{VALUETYPE}}]";
 
         if (IsEnum(vectortype) && vectortype.base_type != BASE_TYPE_UNION) {
-          auto default_value = IsEnum(field.value.type)
-                                   ? GenEnumDefaultValue(field)
-                                   : field.value.constant;
-          buffer_constructor.push_back(indentation + name + ".append(_t." +
-                                       name + "(at: index)!)");
+          const auto default_value = IsEnum(field.value.type)
+                                         ? GenEnumDefaultValue(field)
+                                         : field.value.constant;
+          buffer_constructor.push_back(indentation + field_var + ".append(_t." +
+                                       field_field + "(at: index)!)");
           break;
         }
-        buffer_constructor.push_back(indentation + name + ".append(_t." + name +
-                                     "(at: index))");
+        buffer_constructor.push_back(indentation + field_var + ".append(_t." +
+                                     field_field + "(at: index))");
         break;
       }
     }
@@ -1609,10 +1600,10 @@ class SwiftGenerator : public BaseGenerator {
   void BuildUnionEnumSwitchCaseWritter(const EnumDef &ed) {
     code_ += "switch type {";
     for (auto it = ed.Vals().begin(); it < ed.Vals().end(); ++it) {
-      auto ev = **it;
-      auto variant = namer_.LegacySwiftVariant(ev);
-      auto type = GenType(ev.union_type);
-      auto is_struct = IsStruct(ev.union_type) ? type + Mutable() : type;
+      const auto ev = **it;
+      const auto variant = namer_.LegacySwiftVariant(ev);
+      const auto type = GenType(ev.union_type);
+      const auto is_struct = IsStruct(ev.union_type) ? type + Mutable() : type;
       if (ev.union_type.base_type == BASE_TYPE_NONE) { continue; }
       code_ += "case ." + variant + ":";
       Indent();
@@ -1628,28 +1619,28 @@ class SwiftGenerator : public BaseGenerator {
                                 std::vector<std::string> &buffer_constructor,
                                 const std::string &indentation = "",
                                 const bool is_vector = false) {
-    auto field_name = NameWrappedInNameSpace(ed);
-    code_.SetValue("VALUETYPE", field_name);
-    code_ += "{{ACCESS_TYPE}} var {{VALUENAME}}: \\";
+    const auto ns_type = namer_.NamespacedType(ed);
+    code_.SetValue("VALUETYPE", ns_type);
+    code_ += "{{ACCESS_TYPE}} var {{FIELDVAR}}: \\";
     code_ += is_vector ? "[{{VALUETYPE}}Union?]" : "{{VALUETYPE}}Union?";
 
-    auto vector_reader = is_vector ? "(at: index" : "";
+    const auto vector_reader = is_vector ? "(at: index" : "";
     buffer_constructor.push_back(indentation + "switch _t." + name + "Type" +
                                  vector_reader + (is_vector ? ")" : "") + " {");
 
     for (auto it = ed.Vals().begin(); it < ed.Vals().end(); ++it) {
-      auto ev = **it;
-      auto variant = namer_.LegacySwiftVariant(ev);
+      const auto ev = **it;
+      const auto variant = namer_.LegacySwiftVariant(ev);
       if (ev.union_type.base_type == BASE_TYPE_NONE) { continue; }
-      auto type = IsStruct(ev.union_type)
-                      ? GenType(ev.union_type) + Mutable()
-                      : GenType(ev.union_type);
+      const auto type = IsStruct(ev.union_type)
+                            ? GenType(ev.union_type) + Mutable()
+                            : GenType(ev.union_type);
       buffer_constructor.push_back(indentation + "case ." + variant + ":");
       buffer_constructor.push_back(
           indentation + "  var _v = _t." + name + (is_vector ? "" : "(") +
           vector_reader + (is_vector ? ", " : "") + "type: " + type + ".self)");
-      auto constructor =
-          field_name + "Union(_v?.unpack(), type: ." + variant + ")";
+      const auto constructor =
+          ns_type + "Union(_v?.unpack(), type: ." + variant + ")";
       buffer_constructor.push_back(
           indentation + "  " + name +
           (is_vector ? ".append(" + constructor + ")" : " = " + constructor));
@@ -1659,13 +1650,14 @@ class SwiftGenerator : public BaseGenerator {
   }
 
   void AddMinOrMaxEnumValue(const std::string &str, const std::string &type) {
-    auto current_value = str;
+    const auto current_value = str;
     code_.SetValue(type, current_value);
     code_ += "{{ACCESS_TYPE}} static var " + type +
              ": {{ENUM_NAME}} { return .{{" + type + "}} }";
   }
 
-  void GenLookup(const FieldDef &key_field) {
+  void GenLookup(const FieldDef &key_field, const std::string &struct_type) {
+    code_.SetValue("STRUCTTYPE", struct_type);
     code_.SetValue("OFFSET", NumToString(key_field.value.offset));
     std::string offset_reader =
         "Table.offset(Int32(fbb.capacity) - tableOffset, vOffset: {{OFFSET}}, "
@@ -1675,7 +1667,7 @@ class SwiftGenerator : public BaseGenerator {
     code_ +=
         "fileprivate static func lookupByKey(vector: Int32, key: {{TYPE}}, "
         "fbb: "
-        "ByteBuffer) -> {{VALUENAME}}? {";
+        "ByteBuffer) -> {{STRUCTTYPE}}? {";
     Indent();
     if (IsString(key_field.value.type))
       code_ += "let key = key.utf8.map { $0 }";
@@ -1705,7 +1697,7 @@ class SwiftGenerator : public BaseGenerator {
     Outdent();
     code_ += "} else {";
     Indent();
-    code_ += "return {{VALUENAME}}(fbb, o: tableOffset)";
+    code_ += "return {{STRUCTTYPE}}(fbb, o: tableOffset)";
     Outdent();
     code_ += "}";
     Outdent();
@@ -1719,7 +1711,7 @@ class SwiftGenerator : public BaseGenerator {
     if (field.padding) {
       for (int i = 0; i < 4; i++) {
         if (static_cast<int>(field.padding) & (1 << i)) {
-          auto bits = (1 << i) * 8;
+          const auto bits = (1 << i) * 8;
           code_ += "private let padding" + NumToString((*id)++) + "__: UInt" +
                    NumToString(bits) + " = 0";
         }
@@ -1741,8 +1733,7 @@ class SwiftGenerator : public BaseGenerator {
   }
 
   std::string GenReaderMainBody(const std::string &optional = "") {
-    return "{{ACCESS_TYPE}} var {{VALUENAME}}: {{VALUETYPE}}" + optional +
-           " { ";
+    return "{{ACCESS_TYPE}} var {{FIELDVAR}}: {{VALUETYPE}}" + optional + " { ";
   }
 
   std::string GenReader(const std::string &type,
@@ -1756,36 +1747,34 @@ class SwiftGenerator : public BaseGenerator {
 
   std::string GenMutate(const std::string &offset,
                         const std::string &get_offset, bool isRaw = false) {
-    return "@discardableResult {{ACCESS_TYPE}} func mutate({{VALUENAME}}: "
+    return "@discardableResult {{ACCESS_TYPE}} func mutate({{FIELDVAR}}: "
            "{{VALUETYPE}}) -> Bool {" +
-           get_offset + " return {{ACCESS}}.mutate({{VALUENAME}}" +
+           get_offset + " return {{ACCESS}}.mutate({{FIELDVAR}}" +
            (isRaw ? ".rawValue" : "") + ", index: " + offset + ") }";
   }
 
   std::string GenMutateArray() {
-    return "{{ACCESS_TYPE}} func mutate({{VALUENAME}}: {{VALUETYPE}}, at "
-           "index: "
-           "Int32) -> Bool { " +
+    return "{{ACCESS_TYPE}} func mutate({{FIELDVAR}}: {{VALUETYPE}}, at "
+           "index: Int32) -> Bool { " +
            GenOffset() +
-           "return {{ACCESS}}.directMutate({{VALUENAME}}, index: "
+           "return {{ACCESS}}.directMutate({{FIELDVAR}}, index: "
            "{{ACCESS}}.vector(at: o) + index * {{SIZE}}) }";
   }
 
   std::string GenEnumDefaultValue(const FieldDef &field) {
-    auto &value = field.value;
+    const auto &value = field.value;
     FLATBUFFERS_ASSERT(value.type.enum_def);
-    auto &enum_def = *value.type.enum_def;
+    const auto &enum_def = *value.type.enum_def;
     // Vector of enum defaults are always "[]" which never works.
     const std::string constant = IsVector(value.type) ? "0" : value.constant;
-    auto enum_val = enum_def.FindByValue(constant);
+    const auto enum_val = enum_def.FindByValue(constant);
     std::string name;
     if (enum_val) {
-      name = namer_.LegacySwiftVariant(*enum_val);
+      return "." + namer_.LegacySwiftVariant(*enum_val);
     } else {
       const auto &ev = **enum_def.Vals().begin();
-      name = namer_.LegacySwiftVariant(ev);
+      return "." + namer_.LegacySwiftVariant(ev);
     }
-    return "." + name;
   }
 
   std::string GenEnumConstructor(const std::string &at) {
@@ -1798,10 +1787,9 @@ class SwiftGenerator : public BaseGenerator {
 
   std::string GenType(const Type &type,
                       const bool should_consider_suffix = false) const {
-    return IsScalar(type.base_type)
-               ? GenTypeBasic(type)
-               : (IsArray(type) ? GenType(type.VectorType())
-                                : GenTypePointer(type, should_consider_suffix));
+    return IsScalar(type.base_type) ? GenTypeBasic(type)
+           : IsArray(type)          ? GenType(type.VectorType())
+                           : GenTypePointer(type, should_consider_suffix);
   }
 
   std::string GenTypePointer(const Type &type,
@@ -1810,12 +1798,11 @@ class SwiftGenerator : public BaseGenerator {
       case BASE_TYPE_STRING: return "String";
       case BASE_TYPE_VECTOR: return GenType(type.VectorType());
       case BASE_TYPE_STRUCT: {
-        auto &struct_ = *type.struct_def;
-        if (should_consider_suffix && !struct_.fixed) {
-          return WrapInNameSpace(struct_.defined_namespace,
-                                 namer_.ObjectType(struct_.name));
+        const auto &sd = *type.struct_def;
+        if (should_consider_suffix && !sd.fixed) {
+          return namer_.NamespacedObjectType(sd);
         }
-        return WrapInNameSpace(struct_.defined_namespace, namer_.Type(struct_.name));
+        return namer_.NamespacedType(sd);
       }
       case BASE_TYPE_UNION:
       default: return "FlatbuffersInitializable";
@@ -1826,21 +1813,9 @@ class SwiftGenerator : public BaseGenerator {
     return GenTypeBasic(type, true);
   }
 
-  std::string ObjectAPIName(const std::string &name) const {
-    return parser_.opts.object_prefix + name + parser_.opts.object_suffix;
-  }
-
   void Indent() { code_.IncrementIdentLevel(); }
 
   void Outdent() { code_.DecrementIdentLevel(); }
-
-  std::string NameWrappedInNameSpace(const EnumDef &enum_def) const {
-    return WrapInNameSpace(enum_def.defined_namespace, namer_.Type(enum_def.name));
-  }
-
-  std::string NameWrappedInNameSpace(const StructDef &struct_def) const {
-    return WrapInNameSpace(struct_def.defined_namespace, namer_.Type(struct_def.name));
-  }
 
   std::string GenTypeBasic(const Type &type, bool can_override) const {
     // clang-format off
@@ -1853,7 +1828,7 @@ class SwiftGenerator : public BaseGenerator {
     };
     // clang-format on
     if (can_override) {
-      if (type.enum_def) return NameWrappedInNameSpace(*type.enum_def);
+      if (type.enum_def) return namer_.NamespacedType(*type.enum_def);
       if (type.base_type == BASE_TYPE_BOOL) return "Bool";
     }
     return swift_type[static_cast<int>(type.base_type)];

--- a/src/namer.h
+++ b/src/namer.h
@@ -136,10 +136,6 @@ class Namer {
 
   std::string Function(const Definition &s) const { return Function(s.name); }
 
-  std::string Field(const std::string &s) const {
-    return Format(s, config_.fields);
-  }
-
   std::string Field(const FieldDef &s) const { return Field(s.name); }
 
   std::string Variable(const FieldDef &s) const { return Variable(s.name); }
@@ -232,8 +228,16 @@ class Namer {
     }
   }
 
+  // Legacy fields do not really follow the usual config and should be
+  // considered for deprecation.
+
   std::string LegacyRustNativeVariant(const EnumVal &v) const {
     return ConvertCase(EscapeKeyword(v.name), Case::kUpperCamel);
+  }
+
+  std::string LegacyRustFieldOffsetName(const FieldDef& field) const {
+
+    return "VT_" + ConvertCase(EscapeKeyword(field.name), Case::kAllUpper);
   }
 
  private:
@@ -243,6 +247,10 @@ class Namer {
 
   std::string ObjectType(const std::string &s) const {
     return config_.object_prefix + Type(s) + config_.object_suffix;
+  }
+
+  std::string Field(const std::string &s) const {
+    return Format(s, config_.fields);
   }
 
   std::string Variable(const std::string &s) const {

--- a/src/namer.h
+++ b/src/namer.h
@@ -181,6 +181,11 @@ class Namer {
     return Type(def.name);
   }
 
+  std::string NamespacedType(const std::vector<std::string> &ns,
+                             const std::string &s) const {
+    return Namespace(ns) + config_.namespace_seperator + Type(s);
+  }
+
   // Returns `filename` with the right casing, suffix, and extension.
   std::string File(const std::string &filename,
                    SkipFile skips = SkipFile::None) const {
@@ -246,11 +251,6 @@ class Namer {
 
   std::string Variant(const std::string &s) const {
     return Format(s, config_.variants);
-  }
-
-  std::string NamespacedType(const std::vector<std::string> &ns,
-                             const std::string &s) const {
-    return Namespace(ns) + config_.namespace_seperator + Type(s);
   }
 
   std::string Format(const std::string &s, Case casing) const {

--- a/src/namer.h
+++ b/src/namer.h
@@ -112,8 +112,14 @@ class Namer {
   Namer(Config config, std::set<std::string> keywords)
       : config_(config), keywords_(std::move(keywords)) {}
 
-  std::string Type(const std::string &s) const {
-    return Format(s, config_.types);
+  // Types are always structs or enums so we can only expose these two
+  // overloads.
+  std::string Type(const StructDef &d) const { return Type(d.name); }
+
+  std::string Type(const EnumDef &d) const { return Type(d.name); }
+
+  template<typename T> std::string Method(const T &s) const {
+    return Method(s.name);
   }
 
   std::string Method(const std::string &s) const {
@@ -124,29 +130,31 @@ class Namer {
     return Format(s, config_.constants);
   }
 
+  std::string Function(const Definition &s) const { return Function(s.name); }
+
   std::string Function(const std::string &s) const {
     return Format(s, config_.functions);
   }
 
+  std::string Field(const FieldDef &s) const { return Field(s.name); }
   std::string Field(const std::string &s) const {
     return Format(s, config_.fields);
   }
 
-  std::string Variable(const std::string &s) const {
-    return Format(s, config_.variables);
-  }
+  std::string Variable(const FieldDef &s) const { return Variable(s.name); }
 
-  std::string Variant(const std::string &s) const {
-    return Format(s, config_.variants);
-  }
+  std::string Variable(const StructDef &s) const { return Variable(s.name); }
 
-  std::string EnumVariant(const std::string &e, const std::string v) const {
+  std::string Variant(const EnumVal &s) const { return Variant(s.name); }
+
+  std::string EnumVariant(const EnumDef &e, const EnumVal &v) const {
     return Type(e) + config_.enum_variant_seperator + Variant(v);
   }
 
-  std::string ObjectType(const std::string &s) const {
-    return config_.object_prefix + Type(s) + config_.object_suffix;
+  std::string ObjectType(const StructDef &d) const {
+    return ObjectType(d.name);
   }
+  std::string ObjectType(const EnumDef &d) const { return ObjectType(d.name); }
 
   std::string Namespace(const std::string &s) const {
     return Format(s, config_.namespaces);
@@ -161,9 +169,19 @@ class Namer {
     return result;
   }
 
+  std::string Namespace(const struct Namespace &ns) const {
+    return Namespace(ns.components);
+  }
+
   std::string NamespacedType(const std::vector<std::string> &ns,
                              const std::string &s) const {
     return Namespace(ns) + config_.namespace_seperator + Type(s);
+  }
+  std::string NamespacedType(const Definition &def) const {
+    if (def.defined_namespace != nullptr) {
+      return NamespacedType(def.defined_namespace->components, def.name);
+    }
+    return Type(def.name);
   }
 
   // Returns `filename` with the right casing, suffix, and extension.
@@ -175,6 +193,11 @@ class Namer {
            (skip_suffix ? "" : config_.filename_suffix) +
            (skip_ext ? "" : config_.filename_extension);
   }
+  template<typename T>
+  std::string File(const T &f, SkipFile skips = SkipFile::None) const {
+    return File(f.name, skips);
+  }
+
   // Formats `directories` prefixed with the output_path and joined with the
   // right seperator. Output path prefixing and the trailing separator may be
   // skiped using `skips`.
@@ -194,6 +217,11 @@ class Namer {
     return result;
   }
 
+  std::string Directories(const struct Namespace &ns,
+                          SkipDir skips = SkipDir::None) const {
+    return Directories(ns.components, skips);
+  }
+
   std::string EscapeKeyword(const std::string &name) const {
     if (keywords_.find(name) == keywords_.end()) {
       return name;
@@ -202,7 +230,27 @@ class Namer {
     }
   }
 
+  std::string LegacyRustNativeVariant(const EnumVal &v) const {
+    return ConvertCase(EscapeKeyword(v.name), Case::kUpperCamel);
+  }
+
  private:
+  std::string Type(const std::string &s) const {
+    return Format(s, config_.types);
+  }
+
+  std::string ObjectType(const std::string &s) const {
+    return config_.object_prefix + Type(s) + config_.object_suffix;
+  }
+
+  std::string Variable(const std::string &s) const {
+    return Format(s, config_.variables);
+  }
+
+  std::string Variant(const std::string &s) const {
+    return Format(s, config_.variants);
+  }
+
   std::string Format(const std::string &s, Case casing) const {
     // NOTE: If you need to escape keywords after converting case, which would
     // make more sense than this, make it a config option.

--- a/src/namer.h
+++ b/src/namer.h
@@ -125,7 +125,6 @@ class Namer {
   // Types are always structs or enums so we can only expose these two
   // overloads.
   std::string Type(const StructDef &d) const { return Type(d.name); }
-
   std::string Type(const EnumDef &d) const { return Type(d.name); }
 
   template<typename T> std::string Method(const T &s) const {
@@ -147,6 +146,10 @@ class Namer {
   std::string Function(const Definition &s) const { return Function(s.name); }
 
   std::string Field(const FieldDef &s) const { return Field(s.name); }
+
+  std::string Variable(const std::string &s) const {
+    return Format(s, config_.variables);
+  }
 
   std::string Variable(const FieldDef &s) const { return Variable(s.name); }
 
@@ -181,15 +184,17 @@ class Namer {
   }
 
   std::string NamespacedType(const Definition &def) const {
-    if (def.defined_namespace != nullptr) {
-      return NamespacedType(def.defined_namespace->components, def.name);
-    }
-    return Type(def.name);
+    return NamespacedString(def.defined_namespace, Type(def.name));
   }
 
   std::string NamespacedType(const std::vector<std::string> &ns,
                              const std::string &s) const {
-    return Namespace(ns) + config_.namespace_seperator + Type(s);
+    return (ns.empty() ? "" : (Namespace(ns) + config_.namespace_seperator)) +
+           Type(s);
+  }
+
+  std::string NamespacedObjectType(const Definition &def) const {
+    return NamespacedString(def.defined_namespace, ObjectType(def.name));
   }
 
   // Returns `filename` with the right casing, suffix, and extension.
@@ -272,12 +277,16 @@ class Namer {
     return Format(s, config_.fields);
   }
 
-  std::string Variable(const std::string &s) const {
-    return Format(s, config_.variables);
-  }
-
   std::string Variant(const std::string &s) const {
     return Format(s, config_.variants);
+  }
+
+  std::string NamespacedString(const struct Namespace *ns,
+                               const std::string &str) const {
+    std::string ret;
+    if (ns != nullptr) { ret += Namespace(ns->components); }
+    if (!ret.empty()) ret += config_.namespace_seperator;
+    return ret + str;
   }
 
   std::string Format(const std::string &s, Case casing) const {

--- a/src/namer.h
+++ b/src/namer.h
@@ -130,16 +130,17 @@ class Namer {
     return Format(s, config_.constants);
   }
 
-  std::string Function(const Definition &s) const { return Function(s.name); }
-
   std::string Function(const std::string &s) const {
     return Format(s, config_.functions);
   }
 
-  std::string Field(const FieldDef &s) const { return Field(s.name); }
+  std::string Function(const Definition &s) const { return Function(s.name); }
+
   std::string Field(const std::string &s) const {
     return Format(s, config_.fields);
   }
+
+  std::string Field(const FieldDef &s) const { return Field(s.name); }
 
   std::string Variable(const FieldDef &s) const { return Variable(s.name); }
 
@@ -173,10 +174,6 @@ class Namer {
     return Namespace(ns.components);
   }
 
-  std::string NamespacedType(const std::vector<std::string> &ns,
-                             const std::string &s) const {
-    return Namespace(ns) + config_.namespace_seperator + Type(s);
-  }
   std::string NamespacedType(const Definition &def) const {
     if (def.defined_namespace != nullptr) {
       return NamespacedType(def.defined_namespace->components, def.name);
@@ -249,6 +246,11 @@ class Namer {
 
   std::string Variant(const std::string &s) const {
     return Format(s, config_.variants);
+  }
+
+  std::string NamespacedType(const std::vector<std::string> &ns,
+                             const std::string &s) const {
+    return Namespace(ns) + config_.namespace_seperator + Type(s);
   }
 
   std::string Format(const std::string &s, Case casing) const {


### PR DESCRIPTION
Apply centralized `Namer` to Swift.

Swift was particularly difficult due to mixed usage of CodeWriter's
string replacement as well as explicit strings. Also most things are lowerCamelCase in Swift so
its hard to split that into more explicit kinds of symbols.

lowerCamelCase is interesting because its hard to prepend to lower camel case symbols.
e.g. `create` + `myTable` != `createMyTable`.
My simple workaround was to prepend before converting case, e.g. `namer_.Function("create_" + my_table)` and case conversion will work itself out.

This uses Namer overloads so it depends on #7164

@mustiikhalil 
@dbaileychess 
#7142