### PR TITLE
Annotated Binary Structured Comments

### DIFF
--- a/src/annotated_binary_text_gen.cpp
+++ b/src/annotated_binary_text_gen.cpp
@@ -3,6 +3,8 @@
 #include <sstream>
 #include <string>
 
+#include "binary_annotator.h"
+#include "flatbuffers/base.h"
 #include "flatbuffers/util.h"
 
 namespace flatbuffers {
@@ -54,7 +56,7 @@ template<typename T>
 std::string ToValueString(const BinaryRegion &region, const uint8_t *binary) {
   std::string s;
   s += "0x";
-  const T val = GetScalar<T>(binary + region.offset);
+  const T val = ReadScalar<T>(binary + region.offset);
   const uint64_t start_index = region.offset + region.length - 1;
   for (uint64_t i = 0; i < region.length; ++i) {
     s += ToHex(binary[start_index - i]);
@@ -149,8 +151,113 @@ static std::string GenerateTypeString(const BinaryRegion &region) {
               : "");
 }
 
+static std::string GenerateComment(const BinaryRegionComment &comment,
+                                   const BinarySection &) {
+  std::string s;
+  switch (comment.type) {
+    case BinaryRegionCommentType::Unknown: s = "unknown"; break;
+    case BinaryRegionCommentType::SizePrefix: s = "size prefix"; break;
+    case BinaryRegionCommentType::RootTableOffset:
+      s = "offset to root table `" + comment.name + "`";
+      break;
+    // TODO(dbaileychess): make this lowercase to follow the convention.
+    case BinaryRegionCommentType::FileIdentifier: s = "File Identifier"; break;
+    case BinaryRegionCommentType::Padding: s = "padding"; break;
+    case BinaryRegionCommentType::VTableSize: s = "size of this vtable"; break;
+    case BinaryRegionCommentType::VTableRefferingTableLength:
+      s = "size of referring table";
+      break;
+    case BinaryRegionCommentType::VTableFieldOffset:
+      s = "offset to field `" + comment.name;
+      break;
+    case BinaryRegionCommentType::VTableUnknownFieldOffset:
+      s = "offset to unknown field (id: " + std::to_string(comment.index) + ")";
+      break;
+
+    case BinaryRegionCommentType::TableVTableOffset:
+      s = "offset to vtable";
+      break;
+    case BinaryRegionCommentType::TableField:
+      s = "table field `" + comment.name;
+      break;
+    case BinaryRegionCommentType::TableUnknownField: s = "unknown field"; break;
+    case BinaryRegionCommentType::TableOffsetField:
+      s = "offset to field `" + comment.name + "`";
+      break;
+    case BinaryRegionCommentType::StructField:
+      s = "struct field `" + comment.name + "`";
+      break;
+    case BinaryRegionCommentType::ArrayField:
+      s = "array field `" + comment.name + "`[" +
+          std::to_string(comment.index) + "]";
+      break;
+    case BinaryRegionCommentType::StringLength: s = "length of string"; break;
+    case BinaryRegionCommentType::StringValue: s = "string literal"; break;
+    case BinaryRegionCommentType::StringTerminator:
+      s = "string terminator";
+      break;
+    case BinaryRegionCommentType::VectorLength:
+      s = "length of vector (# items)";
+      break;
+    case BinaryRegionCommentType::VectorValue:
+      s = "value[" + std::to_string(comment.index) + "]";
+      break;
+    case BinaryRegionCommentType::VectorTableValue:
+      s = "offset to table[" + std::to_string(comment.index) + "]";
+      break;
+    case BinaryRegionCommentType::VectorStringValue:
+      s = "offset to string[" + std::to_string(comment.index) + "]";
+      break;
+    case BinaryRegionCommentType::VectorUnionValue:
+      s = "offset to union[" + std::to_string(comment.index) + "]";
+      break;
+
+    default: break;
+  }
+  if (!comment.default_value.empty()) { s += " " + comment.default_value; }
+
+  switch (comment.status) {
+    case BinaryRegionStatus::OK: break;  // no-op
+    case BinaryRegionStatus::WARN: s = "WARN: " + s; break;
+    case BinaryRegionStatus::WARN_NO_REFERENCES:
+      s = "WARN: nothing refers to this section.";
+      break;
+    case BinaryRegionStatus::WARN_CORRUPTED_PADDING:
+      s = "WARN: could be corrupted padding region.";
+      break;
+    case BinaryRegionStatus::WARN_PADDING_LENGTH:
+      s = "WARN: padding is longer than expected.";
+      break;
+    case BinaryRegionStatus::ERROR: s = "ERROR: " + s; break;
+    case BinaryRegionStatus::ERROR_OFFSET_OUT_OF_BINARY:
+      s = "ERROR: " + s + ". Invalid offset, points outside the binary.";
+      break;
+    case BinaryRegionStatus::ERROR_INCOMPLETE_BINARY:
+      s = "ERROR: " + s + ". Incomplete binary, expected to read " +
+          comment.status_message + " bytes.";
+      break;
+    case BinaryRegionStatus::ERROR_LENGTH_TOO_LONG:
+      s = "ERROR: " + s + ". Longer than the binary.";
+      break;
+    case BinaryRegionStatus::ERROR_LENGTH_TOO_SHORT:
+      s = "ERROR: " + s + ". Shorter than the minimum length: ";
+      break;
+    case BinaryRegionStatus::ERROR_REQUIRED_FIELD_NOT_PRESENT:
+      s = "ERROR: " + s + ". Required field is not present.";
+      break;
+    case BinaryRegionStatus::ERROR_INVALID_UNION_TYPE:
+      s = "ERROR: " + s + ". Invalid union type value.";
+      break;
+    case BinaryRegionStatus::ERROR_CYCLE_DETECTED:
+      s = "ERROR: " + s + ". Invalid offset, cycle detected.";
+      break;
+  }
+
+  return s;
+}
+
 static std::string GenerateDocumentation(const BinaryRegion &region,
-                                         const BinarySection &,
+                                         const BinarySection &section,
                                          const uint8_t *binary,
                                          DocContinuation &continuation,
                                          const OutputConfig &output_config) {
@@ -199,11 +306,9 @@ static std::string GenerateDocumentation(const BinaryRegion &region,
   }
 
   s += " ";
-  if (!region.comment.empty()) {
-    s += output_config.delimiter;
-    s += " ";
-    s += region.comment;
-  }
+  s += output_config.delimiter;
+  s += " ";
+  s += GenerateComment(region.comment, section);
 
   return s;
 }

--- a/src/annotated_binary_text_gen.h
+++ b/src/annotated_binary_text_gen.h
@@ -52,8 +52,9 @@ class AnnotatedBinaryTextGenerator {
         options_(options) {}
 
   // Generate the annotated binary for the given `filename`. Returns true if the
-  // annotated binary was succesfully saved.
-  bool Generate(const std::string &filename, const std::string &schema_filename);
+  // annotated binary was successfully saved.
+  bool Generate(const std::string &filename,
+                const std::string &schema_filename);
 
  private:
   const std::map<uint64_t, BinarySection> annotations_;

--- a/src/binary_annotator.cpp
+++ b/src/binary_annotator.cpp
@@ -1,6 +1,7 @@
 #include "binary_annotator.h"
 
 #include <limits>
+#include <string>
 #include <vector>
 
 #include "flatbuffers/reflection.h"
@@ -13,28 +14,34 @@ static bool BinaryRegionSort(const BinaryRegion &a, const BinaryRegion &b) {
   return a.offset < b.offset;
 }
 
+static void SetError(BinaryRegionComment &comment, BinaryRegionStatus status,
+                     std::string message = "") {
+  comment.status = status;
+  comment.status_message = message;
+}
+
 static BinaryRegion MakeBinaryRegion(
     const uint64_t offset = 0, const uint64_t length = 0,
     const BinaryRegionType type = BinaryRegionType::Unknown,
     const uint64_t array_length = 0, const uint64_t points_to_offset = 0,
-    const std::string &comment = "") {
+    const BinaryRegionComment comment = {}) {
   BinaryRegion region;
   region.offset = offset;
   region.length = length;
   region.type = type;
   region.array_length = array_length;
   region.points_to_offset = points_to_offset;
-  region.comment = comment;
+  region.comment = std::move(comment);
   return region;
 }
 
 static BinarySection MakeBinarySection(
     const std::string &name, const BinarySectionType type,
-    const std::vector<BinaryRegion> &regions) {
+    const std::vector<BinaryRegion> regions) {
   BinarySection section;
   section.name = name;
   section.type = type;
-  section.regions = regions;
+  section.regions = std::move(regions);
   return section;
 }
 
@@ -43,7 +50,7 @@ static BinarySection MakeSingleRegionBinarySection(const std::string &name,
                                                    const BinaryRegion &region) {
   std::vector<BinaryRegion> regions;
   regions.push_back(region);
-  return MakeBinarySection(name, type, regions);
+  return MakeBinarySection(name, type, std::move(regions));
 }
 
 static bool IsNonZeroRegion(const uint64_t offset, const uint64_t length,
@@ -67,24 +74,32 @@ static BinarySection GenerateMissingSection(const uint64_t offset,
     // TODO(dbaileychess): We could be a bit smarter with different sized
     // alignments. For now, the 8 byte check encompasses all the smaller
     // alignments.
-    regions.push_back(MakeBinaryRegion(
-        offset, length * sizeof(uint8_t), BinaryRegionType::Unknown, length, 0,
-        length < 8 ? "could be a corrupted padding region (non zero) "
-                     "due to the length < 8 bytes."
-                   : "WARN: nothing refers to this section."));
+    BinaryRegionComment comment;
+    comment.type = BinaryRegionCommentType::Unknown;
+    if (length >= 8) {
+      SetError(comment, BinaryRegionStatus::WARN_NO_REFERENCES);
+    } else {
+      SetError(comment, BinaryRegionStatus::WARN_CORRUPTED_PADDING);
+    }
+
+    regions.push_back(MakeBinaryRegion(offset, length * sizeof(uint8_t),
+                                       BinaryRegionType::Unknown, length, 0,
+                                       comment));
 
     return MakeBinarySection("no known references", BinarySectionType::Unknown,
                              std::move(regions));
   }
 
+  BinaryRegionComment comment;
+  comment.type = BinaryRegionCommentType::Padding;
+  if (length >= 8) {
+    SetError(comment, BinaryRegionStatus::WARN_PADDING_LENGTH);
+  }
+
   // This region is most likely padding.
-  regions.push_back(MakeBinaryRegion(
-      offset, length * sizeof(uint8_t), BinaryRegionType::Uint8, length, 0,
-      // Output a different annotation if the pad bytes exceed what we
-      // expect to be the maximum padding.
-      length > 7 ? "likely padding but might be an unknown section "
-                   "due to being larger than 7 bytes"
-                 : "padding"));
+  regions.push_back(MakeBinaryRegion(offset, length * sizeof(uint8_t),
+                                     BinaryRegionType::Uint8, length, 0,
+                                     comment));
 
   return MakeBinarySection("", BinarySectionType::Padding, std::move(regions));
 }
@@ -138,35 +153,35 @@ uint64_t BinaryAnnotator::BuildHeader(const uint64_t header_offset) {
   uint64_t offset = header_offset;
   // TODO(dbaileychess): sized prefixed value
 
-  const std::string name = std::string("offset to root table `") +
-                           schema_->root_table()->name()->str() + "`";
+  BinaryRegionComment root_offset_comment;
+  root_offset_comment.type = BinaryRegionCommentType::RootTableOffset;
+  root_offset_comment.name = schema_->root_table()->name()->str();
 
-  if (IsValidOffset(root_table_offset.value())) {
-    regions.push_back(MakeBinaryRegion(offset, sizeof(uint32_t),
-                                       BinaryRegionType::UOffset, 0,
-                                       root_table_offset.value(), name));
-  } else {
-    regions.push_back(MakeBinaryRegion(
-        offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
-        root_table_offset.value(),
-        "ERROR: " + name + ". Invalid offset, points to outside the binary."));
+  if (!IsValidOffset(root_table_offset.value())) {
+    SetError(root_offset_comment,
+             BinaryRegionStatus::ERROR_OFFSET_OUT_OF_BINARY);
   }
+
+  regions.push_back(
+      MakeBinaryRegion(offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
+                       root_table_offset.value(), root_offset_comment));
   offset += sizeof(uint32_t);
 
   if (IsValidRead(offset, flatbuffers::kFileIdentifierLength) &&
       IsNonZeroRegion(offset, flatbuffers::kFileIdentifierLength, binary_)) {
+    BinaryRegionComment comment;
+    comment.type = BinaryRegionCommentType::FileIdentifier;
     // Check if the file identifier region has non-zero data, and assume its
     // the file identifier. Otherwise, it will get filled in with padding
     // later.
     regions.push_back(MakeBinaryRegion(
         offset, flatbuffers::kFileIdentifierLength * sizeof(uint8_t),
         BinaryRegionType::Char, flatbuffers::kFileIdentifierLength, 0,
-        std::string("File Identifier")));
+        comment));
   }
 
-  sections_.insert(std::make_pair(
-      header_offset,
-      MakeBinarySection("", BinarySectionType::Header, regions)));
+  AddSection(header_offset, MakeBinarySection("", BinarySectionType::Header,
+                                              std::move(regions)));
 
   return root_table_offset.value();
 }
@@ -180,17 +195,22 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
 
   if (ContainsSection(vtable_offset)) { return; }
 
+  BinaryRegionComment vtable_size_comment;
+  vtable_size_comment.type = BinaryRegionCommentType::VTableSize;
+
   const auto vtable_length = ReadScalar<uint16_t>(vtable_offset);
   if (!vtable_length.has_value()) {
     const uint64_t remaining = RemainingBytes(vtable_offset);
+
+    SetError(vtable_size_comment, BinaryRegionStatus::ERROR_INCOMPLETE_BINARY,
+             "2");
 
     AddSection(vtable_offset,
                MakeSingleRegionBinarySection(
                    table->name()->str(), BinarySectionType::VTable,
                    MakeBinaryRegion(vtable_offset, remaining,
                                     BinaryRegionType::Unknown, remaining, 0,
-                                    "ERROR: size of this vtable. Incomplete "
-                                    "binary, expected to read 2 bytes here")));
+                                    vtable_size_comment)));
     return;
   }
 
