### PR TITLE
Make inclusion of header <optional> opt-out via macro

### DIFF
--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -29,10 +29,13 @@
 #ifndef FLATBUFFERS_USE_STD_OPTIONAL
   // Detect C++17 compatible compiler.
   // __cplusplus >= 201703L - a compiler has support of 'static inline' variables.
-  #define FLATBUFFERS_USE_STD_OPTIONAL ( \
-    (defined(__cplusplus) && __cplusplus >= 201703L) \
-    || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
-#endif
+  #if (defined(__cplusplus) && __cplusplus >= 201703L) \
+      || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
+    #define FLATBUFFERS_USE_STD_OPTIONAL 1
+  #else
+    #define FLATBUFFERS_USE_STD_OPTIONAL 0
+  #endif // (defined(__cplusplus) && __cplusplus >= 201703L) ...
+#endif // FLATBUFFERS_USE_STD_OPTIONAL
 
 #if FLATBUFFERS_USE_STD_OPTIONAL
   #include <optional>

--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -28,17 +28,14 @@
 
 // Detect C++17 compatible compiler.
 // __cplusplus >= 201703L - a compiler has support of 'static inline' variables.
-#if !defined(FLATBUFFERS_DONT_USE_STD_OPTIONAL) \
-    && ( \
-      defined(FLATBUFFERS_USE_STD_OPTIONAL) \
-      || (defined(__cplusplus) && __cplusplus >= 201703L) \
-      || (defined(_MSVC_LANG) &&  _MSVC_LANG >= 201703L) \
-    )
+#if defined(FLATBUFFERS_USE_STD_OPTIONAL) && ( \
+    (defined(__cplusplus) && __cplusplus >= 201703L) \
+    || (defined(_MSVC_LANG) &&  _MSVC_LANG >= 201703L))
   #include <optional>
   #ifndef FLATBUFFERS_USE_STD_OPTIONAL
     #define FLATBUFFERS_USE_STD_OPTIONAL
   #endif
-#endif // !defined(FLATBUFFERS_DONT_USE_STD_OPTIONAL) ...
+#endif // defined(FLATBUFFERS_USE_STD_OPTIONAL) && ...
 
 // The __cpp_lib_span is the predefined feature macro.
 #if defined(FLATBUFFERS_USE_STD_SPAN)

--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -26,16 +26,17 @@
 #include <memory>
 #include <limits>
 
+#ifndef FLATBUFFERS_USE_STD_OPTIONAL
+  #define FLATBUFFERS_USE_STD_OPTIONAL 1
+#endif
+
 // Detect C++17 compatible compiler.
 // __cplusplus >= 201703L - a compiler has support of 'static inline' variables.
-#if defined(FLATBUFFERS_USE_STD_OPTIONAL) && ( \
+#if FLATBUFFERS_USE_STD_OPTIONAL && ( \
     (defined(__cplusplus) && __cplusplus >= 201703L) \
     || (defined(_MSVC_LANG) &&  _MSVC_LANG >= 201703L))
   #include <optional>
-  #ifndef FLATBUFFERS_USE_STD_OPTIONAL
-    #define FLATBUFFERS_USE_STD_OPTIONAL
-  #endif
-#endif // defined(FLATBUFFERS_USE_STD_OPTIONAL) && ...
+#endif // FLATBUFFERS_USE_STD_OPTIONAL && ...
 
 // The __cpp_lib_span is the predefined feature macro.
 #if defined(FLATBUFFERS_USE_STD_SPAN)

--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -28,14 +28,16 @@
 
 // Detect C++17 compatible compiler.
 // __cplusplus >= 201703L - a compiler has support of 'static inline' variables.
-#if defined(FLATBUFFERS_USE_STD_OPTIONAL) \
-    || (defined(__cplusplus) && __cplusplus >= 201703L) \
-    || (defined(_MSVC_LANG) &&  (_MSVC_LANG >= 201703L))
-  #include <optional>
-  #ifndef FLATBUFFERS_USE_STD_OPTIONAL
-    #define FLATBUFFERS_USE_STD_OPTIONAL
-  #endif
-#endif // defined(FLATBUFFERS_USE_STD_OPTIONAL) ...
+#if !defined(FLATBUFFERS_DONT_USE_STD_OPTIONAL)
+  #if defined(FLATBUFFERS_USE_STD_OPTIONAL) \
+      || (defined(__cplusplus) && __cplusplus >= 201703L) \
+      || (defined(_MSVC_LANG) &&  (_MSVC_LANG >= 201703L))
+    #include <optional>
+    #ifndef FLATBUFFERS_USE_STD_OPTIONAL
+      #define FLATBUFFERS_USE_STD_OPTIONAL
+    #endif
+  #endif // defined(FLATBUFFERS_USE_STD_OPTIONAL) ...
+#endif // !defined(FLATBUFFERS_DONT_USE_STD_OPTIONAL)
 
 // The __cpp_lib_span is the predefined feature macro.
 #if defined(FLATBUFFERS_USE_STD_SPAN)

--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -28,16 +28,17 @@
 
 // Detect C++17 compatible compiler.
 // __cplusplus >= 201703L - a compiler has support of 'static inline' variables.
