### PR TITLE
Apply Namer to Java.

### DIFF
--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -20,9 +20,50 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
+#include "idl_namer.h"
 
 namespace flatbuffers {
 namespace java {
+
+Namer::Config JavaDefaultConfig() {
+  return {
+    /*types=*/Case::kKeep,
+    /*constants=*/Case::kScreamingSnake,
+    /*methods=*/Case::kLowerCamel,
+    /*functions=*/Case::kLowerCamel,
+    /*fields=*/Case::kLowerCamel,
+    /*variables=*/Case::kLowerCamel,
+    /*variants=*/Case::kKeep,
+    /*enum_variant_seperator=*/".",
+    /*escape_keywords=*/Namer::Config::Escape::AfterConvertingCase,
+    /*namespaces=*/Case::kSnake,
+    /*namespace_seperator=*/"::",
+    /*object_prefix=*/"",
+    /*object_suffix=*/"T",
+    /*keyword_prefix=*/"",
+    /*keyword_suffix=*/"_",
+    /*filenames=*/Case::kSnake,
+    /*directories=*/Case::kSnake,
+    /*output_path=*/"",
+    /*filename_suffix=*/"_generated",
+    /*filename_extension=*/".java",
+  };
+}
+
+std::set<std::string> JavaKeywords() {
+  return {
+    "abstract", "continue", "for",        "new",       "switch",
+    "assert",   "default",  "goto",       "package",   "synchronized",
+    "boolean",  "do",       "if",         "private",   "this",
+    "break",    "double",   "implements", "protected", "throw",
+    "byte",     "else",     "import",     "public",    "throws",
+    "case",     "enum",     "instanceof", "return",    "transient",
+    "catch",    "extends",  "int",        "short",     "try",
+    "char",     "final",    "interface",  "static",    "void",
+    "class",    "finally",  "long",       "strictfp",  "volatile",
+    "const",    "float",    "native",     "super",     "while",
+  };
+}
 
 static TypedFloatConstantGenerator JavaFloatGen("Double.", "Float.", "NaN",
                                                 "POSITIVE_INFINITY",
@@ -44,7 +85,9 @@ class JavaGenerator : public BaseGenerator {
   JavaGenerator(const Parser &parser, const std::string &path,
                 const std::string &file_name)
       : BaseGenerator(parser, path, file_name, "", ".", "java"),
-        cur_name_space_(nullptr) {}
+        cur_name_space_(nullptr),
+        namer_(WithFlagOptions(JavaDefaultConfig(), parser.opts, path),
+               JavaKeywords()) {}
 
   JavaGenerator &operator=(const JavaGenerator &);
   bool generate() {
@@ -68,7 +111,7 @@ class JavaGenerator : public BaseGenerator {
       if (parser_.opts.generate_object_based_api && enum_def.is_union) {
         enumcode = "";
         GenEnum_ObjectAPI(enum_def, &enumcode, parser_.opts);
-        auto class_name = enum_def.name + "Union";
+        auto class_name = namer_.Type(enum_def) + "Union";
         if (parser_.opts.one_file) {
           one_file_code += enumcode;
         } else {
@@ -97,7 +140,7 @@ class JavaGenerator : public BaseGenerator {
       if (parser_.opts.generate_object_based_api) {
         declcode = "";
         GenStruct_ObjectAPI(struct_def, &declcode, parser_.opts);
-        auto class_name = GenTypeName_ObjectAPI(struct_def.name, parser_.opts);
+        auto class_name = namer_.ObjectType(struct_def);
         if (parser_.opts.one_file) {
           one_file_code += declcode;
         } else {
@@ -337,16 +380,16 @@ class JavaGenerator : public BaseGenerator {
     } else {
       code += "public ";
     }
-    code += "final class " + enum_def.name;
+    code += "final class " + namer_.Type(enum_def);
     code += " {\n";
-    code += "  private " + enum_def.name + "() { }\n";
+    code += "  private " + namer_.Type(enum_def) + "() { }\n";
     for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
       auto &ev = **it;
       GenComment(ev.doc_comment, code_ptr, &comment_config, "  ");
       code += "  public static final ";
       code += GenTypeBasic(DestinationType(enum_def.underlying_type, false));
       code += " ";
-      code += ev.name + " = ";
+      code += namer_.Variant(ev) + " = ";
       code += enum_def.ToString(ev);
       code += ";\n";
     }
@@ -468,7 +511,7 @@ class JavaGenerator : public BaseGenerator {
         for (size_t i = 0; i < array_cnt; i++) code += "[]";
         code += " ";
         code += nameprefix;
-        code += ConvertCase(field.name, Case::kLowerCamel);
+        code += namer_.Field(field);
       }
     }
   }
@@ -515,8 +558,7 @@ class JavaGenerator : public BaseGenerator {
           code += indent + "  builder.put";
           code += GenMethod(type) + "(";
           code += SourceCast(type);
-          auto argname =
-              nameprefix + ConvertCase(field.name, Case::kLowerCamel);
+          auto argname = nameprefix + namer_.Variable(field);
           code += argname;
           size_t array_cnt = index + (IsArray(field_type) ? 1 : 0);
           for (size_t i = 0; in_array && i < array_cnt; i++) {
@@ -614,7 +656,8 @@ class JavaGenerator : public BaseGenerator {
     } else {
       code += "public ";
     }
-    code += "final class " + struct_def.name;
+    const auto struct_class = namer_.Type(struct_def);
+    code += "final class " + struct_class;
     code += " extends ";
     code += struct_def.fixed ? "Struct" : "Table";
     code += " {\n";
@@ -629,18 +672,18 @@ class JavaGenerator : public BaseGenerator {
 
       // Generate a special accessor for the table that when used as the root
       // of a FlatBuffer
-      std::string method_name = "getRootAs" + struct_def.name;
+      std::string method_name = namer_.LegacyJavaMethod2("getRootAs", struct_def, "");
       std::string method_signature =
-          "  public static " + struct_def.name + " " + method_name;
+          "  public static " + struct_class + " " + method_name;
 
       // create convenience method that doesn't require an existing object
       code += method_signature + "(ByteBuffer _bb) ";
-      code += "{ return " + method_name + "(_bb, new " + struct_def.name +
-              "()); }\n";
+      code +=
+          "{ return " + method_name + "(_bb, new " + struct_class + "()); }\n";
 
       // create method that allows object reuse
       code +=
-          method_signature + "(ByteBuffer _bb, " + struct_def.name + " obj) { ";
+          method_signature + "(ByteBuffer _bb, " + struct_class + " obj) { ";
       code += "_bb.order(ByteOrder.LITTLE_ENDIAN); ";
       code += "return (obj.__assign(_bb.getInt(_bb.";
       code += "position()";
@@ -651,8 +694,8 @@ class JavaGenerator : public BaseGenerator {
         if (parser_.file_identifier_.length()) {
           // Check if a buffer has the identifier.
           code += "  public static ";
-          code += "boolean " + struct_def.name;
-          code += "BufferHasIdentifier(ByteBuffer _bb) { return ";
+          code += "boolean " + namer_.LegacyJavaMethod2("", struct_def,
+          "BufferHasIdentifier(ByteBuffer _bb)") + " { return ";
           code += "__has_identifier(_bb, \"";
           code += parser_.file_identifier_;
           code += "\"); }\n";
@@ -665,8 +708,7 @@ class JavaGenerator : public BaseGenerator {
     code += "{ ";
     code += "__reset(_i, _bb); ";
     code += "}\n";
-    code +=
-        "  public " + struct_def.name + " __assign(int _i, ByteBuffer _bb) ";
+    code += "  public " + struct_class + " __assign(int _i, ByteBuffer _bb) ";
     code += "{ __init(_i, _bb); return this; }\n\n";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
@@ -684,7 +726,7 @@ class JavaGenerator : public BaseGenerator {
           "  public " +
           (field.IsRequired() ? "" : GenNullableAnnotation(field.value.type)) +
           GenPureAnnotation(field.value.type) + type_name_dest + optional +
-          " " + ConvertCase(field.name, Case::kLowerCamel);
+          " " + namer_.Field(field);
       std::string obj = "obj";
 
       // Most field accessors need to retrieve and test the field offset first,
@@ -698,7 +740,7 @@ class JavaGenerator : public BaseGenerator {
       if (field.value.type.base_type == BASE_TYPE_STRUCT) {
         // Calls the accessor that takes an accessor object with a new object.
         code += method_start + "() { return ";
-        code += ConvertCase(field.name, Case::kLowerCamel);
+        code += namer_.Field(field);
         code += "(new ";
         code += type_name + "()); }\n";
       } else if (IsSeries(field.value.type) &&
@@ -706,7 +748,7 @@ class JavaGenerator : public BaseGenerator {
         // Accessors for vectors of structs also take accessor objects, this
         // generates a variant without that argument.
         code += method_start + "(int j) { return ";
-        code += ConvertCase(field.name, Case::kLowerCamel);
+        code += namer_.Field(field);
         code += "(new " + type_name + "(), j); }\n";
       }
 
@@ -806,7 +848,7 @@ class JavaGenerator : public BaseGenerator {
       code += member_suffix;
       code += "}\n";
       if (IsVector(field.value.type)) {
-        code += "  public int " + ConvertCase(field.name, Case::kLowerCamel);
+        code += "  public int " + namer_.Field(field);
         code += "Length";
         code += "()";
         code += offset_prefix;
@@ -823,7 +865,7 @@ class JavaGenerator : public BaseGenerator {
             if (key_field.key) {
               auto qualified_name = WrapInNameSpace(sd);
               code += "  public " + qualified_name + " ";
-              code += ConvertCase(field.name, Case::kLowerCamel) + "ByKey(";
+              code += namer_.Method(field) + "ByKey(";
               code += GenTypeNameDest(key_field.value.type) + " key)";
               code += offset_prefix;
               code += qualified_name + ".__lookup_by_key(";
@@ -832,7 +874,7 @@ class JavaGenerator : public BaseGenerator {
               code += "bb) : null; ";
               code += "}\n";
               code += "  public " + qualified_name + " ";
-              code += ConvertCase(field.name, Case::kLowerCamel) + "ByKey(";
+              code += namer_.Method(field) + "ByKey(";
               code += qualified_name + " obj, ";
               code += GenTypeNameDest(key_field.value.type) + " key)";
               code += offset_prefix;
@@ -859,12 +901,11 @@ class JavaGenerator : public BaseGenerator {
         } else {
           vector_type_name = type_name + ".Vector";
         }
-        auto vector_method_start =
-            GenNullableAnnotation(field.value.type) + "  public " +
-            vector_type_name + optional + " " +
-            ConvertCase(field.name, Case::kLowerCamel) + "Vector";
+        auto vector_method_start = GenNullableAnnotation(field.value.type) +
+                                   "  public " + vector_type_name + optional +
+                                   " " + namer_.Field(field, "vector");
         code += vector_method_start + "() { return ";
-        code += ConvertCase(field.name, Case::kLowerCamel) + "Vector";
+        code += namer_.Field(field, "vector");
         code += "(new " + vector_type_name + "()); }\n";
         code += vector_method_start + "(" + vector_type_name + " obj)";
         code += offset_prefix + conditional_cast + obj + ".__assign(";
@@ -880,7 +921,7 @@ class JavaGenerator : public BaseGenerator {
            IsScalar(field.value.type.VectorType().base_type)) ||
           IsString(field.value.type)) {
         code += "  public ByteBuffer ";
-        code += ConvertCase(field.name, Case::kLowerCamel);
+        code += namer_.Field(field);
         code += "AsByteBuffer() { return ";
         code += "__vector_as_bytebuffer(";
         code += NumToString(field.value.offset) + ", ";
@@ -889,7 +930,7 @@ class JavaGenerator : public BaseGenerator {
                                 : InlineSize(field.value.type.VectorType()));
         code += "); }\n";
         code += "  public ByteBuffer ";
-        code += ConvertCase(field.name, Case::kLowerCamel);
+        code += namer_.Field(field);
         code += "InByteBuffer(ByteBuffer _bb) { return ";
         code += "__vector_in_bytebuffer(_bb, ";
         code += NumToString(field.value.offset) + ", ";
@@ -901,8 +942,8 @@ class JavaGenerator : public BaseGenerator {
       // generate object accessors if is nested_flatbuffer
       if (field.nested_flatbuffer) {
         auto nested_type_name = WrapInNameSpace(*field.nested_flatbuffer);
-        auto nested_method_name = ConvertCase(field.name, Case::kLowerCamel) +
-                                  "As" + field.nested_flatbuffer->name;
+        auto nested_method_name =
+            namer_.Field(field) + "As" + field.nested_flatbuffer->name;
         auto get_nested_method_name = nested_method_name;
         code += "  public " + nested_type_name + " ";
         code += nested_method_name + "() { return ";
@@ -928,7 +969,6 @@ class JavaGenerator : public BaseGenerator {
         auto setter_parameter = underlying_type.base_type == BASE_TYPE_BOOL
                                     ? "(byte)(" + field.name + " ? 1 : 0)"
                                     : field.name;
-        auto mutator_prefix = "mutate";
         // A vector mutator also needs the index of the vector element it should
         // mutate.
         auto mutator_params = (is_series ? "(int j, " : "(") +
@@ -946,7 +986,7 @@ class JavaGenerator : public BaseGenerator {
         if (IsScalar(underlying_type.base_type) && !IsUnion(field.value.type)) {
           code += "  public ";
           code += struct_def.fixed ? "void " : "boolean ";
-          code += mutator_prefix + ConvertCase(field.name, Case::kUpperCamel);
+          code += namer_.Method("mutate", field);
           code += mutator_params;
           if (struct_def.fixed) {
             code += GenSetter(underlying_type) + "(" + setter_index + ", ";
@@ -962,10 +1002,9 @@ class JavaGenerator : public BaseGenerator {
       }
       if (parser_.opts.java_primitive_has_method &&
           IsScalar(field.value.type.base_type) && !struct_def.fixed) {
-        auto vt_offset_constant =
-            "  public static final int VT_" +
-            ConvertCase(field.name, Case::kScreamingSnake) + " = " +
-            NumToString(field.value.offset) + ";";
+        auto vt_offset_constant = "  public static final int VT_" +
+                                  namer_.Constant(field) + " = " +
+                                  NumToString(field.value.offset) + ";";
 
         code += vt_offset_constant;
         code += "\n";
@@ -980,7 +1019,7 @@ class JavaGenerator : public BaseGenerator {
       // create a struct constructor function
       code += "  public static " + GenOffsetType() + " ";
       code += "create";
-      code += struct_def.name + "(FlatBufferBuilder builder";
+      code += struct_class + "(FlatBufferBuilder builder";
       GenStructArgs(struct_def, code_ptr, "");
       code += ") {\n";
       GenStructBody(struct_def, code_ptr, "");
@@ -1010,12 +1049,12 @@ class JavaGenerator : public BaseGenerator {
         // Generate a table constructor of the form:
         // public static int createName(FlatBufferBuilder builder, args...)
         code += "  public static " + GenOffsetType() + " ";
-        code += "create" + struct_def.name;
+        code += namer_.LegacyJavaMethod2("create", struct_def, "");
         code += "(FlatBufferBuilder builder";
         for (auto it = struct_def.fields.vec.begin();
              it != struct_def.fields.vec.end(); ++it) {
           auto &field = **it;
-          auto field_name = ConvertCase(field.name, Case::kLowerCamel);
+          auto field_name = namer_.Field(field);
           if (field.deprecated) continue;
           code += ",\n      ";
           code += GenTypeBasic(DestinationType(field.value.type, false));
@@ -1031,21 +1070,19 @@ class JavaGenerator : public BaseGenerator {
           for (auto it = struct_def.fields.vec.rbegin();
                it != struct_def.fields.vec.rend(); ++it) {
             auto &field = **it;
-            auto field_name = ConvertCase(field.name, Case::kLowerCamel);
-            auto method_name = ConvertCase(field.name, Case::kUpperCamel);
+            auto field_name = namer_.Field(field);
             if (!field.deprecated &&
                 (!struct_def.sortbysize ||
                  size == SizeOf(field.value.type.base_type))) {
-              code += "    " + struct_def.name + ".";
-              code += "add";
-              code += method_name + "(builder, " + field_name;
+              code += "    " + struct_class + ".";
+              code += namer_.Method("add", field) + "(builder, " + field_name;
               if (!IsScalar(field.value.type.base_type)) code += "Offset";
               code += ");\n";
             }
           }
         }
-        code += "    return " + struct_def.name + ".";
-        code += "end" + struct_def.name;
+        code += "    return " + struct_class + ".";
+        code += namer_.LegacyJavaMethod2("end", struct_def, "");
         code += "(builder);\n  }\n\n";
       }
       // Generate a set of static methods that allow table construction,
@@ -1054,7 +1091,7 @@ class JavaGenerator : public BaseGenerator {
       // { builder.addShort(id, name, default); }
       // Unlike the Create function, these always work.
       code += "  public static void start";
-      code += struct_def.name;
+      code += struct_class;
       code += "(FlatBufferBuilder builder) { builder.";
       code += "startTable(";
       code += NumToString(struct_def.fields.vec.size()) + "); }\n";
@@ -1063,11 +1100,10 @@ class JavaGenerator : public BaseGenerator {
         auto &field = **it;
         if (field.deprecated) continue;
         if (field.key) key_field = &field;
-        code += "  public static void add";
-        code += ConvertCase(field.name, Case::kUpperCamel);
+        code += "  public static void " + namer_.Method("add", field);
         code += "(FlatBufferBuilder builder, ";
         code += GenTypeBasic(DestinationType(field.value.type, false));
-        auto argname = ConvertCase(field.name, Case::kLowerCamel);
+        auto argname = namer_.Field(field);
         if (!IsScalar(field.value.type.base_type)) argname += "Offset";
         code += " " + argname + ") { builder.add";
         code += GenMethod(field.value.type) + "(";
@@ -1089,20 +1125,17 @@ class JavaGenerator : public BaseGenerator {
                  vector_type.base_type == BASE_TYPE_UCHAR)) {
               // Handle byte[] and ByteBuffers separately for Java
               code += "  public static " + GenVectorOffsetType() + " ";
-              code += "create";
-              code += ConvertCase(field.name, Case::kUpperCamel);
+              code += namer_.Method("create", field);
               code += "Vector(FlatBufferBuilder builder, byte[] data) ";
               code += "{ return builder.createByteVector(data); }\n";
 
               code += "  public static " + GenVectorOffsetType() + " ";
-              code += "create";
-              code += ConvertCase(field.name, Case::kUpperCamel);
+              code += namer_.Method("create", field);
               code += "Vector(FlatBufferBuilder builder, ByteBuffer data) ";
               code += "{ return builder.createByteVector(data); }\n";
             } else {
               code += "  public static " + GenVectorOffsetType() + " ";
-              code += "create";
-              code += ConvertCase(field.name, Case::kUpperCamel);
+              code += namer_.Method("create", field);
               code += "Vector(FlatBufferBuilder builder, ";
               code += GenTypeBasic(DestinationType(vector_type, false)) +
                       "[] data) ";
@@ -1123,8 +1156,7 @@ class JavaGenerator : public BaseGenerator {
           }
           // Generate a method to start a vector, data to be added manually
           // after.
-          code += "  public static void start";
-          code += ConvertCase(field.name, Case::kUpperCamel);
+          code += "  public static void " + namer_.Method("start", field);
           code += "Vector(FlatBufferBuilder builder, int numElems) ";
           code += "{ builder.startVector(";
           code += NumToString(elem_size);
@@ -1133,7 +1165,7 @@ class JavaGenerator : public BaseGenerator {
         }
       }
       code += "  public static " + GenOffsetType() + " ";
-      code += "end" + struct_def.name;
+      code += namer_.LegacyJavaNamer2("end", struct_def, "");
       code += "(FlatBufferBuilder builder) {\n    int o = builder.";
       code += "endTable();\n";
       for (auto it = struct_def.fields.vec.begin();
@@ -1150,8 +1182,8 @@ class JavaGenerator : public BaseGenerator {
         std::string size_prefix[] = { "", "SizePrefixed" };
         for (int i = 0; i < 2; ++i) {
           code += "  public static void ";
-          code += "finish" + size_prefix[i] + struct_def.name;
-          code += "Buffer(FlatBufferBuilder builder, " + GenOffsetType();
+          code += LegacyJavaMethod2("finish" + size_prefix[i], struct_Def, "Buffer");
+          code += "(FlatBufferBuilder builder, " + GenOffsetType();
           code += " offset) {";
           code += " builder.finish" + size_prefix[i] + "(offset";
 
@@ -1170,9 +1202,9 @@ class JavaGenerator : public BaseGenerator {
       code += GenKeyGetter(key_field);
       code += " }\n";
 
-      code += "\n  public static " + struct_def.name;
+      code += "\n  public static " + struct_class;
       code += " __lookup_by_key(";
-      code += struct_def.name + " obj, ";
+      code += struct_class + " obj, ";
       code += "int vectorLocation, ";
       code += GenTypeNameDest(key_field->value.type);
       code += " key, ByteBuffer bb) {\n";
@@ -1194,7 +1226,7 @@ class JavaGenerator : public BaseGenerator {
       code += "        span -= middle;\n";
       code += "      } else {\n";
       code += "        return ";
-      code += "(obj == null ? new " + struct_def.name + "() : obj)";
+      code += "(obj == null ? new " + struct_class + "() : obj)";
       code += ".__assign(tableOffset, bb);\n";
       code += "      }\n    }\n";
       code += "    return null;\n";
@@ -1210,7 +1242,7 @@ class JavaGenerator : public BaseGenerator {
 
   std::string GenOptionalScalarCheck(FieldDef &field) const {
     if (!field.IsScalarOptional()) return "";
-    return "  public boolean has" + ConvertCase(field.name, Case::kUpperCamel) +
+    return "  public boolean " + namer_.Method("has", field) +
            "() { return 0 != __offset(" + NumToString(field.value.offset) +
            "); }\n";
   }
@@ -1234,7 +1266,7 @@ class JavaGenerator : public BaseGenerator {
     code += "__assign(int _vector, int _element_size, ByteBuffer _bb) { ";
     code += "__reset(_vector, _element_size, _bb); return this; }\n\n";
 
-    auto type_name = struct_def.name;
+    auto type_name = namer_.Type(struct_def);
     auto method_start = method_indent + "public " + type_name + " get";
     // Generate the accessors that don't do object reuse.
     code += method_start + "(int j) { return get";
@@ -1276,10 +1308,6 @@ class JavaGenerator : public BaseGenerator {
     code += "  }\n";
   }
 
-  std::string GenGetterFuncName_ObjectAPI(const std::string &field_name) const {
-    return "get" + ConvertCase(field_name, Case::kUpperCamel);
-  }
-
   void GenEnum_ObjectAPI(EnumDef &enum_def, std::string *code_ptr,
                          const IDLOptions &opts) const {
     auto &code = *code_ptr;
@@ -1287,7 +1315,7 @@ class JavaGenerator : public BaseGenerator {
     code += "import com.google.flatbuffers.FlatBufferBuilder;\n\n";
 
     if (!enum_def.attributes.Lookup("private")) { code += "public "; }
-    auto union_name = enum_def.name + "Union";
+    auto union_name = namer_.Type(enum_def) + "Union";
     auto union_type =
         GenTypeBasic(DestinationType(enum_def.underlying_type, false));
     code += "class " + union_name + " {\n";
@@ -1304,8 +1332,9 @@ class JavaGenerator : public BaseGenerator {
     code += "  public void setValue(Object value) { this.value = value; }\n\n";
     // Constructor
     code += "  public " + union_name + "() {\n";
-    code += "    this.type = " + enum_def.name + "." +
-            enum_def.Vals()[0]->name + ";\n";
+    code +=
+        "    this.type = " + namer_.EnumVariant(enum_def, *enum_def.Vals()[0]) +
+        ";\n";
     code += "    this.value = null;\n";
     code += "  }\n\n";
     // As
@@ -1332,7 +1361,7 @@ class JavaGenerator : public BaseGenerator {
       if (ev.union_type.base_type == BASE_TYPE_NONE) {
         continue;
       } else {
-        code += "      case " + enum_def.name + "." + ev.name + ": return ";
+        code += "      case " + namer_.EnumVariant(enum_def, ev) + ": return ";
         if (IsString(ev.union_type)) {
           code += "builder.createString(_o.as" + ev.name + "());\n";
         } else {
@@ -1347,15 +1376,6 @@ class JavaGenerator : public BaseGenerator {
     code += "}\n\n";
   }
 
-  std::string GenSetterFuncName_ObjectAPI(const std::string &field_name) const {
-    return "set" + ConvertCase(field_name, Case::kUpperCamel);
-  }
-
-  std::string GenTypeName_ObjectAPI(const std::string &name,
-                                    const IDLOptions &opts) const {
-    return opts.object_prefix + name + opts.object_suffix;
-  }
-
   void GenUnionUnPack_ObjectAPI(const EnumDef &enum_def, std::string *code_ptr,
                                 const std::string &type_name,
                                 const std::string &camel_name,
@@ -1363,8 +1383,7 @@ class JavaGenerator : public BaseGenerator {
     auto &code = *code_ptr;
 
     std::string variable_type = type_name;
-    std::string variable_name =
-        "_o" + ConvertCase(camel_name, Case::kUpperCamel);
+    std::string variable_name = "_" + namer_.Variable("o", camel_name);
     std::string type_params = "";
     std::string value_params = "";
     std::string func_suffix = "()";
@@ -1399,6 +1418,7 @@ class JavaGenerator : public BaseGenerator {
                      // Java which doesn't handle non Table types. Should be
                      // deleted when issue #6561 is fixed.
         }
+        // DO NOT SUBMIT: CASPER: NamespacedEnumVariant.
         code += indent + "  case " + WrapInNameSpace(enum_def) + "." + ev.name +
                 ":\n";
         auto actual_type = GenTypeGet(ev.union_type);
@@ -1413,7 +1433,7 @@ class JavaGenerator : public BaseGenerator {
     code += indent + "  default: break;\n";
     code += indent + "}\n";
     if (is_vector) {
-      code += indent + "_o" + ConvertCase(camel_name, Case::kUpperCamel) +
+      code += indent + "_" + namer_.Variable("o", camel_name) +
               "[_j] = " + variable_name + ";\n";
     }
   }
@@ -1423,7 +1443,7 @@ class JavaGenerator : public BaseGenerator {
       bool struct_has_create,
       const std::set<FieldDef *> &field_has_create) const {
     auto &code = *code_ptr;
-    auto struct_name = GenTypeName_ObjectAPI(struct_def.name, opts);
+    auto struct_name = namer_.ObjectType(struct_def);
     // unpack()
     code += "  public " + struct_name + " unpack() {\n";
     code += "    " + struct_name + " _o = new " + struct_name + "();\n";
@@ -1434,35 +1454,35 @@ class JavaGenerator : public BaseGenerator {
     code += "  public void unpackTo(" + struct_name + " _o) {\n";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
       if (field.value.type.base_type == BASE_TYPE_UTYPE) continue;
       if (field.value.type.element == BASE_TYPE_UTYPE) continue;
-      auto camel_name = ConvertCase(field.name, Case::kLowerCamel);
-      auto camel_name_with_first = ConvertCase(field.name, Case::kUpperCamel);
+      const auto accessor = namer_.Method(field);
+      const auto variable = "_" + namer_.Variable("o", field);
+      const auto get_field = namer_.Method("get", field);
+
       auto type_name =
           GenTypeGet_ObjectAPI(field.value.type, opts, false, true);
       if (field.IsScalarOptional())
         type_name = ConvertPrimitiveTypeToObjectWrapper_ObjectAPI(type_name);
-      auto start = "    " + type_name + " _o" + camel_name_with_first + " = ";
+      auto start = "    " + type_name + " " + variable + " = ";
       auto call_setter = true;
       switch (field.value.type.base_type) {
         case BASE_TYPE_STRUCT: {
           auto fixed = struct_def.fixed && field.value.type.struct_def->fixed;
           if (fixed) {
-            code += "    " + camel_name + "().unpackTo(_o.get" +
-                    camel_name_with_first + "());\n";
+            code +=
+                "    " + accessor + "().unpackTo(_o." + get_field + "());\n";
           } else {
-            code += "    if (" + camel_name + "() != null) ";
+            code += "    if (" + accessor + "() != null) ";
             if (field.value.type.struct_def->fixed) {
-              code += camel_name + "().unpackTo(_o.get" +
-                      camel_name_with_first + "());\n";
+              code += accessor + "().unpackTo(_o." + get_field + "());\n";
             } else {
-              code += "_o." + GenSetterFuncName_ObjectAPI(field.name) + "(" +
-                      camel_name + "().unpack());\n";
+              code += "_o." + namer_.Method("set", field) + "(" + accessor +
+                      "().unpack());\n";
             }
-            code += "    else _o." + GenSetterFuncName_ObjectAPI(field.name) +
-                    "(null);\n";
+            code += "    else _o." + namer_.Method("set", field) + "(null);\n";
           }
           call_setter = false;
           break;
@@ -1471,11 +1491,10 @@ class JavaGenerator : public BaseGenerator {
           auto length_str = NumToString(field.value.type.fixed_length);
           auto unpack_method =
               field.value.type.struct_def == nullptr ? "" : ".unpack()";
-          code +=
-              start + "_o." + GenGetterFuncName_ObjectAPI(field.name) + "();\n";
-          code += "    for (int _j = 0; _j < " + length_str + "; ++_j) { _o" +
-                  camel_name_with_first + "[_j] = " + camel_name + "(_j)" +
-                  unpack_method + "; }\n";
+          code += start + "_o." + get_field + "();\n";
+          code += "    for (int _j = 0; _j < " + length_str + "; ++_j) { " +
+                  variable + "[_j] = " + accessor + "(_j)" + unpack_method +
+                  "; }\n";
           call_setter = false;
           break;
         }
@@ -1484,25 +1503,26 @@ class JavaGenerator : public BaseGenerator {
             code += start + "new " +
                     GenConcreteTypeGet_ObjectAPI(field.value.type, opts)
                         .substr(0, type_name.length() - 1) +
-                    camel_name + "Length()];\n";
-            code += "    for (int _j = 0; _j < " + camel_name +
-                    "Length(); ++_j) {\n";
+                    accessor + "Length()];\n";
+            code +=
+                "    for (int _j = 0; _j < " + accessor + "Length(); ++_j) {\n";
             GenUnionUnPack_ObjectAPI(*field.value.type.enum_def, code_ptr,
-                                     type_name, camel_name, true);
+                                     type_name, accessor, true);
             code += "    }\n";
           } else if (field.value.type.element != BASE_TYPE_UTYPE) {
             auto fixed = field.value.type.struct_def == nullptr;
+            const auto length_accessor = namer_.Method(field, "length");
             code += start + "new " +
                     GenConcreteTypeGet_ObjectAPI(field.value.type, opts)
                         .substr(0, type_name.length() - 1) +
-                    camel_name + "Length()];\n";
+                    length_accessor + "()];\n";
             code +=
-                "    for (int _j = 0; _j < " + camel_name + "Length(); ++_j) {";
-            code += "_o" + camel_name_with_first + "[_j] = ";
+                "    for (int _j = 0; _j < " + length_accessor + "(); ++_j) {";
+            code += variable + "[_j] = ";
             if (fixed) {
-              code += camel_name + "(_j)";
+              code += accessor + "(_j)";
             } else {
-              code += "(" + camel_name + "(_j) != null ? " + camel_name +
+              code += "(" + accessor + "(_j) != null ? " + accessor +
                       "(_j).unpack() : null)";
             }
             code += ";}\n";
@@ -1511,22 +1531,22 @@ class JavaGenerator : public BaseGenerator {
         case BASE_TYPE_UTYPE: break;
         case BASE_TYPE_UNION: {
           GenUnionUnPack_ObjectAPI(*field.value.type.enum_def, code_ptr,
-                                   type_name, camel_name, false);
+                                   type_name, accessor, false);
           break;
         }
         default: {
           if (field.IsScalarOptional()) {
-            code += start + "has" + camel_name_with_first + "() ? " +
-                    camel_name + "() : null;\n";
+            code += start + namer_.Method("has", field) + "() ? " + accessor +
+                    "() : null;\n";
           } else {
-            code += start + camel_name + "();\n";
+            code += start + accessor + "();\n";
           }
           break;
         }
       }
       if (call_setter) {
-        code += "    _o." + GenSetterFuncName_ObjectAPI(field.name) + "(_o" +
-                camel_name_with_first + ");\n";
+        code +=
+            "    _o." + namer_.Method("set", field) + "(" + variable + ");\n";
       }
     }
     code += "  }\n";
@@ -1538,17 +1558,17 @@ class JavaGenerator : public BaseGenerator {
          it != struct_def.fields.vec.end(); ++it) {
       auto &field = **it;
       if (field.deprecated) continue;
-      auto camel_name = ConvertCase(field.name, Case::kLowerCamel);
-      auto camel_name_with_first = ConvertCase(field.name, Case::kUpperCamel);
+      const auto camel_name = namer_.Field(field);
+      const auto variable = "_" + namer_.Variable("o", field);
+      const auto get_field = namer_.Method("get", field);
       // pre
       switch (field.value.type.base_type) {
         case BASE_TYPE_STRUCT: {
           if (!field.value.type.struct_def->fixed) {
-            code += "    " + GenOffsetType() + " _" + field.name + " = _o." +
-                    GenGetterFuncName_ObjectAPI(field.name) +
+            code += "    " + GenOffsetType() + " _" + namer_.Variable(field) +
+                    " = _o." + get_field +
                     "() == null ? 0 : " + GenTypeGet(field.value.type) +
-                    ".pack(builder, _o." +
-                    GenGetterFuncName_ObjectAPI(field.name) + "());\n";
+                    ".pack(builder, _o." + get_field + "());\n";
           } else if (struct_def.fixed && struct_has_create) {
             std::vector<FieldArrayLength> array_lengths;
             FieldArrayLength tmp_array_length = {
@@ -1563,12 +1583,10 @@ class JavaGenerator : public BaseGenerator {
         }
         case BASE_TYPE_STRING: {
           std::string create_string = "createString";
-          code += "    int _" + camel_name + " = _o." +
-                  GenGetterFuncName_ObjectAPI(field.name) +
+          code += "    int _" + camel_name + " = _o." + get_field +
                   "() == null ? 0 : "
                   "builder." +
-                  create_string + "(_o." +
-                  GenGetterFuncName_ObjectAPI(field.name) + "());\n";
+                  create_string + "(_o." + get_field + "());\n";
           break;
         }
         case BASE_TYPE_VECTOR: {
@@ -1599,7 +1617,7 @@ class JavaGenerator : public BaseGenerator {
                 array_type = GenTypeBasic(DestinationType(
                     field.value.type.enum_def->underlying_type, false));
                 element_type = field.value.type.enum_def->name + "Union";
-                to_array = "_o." + GenGetterFuncName_ObjectAPI(property_name) +
+                to_array = "_o." + namer_.Method("get", property_name) +
                            "()[_j].getType()";
                 break;
               case BASE_TYPE_UNION:
@@ -1608,8 +1626,7 @@ class JavaGenerator : public BaseGenerator {
                     WrapInNameSpace(*field.value.type.enum_def) + "Union";
                 to_array = WrapInNameSpace(*field.value.type.enum_def) +
                            "Union.pack(builder,  _o." +
-                           GenGetterFuncName_ObjectAPI(property_name) +
-                           "()[_j])";
+                           namer_.Method("get", property_name) + "()[_j])";
                 break;
               case BASE_TYPE_UCHAR:  // TODO this branch of the switch is due to
                                      // inconsistent behavior in unsigned byte.
@@ -1620,29 +1637,27 @@ class JavaGenerator : public BaseGenerator {
                 break;
               default:
                 gen_for_loop = false;
-                array_name =
-                    "_o." + GenGetterFuncName_ObjectAPI(property_name) + "()";
+                array_name = "_o." + namer_.Method("get", property_name) + "()";
                 array_type = GenTypeNameDest(field.value.type);
                 element_type = array_type;
                 to_array = "_e";
                 break;
             }
             code += "    int _" + camel_name + " = 0;\n";
-            code += "    if (_o." + GenGetterFuncName_ObjectAPI(property_name) +
+            code += "    if (_o." + namer_.Method("get", property_name) +
                     "() != null) {\n";
             if (gen_for_loop) {
               code += "      " + array_type + "[] " + array_name + " = new " +
                       array_type + "[_o." +
-                      GenGetterFuncName_ObjectAPI(property_name) +
-                      "().length];\n";
+                      namer_.Method("get", property_name) + "().length];\n";
               code += "      int _j = 0;\n";
               code += "      for (" + element_type + " _e : _o." +
-                      GenGetterFuncName_ObjectAPI(property_name) + "()) { ";
+                      namer_.Method("get", property_name) + "()) { ";
               code += array_name + "[_j] = " + to_array + "; _j++;}\n";
             }
-            code += "      _" + camel_name + " = create" +
-                    camel_name_with_first + "Vector(builder, " + array_name +
-                    ");\n";
+            code += "      _" + camel_name + " = " +
+                    namer_.Method("create", field) + "Vector(builder, " +
+                    array_name + ");\n";
             code += "    }\n";
           } else {
             auto type_name = GenTypeGet(field.value.type);
@@ -1651,18 +1666,15 @@ class JavaGenerator : public BaseGenerator {
             auto pack_method =
                 field.value.type.struct_def == nullptr
                     ? "builder.add" + GenMethod(field.value.type.VectorType()) +
-                          "(_o" + camel_name_with_first + "[_j]);"
-                    : type_name + ".pack(builder, _o" + camel_name_with_first +
-                          "[_j]);";
+                          "(" + variable + "[_j]);"
+                    : type_name + ".pack(builder, " + variable + "[_j]);";
             code += "    int _" + camel_name + " = 0;\n";
-            code += "    " + element_type_name + "[] _o" +
-                    camel_name_with_first + " = _o." +
-                    GenGetterFuncName_ObjectAPI(field.name) + "();\n";
-            code += "    if (_o" + camel_name_with_first + " != null) {\n";
-            code += "      start" + camel_name_with_first +
-                    "Vector(builder, _o" + camel_name_with_first +
-                    ".length);\n";
-            code += "      for (int _j = _o" + camel_name_with_first +
+            code += "    " + element_type_name + "[] " + variable + " = _o." +
+                    get_field + "();\n";
+            code += "    if (" + variable + " != null) {\n";
+            code += "      " + namer_.Method("start", field) +
+                    "Vector(builder, " + variable + ".length);\n";
+            code += "      for (int _j = " + variable +
                     ".length - 1; _j >=0; _j--) { ";
             code += pack_method + "}\n";
             code += "      _" + camel_name + " = builder.endVector();\n";
@@ -1683,24 +1695,22 @@ class JavaGenerator : public BaseGenerator {
           } else {
             code += "    " +
                     GenTypeGet_ObjectAPI(field.value.type, opts, false, true) +
-                    " _" + camel_name + " = _o." +
-                    GenGetterFuncName_ObjectAPI(field.name) + "();\n";
+                    " _" + camel_name + " = _o." + get_field + "();\n";
           }
           break;
         }
         case BASE_TYPE_UNION: {
-          code +=
-              "    " +
-              GenTypeBasic(DestinationType(
-                  field.value.type.enum_def->underlying_type, false)) +
-              " _" + camel_name + "Type = _o.get" + camel_name_with_first +
-              "() == null ? " + WrapInNameSpace(*field.value.type.enum_def) +
-              ".NONE : " + "_o.get" + camel_name_with_first + "().getType();\n";
-          code += "    " + GenOffsetType() + " _" + camel_name + " = _o.get" +
-                  camel_name_with_first + "() == null ? 0 : " +
+          code += "    " +
+                  GenTypeBasic(DestinationType(
+                      field.value.type.enum_def->underlying_type, false)) +
+                  " _" + camel_name + "Type = _o." + get_field +
+                  "() == null ? " +
                   WrapInNameSpace(*field.value.type.enum_def) +
-                  "Union.pack(builder, _o.get" + camel_name_with_first +
-                  "());\n";
+                  ".NONE : " + "_o." + get_field + "().getType();\n";
+          code += "    " + GenOffsetType() + " _" + camel_name + " = _o." +
+                  get_field + "() == null ? 0 : " +
+                  WrapInNameSpace(*field.value.type.enum_def) +
+                  "Union.pack(builder, _o." + get_field + "());\n";
           break;
         }
         default: break;
@@ -1708,13 +1718,15 @@ class JavaGenerator : public BaseGenerator {
     }
     if (struct_has_create) {
       // Create
-      code += "    return create" + struct_def.name + "(\n";
+      code += "    return " +
+              namer_.LegacyJavaMethod2("create", struct_def, "") + "(\n";
       code += "      builder";
       for (auto it = struct_def.fields.vec.begin();
            it != struct_def.fields.vec.end(); ++it) {
         auto &field = **it;
         if (field.deprecated) continue;
-        auto camel_name = ConvertCase(field.name, Case::kLowerCamel);
+        const auto camel_name = namer_.Field(field);
+        const auto get_field = namer_.Method("get", field);
         switch (field.value.type.base_type) {
           case BASE_TYPE_STRUCT: {
             if (struct_def.fixed) {
@@ -1757,64 +1769,61 @@ class JavaGenerator : public BaseGenerator {
           }
           default:  // scalar
             code += ",\n";
-            code +=
-                "      _o." + GenGetterFuncName_ObjectAPI(field.name) + "()";
+            code += "      _o." + get_field + "()";
             break;
         }
       }
       code += ");\n";
     } else {
       // Start, End
-      code += "    start" + struct_def.name + "(builder);\n";
+      code += "    " + namer_.LegacyJavaMethod2("start", struct_def, "") +
+              "(builder);\n";
       for (auto it = struct_def.fields.vec.begin();
            it != struct_def.fields.vec.end(); ++it) {
         auto &field = **it;
         if (field.deprecated) continue;
-        auto camel_name = ConvertCase(field.name, Case::kLowerCamel);
-        auto camel_name_with_first = ConvertCase(field.name, Case::kUpperCamel);
+        const auto arg = "_" + namer_.Variable(field);
+        const auto get_field = namer_.Method("get", field);
+        const auto add_field = namer_.Method("add", field);
+
         switch (field.value.type.base_type) {
           case BASE_TYPE_STRUCT: {
             if (field.value.type.struct_def->fixed) {
-              code += "    add" + camel_name_with_first + "(builder, " +
+              code += "    " + add_field + "(builder, " +
                       GenTypeGet(field.value.type) + ".pack(builder, _o." +
-                      GenGetterFuncName_ObjectAPI(field.name) + "()));\n";
+                      get_field + "()));\n";
             } else {
-              code += "    add" + camel_name_with_first + "(builder, _" +
-                      field.name + ");\n";
+              code += "    " + add_field + "(builder, " + arg + ");\n";
             }
             break;
           }
           case BASE_TYPE_STRING: FLATBUFFERS_FALLTHROUGH();  // fall thru
           case BASE_TYPE_ARRAY: FLATBUFFERS_FALLTHROUGH();   // fall thru
           case BASE_TYPE_VECTOR: {
-            code += "    add" + camel_name_with_first + "(builder, _" +
-                    camel_name + ");\n";
+            code += "    " + add_field + "(builder, " + arg + ");\n";
             break;
           }
           case BASE_TYPE_UTYPE: break;
           case BASE_TYPE_UNION: {
-            code += "    add" + camel_name_with_first + "Type(builder, _" +
-                    camel_name + "Type);\n";
-            code += "    add" + camel_name_with_first + "(builder, _" +
-                    camel_name + ");\n";
+            code += "    " + add_field + "Type(builder, " + arg + "Type);\n";
+            code += "    " + add_field + "(builder, " + arg + ");\n";
             break;
           }
           // scalar
           default: {
             if (field.IsScalarOptional()) {
-              code += "    if (_o." + GenGetterFuncName_ObjectAPI(field.name) +
-                      "() != null) { add" + camel_name_with_first +
-                      "(builder, _o." +
-                      GenGetterFuncName_ObjectAPI(field.name) + "()); }\n";
+              code += "    if (_o." + get_field + "() != null) { " + add_field +
+                      "(builder, _o." + get_field + "()); }\n";
             } else {
-              code += "    add" + camel_name_with_first + "(builder, _o." +
-                      GenGetterFuncName_ObjectAPI(field.name) + "());\n";
+              code +=
+                  "    " + add_field + "(builder, _o." + get_field + "());\n";
             }
             break;
           }
         }
       }
-      code += "    return end" + struct_def.name + "(builder);\n";
+      code += "    return " + namer_.LegacyJavaMethod2("end", struct_def, "") +
+              "(builder);\n";
     }
     code += "  }\n";
   }
@@ -1846,7 +1855,7 @@ class JavaGenerator : public BaseGenerator {
         }
         std::string name;
         for (size_t i = 0; i < array_lengths.size(); ++i) {
-          name += "_" + ConvertCase(array_lengths[i].name, Case::kLowerCamel);
+          name += "_" + namer_.Variable(array_lengths[i].name);
         }
         code += "    " + GenTypeBasic(field_type);
         if (array_only_lengths.size() > 0) {
@@ -1878,8 +1887,7 @@ class JavaGenerator : public BaseGenerator {
           }
           code += "] = _o";
           for (size_t i = 0, j = 0; i < array_lengths.size(); ++i) {
-            code +=
-                "." + GenGetterFuncName_ObjectAPI(array_lengths[i].name) + "()";
+            code += "." + namer_.Method("get", array_lengths[i].name) + "()";
             if (array_lengths[i].length <= 0) continue;
             code += "[idx" + NumToString(j++) + "]";
           }
@@ -1891,8 +1899,7 @@ class JavaGenerator : public BaseGenerator {
           code += " " + name + " = ";
           code += "_o";
           for (size_t i = 0; i < array_lengths.size(); ++i) {
-            code +=
-                "." + GenGetterFuncName_ObjectAPI(array_lengths[i].name) + "()";
+            code += "." + namer_.Method("get", array_lengths[i].name) + "()";
           }
           code += ";";
         }
@@ -1911,12 +1918,11 @@ class JavaGenerator : public BaseGenerator {
       auto &field = **it;
       const auto &field_type = field.value.type;
       if (field_type.struct_def != nullptr) {
-        GenStructPackCall_ObjectAPI(
-            *field_type.struct_def, code_ptr,
-            prefix + ConvertCase(field.name, Case::kLowerCamel) + "_");
+        GenStructPackCall_ObjectAPI(*field_type.struct_def, code_ptr,
+                                    prefix + namer_.Field(field) + "_");
       } else {
         code += ",\n";
-        code += prefix + ConvertCase(field.name, Case::kLowerCamel);
+        code += prefix + namer_.Field(field);
       }
     }
   }
@@ -1953,8 +1959,7 @@ class JavaGenerator : public BaseGenerator {
       case BASE_TYPE_VECTOR: {
         if (type.struct_def != nullptr) {
           auto type_name_length = type.struct_def->name.length();
-          auto new_type_name =
-              GenTypeName_ObjectAPI(type.struct_def->name, opts);
+          auto new_type_name = namer_.ObjectType(*type.struct_def);
           type_name.replace(type_name.length() - type_name_length,
                             type_name_length, new_type_name);
         } else if (type.element == BASE_TYPE_UNION) {
@@ -1999,8 +2004,7 @@ class JavaGenerator : public BaseGenerator {
       case BASE_TYPE_VECTOR: {
         if (type.struct_def != nullptr) {
           auto type_name_length = type.struct_def->name.length();
-          auto new_type_name =
-              GenTypeName_ObjectAPI(type.struct_def->name, opts);
+          auto new_type_name = namer_.ObjectType(*type.struct_def);
           type_name.replace(type_name.length() - type_name_length,
                             type_name_length, new_type_name);
         } else if (type.element == BASE_TYPE_UNION) {
@@ -2037,7 +2041,7 @@ class JavaGenerator : public BaseGenerator {
       code += "public ";
     }
 
-    auto class_name = GenTypeName_ObjectAPI(struct_def.name, opts);
+    auto class_name = namer_.ObjectType(struct_def);
     code += "class " + class_name;
     code += " {\n";
     // Generate Properties
@@ -2051,24 +2055,25 @@ class JavaGenerator : public BaseGenerator {
           GenTypeGet_ObjectAPI(field.value.type, opts, false, true);
       if (field.IsScalarOptional())
         type_name = ConvertPrimitiveTypeToObjectWrapper_ObjectAPI(type_name);
-      auto camel_name = ConvertCase(field.name, Case::kLowerCamel);
+      auto camel_name = namer_.Field(field);
       code += "  private " + type_name + " " + camel_name + ";\n";
     }
     // Generate Java getters and setters
     code += "\n";
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
-      auto &field = **it;
+      const auto &field = **it;
       if (field.deprecated) continue;
       if (field.value.type.base_type == BASE_TYPE_UTYPE) continue;
       if (field.value.type.element == BASE_TYPE_UTYPE) continue;
+      const auto camel_name = namer_.Field(field);
+      const auto get_field = namer_.Method("get", field);
       auto type_name =
           GenTypeGet_ObjectAPI(field.value.type, opts, false, true);
       if (field.IsScalarOptional())
         type_name = ConvertPrimitiveTypeToObjectWrapper_ObjectAPI(type_name);
-      auto camel_name = ConvertCase(field.name, Case::kLowerCamel);
-      code += "  public " + type_name + " " +
-              GenGetterFuncName_ObjectAPI(field.name) + "() { return " +
+
+      code += "  public " + type_name + " " + get_field + "() { return " +
               camel_name + "; }\n\n";
       std::string array_validation = "";
       if (field.value.type.base_type == BASE_TYPE_ARRAY) {
@@ -2076,9 +2081,9 @@ class JavaGenerator : public BaseGenerator {
             "if (" + camel_name + " != null && " + camel_name +
             ".length == " + NumToString(field.value.type.fixed_length) + ") ";
       }
-      code += "  public void " + GenSetterFuncName_ObjectAPI(field.name) + "(" +
-              type_name + " " + camel_name + ") { " + array_validation +
-              "this." + camel_name + " = " + camel_name + "; }\n\n";
+      code += "  public void " + namer_.Method("set", field) + "(" + type_name +
+              " " + camel_name + ") { " + array_validation + "this." +
+              camel_name + " = " + camel_name + "; }\n\n";
     }
     // Generate Constructor
     code += "\n";
@@ -2089,7 +2094,9 @@ class JavaGenerator : public BaseGenerator {
       if (field.deprecated) continue;
       if (field.value.type.base_type == BASE_TYPE_UTYPE) continue;
       if (field.value.type.element == BASE_TYPE_UTYPE) continue;
-      code += "    this." + ConvertCase(field.name, Case::kLowerCamel) + " = ";
+      const auto get_field = namer_.Method("get", field);
+
+      code += "    this." + namer_.Field(field) + " = ";
       auto type_name =
           GenTypeGet_ObjectAPI(field.value.type, opts, false, true);
       if (IsScalar(field.value.type.base_type)) {
@@ -2122,15 +2129,18 @@ class JavaGenerator : public BaseGenerator {
     }
     code += "  }\n";
     if (parser_.root_struct_def_ == &struct_def) {
+      const std::string struct_type = namer_.Type(struct_def);
       code += "  public static " + class_name +
               " deserializeFromBinary(byte[] fbBuffer) {\n";
-      code += "    return " + struct_def.name + ".getRootAs" + struct_def.name +
+      code += "    return " + struct_type + "." +
+              namer_.LegacyJavaMethod2("getRootAs", struct_def, "") +
               "(ByteBuffer.wrap(fbBuffer)).unpack();\n";
       code += "  }\n";
       code += "  public byte[] serializeToBinary() {\n";
       code += "    FlatBufferBuilder fbb = new FlatBufferBuilder();\n";
-      code += "    " + struct_def.name + ".finish" + struct_def.name +
-              "Buffer(fbb, " + struct_def.name + ".pack(fbb, this));\n";
+      code += "    " + struct_type + "." +
+              namer_.LegacyJavaMethod2("finish", struct_def, "Buffer") +
+              "(fbb, " + struct_type + ".pack(fbb, this));\n";
       code += "    return fbb.sizedByteArray();\n";
       code += "  }\n";
     }
@@ -2140,6 +2150,7 @@ class JavaGenerator : public BaseGenerator {
   // This tracks the current namespace used to determine if a type need to be
   // prefixed by its namespace
   const Namespace *cur_name_space_;
+  const IdlNamer namer_;
 };
 }  // namespace java
 

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -110,7 +110,7 @@ class JavaGenerator : public BaseGenerator {
 
       if (parser_.opts.generate_object_based_api && enum_def.is_union) {
         enumcode = "";
-        GenEnum_ObjectAPI(enum_def, &enumcode, parser_.opts);
+        GenEnum_ObjectAPI(enum_def, &enumcode);
         auto class_name = namer_.Type(enum_def) + "Union";
         if (parser_.opts.one_file) {
           one_file_code += enumcode;
@@ -139,7 +139,7 @@ class JavaGenerator : public BaseGenerator {
 
       if (parser_.opts.generate_object_based_api) {
         declcode = "";
-        GenStruct_ObjectAPI(struct_def, &declcode, parser_.opts);
+        GenStruct_ObjectAPI(struct_def, &declcode);
         auto class_name = namer_.ObjectType(struct_def);
         if (parser_.opts.one_file) {
           one_file_code += declcode;
@@ -1316,8 +1316,7 @@ class JavaGenerator : public BaseGenerator {
     code += "  }\n";
   }
 
-  void GenEnum_ObjectAPI(EnumDef &enum_def, std::string *code_ptr,
-                         const IDLOptions &opts) const {
+  void GenEnum_ObjectAPI(EnumDef &enum_def, std::string *code_ptr) const {
     auto &code = *code_ptr;
     if (enum_def.generated) return;
     code += "import com.google.flatbuffers.FlatBufferBuilder;\n\n";
@@ -1465,8 +1464,7 @@ class JavaGenerator : public BaseGenerator {
       const auto get_field = namer_.Method("get", field);
       const auto set_field = namer_.Method("set", field);
 
-      auto type_name =
-          GenTypeGet_ObjectAPI(field.value.type, false, true);
+      auto type_name = GenTypeGet_ObjectAPI(field.value.type, false, true);
       if (field.IsScalarOptional())
         type_name = ConvertPrimitiveTypeToObjectWrapper_ObjectAPI(type_name);
       auto start = "    " + type_name + " " + variable + " = ";
@@ -1503,7 +1501,7 @@ class JavaGenerator : public BaseGenerator {
         case BASE_TYPE_VECTOR:
           if (field.value.type.element == BASE_TYPE_UNION) {
             code += start + "new " +
-                    GenConcreteTypeGet_ObjectAPI(field.value.type, opts)
+                    GenConcreteTypeGet_ObjectAPI(field.value.type)
                         .substr(0, type_name.length() - 1) +
                     accessor + "Length()];\n";
             code +=
@@ -1515,7 +1513,7 @@ class JavaGenerator : public BaseGenerator {
             auto fixed = field.value.type.struct_def == nullptr;
             const auto length_accessor = namer_.Method(field, "length");
             code += start + "new " +
-                    GenConcreteTypeGet_ObjectAPI(field.value.type, opts)
+                    GenConcreteTypeGet_ObjectAPI(field.value.type)
                         .substr(0, type_name.length() - 1) +
                     length_accessor + "()];\n";
             code +=
@@ -1694,8 +1692,8 @@ class JavaGenerator : public BaseGenerator {
                                         array_lengths);
           } else {
             code += "    " +
-                    GenTypeGet_ObjectAPI(field.value.type, false, true) +
-                    " _" + field_name + " = _o." + get_field + "();\n";
+                    GenTypeGet_ObjectAPI(field.value.type, false, true) + " _" +
+                    field_name + " = _o." + get_field + "();\n";
           }
           break;
         }
@@ -1949,7 +1947,7 @@ class JavaGenerator : public BaseGenerator {
   }
 
   std::string GenTypeGet_ObjectAPI(const flatbuffers::Type &type,
-                                  bool vectorelem,
+                                   bool vectorelem,
                                    bool wrap_in_namespace) const {
     auto type_name = GenTypeNameDest(type);
     // Replace to ObjectBaseAPI Type Name
@@ -1994,8 +1992,8 @@ class JavaGenerator : public BaseGenerator {
     return type_name;
   }
 
-  std::string GenConcreteTypeGet_ObjectAPI(const flatbuffers::Type &type,
-                                           const IDLOptions &opts) const {
+  std::string GenConcreteTypeGet_ObjectAPI(
+      const flatbuffers::Type &type) const {
     auto type_name = GenTypeNameDest(type);
     // Replace to ObjectBaseAPI Type Name
     switch (type.base_type) {
@@ -2031,8 +2029,8 @@ class JavaGenerator : public BaseGenerator {
     return type_name;
   }
 
-  void GenStruct_ObjectAPI(const StructDef &struct_def, std::string *code_ptr,
-                           const IDLOptions &opts) const {
+  void GenStruct_ObjectAPI(const StructDef &struct_def,
+                           std::string *code_ptr) const {
     if (struct_def.generated) return;
     auto &code = *code_ptr;
     if (struct_def.attributes.Lookup("private")) {
@@ -2051,8 +2049,7 @@ class JavaGenerator : public BaseGenerator {
       if (field.deprecated) continue;
       if (field.value.type.base_type == BASE_TYPE_UTYPE) continue;
       if (field.value.type.element == BASE_TYPE_UTYPE) continue;
-      auto type_name =
-          GenTypeGet_ObjectAPI(field.value.type, false, true);
+      auto type_name = GenTypeGet_ObjectAPI(field.value.type, false, true);
       if (field.IsScalarOptional())
         type_name = ConvertPrimitiveTypeToObjectWrapper_ObjectAPI(type_name);
       const auto field_name = namer_.Field(field);
@@ -2068,8 +2065,7 @@ class JavaGenerator : public BaseGenerator {
       if (field.value.type.element == BASE_TYPE_UTYPE) continue;
       const auto field_name = namer_.Field(field);
       const auto get_field = namer_.Method("get", field);
-      auto type_name =
-          GenTypeGet_ObjectAPI(field.value.type, false, true);
+      auto type_name = GenTypeGet_ObjectAPI(field.value.type, false, true);
       if (field.IsScalarOptional())
         type_name = ConvertPrimitiveTypeToObjectWrapper_ObjectAPI(type_name);
 

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -672,7 +672,8 @@ class JavaGenerator : public BaseGenerator {
 
       // Generate a special accessor for the table that when used as the root
       // of a FlatBuffer
-      std::string method_name = namer_.LegacyJavaMethod2("getRootAs", struct_def, "");
+      std::string method_name =
+          namer_.LegacyJavaMethod2("getRootAs", struct_def, "");
       std::string method_signature =
           "  public static " + struct_class + " " + method_name;
 
@@ -694,8 +695,10 @@ class JavaGenerator : public BaseGenerator {
         if (parser_.file_identifier_.length()) {
           // Check if a buffer has the identifier.
           code += "  public static ";
-          code += "boolean " + namer_.LegacyJavaMethod2("", struct_def,
-          "BufferHasIdentifier(ByteBuffer _bb)") + " { return ";
+          code += "boolean " +
+                  namer_.LegacyJavaMethod2(
+                      "", struct_def, "BufferHasIdentifier(ByteBuffer _bb)") +
+                  " { return ";
           code += "__has_identifier(_bb, \"";
           code += parser_.file_identifier_;
           code += "\"); }\n";
@@ -1165,7 +1168,7 @@ class JavaGenerator : public BaseGenerator {
         }
       }
       code += "  public static " + GenOffsetType() + " ";
-      code += namer_.LegacyJavaNamer2("end", struct_def, "");
+      code += namer_.LegacyJavaMethod2("end", struct_def, "");
       code += "(FlatBufferBuilder builder) {\n    int o = builder.";
       code += "endTable();\n";
       for (auto it = struct_def.fields.vec.begin();
@@ -1182,7 +1185,8 @@ class JavaGenerator : public BaseGenerator {
         std::string size_prefix[] = { "", "SizePrefixed" };
         for (int i = 0; i < 2; ++i) {
           code += "  public static void ";
-          code += LegacyJavaMethod2("finish" + size_prefix[i], struct_Def, "Buffer");
+          code += namer_.LegacyJavaMethod2("finish" + size_prefix[i],
+                                           struct_def, "Buffer");
           code += "(FlatBufferBuilder builder, " + GenOffsetType();
           code += " offset) {";
           code += " builder.finish" + size_prefix[i] + "(offset";
@@ -1461,6 +1465,7 @@ class JavaGenerator : public BaseGenerator {
       const auto accessor = namer_.Method(field);
       const auto variable = "_" + namer_.Variable("o", field);
       const auto get_field = namer_.Method("get", field);
+      const auto set_field = namer_.Method("set", field);
 
       auto type_name =
           GenTypeGet_ObjectAPI(field.value.type, opts, false, true);
@@ -1479,10 +1484,9 @@ class JavaGenerator : public BaseGenerator {
             if (field.value.type.struct_def->fixed) {
               code += accessor + "().unpackTo(_o." + get_field + "());\n";
             } else {
-              code += "_o." + namer_.Method("set", field) + "(" + accessor +
-                      "().unpack());\n";
+              code += "_o." + set_field + "(" + accessor + "().unpack());\n";
             }
-            code += "    else _o." + namer_.Method("set", field) + "(null);\n";
+            code += "    else _o." + set_field + "(null);\n";
           }
           call_setter = false;
           break;
@@ -1545,8 +1549,7 @@ class JavaGenerator : public BaseGenerator {
         }
       }
       if (call_setter) {
-        code +=
-            "    _o." + namer_.Method("set", field) + "(" + variable + ");\n";
+        code += "    _o." + set_field + "(" + variable + ");\n";
       }
     }
     code += "  }\n";

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -1466,7 +1466,7 @@ class JavaGenerator : public BaseGenerator {
       const auto set_field = namer_.Method("set", field);
 
       auto type_name =
-          GenTypeGet_ObjectAPI(field.value.type, opts, false, true);
+          GenTypeGet_ObjectAPI(field.value.type, false, true);
       if (field.IsScalarOptional())
         type_name = ConvertPrimitiveTypeToObjectWrapper_ObjectAPI(type_name);
       auto start = "    " + type_name + " " + variable + " = ";
@@ -1609,7 +1609,7 @@ class JavaGenerator : public BaseGenerator {
               case BASE_TYPE_STRUCT:
                 array_type = "int";
                 element_type =
-                    GenTypeGet_ObjectAPI(field.value.type, opts, true, true);
+                    GenTypeGet_ObjectAPI(field.value.type, true, true);
                 ;
                 to_array = GenTypeGet(field.value.type) + ".pack(builder, _e)";
                 break;
@@ -1662,7 +1662,7 @@ class JavaGenerator : public BaseGenerator {
           } else {
             auto type_name = GenTypeGet(field.value.type);
             auto element_type_name =
-                GenTypeGet_ObjectAPI(field.value.type, opts, true, true);
+                GenTypeGet_ObjectAPI(field.value.type, true, true);
             auto pack_method =
                 field.value.type.struct_def == nullptr
                     ? "builder.add" + GenMethod(field.value.type.VectorType()) +
@@ -1694,7 +1694,7 @@ class JavaGenerator : public BaseGenerator {
                                         array_lengths);
           } else {
             code += "    " +
-                    GenTypeGet_ObjectAPI(field.value.type, opts, false, true) +
+                    GenTypeGet_ObjectAPI(field.value.type, false, true) +
                     " _" + field_name + " = _o." + get_field + "();\n";
           }
           break;
@@ -1966,7 +1966,7 @@ class JavaGenerator : public BaseGenerator {
           if (wrap_in_namespace) {
             type_name = namer_.NamespacedType(*type.enum_def) + "Union";
           } else {
-            type_name = type.enum_def->name + "Union";
+            type_name = namer_.Type(*type.enum_def) + "Union";
           }
         }
         break;
@@ -1976,7 +1976,7 @@ class JavaGenerator : public BaseGenerator {
         if (wrap_in_namespace) {
           type_name = namer_.NamespacedType(*type.enum_def) + "Union";
         } else {
-          type_name = type.enum_def->name + "Union";
+          type_name = namer_.Type(*type.enum_def) + "Union";
         }
         break;
       }

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -1399,7 +1399,6 @@ class JavaGenerator : public BaseGenerator {
                      // Java which doesn't handle non Table types. Should be
                      // deleted when issue #6561 is fixed.
         }
-        // DO NOT SUBMIT: CASPER: NamespacedEnumVariant.
         code += indent + "  case " +
                 namer_.NamespacedEnumVariant(enum_def, ev) + ":\n";
         auto actual_type = GenTypeGet(ev.union_type);

--- a/src/idl_namer.h
+++ b/src/idl_namer.h
@@ -25,6 +25,8 @@ class IdlNamer : public Namer {
   using Namer::Variable;
   using Namer::Variant;
 
+  std::string Constant(const FieldDef &d) const { return Constant(d.name); }
+
   // Types are always structs or enums so we can only expose these two
   // overloads.
   std::string Type(const StructDef &d) const { return Type(d.name); }
@@ -33,6 +35,9 @@ class IdlNamer : public Namer {
   std::string Function(const Definition &s) const { return Function(s.name); }
 
   std::string Field(const FieldDef &s) const { return Field(s.name); }
+  std::string Field(const FieldDef &d, const std::string &s) const {
+    return Field(d.name + "_" + s);
+  }
 
   std::string Variable(const FieldDef &s) const { return Variable(s.name); }
 
@@ -48,6 +53,13 @@ class IdlNamer : public Namer {
     return ObjectType(d.name);
   }
   std::string ObjectType(const EnumDef &d) const { return ObjectType(d.name); }
+
+  std::string Method(const FieldDef &d, const std::string &suffix) const {
+    return Method(d.name, suffix);
+  }
+  std::string Method(const std::string &prefix, const FieldDef &d) const {
+    return Method(prefix, d.name);
+  }
 
   std::string Namespace(const struct Namespace &ns) const {
     return Namespace(ns.components);
@@ -84,6 +96,11 @@ class IdlNamer : public Namer {
       std::transform(name.begin(), name.end(), name.begin(), CharToLower);
     }
     return EscapeKeyword(ConvertCase(name, Case::kLowerCamel));
+  }
+
+  std::string LegacyJavaMethod2(const std::string &prefix, const StructDef &sd,
+                                const std::string &suffix) const {
+    return prefix + sd.name + suffix;
   }
 
  private:

--- a/src/idl_namer.h
+++ b/src/idl_namer.h
@@ -65,6 +65,10 @@ class IdlNamer : public Namer {
     return Namespace(ns.components);
   }
 
+  std::string NamespacedEnumVariant(const EnumDef &e, const EnumVal &v) const {
+    return NamespacedString(e.defined_namespace, EnumVariant(e, v));
+  }
+
   std::string NamespacedType(const Definition &def) const {
     return NamespacedString(def.defined_namespace, Type(def.name));
   }

--- a/src/namer.h
+++ b/src/namer.h
@@ -112,6 +112,11 @@ class Namer {
     return Method(s.name);
   }
 
+  virtual std::string Method(const std::string &pre,
+                             const std::string &suf) const {
+    return Format(pre + "_" + suf, config_.methods);
+  }
+
   virtual std::string Method(const std::string &s) const {
     return Format(s, config_.methods);
   }
@@ -126,6 +131,15 @@ class Namer {
 
   virtual std::string Variable(const std::string &s) const {
     return Format(s, config_.variables);
+  }
+
+  template<typename T>
+  std::string Variable(const std::string &p, const T &s) const {
+    return Format(p + "_" + s.name, config_.variables);
+  }
+  virtual std::string Variable(const std::string &p,
+                               const std::string &s) const {
+    return Format(p + "_" + s, config_.variables);
   }
 
   virtual std::string Namespace(const std::string &s) const {
@@ -190,6 +204,9 @@ class Namer {
 
   virtual std::string Type(const std::string &s) const {
     return Format(s, config_.types);
+  }
+  virtual std::string Type(const std::string &t, const std::string &s) const {
+    return Format(t + "_" + s, config_.types);
   }
 
   virtual std::string ObjectType(const std::string &s) const {

--- a/tests/MyGame/Example/Monster.java
+++ b/tests/MyGame/Example/Monster.java
@@ -616,7 +616,7 @@ public final class Monster extends Table {
     if (_o.getVectorOfDoubles() != null) {
       _vectorOfDoubles = createVectorOfDoublesVector(builder, _o.getVectorOfDoubles());
     }
-    int _parent_namespace_test = _o.getParentNamespaceTest() == null ? 0 : MyGame.InParentNamespace.pack(builder, _o.getParentNamespaceTest());
+    int _parentNamespaceTest = _o.getParentNamespaceTest() == null ? 0 : MyGame.InParentNamespace.pack(builder, _o.getParentNamespaceTest());
     int _vectorOfReferrables = 0;
     if (_o.getVectorOfReferrables() != null) {
       int[] __vectorOfReferrables = new int[_o.getVectorOfReferrables().length];
@@ -702,7 +702,7 @@ public final class Monster extends Table {
     addTest5(builder, _test5);
     addVectorOfLongs(builder, _vectorOfLongs);
     addVectorOfDoubles(builder, _vectorOfDoubles);
-    addParentNamespaceTest(builder, _parent_namespace_test);
+    addParentNamespaceTest(builder, _parentNamespaceTest);
     addVectorOfReferrables(builder, _vectorOfReferrables);
     addSingleWeakReference(builder, _o.getSingleWeakReference());
     addVectorOfWeakReferences(builder, _vectorOfWeakReferences);


### PR DESCRIPTION
@paulovap @dbaileychess 

This PR applies the centralized `Namer` class  to idl_gen_java.
See #7142 for context on centralizing the naming convention.
This should be an invisible change to most users.


Initial commit notes:
- Java didn't previously have keyword escaping
- I started adding prefixes and suffixes to the Namer methods where needed.
  - e.g. `namer_.Method("get", field, "length") => "getFieldNameLength"`
  - Previously, I'd hack it in with string manipulation. 
  - TODO: migrate previous namer applications to using pre/suffixes
- Java methods / functions are interesting, it's mostly camel case
with exceptions, sometime, when it involves a struct/enum name. That "section" is Keep case
  - e.g. a table `foo_bar` would get a `startfoo_bar` builder method rather than `startFooBar`. 
  - I added LegacyJavaMethod2 to deal with that, but this mixed casing thing doesn't fit very well with Namer generally.
- Variables like "_oFieldName" don't work well with ConvertCase due to the leading underscore. This can be addressed in another PR. 
- I changed the casing for some internal arguments/variables. This violates the "don't change genfiles" rule that I've been using but it shouldn't break user code.