@@ -198,25 +218,26 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
   const uint16_t vtable_size = vtable_length.value();
 
   if (!IsValidOffset(vtable_offset + vtable_size - 1)) {
+    SetError(vtable_size_comment, BinaryRegionStatus::ERROR_LENGTH_TOO_LONG);
     // The vtable_size points to off the end of the binary.
-    AddSection(
-        vtable_offset,
-        MakeSingleRegionBinarySection(
-            table->name()->str(), BinarySectionType::VTable,
-            MakeBinaryRegion(
-                vtable_offset, sizeof(uint16_t), BinaryRegionType::Uint16, 0, 0,
-                "ERROR: size of this vtable. Longer than the binary")));
+    AddSection(vtable_offset,
+               MakeSingleRegionBinarySection(
+                   table->name()->str(), BinarySectionType::VTable,
+                   MakeBinaryRegion(vtable_offset, sizeof(uint16_t),
+                                    BinaryRegionType::Uint16, 0, 0,
+                                    vtable_size_comment)));
 
     return;
   } else if (vtable_size < 2 * sizeof(uint16_t)) {
+    SetError(vtable_size_comment, BinaryRegionStatus::ERROR_LENGTH_TOO_SHORT,
+             "4");
     // The size includes itself and the table size which are both uint16_t.
     AddSection(vtable_offset,
                MakeSingleRegionBinarySection(
                    table->name()->str(), BinarySectionType::VTable,
                    MakeBinaryRegion(vtable_offset, sizeof(uint16_t),
                                     BinaryRegionType::Uint16, 0, 0,
-                                    "ERROR: size of this vtable. Shorter than "
-                                    "the minimum 4 bytes")));
+                                    vtable_size_comment)));
     return;
   }
 
@@ -224,8 +245,12 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
 
   regions.push_back(MakeBinaryRegion(vtable_offset, sizeof(uint16_t),
                                      BinaryRegionType::Uint16, 0, 0,
-                                     std::string("size of this vtable")));
+                                     vtable_size_comment));
   uint64_t offset = vtable_offset + sizeof(uint16_t);
+
+  BinaryRegionComment ref_table_len_comment;
+  ref_table_len_comment.type =
+      BinaryRegionCommentType::VTableRefferingTableLength;
 
   // Ensure we can read the next uint16_t field, which is the size of the
   // referring table.
@@ -233,14 +258,14 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
 
   if (!table_length.has_value()) {
     const uint64_t remaining = RemainingBytes(offset);
+    SetError(ref_table_len_comment, BinaryRegionStatus::ERROR_INCOMPLETE_BINARY,
+             "2");
 
-    AddSection(offset,
-               MakeSingleRegionBinarySection(
-                   table->name()->str(), BinarySectionType::VTable,
-                   MakeBinaryRegion(offset, remaining,
-                                    BinaryRegionType::Unknown, remaining, 0,
-                                    "ERROR: sizeof referring table. Incomplete "
-                                    "binary, expected to read 2 bytes here")));
+    AddSection(offset, MakeSingleRegionBinarySection(
+                           table->name()->str(), BinarySectionType::VTable,
+                           MakeBinaryRegion(
+                               offset, remaining, BinaryRegionType::Unknown,
+                               remaining, 0, ref_table_len_comment)));
     return;
   }
 
@@ -248,20 +273,15 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
   const uint16_t table_size = table_length.value();
 
   if (!IsValidOffset(offset_of_referring_table + table_size - 1)) {
-    regions.push_back(MakeBinaryRegion(
-        offset, sizeof(uint16_t), BinaryRegionType::Uint16, 0, 0,
-        std::string("ERROR: size of referring table. Size of table is larger "
-                    "than the binary.")));
+    SetError(ref_table_len_comment, BinaryRegionStatus::ERROR_LENGTH_TOO_LONG);
   } else if (table_size < 4) {
-    regions.push_back(MakeBinaryRegion(
-        offset, sizeof(uint16_t), BinaryRegionType::Uint16, 0, 0,
-        std::string("ERROR: size of referring table. Size of table is "
-                    "smaller than the minimum 4 bytes")));
-  } else {
-    regions.push_back(MakeBinaryRegion(offset, sizeof(uint16_t),
-                                       BinaryRegionType::Uint16, 0, 0,
-                                       std::string("size of referring table")));
+    SetError(ref_table_len_comment, BinaryRegionStatus::ERROR_LENGTH_TOO_SHORT,
+             "4");
   }
+
+  regions.push_back(MakeBinaryRegion(offset, sizeof(uint16_t),
+                                     BinaryRegionType::Uint16, 0, 0,
+                                     ref_table_len_comment));
   offset += sizeof(uint16_t);
 
   const uint64_t offset_start = offset;
@@ -290,29 +310,30 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
       return;
     }
 
-    const std::string field_comment =
-        std::string("offset to field `") + field->name()->c_str() +
-        "` (id: " + std::to_string(field->id()) + ")";
+    BinaryRegionComment field_comment;
+    field_comment.type = BinaryRegionCommentType::VTableFieldOffset;
+    field_comment.name = std::string(field->name()->c_str()) +
+                         "` (id: " + std::to_string(field->id()) + ")";
 
     const auto offset_from_table = ReadScalar<uint16_t>(field_offset);
 
     if (!offset_from_table.has_value()) {
       const uint64_t remaining = RemainingBytes(field_offset);
 
-      regions.push_back(MakeBinaryRegion(
-          field_offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-          "ERROR: " + field_comment +
-              ". Incomplete binary, expected to read 2 bytes here"));
+      SetError(field_comment, BinaryRegionStatus::ERROR_INCOMPLETE_BINARY, "2");
+      regions.push_back(MakeBinaryRegion(field_offset, remaining,
+                                         BinaryRegionType::Unknown, remaining,
+                                         0, field_comment));
 
       return;
     }
 
     if (!IsValidOffset(offset_of_referring_table + offset_from_table.value() -
                        1)) {
-      regions.push_back(MakeBinaryRegion(
-          field_offset, sizeof(uint16_t), BinaryRegionType::VOffset, 0, 0,
-          "ERROR: " + field_comment +
-              ". Invalid offset, points to outside the binary."));
+      SetError(field_comment, BinaryRegionStatus::ERROR_OFFSET_OUT_OF_BINARY);
+      regions.push_back(MakeBinaryRegion(field_offset, sizeof(uint16_t),
+                                         BinaryRegionType::VOffset, 0, 0,
+                                         field_comment));
       return;
     }
 
@@ -325,54 +346,64 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
     if (offset_from_table.value() == 0) {
       // Not present, so could be default or be optional.
       if (field->required()) {
+        SetError(field_comment,
+                 BinaryRegionStatus::ERROR_REQUIRED_FIELD_NOT_PRESENT);
         // If this is a required field, make it known this is an error.
-        regions.push_back(MakeBinaryRegion(
-            field_offset, sizeof(uint16_t), BinaryRegionType::VOffset, 0, 0,
-            std::string("ERROR: required field `") + field->name()->c_str() +
-                "` (id: " + std::to_string(field->id()) + ") is not present!"));
+        regions.push_back(MakeBinaryRegion(field_offset, sizeof(uint16_t),
+                                           BinaryRegionType::VOffset, 0, 0,
+                                           field_comment));
         return;
       } else {
         // Its an optional field, so get the default value and interpret and
         // provided an annotation for it.
         if (IsScalar(field->type()->base_type())) {
-          default_label += " <defaults to ";
+          default_label += "<defaults to ";
           default_label += IsFloat(field->type()->base_type())
                                ? std::to_string(field->default_real())
                                : std::to_string(field->default_integer());
           default_label += "> (";
         } else {
-          default_label += " <null> (";
+          default_label += "<null> (";
         }
         default_label +=
             reflection::EnumNameBaseType(field->type()->base_type());
         default_label += ")";
       }
     }
+    field_comment.default_value = default_label;
 
     regions.push_back(MakeBinaryRegion(field_offset, sizeof(uint16_t),
                                        BinaryRegionType::VOffset, 0, 0,
-                                       field_comment + default_label));
+                                       field_comment));
 
     fields_processed++;
   });
 
   // Check if we covered all the expectant fields. If not, we need to add them
   // as unknown fields.
-  const uint16_t expectant_vtable_fields =
+  uint16_t expectant_vtable_fields =
       (vtable_size - sizeof(uint16_t) - sizeof(uint16_t)) / sizeof(uint16_t);
+
+  // Prevent a bad binary from declaring a really large vtable_size, that we can
+  // not indpendently verify.
+  expectant_vtable_fields = std::min(
+      static_cast<uint16_t>(fields_processed * 3), expectant_vtable_fields);
 
   for (uint16_t id = fields_processed; id < expectant_vtable_fields; ++id) {
     const uint64_t field_offset = offset_start + id * sizeof(uint16_t);
 
     const auto offset_from_table = ReadScalar<uint16_t>(field_offset);
 
+    BinaryRegionComment field_comment;
+    field_comment.type = BinaryRegionCommentType::VTableUnknownFieldOffset;
+    field_comment.index = id;
+
     if (!offset_from_table.has_value()) {
       const uint64_t remaining = RemainingBytes(field_offset);
-
-      regions.push_back(MakeBinaryRegion(
-          field_offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-          "ERROR: offset to unknown field (id: " + std::to_string(id) +
-              "). Incomplete binary, expected to read 2 bytes here"));
+      SetError(field_comment, BinaryRegionStatus::ERROR_INCOMPLETE_BINARY, "2");
+      regions.push_back(MakeBinaryRegion(field_offset, remaining,
+                                         BinaryRegionType::Unknown, remaining,
+                                         0, field_comment));
       continue;
     }
 
@@ -381,10 +412,9 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
     entry.offset_from_table = offset_from_table.value();
     fields.insert(std::make_pair(id, entry));
 
-    regions.push_back(MakeBinaryRegion(
-        field_offset, sizeof(uint16_t), BinaryRegionType::VOffset, 0, 0,
-        std::string("offset to unknown field (id: " + std::to_string(id) +
-                    ")")));
+    regions.push_back(MakeBinaryRegion(field_offset, sizeof(uint16_t),
+                                       BinaryRegionType::VOffset, 0, 0,
+                                       field_comment));
   }
 
   sections_[vtable_offset] = MakeBinarySection(
@@ -403,18 +433,22 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
                                  const reflection::Object *const table) {
   if (ContainsSection(table_offset)) { return; }
 
+  BinaryRegionComment vtable_offset_comment;
+  vtable_offset_comment.type = BinaryRegionCommentType::TableVTableOffset;
+
   const auto vtable_soffset = ReadScalar<int32_t>(table_offset);
 
   if (!vtable_soffset.has_value()) {
     const uint64_t remaining = RemainingBytes(table_offset);
+    SetError(vtable_offset_comment, BinaryRegionStatus::ERROR_INCOMPLETE_BINARY,
+             "4");
 
-    AddSection(table_offset,
-               MakeSingleRegionBinarySection(
-                   table->name()->str(), type,
-                   MakeBinaryRegion(table_offset, remaining,
-                                    BinaryRegionType::Unknown, remaining, 0,
-                                    "ERROR: offset to vtable. Incomplete "
-                                    "binary, expected to read 4 bytes here")));
+    AddSection(
+        table_offset,
+        MakeSingleRegionBinarySection(
+            table->name()->str(), type,
+            MakeBinaryRegion(table_offset, remaining, BinaryRegionType::Unknown,
+                             remaining, 0, vtable_offset_comment)));
 
     // If there aren't enough bytes left to read the vtable offset, there is
     // nothing we can do.
@@ -425,13 +459,15 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
   const uint64_t vtable_offset = table_offset - vtable_soffset.value();
 
   if (!IsValidOffset(vtable_offset)) {
+    SetError(vtable_offset_comment,
+             BinaryRegionStatus::ERROR_OFFSET_OUT_OF_BINARY);
+
     AddSection(table_offset,
                MakeSingleRegionBinarySection(
                    table->name()->str(), type,
                    MakeBinaryRegion(table_offset, sizeof(int32_t),
                                     BinaryRegionType::SOffset, 0, vtable_offset,
-                                    "ERROR: offset to vtable. Invalid offset, "
-                                    "points to outside the binary.")));
+                                    vtable_offset_comment)));
 
     // There isn't much to do with an invalid vtable offset, as we won't be able
     // to intepret the rest of the table fields.
