### PR TITLE
Adds no-includes flags to the swift code generator

### DIFF
--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -367,7 +367,7 @@ flatc(
 # Swift Tests
 swift_prefix = "FlatBuffers.Test.Swift/Tests/FlatBuffers.Test.SwiftTests"
 flatc(
-    SWIFT_OPTS + NO_INCL_OPTS + ["--grpc"],
+    SWIFT_OPTS + BASE_OPTS + ["--grpc"],
     schema="monster_test.fbs",
     include="include_test",
     prefix=swift_prefix,

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -167,9 +167,10 @@ class SwiftGenerator : public BaseGenerator {
     code_ += "// " + std::string(FlatBuffersGeneratedWarning());
     code_ += "// swiftlint:disable all";
     code_ += "// swiftformat:disable all\n";
-    code_ += "import FlatBuffers\n";
-    // Generate code for all the enum declarations.
+    if (parser_.opts.include_dependence_headers || parser_.opts.generate_all)
+      code_ += "import FlatBuffers\n";
 
+    // Generate code for all the enum declarations.
     for (auto it = parser_.enums_.vec.begin(); it != parser_.enums_.vec.end();
          ++it) {
       const auto &enum_def = **it;


### PR DESCRIPTION
The following PR adds the `--no-includes` flag to the swift code generator.

Closes #7163 