### PR TITLE
Move flatbuffer_ts_library to typescript.bzl

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -5,8 +5,6 @@
 Rules for building C++ flatbuffers with Bazel.
 """
 
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
-load("@npm//@bazel/typescript:index.bzl", "ts_project")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 flatc_path = "@com_github_google_flatbuffers//:flatc"
@@ -25,15 +23,6 @@ DEFAULT_FLATC_ARGS = [
     "--gen-mutable",
     "--reflect-names",
     "--cpp-ptr-type flatbuffers::unique_ptr",
-]
-
-DEFAULT_FLATC_TS_ARGS = [
-    "--gen-object-api",
-    "--gen-mutable",
-    "--reflect-names",
-    "--gen-name-strings",
-    "--ts-flat-files",
-    "--keep-prefix",
 ]
 
 def flatbuffer_library_public(
@@ -263,92 +252,4 @@ def flatbuffer_cc_library(
         compatible_with = compatible_with,
         restricted_to = restricted_to,
         visibility = srcs_filegroup_visibility if srcs_filegroup_visibility != None else visibility,
-    )
-
-def flatbuffer_ts_library(
-        name,
-        srcs,
-        compatible_with = None,
-        target_compatible_with = None,
-        deps = [],
-        include_paths = DEFAULT_INCLUDE_PATHS,
-        flatc_args = DEFAULT_FLATC_TS_ARGS,
-        visibility = None,
-        restricted_to = None,
-        include_reflection = True):
-    """Generates a ts_library rule for a given flatbuffer definition.
-
-    Args:
-      name: Name of the generated ts_library rule.
-      srcs: Source .fbs file(s).
-      deps: Other flatbuffer_ts_library's to depend on. Note that currently
-            you must specify all your transitive dependencies manually.
-      include_paths: Optional, list of paths the includes files can be found in.
-      flatc_args: Optional list of additional arguments to pass to flatc
-          (e.g. --gen-mutable).
-      visibility: The visibility of the generated cc_library. By default, use the
-          default visibility of the project.
-      compatible_with: Optional, The list of environments this rule can be built
-        for, in addition to default-supported environments.
-      restricted_to: Optional, The list of environments this rule can be built
-        for, instead of default-supported environments.
-      target_compatible_with: Optional, The list of target platform constraints
-        to use.
-      include_reflection: Optional, Whether to depend on the flatbuffer
-        reflection library automatically. Only really relevant for the
-        target that builds the reflection library itself.
-    """
-    srcs_lib = "%s_srcs" % (name)
-    outs = ["%s_generated.ts" % (s.replace(".fbs", "").split("/")[-1]) for s in srcs]
-    includes = [d + "_includes" for d in deps]
-    flatbuffer_library_public(
-        name = srcs_lib,
-        srcs = srcs,
-        outs = outs,
-        language_flag = "--ts",
-        includes = includes,
-        include_paths = include_paths,
-        flatc_args = flatc_args,
-        compatible_with = compatible_with,
-        restricted_to = restricted_to,
-        target_compatible_with = target_compatible_with,
-    )
-    ts_project(
-        name = name + "_ts",
-        srcs = outs,
-        declaration = True,
-        visibility = visibility,
-        compatible_with = compatible_with,
-        restricted_to = restricted_to,
-        target_compatible_with = target_compatible_with,
-        tsconfig = {
-            "compilerOptions": {
-                "declaration": True,
-                "lib": [
-                    "ES2015",
-                    "ES2020.BigInt",
-                    "DOM",
-                ],
-                "module": "commonjs",
-                "moduleResolution": "node",
-                "strict": True,
-                "types": ["node"],
-            },
-        },
-        deps = deps + ["//ts:flatbuffers"] + (["//reflection:reflection_ts_fbs"] if include_reflection else []),
-    )
-    js_library(
-        name = name,
-        visibility = visibility,
-        compatible_with = compatible_with,
-        restricted_to = restricted_to,
-        target_compatible_with = target_compatible_with,
-        deps = [name + "_ts"],
-    )
-    native.filegroup(
-        name = "%s_includes" % (name),
-        srcs = srcs + includes,
-        compatible_with = compatible_with,
-        restricted_to = restricted_to,
-        visibility = visibility,
     )

--- a/reflection/BUILD.bazel
+++ b/reflection/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:build_defs.bzl", "flatbuffer_ts_library")
+load("//:typescript.bzl", "flatbuffer_ts_library")
 
 filegroup(
     name = "reflection_fbs_schema",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
-load("//:build_defs.bzl", "flatbuffer_cc_library", "flatbuffer_ts_library")
+load("//:build_defs.bzl", "flatbuffer_cc_library")
+load("//:typescript.bzl", "flatbuffer_ts_library")
 
 package(default_visibility = ["//visibility:private"])
 

--- a/tests/test_dir/BUILD.bazel
+++ b/tests/test_dir/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:build_defs.bzl", "flatbuffer_ts_library")
+load("//:typescript.bzl", "flatbuffer_ts_library")
 
 flatbuffer_ts_library(
     name = "typescript_transitive_ts_fbs",

--- a/typescript.bzl
+++ b/typescript.bzl
@@ -1,0 +1,104 @@
+"""
+Rules for building typescript flatbuffers with Bazel.
+"""
+
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("@npm//@bazel/typescript:index.bzl", "ts_project")
+load(":build_defs.bzl", "DEFAULT_INCLUDE_PATHS", "flatbuffer_library_public")
+
+DEFAULT_FLATC_TS_ARGS = [
+    "--gen-object-api",
+    "--gen-mutable",
+    "--reflect-names",
+    "--gen-name-strings",
+    "--ts-flat-files",
+    "--keep-prefix",
+]
+
+def flatbuffer_ts_library(
+        name,
+        srcs,
+        compatible_with = None,
+        target_compatible_with = None,
+        deps = [],
+        include_paths = DEFAULT_INCLUDE_PATHS,
+        flatc_args = DEFAULT_FLATC_TS_ARGS,
+        visibility = None,
+        restricted_to = None,
+        include_reflection = True):
+    """Generates a ts_library rule for a given flatbuffer definition.
+
+    Args:
+      name: Name of the generated ts_library rule.
+      srcs: Source .fbs file(s).
+      deps: Other flatbuffer_ts_library's to depend on. Note that currently
+            you must specify all your transitive dependencies manually.
+      include_paths: Optional, list of paths the includes files can be found in.
+      flatc_args: Optional list of additional arguments to pass to flatc
+          (e.g. --gen-mutable).
+      visibility: The visibility of the generated cc_library. By default, use the
+          default visibility of the project.
+      compatible_with: Optional, The list of environments this rule can be built
+        for, in addition to default-supported environments.
+      restricted_to: Optional, The list of environments this rule can be built
+        for, instead of default-supported environments.
+      target_compatible_with: Optional, The list of target platform constraints
+        to use.
+      include_reflection: Optional, Whether to depend on the flatbuffer
+        reflection library automatically. Only really relevant for the
+        target that builds the reflection library itself.
+    """
+    srcs_lib = "%s_srcs" % (name)
+    outs = ["%s_generated.ts" % (s.replace(".fbs", "").split("/")[-1]) for s in srcs]
+    includes = [d + "_includes" for d in deps]
+    flatbuffer_library_public(
+        name = srcs_lib,
+        srcs = srcs,
+        outs = outs,
+        language_flag = "--ts",
+        includes = includes,
+        include_paths = include_paths,
+        flatc_args = flatc_args,
+        compatible_with = compatible_with,
+        restricted_to = restricted_to,
+        target_compatible_with = target_compatible_with,
+    )
+    ts_project(
+        name = name + "_ts",
+        srcs = outs,
+        declaration = True,
+        visibility = visibility,
+        compatible_with = compatible_with,
+        restricted_to = restricted_to,
+        target_compatible_with = target_compatible_with,
+        tsconfig = {
+            "compilerOptions": {
+                "declaration": True,
+                "lib": [
+                    "ES2015",
+                    "ES2020.BigInt",
+                    "DOM",
+                ],
+                "module": "commonjs",
+                "moduleResolution": "node",
+                "strict": True,
+                "types": ["node"],
+            },
+        },
+        deps = deps + ["//ts:flatbuffers"] + (["//reflection:reflection_ts_fbs"] if include_reflection else []),
+    )
+    js_library(
+        name = name,
+        visibility = visibility,
+        compatible_with = compatible_with,
+        restricted_to = restricted_to,
+        target_compatible_with = target_compatible_with,
+        deps = [name + "_ts"],
+    )
+    native.filegroup(
+        name = "%s_includes" % (name),
+        srcs = srcs + includes,
+        compatible_with = compatible_with,
+        restricted_to = restricted_to,
+        visibility = visibility,
+    )


### PR DESCRIPTION
This makes it so that users of flatbuffer_cc_library don't need to have
rules_nodejs available in their WORKSPACE, addressing #7179.