@@ -439,9 +475,9 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
   }
 
   std::vector<BinaryRegion> regions;
-  regions.push_back(
-      MakeBinaryRegion(table_offset, sizeof(int32_t), BinaryRegionType::SOffset,
-                       0, vtable_offset, std::string("offset to vtable")));
+  regions.push_back(MakeBinaryRegion(table_offset, sizeof(int32_t),
+                                     BinaryRegionType::SOffset, 0,
+                                     vtable_offset, vtable_offset_comment));
 
   // Parse the vtable first so we know what the rest of the fields in the table
   // are.
@@ -509,31 +545,41 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
                : table_end_offset) -
           field_offset;
 
+      if (unknown_field_length == 0) { continue; }
+
       std::string hint;
 
       if (unknown_field_length == 4) {
         const auto relative_offset = ReadScalar<uint32_t>(field_offset);
         if (relative_offset.has_value()) {
           // The field is 4 in length, so it could be an offset? Provide a hint.
-          hint += " <possibly an offset? Check Loc: +0x";
+          hint += "<possibly an offset? Check Loc: +0x";
           hint += ToHex(field_offset + relative_offset.value());
           hint += ">";
         }
       }
 
+      BinaryRegionComment unknown_field_comment;
+      unknown_field_comment.type = BinaryRegionCommentType::TableUnknownField;
+
       if (!IsValidRead(field_offset, unknown_field_length)) {
         const uint64_t remaining = RemainingBytes(field_offset);
 
-        regions.push_back(MakeBinaryRegion(
-            field_offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-            "ERRROR: Unknown field. Expect to read " +
-                std::to_string(unknown_field_length) + " bytes."));
+        SetError(unknown_field_comment,
+                 BinaryRegionStatus::ERROR_INCOMPLETE_BINARY,
+                 std::to_string(unknown_field_length));
+
+        regions.push_back(MakeBinaryRegion(field_offset, remaining,
+                                           BinaryRegionType::Unknown, remaining,
+                                           0, unknown_field_comment));
         continue;
       }
 
+      unknown_field_comment.default_value = hint;
+
       regions.push_back(MakeBinaryRegion(
           field_offset, unknown_field_length, BinaryRegionType::Unknown,
-          unknown_field_length, 0, std::string("Unknown field") + hint));
+          unknown_field_length, 0, unknown_field_comment));
       continue;
     }
 
@@ -543,17 +589,21 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
       const BinaryRegionType region_type =
           GetRegionType(field->type()->base_type());
 
-      const std::string name =
-          "table field `" + std::string(field->name()->c_str()) + "` (" +
+      BinaryRegionComment scalar_field_comment;
+      scalar_field_comment.type = BinaryRegionCommentType::TableField;
+      scalar_field_comment.name =
+          std::string(field->name()->c_str()) + "` (" +
           reflection::EnumNameBaseType(field->type()->base_type()) + ")";
 
       if (!IsValidRead(field_offset, type_size)) {
         const uint64_t remaining = RemainingBytes(field_offset);
+        SetError(scalar_field_comment,
+                 BinaryRegionStatus::ERROR_INCOMPLETE_BINARY,
+                 std::to_string(type_size));
 
-        regions.push_back(MakeBinaryRegion(
-            field_offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-            "ERROR: " + name + ". Expected " + std::to_string(type_size) +
-                " bytes."));
+        regions.push_back(MakeBinaryRegion(field_offset, remaining,
+                                           BinaryRegionType::Unknown, remaining,
+                                           0, scalar_field_comment));
         continue;
       }
 
@@ -561,23 +611,29 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
         // This is a type for a union. Validate the value
         const auto enum_value = ReadScalar<uint8_t>(field_offset);
 
-        // This should alawys have a value, due to the IsValidRead check above.
+        // This should always have a value, due to the IsValidRead check above.
         if (!IsValidUnionValue(field, enum_value.value())) {
-          regions.push_back(MakeBinaryRegion(
-              field_offset, type_size, region_type, 0, 0,
-              "ERROR: " + name + " . Invalid union type value."));
+          SetError(scalar_field_comment,
+                   BinaryRegionStatus::ERROR_INVALID_UNION_TYPE);
+
+          regions.push_back(MakeBinaryRegion(field_offset, type_size,
+                                             region_type, 0, 0,
+                                             scalar_field_comment));
           continue;
         }
       }
 
-      regions.push_back(
-          MakeBinaryRegion(field_offset, type_size, region_type, 0, 0, name));
+      regions.push_back(MakeBinaryRegion(field_offset, type_size, region_type,
+                                         0, 0, scalar_field_comment));
       continue;
     }
 
     // Read the offset
     const auto offset_from_field = ReadScalar<uint32_t>(field_offset);
     uint64_t offset_of_next_item = 0;
+    BinaryRegionComment offset_field_comment;
+    offset_field_comment.type = BinaryRegionCommentType::TableOffsetField;
+    offset_field_comment.name = field->name()->c_str();
     const std::string offset_prefix =
         "offset to field `" + std::string(field->name()->c_str()) + "`";
 
@@ -585,21 +641,24 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
     if (!IsInlineField(field)) {
       if (!offset_from_field.has_value()) {
         const uint64_t remaining = RemainingBytes(field_offset);
-        regions.push_back(MakeBinaryRegion(
-            field_offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-            std::string("ERROR: ") + offset_prefix +
-                ". Incomplete binary, expected to read 4 bytes here"));
+
+        SetError(offset_field_comment,
+                 BinaryRegionStatus::ERROR_INCOMPLETE_BINARY, "4");
+
+        regions.push_back(MakeBinaryRegion(field_offset, remaining,
+                                           BinaryRegionType::Unknown, remaining,
+                                           0, offset_field_comment));
         continue;
       }
 
       offset_of_next_item = field_offset + offset_from_field.value();
 
       if (!IsValidOffset(offset_of_next_item)) {
-        regions.push_back(
-            MakeBinaryRegion(field_offset, sizeof(uint32_t),
-                             BinaryRegionType::UOffset, 0, offset_of_next_item,
-                             std::string("ERROR: ") + offset_prefix +
-                                 ". Location is outside the binary."));
+        SetError(offset_field_comment,
+                 BinaryRegionStatus::ERROR_OFFSET_OUT_OF_BINARY);
+        regions.push_back(MakeBinaryRegion(
+            field_offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
+            offset_of_next_item, offset_field_comment));
         continue;
       }
     }
@@ -613,9 +672,11 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
           // Structs are stored inline.
           BuildStruct(field_offset, regions, next_object);
         } else {
+          offset_field_comment.default_value = "(table)";
+
           regions.push_back(MakeBinaryRegion(
               field_offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
-              offset_of_next_item, offset_prefix + " (table)"));
+              offset_of_next_item, offset_field_comment));
 
           BuildTable(offset_of_next_item, BinarySectionType::Table,
                      next_object);
@@ -623,16 +684,18 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
       } break;
 
       case reflection::BaseType::String: {
+        offset_field_comment.default_value = "(string)";
         regions.push_back(MakeBinaryRegion(
             field_offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
-            offset_of_next_item, offset_prefix + " (string)"));
+            offset_of_next_item, offset_field_comment));
         BuildString(offset_of_next_item, table, field);
       } break;
 
       case reflection::BaseType::Vector: {
+        offset_field_comment.default_value = "(vector)";
         regions.push_back(MakeBinaryRegion(
             field_offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
-            offset_of_next_item, offset_prefix + " (vector)"));
+            offset_of_next_item, offset_field_comment));
         BuildVector(offset_of_next_item, table, field, table_offset, vtable);
       } break;
 
@@ -647,6 +710,7 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
           // TODO(dbaileychess): need to capture this error condition.
           break;
         }
+        offset_field_comment.default_value = "(union)";
 
         const uint64_t type_offset =
             table_offset + vtable_field->second.offset_from_table;
@@ -654,10 +718,11 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
         const auto realized_type = ReadScalar<uint8_t>(type_offset);
         if (!realized_type.has_value()) {
           const uint64_t remaining = RemainingBytes(type_offset);
+          SetError(offset_field_comment,
+                   BinaryRegionStatus::ERROR_INCOMPLETE_BINARY, "1");
           regions.push_back(MakeBinaryRegion(
               type_offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-              "ERROR: " + offset_prefix +
-                  " (union). Incomplete binary, expected to read 1 byte here"));
+              offset_field_comment));
           continue;
         }
 
@@ -671,10 +736,12 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
         const std::string enum_type =
             BuildUnion(union_offset, realized_type.value(), field);
 
-        regions.push_back(MakeBinaryRegion(
-            field_offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
-            union_offset,
-            offset_prefix + " (union of type `" + enum_type + "`)"));
+        offset_field_comment.default_value =
+            "(union of type `" + enum_type + "`)";
+
+        regions.push_back(MakeBinaryRegion(field_offset, sizeof(uint32_t),
+                                           BinaryRegionType::UOffset, 0,
+                                           union_offset, offset_field_comment));
 
       } break;
 
