### PR TITLE
[swift] Add bazel configuration for Swift

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,6 +4,13 @@ platforms:
   ubuntu1804:
     environment:
       CC: clang
+      SWIFT_VERSION: "5.5.3"
+      SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
+      PATH: "$PATH:$SWIFT_HOME/usr/bin"
+    shell_commands:
+      - "echo --- Downloading and extracting Swift $SWIFT_VERSION to $SWIFT_HOME"
+      - "mkdir $SWIFT_HOME"
+      - "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu1804/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu18.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
     build_targets:
     - "//..."
     test_targets:
@@ -11,6 +18,13 @@ platforms:
   ubuntu2004:
     environment:
       CC: clang
+      SWIFT_VERSION: "5.5.3"
+      SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
+      PATH: "$PATH:$SWIFT_HOME/usr/bin"
+    shell_commands:
+      - "echo --- Downloading and extracting Swift $SWIFT_VERSION to $SWIFT_HOME"
+      - "mkdir $SWIFT_HOME"
+      - "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
     build_targets:
     - "//..."
     test_targets:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,11 +2,15 @@
 buildifier: latest
 platforms:
   ubuntu1804:
+    environment:
+      CC: clang
     build_targets:
     - "//..."
     test_targets:
     - "//..."
   ubuntu2004:
+    environment:
+      CC: clang
     build_targets:
     - "//..."
     test_targets:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,6 +3,35 @@ workspace(name = "com_github_google_flatbuffers")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "platforms",
+    sha256 = "379113459b0feaf6bfbb584a91874c065078aa673222846ac765f86661c27407",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "build_bazel_rules_swift",
+    sha256 = "a2fd565e527f83fb3f9eb07eb9737240e668c9242d3bc318712efa54a7deda97",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.27.0/rules_swift.0.27.0.tar.gz",
+)
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
+)
+
+swift_rules_extra_dependencies()
+
+http_archive(
     name = "io_bazel_rules_go",
     sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
     urls = [

--- a/swift/BUILD.bazel
+++ b/swift/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+swift_library(
+    name = "swift",
+    srcs = glob(["Sources/FlatBuffers/*.swift"]),
+    module_name = "FlatBuffers",
+)


### PR DESCRIPTION
This change adds a simple bazel BUILD file for consuming the Swift
support. This also bumps the platforms bazel repo to fix support for M1s
and bazel 5.1+ https://github.com/bazelbuild/bazel/issues/15099#issuecomment-1075368289

The rules_swift inclusion here must happen before gRPC to ensure we
don't pull in an older version.