-#if !defined(FLATBUFFERS_DONT_USE_STD_OPTIONAL)
-  #if defined(FLATBUFFERS_USE_STD_OPTIONAL) \
+#if !defined(FLATBUFFERS_DONT_USE_STD_OPTIONAL) \
+    && ( \
+      defined(FLATBUFFERS_USE_STD_OPTIONAL) \
       || (defined(__cplusplus) && __cplusplus >= 201703L) \
-      || (defined(_MSVC_LANG) &&  (_MSVC_LANG >= 201703L))
-    #include <optional>
-    #ifndef FLATBUFFERS_USE_STD_OPTIONAL
-      #define FLATBUFFERS_USE_STD_OPTIONAL
-    #endif
-  #endif // defined(FLATBUFFERS_USE_STD_OPTIONAL) ...
-#endif // !defined(FLATBUFFERS_DONT_USE_STD_OPTIONAL)
+      || (defined(_MSVC_LANG) &&  _MSVC_LANG >= 201703L) \
+    )
+  #include <optional>
+  #ifndef FLATBUFFERS_USE_STD_OPTIONAL
+    #define FLATBUFFERS_USE_STD_OPTIONAL
+  #endif
+#endif // !defined(FLATBUFFERS_DONT_USE_STD_OPTIONAL) ...
 
 // The __cpp_lib_span is the predefined feature macro.
 #if defined(FLATBUFFERS_USE_STD_SPAN)

--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -34,7 +34,7 @@
     || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
 #endif
 
-#if FLATBUFFERS_USE_STD_OPTIONAL
+#if (FLATBUFFERS_USE_STD_OPTIONAL)
   #include <optional>
 #endif
 

--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -27,16 +27,16 @@
 #include <limits>
 
 #ifndef FLATBUFFERS_USE_STD_OPTIONAL
-  #define FLATBUFFERS_USE_STD_OPTIONAL 1
+  // Detect C++17 compatible compiler.
+  // __cplusplus >= 201703L - a compiler has support of 'static inline' variables.
+  #define FLATBUFFERS_USE_STD_OPTIONAL ( \
+    defined(__cplusplus) && __cplusplus >= 201703L) \
+    || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
 #endif
 
-// Detect C++17 compatible compiler.
-// __cplusplus >= 201703L - a compiler has support of 'static inline' variables.
-#if FLATBUFFERS_USE_STD_OPTIONAL && ( \
-    (defined(__cplusplus) && __cplusplus >= 201703L) \
-    || (defined(_MSVC_LANG) &&  _MSVC_LANG >= 201703L))
+#if FLATBUFFERS_USE_STD_OPTIONAL
   #include <optional>
-#endif // FLATBUFFERS_USE_STD_OPTIONAL && ...
+#endif
 
 // The __cpp_lib_span is the predefined feature macro.
 #if defined(FLATBUFFERS_USE_STD_SPAN)

--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -30,7 +30,7 @@
   // Detect C++17 compatible compiler.
   // __cplusplus >= 201703L - a compiler has support of 'static inline' variables.
   #if (defined(__cplusplus) && __cplusplus >= 201703L) \
-      || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
+      || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
     #define FLATBUFFERS_USE_STD_OPTIONAL 1
   #else
     #define FLATBUFFERS_USE_STD_OPTIONAL 0

--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -30,11 +30,11 @@
   // Detect C++17 compatible compiler.
   // __cplusplus >= 201703L - a compiler has support of 'static inline' variables.
   #define FLATBUFFERS_USE_STD_OPTIONAL ( \
-    defined(__cplusplus) && __cplusplus >= 201703L) \
+    (defined(__cplusplus) && __cplusplus >= 201703L) \
     || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
 #endif
 
-#if (FLATBUFFERS_USE_STD_OPTIONAL)
+#if FLATBUFFERS_USE_STD_OPTIONAL
   #include <optional>
 #endif
 
@@ -129,7 +129,7 @@ namespace flatbuffers {
   };
 #endif  // defined(FLATBUFFERS_TEMPLATES_ALIASES)
 
-#if (FLATBUFFERS_USE_STD_OPTIONAL)
+#if FLATBUFFERS_USE_STD_OPTIONAL
 template<class T>
 using Optional = std::optional<T>;
 using nullopt_t = std::nullopt_t;
@@ -267,7 +267,7 @@ FLATBUFFERS_CONSTEXPR_CPP11 bool operator==(const Optional<T>& lhs, const Option
               ? false
               : !static_cast<bool>(lhs) ? false : (*lhs == *rhs);
 }
-#endif // (FLATBUFFERS_USE_STD_OPTIONAL)
+#endif // FLATBUFFERS_USE_STD_OPTIONAL
 
 
 // Very limited and naive partial implementation of C++20 std::span<T,Extent>.

--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -129,7 +129,7 @@ namespace flatbuffers {
   };
 #endif  // defined(FLATBUFFERS_TEMPLATES_ALIASES)
 
-#ifdef FLATBUFFERS_USE_STD_OPTIONAL
+#if (FLATBUFFERS_USE_STD_OPTIONAL)
 template<class T>
 using Optional = std::optional<T>;
 using nullopt_t = std::nullopt_t;
@@ -267,7 +267,7 @@ FLATBUFFERS_CONSTEXPR_CPP11 bool operator==(const Optional<T>& lhs, const Option
               ? false
               : !static_cast<bool>(lhs) ? false : (*lhs == *rhs);
 }
-#endif // FLATBUFFERS_USE_STD_OPTIONAL
+#endif // (FLATBUFFERS_USE_STD_OPTIONAL)
 
 
 // Very limited and naive partial implementation of C++20 std::span<T,Extent>.


### PR DESCRIPTION
Standard library header `<optional>` will be included (if the compiler settings support it) unless the macro `FLATBUFFERS_USE_STD_OPTIONAL` is set to `0`.

My organization is currently compiling with a combination of C++17 language and C++14 standard library. The code as it stands is detecting C++17 on our systems, but including `<optional>` fails because that header doesn't exist in the C++14 standard library. We need a way to avoid the auto-detection mechanism.