@@ -689,9 +756,13 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
 
   if (i < table_end_offset) {
     const uint64_t pad_bytes = table_end_offset - i + 1;
+
+    BinaryRegionComment padding_comment;
+    padding_comment.type = BinaryRegionCommentType::Padding;
+
     regions.push_back(MakeBinaryRegion(i - 1, pad_bytes * sizeof(uint8_t),
                                        BinaryRegionType::Uint8, pad_bytes, 0,
-                                       "padding"));
+                                       padding_comment));
   }
 
   AddSection(table_offset,
@@ -712,17 +783,22 @@ uint64_t BinaryAnnotator::BuildStruct(const uint64_t struct_offset,
       const BinaryRegionType region_type =
           GetRegionType(field->type()->base_type());
 
-      const std::string name =
-          std::string("struct field `") + object->name()->c_str() + "." +
-          field->name()->c_str() + "` (" +
-          reflection::EnumNameBaseType(field->type()->base_type()) + ")";
+      BinaryRegionComment comment;
+      comment.type = BinaryRegionCommentType::StructField;
+      comment.name =
+          std::string(object->name()->c_str()) + "." + field->name()->c_str();
+      comment.default_value = "(" +
+                              std::string(reflection::EnumNameBaseType(
+                                  field->type()->base_type())) +
+                              ")";
 
       if (!IsValidRead(offset, type_size)) {
         const uint64_t remaining = RemainingBytes(offset);
-        regions.push_back(MakeBinaryRegion(
-            offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-            "ERROR: " + name + ". Expected to read " +
-                std::to_string(type_size) + " bytes."));
+        SetError(comment, BinaryRegionStatus::ERROR_INCOMPLETE_BINARY,
+                 std::to_string(type_size));
+        regions.push_back(MakeBinaryRegion(offset, remaining,
+                                           BinaryRegionType::Unknown, remaining,
+                                           0, comment));
 
         // TODO(dbaileychess): Should I bail out here? This sets offset to the
         // end of the binary. So all other reads in the loop should fail.
@@ -731,7 +807,7 @@ uint64_t BinaryAnnotator::BuildStruct(const uint64_t struct_offset,
       }
 
       regions.push_back(
-          MakeBinaryRegion(offset, type_size, region_type, 0, 0, name));
+          MakeBinaryRegion(offset, type_size, region_type, 0, 0, comment));
       offset += type_size;
     } else if (field->type()->base_type() == reflection::BaseType::Obj) {
       // Structs are stored inline, even when nested.
@@ -746,17 +822,26 @@ uint64_t BinaryAnnotator::BuildStruct(const uint64_t struct_offset,
       // Arrays are just repeated structures.
       for (uint16_t i = 0; i < field->type()->fixed_length(); ++i) {
         if (is_scalar) {
-          const std::string name =
-              std::string("array field `") + object->name()->c_str() + "." +
-              field->name()->c_str() + "[" + std::to_string(i) + "]` (" +
-              reflection::EnumNameBaseType(field->type()->element()) + ")";
+          BinaryRegionComment array_comment;
+          array_comment.type = BinaryRegionCommentType::ArrayField;
+          array_comment.name = std::string(object->name()->c_str()) + "." +
+                               field->name()->c_str();
+          array_comment.index = i;
+          array_comment.default_value =
+              "(" +
+              std::string(
+                  reflection::EnumNameBaseType(field->type()->element())) +
+              ")";
 
           if (!IsValidRead(offset, type_size)) {
             const uint64_t remaining = RemainingBytes(offset);
-            regions.push_back(MakeBinaryRegion(
-                offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-                "ERROR: " + name + ". Expected to read " +
-                    std::to_string(type_size) + " bytes."));
+
+            SetError(array_comment, BinaryRegionStatus::ERROR_INCOMPLETE_BINARY,
+                     std::to_string(type_size));
+
+            regions.push_back(MakeBinaryRegion(offset, remaining,
+                                               BinaryRegionType::Unknown,
+                                               remaining, 0, array_comment));
 
             // TODO(dbaileychess): Should I bail out here? This sets offset to
             // the end of the binary. So all other reads in the loop should
@@ -765,8 +850,8 @@ uint64_t BinaryAnnotator::BuildStruct(const uint64_t struct_offset,
             break;
           }
 
-          regions.push_back(
-              MakeBinaryRegion(offset, type_size, region_type, 0, 0, name));
+          regions.push_back(MakeBinaryRegion(offset, type_size, region_type, 0,
+                                             0, array_comment));
 
           offset += type_size;
         } else {
@@ -795,13 +880,18 @@ void BinaryAnnotator::BuildString(const uint64_t string_offset,
   std::vector<BinaryRegion> regions;
   const auto string_length = ReadScalar<uint32_t>(string_offset);
 
+  BinaryRegionComment string_length_comment;
+  string_length_comment.type = BinaryRegionCommentType::StringLength;
+
   if (!string_length.has_value()) {
     const uint64_t remaining = RemainingBytes(string_offset);
 
-    regions.push_back(MakeBinaryRegion(
-        string_offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-        std::string("ERROR: length of string. Incomplete binary, expected to "
-                    "read 4 bytes here")));
+    SetError(string_length_comment, BinaryRegionStatus::ERROR_INCOMPLETE_BINARY,
+             "4");
+
+    regions.push_back(MakeBinaryRegion(string_offset, remaining,
+                                       BinaryRegionType::Unknown, remaining, 0,
+                                       string_length_comment));
 
   } else {
     const uint32_t string_size = string_length.value();
@@ -809,22 +899,31 @@ void BinaryAnnotator::BuildString(const uint64_t string_offset,
         string_offset + sizeof(uint32_t) + string_size + sizeof(char);
 
     if (!IsValidOffset(string_end - 1)) {
-      regions.push_back(MakeBinaryRegion(
-          string_offset, sizeof(uint32_t), BinaryRegionType::Uint32, 0, 0,
-          std::string(
-              "ERROR: length of string. Length is longer than the binary.")));
+      SetError(string_length_comment,
+               BinaryRegionStatus::ERROR_LENGTH_TOO_LONG);
+
+      regions.push_back(MakeBinaryRegion(string_offset, sizeof(uint32_t),
+                                         BinaryRegionType::Uint32, 0, 0,
+                                         string_length_comment));
     } else {
       regions.push_back(MakeBinaryRegion(string_offset, sizeof(uint32_t),
                                          BinaryRegionType::Uint32, 0, 0,
-                                         "length of string"));
+                                         string_length_comment));
+
+      BinaryRegionComment string_comment;
+      string_comment.type = BinaryRegionCommentType::StringValue;
 
       regions.push_back(MakeBinaryRegion(string_offset + sizeof(uint32_t),
                                          string_size, BinaryRegionType::Char,
-                                         string_size, 0, ""));
+                                         string_size, 0, string_comment));
+
+      BinaryRegionComment string_terminator_comment;
+      string_terminator_comment.type =
+          BinaryRegionCommentType::StringTerminator;
 
       regions.push_back(MakeBinaryRegion(
           string_offset + sizeof(uint32_t) + string_size, sizeof(char),
-          BinaryRegionType::Char, 0, 0, std::string("string terminator")));
+          BinaryRegionType::Char, 0, 0, string_terminator_comment));
     }
   }
 
@@ -841,9 +940,14 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
                                   const VTable &vtable) {
   if (ContainsSection(vector_offset)) { return; }
 
+  BinaryRegionComment vector_length_comment;
+  vector_length_comment.type = BinaryRegionCommentType::VectorLength;
+
   const auto vector_length = ReadScalar<uint32_t>(vector_offset);
   if (!vector_length.has_value()) {
     const uint64_t remaining = RemainingBytes(vector_offset);
+    SetError(vector_length_comment, BinaryRegionStatus::ERROR_INCOMPLETE_BINARY,
+             "4");
 
     AddSection(
         vector_offset,
@@ -852,8 +956,7 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
             BinarySectionType::Vector,
             MakeBinaryRegion(vector_offset, remaining,
                              BinaryRegionType::Unknown, remaining, 0,
-                             "ERROR: length of vector (# items). Incomplete "
-                             "binary, expected to read 4 bytes here")));
+                             vector_length_comment)));
     return;
   }
 
@@ -864,6 +967,7 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
       vector_length.value() * GetElementSize(field);
 
   if (!IsValidOffset(last_item_offset - 1)) {
+    SetError(vector_length_comment, BinaryRegionStatus::ERROR_LENGTH_TOO_LONG);
     AddSection(
         vector_offset,
         MakeSingleRegionBinarySection(
@@ -871,17 +975,16 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
             BinarySectionType::Vector,
             MakeBinaryRegion(vector_offset, sizeof(uint32_t),
                              BinaryRegionType::Uint32, 0, 0,
-                             "ERROR: length of vector (# items). Invalid "
-                             "length, points outside the binary.")));
+                             vector_length_comment)));
 
     return;
   }
 
   std::vector<BinaryRegion> regions;
 
-  regions.push_back(MakeBinaryRegion(
-      vector_offset, sizeof(uint32_t), BinaryRegionType::Uint32, 0, 0,
-      std::string("length of vector (# items)")));
+  regions.push_back(MakeBinaryRegion(vector_offset, sizeof(uint32_t),
+                                     BinaryRegionType::Uint32, 0, 0,
+                                     vector_length_comment));
 
   uint64_t offset = vector_offset + sizeof(uint32_t);
 
@@ -901,17 +1004,20 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
       } else {
         // Vector of objects
         for (size_t i = 0; i < vector_length.value(); ++i) {
-          const std::string name = "offset to table[" + std::to_string(i) + "]";
+          BinaryRegionComment vector_object_comment;
+          vector_object_comment.type =
+              BinaryRegionCommentType::VectorTableValue;
+          vector_object_comment.index = i;
 
           const auto table_relative_offset = ReadScalar<uint32_t>(offset);
           if (!table_relative_offset.has_value()) {
             const uint64_t remaining = RemainingBytes(offset);
+            SetError(vector_object_comment,
+                     BinaryRegionStatus::ERROR_INCOMPLETE_BINARY, "4");
 
-            regions.push_back(MakeBinaryRegion(
-                offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-                "ERROR: " + name +
-                    ". Incomplete binary, expected to "
-                    "read 4 bytes here"));
+            regions.push_back(
+                MakeBinaryRegion(offset, remaining, BinaryRegionType::Unknown,
+                                 remaining, 0, vector_object_comment));
             break;
           }
 
@@ -919,40 +1025,56 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
           const uint64_t table_offset = offset + table_relative_offset.value();
 
           if (!IsValidOffset(table_offset)) {
+            SetError(vector_object_comment,
+                     BinaryRegionStatus::ERROR_OFFSET_OUT_OF_BINARY);
             regions.push_back(MakeBinaryRegion(
                 offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
-                table_offset,
-                "ERROR: " + name +
-                    ". Invalid offset, points to outside the binary."));
+                table_offset, vector_object_comment));
 
             offset += sizeof(uint32_t);
             continue;
           }
 
-          regions.push_back(MakeBinaryRegion(offset, sizeof(uint32_t),
-                                             BinaryRegionType::UOffset, 0,
-                                             table_offset, name));
+          if (table_offset == parent_table_offset) {
+            SetError(vector_object_comment,
+                     BinaryRegionStatus::ERROR_CYCLE_DETECTED);
+            // A cycle detected where a table vector field is pointing to
+            // itself. This should only happen in corrupted files.
+            regions.push_back(MakeBinaryRegion(
+                offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
+                table_offset, vector_object_comment));
 
-          BuildTable(table_offset, BinarySectionType::Table, object);
+            offset += sizeof(uint32_t);
+            continue;
+          }
+
+          regions.push_back(MakeBinaryRegion(
+              offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
+              table_offset, vector_object_comment));
 
           offset += sizeof(uint32_t);
+
+          BuildTable(table_offset, BinarySectionType::Table, object);
         }
       }
     } break;
     case reflection::BaseType::String: {
       // Vector of strings
       for (size_t i = 0; i < vector_length.value(); ++i) {
-        const std::string name = "offset to string[" + std::to_string(i) + "]";
+        BinaryRegionComment vector_object_comment;
+        vector_object_comment.type = BinaryRegionCommentType::VectorStringValue;
+        vector_object_comment.index = i;
 
         const auto string_relative_offset = ReadScalar<uint32_t>(offset);
         if (!string_relative_offset.has_value()) {
           const uint64_t remaining = RemainingBytes(offset);
 
-          regions.push_back(MakeBinaryRegion(
-              offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-              "ERROR: " + name +
-                  ". Incomplete binary, expected to "
-                  "read 4 bytes here"));
+          SetError(vector_object_comment,
+                   BinaryRegionStatus::ERROR_INCOMPLETE_BINARY, "4");
+
+          regions.push_back(
+              MakeBinaryRegion(offset, remaining, BinaryRegionType::Unknown,
+                               remaining, 0, vector_object_comment));
           break;
         }
 
@@ -960,19 +1082,19 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
         const uint64_t string_offset = offset + string_relative_offset.value();
 
         if (!IsValidOffset(string_offset)) {
+          SetError(vector_object_comment,
+                   BinaryRegionStatus::ERROR_OFFSET_OUT_OF_BINARY);
           regions.push_back(MakeBinaryRegion(
               offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
-              string_offset,
-              "ERROR: " + name +
-                  ". Invalid offset, points to outside the binary."));
+              string_offset, vector_object_comment));
 
           offset += sizeof(uint32_t);
           continue;
         }
 
-        regions.push_back(MakeBinaryRegion(offset, sizeof(uint32_t),
-                                           BinaryRegionType::UOffset, 0,
-                                           string_offset, name));
+        regions.push_back(MakeBinaryRegion(
+            offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
+            string_offset, vector_object_comment));
 
         BuildString(string_offset, table, field);
 
@@ -1000,11 +1122,14 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
 
       if (!union_type_vector_field_relative_offset.has_value()) {
         const uint64_t remaining = RemainingBytes(offset);
+        BinaryRegionComment vector_union_comment;
+        vector_union_comment.type = BinaryRegionCommentType::VectorUnionValue;
+        SetError(vector_union_comment,
+                 BinaryRegionStatus::ERROR_INCOMPLETE_BINARY, "2");
 
-        regions.push_back(MakeBinaryRegion(
-            offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-            "ERROR: Union vector offset. Incomplete binary, expected to "
-            "read 2 bytes here."));
+        regions.push_back(MakeBinaryRegion(offset, remaining,
+                                           BinaryRegionType::Unknown, remaining,
+                                           0, vector_union_comment));
 
         break;
       }
@@ -1017,17 +1142,19 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
           union_type_vector_field_relative_offset.value() + sizeof(uint32_t);
 
       for (size_t i = 0; i < vector_length.value(); ++i) {
-        const std::string name = "offset to union[" + std::to_string(i) + "]";
+        BinaryRegionComment comment;
+        comment.type = BinaryRegionCommentType::VectorUnionValue;
+        comment.index = i;
 
         const auto union_relative_offset = ReadScalar<uint32_t>(offset);
         if (!union_relative_offset.has_value()) {
           const uint64_t remaining = RemainingBytes(offset);
 
-          regions.push_back(MakeBinaryRegion(
-              offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-              "ERROR: " + name +
-                  ". Incomplete binary, expected to "
-                  "read 4 bytes here"));
+          SetError(comment, BinaryRegionStatus::ERROR_INCOMPLETE_BINARY, "4");
+
+          regions.push_back(MakeBinaryRegion(offset, remaining,
+                                             BinaryRegionType::Unknown,
+                                             remaining, 0, comment));
 
           break;
         }
@@ -1036,22 +1163,21 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
         const uint64_t union_offset = offset + union_relative_offset.value();
 
         if (!IsValidOffset(union_offset)) {
-          regions.push_back(MakeBinaryRegion(
-              offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
-              union_offset,
-              "ERROR: " + name +
-                  ". Invalid offset, points to outside the binary."));
+          SetError(comment, BinaryRegionStatus::ERROR_OFFSET_OUT_OF_BINARY);
+
+          regions.push_back(MakeBinaryRegion(offset, sizeof(uint32_t),
+                                             BinaryRegionType::UOffset, 0,
+                                             union_offset, comment));
           continue;
         }
 
         const auto realized_type =
             ReadScalar<uint8_t>(union_type_vector_data_offset + i);
+
         if (!realized_type.has_value()) {
-          regions.push_back(
-              MakeBinaryRegion(offset, 0, BinaryRegionType::Unknown, 0, 0,
-                               "ERROR: " + name +
-                                   ". Incomplete binary, expected to "
-                                   "read 1 byte here."));
+          SetError(comment, BinaryRegionStatus::ERROR_INCOMPLETE_BINARY, "1");
+          regions.push_back(MakeBinaryRegion(
+              offset, 0, BinaryRegionType::Unknown, 0, 0, comment));
           continue;
         }
 
@@ -1067,9 +1193,10 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
         const std::string enum_type =
             BuildUnion(union_offset, realized_type.value(), field);
 
-        regions.push_back(MakeBinaryRegion(
-            offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
-            union_offset, name + " (`" + enum_type + "`)"));
+        comment.default_value = "(`" + enum_type + "`)";
+        regions.push_back(MakeBinaryRegion(offset, sizeof(uint32_t),
+                                           BinaryRegionType::UOffset, 0,
+                                           union_offset, comment));
 
         offset += sizeof(uint32_t);
       }
@@ -1084,17 +1211,20 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
         // TODO(dbaileychess): It might be nicer to user the
         // BinaryRegion.array_length field to indicate this.
         for (size_t i = 0; i < vector_length.value(); ++i) {
-          const std::string name =
-              std::string("value[") + std::to_string(i) + "]";
+          BinaryRegionComment vector_scalar_comment;
+          vector_scalar_comment.type = BinaryRegionCommentType::VectorValue;
+          vector_scalar_comment.index = i;
+
           if (!IsValidRead(offset, type_size)) {
             const uint64_t remaining = RemainingBytes(offset);
 
-            regions.push_back(MakeBinaryRegion(
-                offset, remaining, BinaryRegionType::Unknown, remaining, 0,
-                "ERROR: " + name +
-                    ". Incomplete "
-                    "binary, expected to read " +
-                    std::to_string(type_size) + " bytes here"));
+            SetError(vector_scalar_comment,
+                     BinaryRegionStatus::ERROR_INCOMPLETE_BINARY,
+                     std::to_string(type_size));
+
+            regions.push_back(
+                MakeBinaryRegion(offset, remaining, BinaryRegionType::Unknown,
+                                 remaining, 0, vector_scalar_comment));
             break;
           }
 
@@ -1102,31 +1232,32 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
             // This is a type for a union. Validate the value
             const auto enum_value = ReadScalar<uint8_t>(offset);
 
-            // This should alawys have a value, due to the IsValidRead check
+            // This should always have a value, due to the IsValidRead check
             // above.
             if (!IsValidUnionValue(field->type()->index(),
                                    enum_value.value())) {
-              regions.push_back(MakeBinaryRegion(
-                  offset, type_size, binary_region_type, 0, 0,
-                  "ERROR: " + name + ". Invalid union type value."));
+              SetError(vector_scalar_comment,
+                       BinaryRegionStatus::ERROR_INVALID_UNION_TYPE);
+              regions.push_back(MakeBinaryRegion(offset, type_size,
+                                                 binary_region_type, 0, 0,
+                                                 vector_scalar_comment));
               offset += type_size;
               continue;
             }
           }
 
           regions.push_back(MakeBinaryRegion(offset, type_size,
-                                             binary_region_type, 0, 0, name));
+                                             binary_region_type, 0, 0,
+                                             vector_scalar_comment));
           offset += type_size;
         }
       }
     } break;
   }
-
-  sections_.insert(std::make_pair(
-      vector_offset,
-      MakeBinarySection(
-          std::string(table->name()->c_str()) + "." + field->name()->c_str(),
-          BinarySectionType::Vector, std::move(regions))));
+  AddSection(vector_offset,
+             MakeBinarySection(std::string(table->name()->c_str()) + "." +
+                                   field->name()->c_str(),
+                               BinarySectionType::Vector, std::move(regions)));
 }
 
 std::string BinaryAnnotator::BuildUnion(const uint64_t union_offset,
@@ -1187,14 +1318,18 @@ void BinaryAnnotator::FixMissingRegions() {
       if (offset < next_offset) {
         const uint64_t padding_bytes = next_offset - offset;
 
+        BinaryRegionComment comment;
+        comment.type = BinaryRegionCommentType::Padding;
+
         if (IsNonZeroRegion(offset, padding_bytes, binary_)) {
-          regions_to_insert.push_back(MakeBinaryRegion(
-              offset, padding_bytes, BinaryRegionType::Unknown, padding_bytes,
-              0, "WARN: nothing refers to this region."));
+          SetError(comment, BinaryRegionStatus::WARN_NO_REFERENCES);
+          regions_to_insert.push_back(
+              MakeBinaryRegion(offset, padding_bytes, BinaryRegionType::Unknown,
+                               padding_bytes, 0, comment));
         } else {
           regions_to_insert.push_back(
               MakeBinaryRegion(offset, padding_bytes, BinaryRegionType::Uint8,
-                               padding_bytes, 0, "padding"));
+                               padding_bytes, 0, comment));
         }
       }
       offset = next_offset + region.length;
@@ -1240,9 +1375,25 @@ void BinaryAnnotator::FixMissingSections() {
   }
 
   for (const BinarySection &section_to_insert : sections_to_insert) {
-    sections_.insert(
-        std::make_pair(section_to_insert.regions[0].offset, section_to_insert));
+    AddSection(section_to_insert.regions[0].offset, section_to_insert);
   }
+}
+
+bool BinaryAnnotator::ContainsSection(const uint64_t offset) {
+  auto it = sections_.lower_bound(offset);
+  // If the section is found, check that it is exactly equal its offset.
+  if (it != sections_.end() && it->first == offset) { return true; }
+
+  // If this was the first section, there are no other previous sections to
+  // check.
+  if (it == sections_.begin()) { return false; }
+
+  // Go back one section.
+  --it;
+
+  // And check that if the offset is covered by the section.
+  return offset >= it->first && offset <= it->second.regions.back().offset +
+                                              it->second.regions.back().length;
 }
 
 }  // namespace flatbuffers

--- a/tests/annotated_binary/annotated_binary.afb
+++ b/tests/annotated_binary/annotated_binary.afb
@@ -54,9 +54,9 @@ root_table (AnnotatedBinary.Foo):
   +0x0058 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t    | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t    | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t    | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
@@ -78,7 +78,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t   | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]    | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]    | alice                          | string literal
   +0x00B5 | 00                      | char       | 0x00 (0)                       | string terminator
 
 padding:
@@ -162,17 +162,17 @@ vector (AnnotatedBinary.Foo.names):
 
 string (AnnotatedBinary.Foo.names):
   +0x017C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
   +0x0187 | 00                      | char       | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0188 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]    | bob                            
+  +0x018C | 62 6F 62                | char[3]    | bob                            | string literal
   +0x018F | 00                      | char       | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0190 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]    | alice                          
+  +0x0194 | 61 6C 69 63 65          | char[5]    | alice                          | string literal
   +0x0199 | 00                      | char       | 0x00 (0)                       | string terminator
 
 padding:
@@ -180,12 +180,12 @@ padding:
 
 string (AnnotatedBinary.Foo.alice):
   +0x019C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
   +0x01A7 | 00                      | char       | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.bob):
   +0x01A8 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]    | charlie                        
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
   +0x01B3 | 00                      | char       | 0x00 (0)                       | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
@@ -261,7 +261,7 @@ table (AnnotatedBinary.Baz):
 
 string (AnnotatedBinary.Foo.name):
   +0x023C | 2F 00 00 00             | uint32_t   | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]   | This is                        
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]   | This is                        | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |            | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |            | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |            |  show ho

--- a/tests/annotated_binary/tests/invalid_root_offset.afb
+++ b/tests/annotated_binary/tests/invalid_root_offset.afb
@@ -4,7 +4,7 @@
 // Binary file: tests/invalid_root_offset.bin
 
 header:
-  +0x0000 | FF FF 00 00             | UOffset32     | 0x0000FFFF (65535) Loc: +0xFFFF | ERROR: offset to root table `AnnotatedBinary.Foo`. Invalid offset, points to outside the binary.
+  +0x0000 | FF FF 00 00             | UOffset32     | 0x0000FFFF (65535) Loc: +0xFFFF | ERROR: offset to root table `AnnotatedBinary.Foo`. Invalid offset, points outside the binary.
   +0x0004 | 41 4E 4E 4F             | char[4]       | ANNO                            | File Identifier
 
 unknown (no known references):

--- a/tests/annotated_binary/tests/invalid_root_table_too_short.afb
+++ b/tests/annotated_binary/tests/invalid_root_table_too_short.afb
@@ -18,4 +18,4 @@ unknown (no known references):
   +0x40 | 00 00 64 00             |              | ..d.
 
 root_table (AnnotatedBinary.Foo):
-  +0x44 | 3A 00                   | ?uint8_t[2]  | :.                         | ERROR: offset to vtable. Incomplete binary, expected to read 4 bytes here
+  +0x44 | 3A 00                   | ?uint8_t[2]  | :.                         | ERROR: offset to vtable. Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_root_table_vtable_offset.afb
+++ b/tests/annotated_binary/tests/invalid_root_table_vtable_offset.afb
@@ -18,7 +18,7 @@ unknown (no known references):
   +0x0040 | 00 00 64 00             |               | ..d.
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | FF FF 00 00             | SOffset32     | 0x0000FFFF (65535) Loc: +0xFFFFFFFFFFFF0045 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x0044 | FF FF 00 00             | SOffset32     | 0x0000FFFF (65535) Loc: +0xFFFFFFFFFFFF0045 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x0048 | 00 00 00 01 02 02 01 01 | ?uint8_t[600] | ........                                    | WARN: nothing refers to this section.

--- a/tests/annotated_binary/tests/invalid_string_length.afb
+++ b/tests/annotated_binary/tests/invalid_string_length.afb
@@ -54,9 +54,9 @@ root_table (AnnotatedBinary.Foo):
   +0x0058 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t     | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t     | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t     | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
@@ -77,7 +77,7 @@ root_table (AnnotatedBinary.Foo):
   +0x00A8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | FF FF 00 00             | uint32_t    | 0x0000FFFF (65535)             | ERROR: length of string. Length is longer than the binary.
+  +0x00AC | FF FF 00 00             | uint32_t    | 0x0000FFFF (65535)             | ERROR: length of string. Longer than the binary.
 
 unknown (no known references):
   +0x00B0 | 61 6C 69 63 65 00 00 00 | ?uint8_t[8] | alice...                       | WARN: nothing refers to this section.
@@ -160,17 +160,17 @@ vector (AnnotatedBinary.Foo.names):
 
 string (AnnotatedBinary.Foo.names):
   +0x017C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
   +0x0187 | 00                      | char        | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0188 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]     | bob                            
+  +0x018C | 62 6F 62                | char[3]     | bob                            | string literal
   +0x018F | 00                      | char        | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0190 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]     | alice                          
+  +0x0194 | 61 6C 69 63 65          | char[5]     | alice                          | string literal
   +0x0199 | 00                      | char        | 0x00 (0)                       | string terminator
 
 padding:
@@ -178,12 +178,12 @@ padding:
 
 string (AnnotatedBinary.Foo.alice):
   +0x019C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
   +0x01A7 | 00                      | char        | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.bob):
   +0x01A8 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]     | charlie                        
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
   +0x01B3 | 00                      | char        | 0x00 (0)                       | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
@@ -259,7 +259,7 @@ table (AnnotatedBinary.Baz):
 
 string (AnnotatedBinary.Foo.name):
   +0x023C | 2F 00 00 00             | uint32_t    | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]    | This is                        
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]    | This is                        | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |             | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |             | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |             |  show ho

--- a/tests/annotated_binary/tests/invalid_string_length_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_string_length_cut_short.afb
@@ -50,31 +50,31 @@ root_table (AnnotatedBinary.Foo):
   +0x4E | 01                      | UType8      | 0x01 (1)                     | table field `measurement_type` (UType)
   +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
   +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
-  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Location is outside the binary.
+  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
   +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)              | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)              | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x70 | 01                      | uint8_t     | 0x01 (1)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x71 | 02                      | uint8_t     | 0x02 (2)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x72 | 03                      | uint8_t     | 0x03 (3)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x73 | 00                      | uint8_t[1]  | .                            | padding
-  +0x74 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x23C | ERROR: offset to field `name`. Location is outside the binary.
-  +0x78 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x1D4 | ERROR: offset to field `bars`. Location is outside the binary.
-  +0x7C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: +0x1CC | ERROR: offset to field `bar_baz`. Location is outside the binary.
-  +0x80 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: +0x1B4 | ERROR: offset to field `accounts`. Location is outside the binary.
-  +0x84 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: +0x1A8 | ERROR: offset to field `bob`. Location is outside the binary.
-  +0x88 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: +0x19C | ERROR: offset to field `alice`. Location is outside the binary.
+  +0x74 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x23C | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x78 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x1D4 | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x7C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: +0x1CC | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
+  +0x80 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: +0x1B4 | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
+  +0x84 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: +0x1A8 | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
+  +0x88 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: +0x19C | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
   +0x8C | 0D 00 00 00             | uint32_t    | 0x0000000D (13)              | table field `just_i32` (Int)
-  +0x90 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: +0x16C | ERROR: offset to field `names`. Location is outside the binary.
-  +0x94 | A0 00 00 00             | UOffset32   | 0x000000A0 (160) Loc: +0x134 | ERROR: offset to field `points_of_interest`. Location is outside the binary.
-  +0x98 | 94 00 00 00             | UOffset32   | 0x00000094 (148) Loc: +0x12C | ERROR: offset to field `foobars_type`. Location is outside the binary.
-  +0x9C | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0xD4   | ERROR: offset to field `foobars`. Location is outside the binary.
-  +0xA0 | 33 00 00 00             | UOffset32   | 0x00000033 (51) Loc: +0xD3   | ERROR: offset to field `measurement`. Location is outside the binary.
-  +0xA4 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0xC0   | ERROR: offset to field `anything`. Location is outside the binary.
+  +0x90 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: +0x16C | ERROR: offset to field `names`. Invalid offset, points outside the binary.
+  +0x94 | A0 00 00 00             | UOffset32   | 0x000000A0 (160) Loc: +0x134 | ERROR: offset to field `points_of_interest`. Invalid offset, points outside the binary.
+  +0x98 | 94 00 00 00             | UOffset32   | 0x00000094 (148) Loc: +0x12C | ERROR: offset to field `foobars_type`. Invalid offset, points outside the binary.
+  +0x9C | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0xD4   | ERROR: offset to field `foobars`. Invalid offset, points outside the binary.
+  +0xA0 | 33 00 00 00             | UOffset32   | 0x00000033 (51) Loc: +0xD3   | ERROR: offset to field `measurement`. Invalid offset, points outside the binary.
+  +0xA4 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0xC0   | ERROR: offset to field `anything`. Invalid offset, points outside the binary.
   +0xA8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0xAC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0xAC | 05 00                   | ?uint8_t[2] | ..                           | ERROR: length of string. Incomplete binary, expected to read 4 bytes here
+  +0xAC | 05 00                   | ?uint8_t[2] | ..                           | ERROR: length of string. Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_struct_array_field_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_struct_array_field_cut_short.afb
@@ -12,34 +12,34 @@ padding:
 
 vtable (AnnotatedBinary.Foo):
   +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                  | size of this vtable
-  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                 | ERROR: size of referring table. Size of table is larger than the binary.
+  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                 | ERROR: size of referring table. Longer than the binary.
   +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                  | offset to field `counter` (id: 0)
   +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                   | offset to field `healthy` (id: 1)
   +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `level` (id: 2) <defaults to 99> (Long)
   +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                   | offset to field `meal` (id: 3)
   +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                  | offset to field `bar` (id: 4)
   +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                  | offset to field `home` (id: 5)
-  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                  | ERROR: offset to field `name` (id: 6). Invalid offset, points to outside the binary.
-  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                  | ERROR: offset to field `bars` (id: 7). Invalid offset, points to outside the binary.
+  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                  | ERROR: offset to field `name` (id: 6). Invalid offset, points outside the binary.
+  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                  | ERROR: offset to field `bars` (id: 7). Invalid offset, points outside the binary.
   +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                   | offset to field `bar_baz_type` (id: 8)
-  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                  | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points to outside the binary.
-  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                  | ERROR: offset to field `accounts` (id: 10). Invalid offset, points to outside the binary.
-  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                  | ERROR: offset to field `bob` (id: 11). Invalid offset, points to outside the binary.
-  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                  | ERROR: offset to field `alice` (id: 12). Invalid offset, points to outside the binary.
+  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                  | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points outside the binary.
+  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                  | ERROR: offset to field `accounts` (id: 10). Invalid offset, points outside the binary.
+  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                  | ERROR: offset to field `bob` (id: 11). Invalid offset, points outside the binary.
+  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                  | ERROR: offset to field `alice` (id: 12). Invalid offset, points outside the binary.
   +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
   +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points to outside the binary.
-  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                  | ERROR: offset to field `names` (id: 16). Invalid offset, points to outside the binary.
-  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                  | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points to outside the binary.
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points to outside the binary.
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | ERROR: offset to field `foobars` (id: 19). Invalid offset, points to outside the binary.
+  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points outside the binary.
+  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                  | ERROR: offset to field `names` (id: 16). Invalid offset, points outside the binary.
+  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                  | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points outside the binary.
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
   +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                  | offset to field `measurement_type` (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | ERROR: offset to field `measurement` (id: 21). Invalid offset, points to outside the binary.
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
   +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                  | offset to field `anything_type` (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | ERROR: offset to field `anything` (id: 23). Invalid offset, points to outside the binary.
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
   +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
   +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | ERROR: offset to field `charlie` (id: 26). Invalid offset, points to outside the binary.
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
   +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 13)
   +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 14)
   +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | offset to unknown field (id: 15)
@@ -64,9 +64,9 @@ root_table (AnnotatedBinary.Foo):
   +0x4E | 01                      | UType8      | 0x01 (1)                     | table field `measurement_type` (UType)
   +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
   +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
-  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Location is outside the binary.
+  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
   +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x68 | 0C 00                   | ?uint8_t[2] | ..                           | ERROR: array field `AnnotatedBinary.Dimension.values[1]` (Int). Expected to read 4 bytes.
+  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x68 | 0C 00                   | ?uint8_t[2] | ..                           | ERROR: array field `AnnotatedBinary.Dimension.values`[1] (Int). Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_struct_field_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_struct_field_cut_short.afb
@@ -12,34 +12,34 @@ padding:
 
 vtable (AnnotatedBinary.Foo):
   +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                  | size of this vtable
-  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                 | ERROR: size of referring table. Size of table is larger than the binary.
+  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                 | ERROR: size of referring table. Longer than the binary.
   +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                  | offset to field `counter` (id: 0)
   +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                   | offset to field `healthy` (id: 1)
   +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `level` (id: 2) <defaults to 99> (Long)
   +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                   | offset to field `meal` (id: 3)
   +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                  | offset to field `bar` (id: 4)
   +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                  | offset to field `home` (id: 5)
-  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                  | ERROR: offset to field `name` (id: 6). Invalid offset, points to outside the binary.
-  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                  | ERROR: offset to field `bars` (id: 7). Invalid offset, points to outside the binary.
+  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                  | ERROR: offset to field `name` (id: 6). Invalid offset, points outside the binary.
+  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                  | ERROR: offset to field `bars` (id: 7). Invalid offset, points outside the binary.
   +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                   | offset to field `bar_baz_type` (id: 8)
-  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                  | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points to outside the binary.
-  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                  | ERROR: offset to field `accounts` (id: 10). Invalid offset, points to outside the binary.
-  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                  | ERROR: offset to field `bob` (id: 11). Invalid offset, points to outside the binary.
-  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                  | ERROR: offset to field `alice` (id: 12). Invalid offset, points to outside the binary.
+  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                  | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points outside the binary.
+  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                  | ERROR: offset to field `accounts` (id: 10). Invalid offset, points outside the binary.
+  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                  | ERROR: offset to field `bob` (id: 11). Invalid offset, points outside the binary.
+  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                  | ERROR: offset to field `alice` (id: 12). Invalid offset, points outside the binary.
   +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
   +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points to outside the binary.
-  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                  | ERROR: offset to field `names` (id: 16). Invalid offset, points to outside the binary.
-  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                  | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points to outside the binary.
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points to outside the binary.
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | ERROR: offset to field `foobars` (id: 19). Invalid offset, points to outside the binary.
+  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points outside the binary.
+  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                  | ERROR: offset to field `names` (id: 16). Invalid offset, points outside the binary.
+  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                  | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points outside the binary.
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
   +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                  | offset to field `measurement_type` (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | ERROR: offset to field `measurement` (id: 21). Invalid offset, points to outside the binary.
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
   +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                  | offset to field `anything_type` (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | ERROR: offset to field `anything` (id: 23). Invalid offset, points to outside the binary.
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
   +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
   +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | ERROR: offset to field `charlie` (id: 26). Invalid offset, points to outside the binary.
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
   +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 13)
   +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 14)
   +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | offset to unknown field (id: 15)
@@ -64,6 +64,6 @@ root_table (AnnotatedBinary.Foo):
   +0x4E | 01                      | UType8      | 0x01 (1)                     | table field `measurement_type` (UType)
   +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
   +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
-  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Location is outside the binary.
+  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
   +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x5C | 02 00                   | ?uint8_t[2] | ..                           | ERROR: struct field `AnnotatedBinary.Building.doors` (Int). Expected to read 4 bytes.
+  +0x5C | 02 00                   | ?uint8_t[2] | ..                           | ERROR: struct field `AnnotatedBinary.Building.doors` (Int). Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_table_field_offset.afb
+++ b/tests/annotated_binary/tests/invalid_table_field_offset.afb
@@ -12,7 +12,7 @@ padding:
 
 vtable (AnnotatedBinary.Foo):
   +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                  | size of this vtable
-  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                 | ERROR: size of referring table. Size of table is larger than the binary.
+  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                 | ERROR: size of referring table. Longer than the binary.
   +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                  | offset to field `counter` (id: 0)
   +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                   | offset to field `healthy` (id: 1)
   +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `level` (id: 2) <defaults to 99> (Long)
@@ -31,15 +31,15 @@ vtable (AnnotatedBinary.Foo):
   +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | offset to field `just_i32` (id: 15)
   +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                  | offset to field `names` (id: 16)
   +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                  | offset to field `points_of_interest` (id: 17)
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points to outside the binary.
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | ERROR: offset to field `foobars` (id: 19). Invalid offset, points to outside the binary.
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
   +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                  | offset to field `measurement_type` (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | ERROR: offset to field `measurement` (id: 21). Invalid offset, points to outside the binary.
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
   +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                  | offset to field `anything_type` (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | ERROR: offset to field `anything` (id: 23). Invalid offset, points to outside the binary.
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
   +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
   +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | ERROR: offset to field `charlie` (id: 26). Invalid offset, points to outside the binary.
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
   +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                  | offset to unknown field (id: 22)
   +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | offset to unknown field (id: 23)
   +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 24)
@@ -55,23 +55,23 @@ root_table (AnnotatedBinary.Foo):
   +0x4E | 01                      | UType8      | 0x01 (1)                     | table field `measurement_type` (UType)
   +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
   +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
-  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Location is outside the binary.
+  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
   +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)              | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)              | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x70 | 01                      | uint8_t     | 0x01 (1)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x71 | 02                      | uint8_t     | 0x02 (2)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x72 | 03                      | uint8_t     | 0x03 (3)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x73 | 00                      | uint8_t[1]  | .                            | padding
-  +0x74 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x23C | ERROR: offset to field `name`. Location is outside the binary.
-  +0x78 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x1D4 | ERROR: offset to field `bars`. Location is outside the binary.
-  +0x7C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: +0x1CC | ERROR: offset to field `bar_baz`. Location is outside the binary.
-  +0x80 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: +0x1B4 | ERROR: offset to field `accounts`. Location is outside the binary.
-  +0x84 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: +0x1A8 | ERROR: offset to field `bob`. Location is outside the binary.
-  +0x88 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: +0x19C | ERROR: offset to field `alice`. Location is outside the binary.
+  +0x74 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x23C | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x78 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x1D4 | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x7C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: +0x1CC | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
+  +0x80 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: +0x1B4 | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
+  +0x84 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: +0x1A8 | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
+  +0x88 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: +0x19C | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
   +0x8C | 0D 00 00 00             | uint32_t    | 0x0000000D (13)              | table field `just_i32` (Int)
-  +0x90 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: +0x16C | ERROR: offset to field `names`. Location is outside the binary.
-  +0x94 | A0 00                   | ?uint8_t[2] | ..                           | ERROR: offset to field `points_of_interest`. Incomplete binary, expected to read 4 bytes here
+  +0x90 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: +0x16C | ERROR: offset to field `names`. Invalid offset, points outside the binary.
+  +0x94 | A0 00                   | ?uint8_t[2] | ..                           | ERROR: offset to field `points_of_interest`. Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_table_field_size.afb
+++ b/tests/annotated_binary/tests/invalid_table_field_size.afb
@@ -12,34 +12,34 @@ padding:
 
 vtable (AnnotatedBinary.Foo):
   +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                | size of this vtable
-  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)               | ERROR: size of referring table. Size of table is larger than the binary.
+  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)               | ERROR: size of referring table. Longer than the binary.
   +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                | offset to field `counter` (id: 0)
   +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                 | offset to field `healthy` (id: 1)
   +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to field `level` (id: 2) <defaults to 99> (Long)
   +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                 | offset to field `meal` (id: 3)
-  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                | ERROR: offset to field `bar` (id: 4). Invalid offset, points to outside the binary.
-  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                | ERROR: offset to field `home` (id: 5). Invalid offset, points to outside the binary.
-  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                | ERROR: offset to field `name` (id: 6). Invalid offset, points to outside the binary.
-  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                | ERROR: offset to field `bars` (id: 7). Invalid offset, points to outside the binary.
+  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                | ERROR: offset to field `bar` (id: 4). Invalid offset, points outside the binary.
+  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                | ERROR: offset to field `home` (id: 5). Invalid offset, points outside the binary.
+  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                | ERROR: offset to field `name` (id: 6). Invalid offset, points outside the binary.
+  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                | ERROR: offset to field `bars` (id: 7). Invalid offset, points outside the binary.
   +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                 | offset to field `bar_baz_type` (id: 8)
-  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points to outside the binary.
-  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                | ERROR: offset to field `accounts` (id: 10). Invalid offset, points to outside the binary.
-  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                | ERROR: offset to field `bob` (id: 11). Invalid offset, points to outside the binary.
-  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                | ERROR: offset to field `alice` (id: 12). Invalid offset, points to outside the binary.
+  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points outside the binary.
+  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                | ERROR: offset to field `accounts` (id: 10). Invalid offset, points outside the binary.
+  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                | ERROR: offset to field `bob` (id: 11). Invalid offset, points outside the binary.
+  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                | ERROR: offset to field `alice` (id: 12). Invalid offset, points outside the binary.
   +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
   +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points to outside the binary.
-  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                | ERROR: offset to field `names` (id: 16). Invalid offset, points to outside the binary.
-  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points to outside the binary.
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points to outside the binary.
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                | ERROR: offset to field `foobars` (id: 19). Invalid offset, points to outside the binary.
+  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points outside the binary.
+  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                | ERROR: offset to field `names` (id: 16). Invalid offset, points outside the binary.
+  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points outside the binary.
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
   +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                | offset to field `measurement_type` (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                | ERROR: offset to field `measurement` (id: 21). Invalid offset, points to outside the binary.
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
   +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                | offset to field `anything_type` (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                | ERROR: offset to field `anything` (id: 23). Invalid offset, points to outside the binary.
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
   +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
   +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)               | ERROR: offset to field `charlie` (id: 26). Invalid offset, points to outside the binary.
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)               | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
   +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                | offset to unknown field (id: 11)
   +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                | offset to unknown field (id: 12)
   +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to unknown field (id: 13)
@@ -65,4 +65,4 @@ root_table (AnnotatedBinary.Foo):
   +0x4D | 02                      | UType8      | 0x02 (2)                   | table field `bar_baz_type` (UType)
   +0x4E | 01                      | UType8      | 0x01 (1)                   | table field `measurement_type` (UType)
   +0x4F | 01                      | UType8      | 0x01 (1)                   | table field `anything_type` (UType)
-  +0x50 | D2 04                   | ?uint8_t[2] | ..                         | ERROR: table field `counter` (Int). Expected 4 bytes.
+  +0x50 | D2 04                   | ?uint8_t[2] | ..                         | ERROR: table field `counter` (Int). Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_union_type_value.afb
+++ b/tests/annotated_binary/tests/invalid_union_type_value.afb
@@ -46,7 +46,7 @@ root_table (AnnotatedBinary.Foo):
   +0x0048 | 00 00 00                | uint8_t[3]   | ...                            | padding
   +0x004B | 01                      | uint8_t      | 0x01 (1)                       | table field `healthy` (Bool)
   +0x004C | 02                      | uint8_t      | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | FF                      | UType8       | 0xFF (255)                     | ERROR: table field `bar_baz_type` (UType) . Invalid union type value.
+  +0x004D | FF                      | UType8       | 0xFF (255)                     | ERROR: table field `bar_baz_type` (UType). Invalid union type value.
   +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
@@ -54,16 +54,16 @@ root_table (AnnotatedBinary.Foo):
   +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
-  +0x007C | 50 01 00 00             | ?uint8_t[4]  | P...                           | WARN: nothing refers to this region.
+  +0x007C | 50 01 00 00             | ?uint8_t[4]  | P...                           | WARN: nothing refers to this section.
   +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
   +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
   +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
@@ -78,7 +78,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -162,17 +162,17 @@ vector (AnnotatedBinary.Foo.names):
 
 string (AnnotatedBinary.Foo.names):
   +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            
+  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
   +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -180,12 +180,12 @@ padding:
 
 string (AnnotatedBinary.Foo.alice):
   +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.bob):
   +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
@@ -257,7 +257,7 @@ table (AnnotatedBinary.Baz):
 
 string (AnnotatedBinary.Foo.name):
   +0x023C | 2F 00 00 00             | uint32_t     | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                        
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                        | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |              | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |              | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |              |  show ho

--- a/tests/annotated_binary/tests/invalid_vector_length_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_length_cut_short.afb
@@ -50,25 +50,25 @@ root_table (AnnotatedBinary.Foo):
   +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Location is outside the binary.
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
   +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Location is outside the binary.
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Location is outside the binary.
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Location is outside the binary.
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | ERROR: offset to field `accounts`. Location is outside the binary.
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | ERROR: offset to field `bob`. Location is outside the binary.
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | ERROR: offset to field `alice`. Location is outside the binary.
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
   +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | ERROR: offset to field `names`. Location is outside the binary.
+  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | ERROR: offset to field `names`. Invalid offset, points outside the binary.
   +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
   +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
   +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
@@ -78,7 +78,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -106,7 +106,7 @@ vector (AnnotatedBinary.Foo.foobars):
   +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
@@ -122,7 +122,7 @@ table (AnnotatedBinary.Baz):
   +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
@@ -137,4 +137,4 @@ vector (AnnotatedBinary.Foo.foobars_type):
   +0x0132 | 01                      | UType8       | 0x01 (1)                       | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00                   | ?uint8_t[2]  | ..                             | ERROR: length of vector (# items). Incomplete binary, expected to read 4 bytes here
+  +0x0134 | 03 00                   | ?uint8_t[2]  | ..                             | ERROR: length of vector (# items). Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_vector_scalars_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_scalars_cut_short.afb
@@ -50,20 +50,20 @@ root_table (AnnotatedBinary.Foo):
   +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Location is outside the binary.
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
   +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Location is outside the binary.
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Location is outside the binary.
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Location is outside the binary.
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
   +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
   +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
   +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
@@ -78,7 +78,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -106,7 +106,7 @@ vector (AnnotatedBinary.Foo.foobars):
   +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
@@ -122,7 +122,7 @@ table (AnnotatedBinary.Baz):
   +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
@@ -156,17 +156,17 @@ vector (AnnotatedBinary.Foo.names):
 
 string (AnnotatedBinary.Foo.names):
   +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            
+  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
   +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -174,16 +174,16 @@ padding:
 
 string (AnnotatedBinary.Foo.alice):
   +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.bob):
   +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
-  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                 | ERROR: length of vector (# items). Invalid length, points outside the binary.
+  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                 | ERROR: length of vector (# items). Longer than the binary.
 
 unknown (no known references):
   +0x01B8 | 09 00 08 00 07 00 01 00 | ?uint8_t[9]  | ........                       | WARN: nothing refers to this section.

--- a/tests/annotated_binary/tests/invalid_vector_strings_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_strings_cut_short.afb
@@ -50,23 +50,23 @@ root_table (AnnotatedBinary.Foo):
   +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Location is outside the binary.
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
   +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Location is outside the binary.
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Location is outside the binary.
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Location is outside the binary.
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | ERROR: offset to field `accounts`. Location is outside the binary.
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | ERROR: offset to field `bob`. Location is outside the binary.
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | ERROR: offset to field `alice`. Location is outside the binary.
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
   +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
   +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
   +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
@@ -78,7 +78,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -106,7 +106,7 @@ vector (AnnotatedBinary.Foo.foobars):
   +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
@@ -122,7 +122,7 @@ table (AnnotatedBinary.Baz):
   +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
@@ -149,7 +149,7 @@ padding:
   +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | ERROR: length of vector (# items). Invalid length, points outside the binary.
+  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | ERROR: length of vector (# items). Longer than the binary.
 
 unknown (no known references):
-  +0x0170 | 20 00 00 00 14 00       | ?uint8_t[6]  |  .....                         | could be a corrupted padding region (non zero) due to the length < 8 bytes.
+  +0x0170 | 20 00 00 00 14 00       | ?uint8_t[6]  |  .....                         | WARN: could be corrupted padding region.

--- a/tests/annotated_binary/tests/invalid_vector_structs_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_structs_cut_short.afb
@@ -50,25 +50,25 @@ root_table (AnnotatedBinary.Foo):
   +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Location is outside the binary.
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
   +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Location is outside the binary.
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Location is outside the binary.
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Location is outside the binary.
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | ERROR: offset to field `accounts`. Location is outside the binary.
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | ERROR: offset to field `bob`. Location is outside the binary.
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | ERROR: offset to field `alice`. Location is outside the binary.
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
   +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | ERROR: offset to field `names`. Location is outside the binary.
+  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | ERROR: offset to field `names`. Invalid offset, points outside the binary.
   +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
   +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
   +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
@@ -78,7 +78,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -106,7 +106,7 @@ vector (AnnotatedBinary.Foo.foobars):
   +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
@@ -122,7 +122,7 @@ table (AnnotatedBinary.Baz):
   +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
@@ -137,7 +137,7 @@ vector (AnnotatedBinary.Foo.foobars_type):
   +0x0132 | 01                      | UType8       | 0x01 (1)                       | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | ERROR: length of vector (# items). Invalid length, points outside the binary.
+  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | ERROR: length of vector (# items). Longer than the binary.
 
 unknown (no known references):
   +0x0138 | 33 33 33 33 33 A3 45 40 | ?uint8_t[28] | 33333.E@                       | WARN: nothing refers to this section.

--- a/tests/annotated_binary/tests/invalid_vector_tables_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_tables_cut_short.afb
@@ -50,18 +50,18 @@ root_table (AnnotatedBinary.Foo):
   +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Location is outside the binary.
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
   +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Location is outside the binary.
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
   +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | offset to field `bar_baz` (union of type `Baz`)
   +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
@@ -78,7 +78,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -106,7 +106,7 @@ vector (AnnotatedBinary.Foo.foobars):
   +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
@@ -122,7 +122,7 @@ table (AnnotatedBinary.Baz):
   +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
@@ -156,17 +156,17 @@ vector (AnnotatedBinary.Foo.names):
 
 string (AnnotatedBinary.Foo.names):
   +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            
+  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
   +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -174,12 +174,12 @@ padding:
 
 string (AnnotatedBinary.Foo.alice):
   +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.bob):
   +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
@@ -198,13 +198,13 @@ padding:
   +0x01CA | 00 00                   | uint8_t[2]   | ..                             | padding
 
 table (AnnotatedBinary.Baz):
-  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: +0x0292 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: +0x0292 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x01D0 | 00 00 00 03             | ?uint8_t[4]  | ....                           | could be a corrupted padding region (non zero) due to the length < 8 bytes.
+  +0x01D0 | 00 00 00 03             | ?uint8_t[4]  | ....                           | WARN: could be corrupted padding region.
 
 vector (AnnotatedBinary.Foo.bars):
-  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | ERROR: length of vector (# items). Invalid length, points outside the binary.
+  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | ERROR: length of vector (# items). Longer than the binary.
 
 unknown (no known references):
-  +0x01D8 | 44 00 00 00 10 00       | ?uint8_t[6]  | D.....                         | could be a corrupted padding region (non zero) due to the length < 8 bytes.
+  +0x01D8 | 44 00 00 00 10 00       | ?uint8_t[6]  | D.....                         | WARN: could be corrupted padding region.

--- a/tests/annotated_binary/tests/invalid_vector_union_type_value.afb
+++ b/tests/annotated_binary/tests/invalid_vector_union_type_value.afb
@@ -54,9 +54,9 @@ root_table (AnnotatedBinary.Foo):
   +0x0058 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t     | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t     | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t     | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
@@ -78,7 +78,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t    | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]     | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]     | alice                          | string literal
   +0x00B5 | 00                      | char        | 0x00 (0)                       | string terminator
 
 padding:
@@ -102,7 +102,7 @@ union (AnnotatedBinary.Tolerance.measurement):
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
   +0x00D8 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | ?uint8_t[4] | ,...                           | WARN: nothing refers to this region.
+  +0x00DC | 2C 00 00 00             | ?uint8_t[4] | ,...                           | WARN: nothing refers to this section.
   +0x00E0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
@@ -158,17 +158,17 @@ vector (AnnotatedBinary.Foo.names):
 
 string (AnnotatedBinary.Foo.names):
   +0x017C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
   +0x0187 | 00                      | char        | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0188 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]     | bob                            
+  +0x018C | 62 6F 62                | char[3]     | bob                            | string literal
   +0x018F | 00                      | char        | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0190 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]     | alice                          
+  +0x0194 | 61 6C 69 63 65          | char[5]     | alice                          | string literal
   +0x0199 | 00                      | char        | 0x00 (0)                       | string terminator
 
 padding:
@@ -176,12 +176,12 @@ padding:
 
 string (AnnotatedBinary.Foo.alice):
   +0x019C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
   +0x01A7 | 00                      | char        | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.bob):
   +0x01A8 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]     | charlie                        
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
   +0x01B3 | 00                      | char        | 0x00 (0)                       | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
@@ -257,7 +257,7 @@ table (AnnotatedBinary.Baz):
 
 string (AnnotatedBinary.Foo.name):
   +0x023C | 2F 00 00 00             | uint32_t    | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]    | This is                        
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]    | This is                        | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |             | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |             | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |             |  show ho

--- a/tests/annotated_binary/tests/invalid_vector_unions_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_unions_cut_short.afb
@@ -50,18 +50,18 @@ root_table (AnnotatedBinary.Foo):
   +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Location is outside the binary.
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
   +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Location is outside the binary.
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
   +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | offset to field `bar_baz` (union of type `Baz`)
   +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
@@ -78,7 +78,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -106,7 +106,7 @@ vector (AnnotatedBinary.Foo.foobars):
   +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
@@ -122,7 +122,7 @@ table (AnnotatedBinary.Baz):
   +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
   +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
@@ -156,17 +156,17 @@ vector (AnnotatedBinary.Foo.names):
 
 string (AnnotatedBinary.Foo.names):
   +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            
+  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
   +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -174,12 +174,12 @@ padding:
 
 string (AnnotatedBinary.Foo.alice):
   +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.bob):
   +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
@@ -198,13 +198,13 @@ padding:
   +0x01CA | 00 00                   | uint8_t[2]   | ..                             | padding
 
 table (AnnotatedBinary.Baz):
-  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: +0x0292 | ERROR: offset to vtable. Invalid offset, points to outside the binary.
+  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: +0x0292 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x01D0 | 00 00 00 03             | ?uint8_t[4]  | ....                           | could be a corrupted padding region (non zero) due to the length < 8 bytes.
+  +0x01D0 | 00 00 00 03             | ?uint8_t[4]  | ....                           | WARN: could be corrupted padding region.
 
 vector (AnnotatedBinary.Foo.bars):
-  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | ERROR: length of vector (# items). Invalid length, points outside the binary.
+  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | ERROR: length of vector (# items). Longer than the binary.
 
 unknown (no known references):
-  +0x01D8 | 44 00 00 00 10 00       | ?uint8_t[6]  | D.....                         | could be a corrupted padding region (non zero) due to the length < 8 bytes.
+  +0x01D8 | 44 00 00 00 10 00       | ?uint8_t[6]  | D.....                         | WARN: could be corrupted padding region.

--- a/tests/annotated_binary/tests/invalid_vtable_field_offset.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_field_offset.afb
@@ -17,7 +17,7 @@ vtable (AnnotatedBinary.Foo):
   +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `healthy` (id: 1)
   +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
   +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | FF FF                   | VOffset16    | 0xFFFF (65535)                 | ERROR: offset to field `bar` (id: 4). Invalid offset, points to outside the binary.
+  +0x0016 | FF FF                   | VOffset16    | 0xFFFF (65535)                 | ERROR: offset to field `bar` (id: 4). Invalid offset, points outside the binary.
   +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                    | offset to field `home` (id: 5)
   +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                    | offset to field `name` (id: 6)
   +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                    | offset to field `bars` (id: 7)
@@ -51,13 +51,13 @@ root_table (AnnotatedBinary.Foo):
   +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | ?uint8_t[4]  | (...                           | WARN: nothing refers to this region.
+  +0x0054 | 28 02 00 00             | ?uint8_t[4]  | (...                           | WARN: nothing refers to this section.
   +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
@@ -79,7 +79,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -163,17 +163,17 @@ vector (AnnotatedBinary.Foo.names):
 
 string (AnnotatedBinary.Foo.names):
   +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            
+  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
   +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -181,12 +181,12 @@ padding:
 
 string (AnnotatedBinary.Foo.alice):
   +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.bob):
   +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
@@ -262,7 +262,7 @@ table (AnnotatedBinary.Baz):
 
 string (AnnotatedBinary.Foo.name):
   +0x023C | 2F 00 00 00             | uint32_t     | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                        
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                        | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |              | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |              | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |              |  show ho

--- a/tests/annotated_binary/tests/invalid_vtable_ref_table_size.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_ref_table_size.afb
@@ -12,7 +12,7 @@ padding:
 
 vtable (AnnotatedBinary.Foo):
   +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                    | size of this vtable
-  +0x000C | FF FF                   | uint16_t     | 0xFFFF (65535)                 | ERROR: size of referring table. Size of table is larger than the binary.
+  +0x000C | FF FF                   | uint16_t     | 0xFFFF (65535)                 | ERROR: size of referring table. Longer than the binary.
   +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `counter` (id: 0)
   +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `healthy` (id: 1)
   +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
@@ -54,9 +54,9 @@ root_table (AnnotatedBinary.Foo):
   +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
@@ -141,7 +141,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -225,17 +225,17 @@ vector (AnnotatedBinary.Foo.names):
 
 string (AnnotatedBinary.Foo.names):
   +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            
+  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
   +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
   +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
 
 padding:
@@ -243,12 +243,12 @@ padding:
 
 string (AnnotatedBinary.Foo.alice):
   +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.bob):
   +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
   +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
@@ -324,7 +324,7 @@ table (AnnotatedBinary.Baz):
 
 string (AnnotatedBinary.Foo.name):
   +0x023C | 2F 00 00 00             | uint32_t     | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                        
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                        | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |              | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |              | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |              |  show ho

--- a/tests/annotated_binary/tests/invalid_vtable_ref_table_size_short.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_ref_table_size_short.afb
@@ -12,7 +12,7 @@ padding:
 
 vtable (AnnotatedBinary.Foo):
   +0x000A | 3A 00                   | uint16_t   | 0x003A (58)                    | size of this vtable
-  +0x000C | 01 00                   | uint16_t   | 0x0001 (1)                     | ERROR: size of referring table. Size of table is smaller than the minimum 4 bytes
+  +0x000C | 01 00                   | uint16_t   | 0x0001 (1)                     | ERROR: size of referring table. Shorter than the minimum length: 
   +0x000E | 0C 00                   | VOffset16  | 0x000C (12)                    | offset to field `counter` (id: 0)
   +0x0010 | 07 00                   | VOffset16  | 0x0007 (7)                     | offset to field `healthy` (id: 1)
   +0x0012 | 00 00                   | VOffset16  | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
@@ -54,9 +54,9 @@ root_table (AnnotatedBinary.Foo):
   +0x0058 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
   +0x005C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
   +0x0060 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values[0]` (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values[1]` (Int)
-  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values[2]` (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
+  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
   +0x0070 | 01                      | uint8_t    | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0071 | 02                      | uint8_t    | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
   +0x0072 | 03                      | uint8_t    | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
@@ -78,7 +78,7 @@ root_table (AnnotatedBinary.Foo):
 
 string (AnnotatedBinary.Foo.charlie):
   +0x00AC | 05 00 00 00             | uint32_t   | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]    | alice                          
+  +0x00B0 | 61 6C 69 63 65          | char[5]    | alice                          | string literal
   +0x00B5 | 00                      | char       | 0x00 (0)                       | string terminator
 
 padding:
@@ -162,17 +162,17 @@ vector (AnnotatedBinary.Foo.names):
 
 string (AnnotatedBinary.Foo.names):
   +0x017C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
   +0x0187 | 00                      | char       | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0188 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]    | bob                            
+  +0x018C | 62 6F 62                | char[3]    | bob                            | string literal
   +0x018F | 00                      | char       | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.names):
   +0x0190 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]    | alice                          
+  +0x0194 | 61 6C 69 63 65          | char[5]    | alice                          | string literal
   +0x0199 | 00                      | char       | 0x00 (0)                       | string terminator
 
 padding:
@@ -180,12 +180,12 @@ padding:
 
 string (AnnotatedBinary.Foo.alice):
   +0x019C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
   +0x01A7 | 00                      | char       | 0x00 (0)                       | string terminator
 
 string (AnnotatedBinary.Foo.bob):
   +0x01A8 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]    | charlie                        
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
   +0x01B3 | 00                      | char       | 0x00 (0)                       | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
@@ -261,7 +261,7 @@ table (AnnotatedBinary.Baz):
 
 string (AnnotatedBinary.Foo.name):
   +0x023C | 2F 00 00 00             | uint32_t   | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]   | This is                        
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]   | This is                        | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |            | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |            | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |            |  show ho

--- a/tests/annotated_binary/tests/invalid_vtable_size.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_size.afb
@@ -11,7 +11,7 @@ padding:
   +0x0008 | 00 00                   | uint8_t[2]    | ..                           | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | FF FF                   | uint16_t      | 0xFFFF (65535)               | ERROR: size of this vtable. Longer than the binary
+  +0x000A | FF FF                   | uint16_t      | 0xFFFF (65535)               | ERROR: size of this vtable. Longer than the binary.
 
 unknown (no known references):
   +0x000C | 68 00 0C 00 07 00 00 00 | ?uint8_t[660] | h.......                     | WARN: nothing refers to this section.

--- a/tests/annotated_binary/tests/invalid_vtable_size_short.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_size_short.afb
@@ -11,7 +11,7 @@ padding:
   +0x0008 | 00 00                   | uint8_t[2]    | ..                           | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 01 00                   | uint16_t      | 0x0001 (1)                   | ERROR: size of this vtable. Shorter than the minimum 4 bytes
+  +0x000A | 01 00                   | uint16_t      | 0x0001 (1)                   | ERROR: size of this vtable. Shorter than the minimum length: 
 
 unknown (no known references):
   +0x000C | 68 00 0C 00 07 00 00 00 | ?uint8_t[660] | h.......                     | WARN: nothing refers to this section.


### PR DESCRIPTION
This switches over to using structure comment fields for the binary annotator. This greatly reduces the memory usage of the annotation process.

Fixed a few memory bugs the fuzzer found as well.