### PR TITLE
fixed padding in struct for annotated binary

### DIFF
--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -20,7 +20,6 @@ import glob
 import platform
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 parser = argparse.ArgumentParser()
@@ -68,9 +67,7 @@ samples_path = Path(root_path, "samples")
 reflection_path = Path(root_path, "reflection")
 
 # Execute the flatc compiler with the specified parameters
-def flatc(
-    options, schema, prefix=None, include=None, data=None, cwd=tests_path
-):
+def flatc(options, schema, prefix=None, include=None, data=None, cwd=tests_path):
     cmd = [str(flatc_path)] + options
     if prefix:
         cmd += ["-o"] + [prefix]
@@ -125,7 +122,12 @@ CPP_17_OPTS = NO_INCL_OPTS + [
     "--cpp-static-reflection",
     "--gen-object-api",
 ]
-RUST_OPTS = BASE_OPTS + ["--rust", "--gen-all", "--gen-name-strings", "--rust-module-root-file"]
+RUST_OPTS = BASE_OPTS + [
+    "--rust",
+    "--gen-all",
+    "--gen-name-strings",
+    "--rust-module-root-file",
+]
 RUST_SERIALIZE_OPTS = BASE_OPTS + [
     "--rust",
     "--gen-all",
@@ -219,13 +221,7 @@ flatc(
 )
 
 flatc(
-    BASE_OPTS
-    + CPP_OPTS
-    + CS_OPTS
-    + TS_OPTS
-    + JAVA_OPTS
-    + KOTLIN_OPTS
-    + PHP_OPTS,
+    BASE_OPTS + CPP_OPTS + CS_OPTS + TS_OPTS + JAVA_OPTS + KOTLIN_OPTS + PHP_OPTS,
     prefix="union_vector",
     schema="union_vector/union_vector.fbs",
 )
@@ -297,12 +293,7 @@ flatc(
 
 if not args.skip_monster_extra:
     flatc(
-        CPP_OPTS
-        + CS_OPTS
-        + NO_INCL_OPTS
-        + JAVA_OPTS
-        + KOTLIN_OPTS
-        + PYTHON_OPTS,
+        CPP_OPTS + CS_OPTS + NO_INCL_OPTS + JAVA_OPTS + KOTLIN_OPTS + PYTHON_OPTS,
         schema="monster_extra.fbs",
         data="monsterdata_extra.json",
     )
@@ -313,11 +304,7 @@ if not args.skip_monster_extra:
     )
 
 flatc(
-    CPP_OPTS
-    + CS_OPTS
-    + NO_INCL_OPTS
-    + JAVA_OPTS
-    + ["--jsonschema", "--scoped-enums"],
+    CPP_OPTS + CS_OPTS + NO_INCL_OPTS + JAVA_OPTS + ["--jsonschema", "--scoped-enums"],
     schema="arrays_test.fbs",
 )
 
@@ -335,9 +322,7 @@ flatc(
 
 # Optional Scalars
 optional_scalars_schema = "optional_scalars.fbs"
-flatc(
-    ["--java", "--kotlin", "--lobster", "--ts"], schema=optional_scalars_schema
-)
+flatc(["--java", "--kotlin", "--lobster", "--ts"], schema=optional_scalars_schema)
 
 flatc(["--csharp", "--gen-object-api"], schema=optional_scalars_schema)
 
@@ -397,17 +382,13 @@ flatc(
 
 # --filename-suffix and --filename-ext tests
 flatc(
-    CPP_OPTS
-    + NO_INCL_OPTS
-    + ["--filename-suffix", "_suffix", "--filename-ext", "hpp"],
+    CPP_OPTS + NO_INCL_OPTS + ["--filename-suffix", "_suffix", "--filename-ext", "hpp"],
     include="include_test",
     schema="monster_test.fbs",
 )
 orig_monster_file = Path(tests_path, "monster_test_generated.h")
 new_monster_file = Path(tests_path, "monster_test_suffix.hpp")
-assert (
-    new_monster_file.exists()
-), "filename suffix option did not produce a file"
+assert new_monster_file.exists(), "filename suffix option did not produce a file"
 assert filecmp.cmp(
     str(orig_monster_file), str(new_monster_file)
 ), "filename suffix option did not produce identical results"
@@ -434,12 +415,8 @@ flatc(
 
 # Sample files
 samples_schema = "monster.fbs"
-flatc(
-    BASE_OPTS + CPP_OPTS + LOBSTER_OPTS, schema=samples_schema, cwd=samples_path
-)
-flatc(
-    RUST_OPTS, prefix="rust_generated", schema=samples_schema, cwd=samples_path
-)
+flatc(BASE_OPTS + CPP_OPTS + LOBSTER_OPTS, schema=samples_schema, cwd=samples_path)
+flatc(RUST_OPTS, prefix="rust_generated", schema=samples_schema, cwd=samples_path)
 flatc(
     BINARY_OPTS + ["--bfbs-filenames", str(samples_path)],
     schema=samples_schema,
@@ -451,9 +428,27 @@ flatc(
 # Skip generating the reflection if told too, as we run this script after
 # building flatc which uses the reflection_generated.h itself.
 if not args.skip_gen_reflection:
-  # C++ Reflection
-  flatc_reflection(["-c", "--cpp-std", "c++0x"], "include/flatbuffers",
-                   "reflection_generated.h")
+    # C++ Reflection
+    flatc_reflection(
+        ["-c", "--cpp-std", "c++0x"], "include/flatbuffers", "reflection_generated.h"
+    )
 
 # Python Reflection
 flatc_reflection(["-p"], "python/flatbuffers", "reflection")
+
+# Annotation
+
+
+def flatc_annotate(schema, include=None, data=None, cwd=tests_path):
+    cmd = [str(flatc_path)]
+    if include:
+        cmd += ["-I"] + [include]
+    cmd += ["--annotate", schema]
+    if data:
+        cmd += [data] if isinstance(data, str) else data
+    subprocess.run(cmd, cwd=str(cwd), check=True)
+
+
+flatc_annotate(
+    schema="monster_test.fbs", include="include_test", data="monsterdata_test.mon"
+)

--- a/src/binary_annotator.cpp
+++ b/src/binary_annotator.cpp
@@ -865,6 +865,18 @@ uint64_t BinaryAnnotator::BuildStruct(const uint64_t struct_offset,
         }
       }
     }
+
+    // Insert any padding after this field.
+    const uint16_t padding = field->padding();
+    if (padding > 0 && IsValidOffset(offset + padding)) {
+      BinaryRegionComment padding_comment;
+      padding_comment.type = BinaryRegionCommentType::Padding;
+
+      regions.push_back(MakeBinaryRegion(offset, padding,
+                                         BinaryRegionType::Uint8, padding, 0,
+                                         padding_comment));
+      offset += padding;
+    }
   });
 
   return offset;
@@ -1104,7 +1116,7 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
     case reflection::BaseType::Union: {
       // Vector of unions
       // Unions have both their realized type (uint8_t for now) that are
-      // stored sperately. These are stored in the field->index() - 1
+      // stored separately. These are stored in the field->index() - 1
       // location.
       const uint16_t union_type_vector_id = field->id() - 1;
 

--- a/tests/monsterdata_test.afb
+++ b/tests/monsterdata_test.afb
@@ -1,0 +1,276 @@
+// Annotated Flatbuffer Binary
+//
+// Schema file: monster_test.fbs
+// Binary file: monsterdata_test.mon
+
+header:
+  +0x0000 | 78 00 00 00             | UOffset32  | 0x00000078 (120) Loc: +0x0078            | offset to root table `MyGame.Example.Monster`
+  +0x0004 | 4D 4F 4E 53             | char[4]    | MONS                                     | File Identifier
+
+padding:
+  +0x0008 | 00 00 00 00             | uint8_t[4] | ....                                     | padding
+
+vtable (MyGame.Example.Monster):
+  +0x000C | 6C 00                   | uint16_t   | 0x006C (108)                             | size of this vtable
+  +0x000E | 94 00                   | uint16_t   | 0x0094 (148)                             | size of referring table
+  +0x0010 | 08 00                   | VOffset16  | 0x0008 (8)                               | offset to field `pos` (id: 0)
+  +0x0012 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `mana` (id: 1) <defaults to 150> (Short)
+  +0x0014 | 06 00                   | VOffset16  | 0x0006 (6)                               | offset to field `hp` (id: 2)
+  +0x0016 | 2C 00                   | VOffset16  | 0x002C (44)                              | offset to field `name` (id: 3)
+  +0x0018 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `friendly` (id: 4) <defaults to 0> (Bool)
+  +0x001A | 30 00                   | VOffset16  | 0x0030 (48)                              | offset to field `inventory` (id: 5)
+  +0x001C | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `color` (id: 6) <defaults to 8> (UByte)
+  +0x001E | 04 00                   | VOffset16  | 0x0004 (4)                               | offset to field `test_type` (id: 7)
+  +0x0020 | 34 00                   | VOffset16  | 0x0034 (52)                              | offset to field `test` (id: 8)
+  +0x0022 | 38 00                   | VOffset16  | 0x0038 (56)                              | offset to field `test4` (id: 9)
+  +0x0024 | 3C 00                   | VOffset16  | 0x003C (60)                              | offset to field `testarrayofstring` (id: 10)
+  +0x0026 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `testarrayoftables` (id: 11) <null> (Vector)
+  +0x0028 | 40 00                   | VOffset16  | 0x0040 (64)                              | offset to field `enemy` (id: 12)
+  +0x002A | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `testnestedflatbuffer` (id: 13) <null> (Vector)
+  +0x002C | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `testempty` (id: 14) <null> (Obj)
+  +0x002E | 05 00                   | VOffset16  | 0x0005 (5)                               | offset to field `testbool` (id: 15)
+  +0x0030 | 44 00                   | VOffset16  | 0x0044 (68)                              | offset to field `testhashs32_fnv1` (id: 16)
+  +0x0032 | 48 00                   | VOffset16  | 0x0048 (72)                              | offset to field `testhashu32_fnv1` (id: 17)
+  +0x0034 | 70 00                   | VOffset16  | 0x0070 (112)                             | offset to field `testhashs64_fnv1` (id: 18)
+  +0x0036 | 78 00                   | VOffset16  | 0x0078 (120)                             | offset to field `testhashu64_fnv1` (id: 19)
+  +0x0038 | 4C 00                   | VOffset16  | 0x004C (76)                              | offset to field `testhashs32_fnv1a` (id: 20)
+  +0x003A | 50 00                   | VOffset16  | 0x0050 (80)                              | offset to field `testhashu32_fnv1a` (id: 21)
+  +0x003C | 80 00                   | VOffset16  | 0x0080 (128)                             | offset to field `testhashs64_fnv1a` (id: 22)
+  +0x003E | 88 00                   | VOffset16  | 0x0088 (136)                             | offset to field `testhashu64_fnv1a` (id: 23)
+  +0x0040 | 54 00                   | VOffset16  | 0x0054 (84)                              | offset to field `testarrayofbools` (id: 24)
+  +0x0042 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `testf` (id: 25) <defaults to 3.141590> (Float)
+  +0x0044 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `testf2` (id: 26) <defaults to 3.000000> (Float)
+  +0x0046 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `testf3` (id: 27) <defaults to 0.000000> (Float)
+  +0x0048 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `testarrayofstring2` (id: 28) <null> (Vector)
+  +0x004A | 58 00                   | VOffset16  | 0x0058 (88)                              | offset to field `testarrayofsortedstruct` (id: 29)
+  +0x004C | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `flex` (id: 30) <null> (Vector)
+  +0x004E | 5C 00                   | VOffset16  | 0x005C (92)                              | offset to field `test5` (id: 31)
+  +0x0050 | 60 00                   | VOffset16  | 0x0060 (96)                              | offset to field `vector_of_longs` (id: 32)
+  +0x0052 | 64 00                   | VOffset16  | 0x0064 (100)                             | offset to field `vector_of_doubles` (id: 33)
+  +0x0054 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `parent_namespace_test` (id: 34) <null> (Obj)
+  +0x0056 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `vector_of_referrables` (id: 35) <null> (Vector)
+  +0x0058 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `single_weak_reference` (id: 36) <defaults to 0> (ULong)
+  +0x005A | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `vector_of_weak_references` (id: 37) <null> (Vector)
+  +0x005C | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `vector_of_strong_referrables` (id: 38) <null> (Vector)
+  +0x005E | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `co_owning_reference` (id: 39) <defaults to 0> (ULong)
+  +0x0060 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `vector_of_co_owning_references` (id: 40) <null> (Vector)
+  +0x0062 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `non_owning_reference` (id: 41) <defaults to 0> (ULong)
+  +0x0064 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `vector_of_non_owning_references` (id: 42) <null> (Vector)
+  +0x0066 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `any_unique_type` (id: 43) <defaults to 0> (UType)
+  +0x0068 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `any_unique` (id: 44) <null> (Union)
+  +0x006A | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `any_ambiguous_type` (id: 45) <defaults to 0> (UType)
+  +0x006C | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `any_ambiguous` (id: 46) <null> (Union)
+  +0x006E | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `vector_of_enums` (id: 47) <null> (Vector)
+  +0x0070 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `signed_enum` (id: 48) <defaults to -1> (Byte)
+  +0x0072 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `testrequirednestedflatbuffer` (id: 49) <null> (Vector)
+  +0x0074 | 68 00                   | VOffset16  | 0x0068 (104)                             | offset to field `scalar_key_sorted_tables` (id: 50)
+  +0x0076 | 6C 00                   | VOffset16  | 0x006C (108)                             | offset to field `native_inline` (id: 51)
+
+root_table (MyGame.Example.Monster):
+  +0x0078 | 6C 00 00 00             | SOffset32  | 0x0000006C (108) Loc: +0x000C            | offset to vtable
+  +0x007C | 01                      | UType8     | 0x01 (1)                                 | table field `test_type` (UType)
+  +0x007D | 01                      | uint8_t    | 0x01 (1)                                 | table field `testbool` (Bool)
+  +0x007E | 50 00                   | int16_t    | 0x0050 (80)                              | table field `hp` (Short)
+  +0x0080 | 00 00 80 3F             | float      | 0x3F800000 (1)                           | struct field `MyGame.Example.Vec3.x` (Float)
+  +0x0084 | 00 00 00 40             | float      | 0x40000000 (2)                           | struct field `MyGame.Example.Vec3.y` (Float)
+  +0x0088 | 00 00 40 40             | float      | 0x40400000 (3)                           | struct field `MyGame.Example.Vec3.z` (Float)
+  +0x008C | 00 00 00 00             | uint8_t[4] | ....                                     | padding
+  +0x0090 | 00 00 00 00 00 00 08 40 | double     | 0x4008000000000000 (3)                   | struct field `MyGame.Example.Vec3.test1` (Double)
+  +0x0098 | 02                      | uint8_t    | 0x02 (2)                                 | struct field `MyGame.Example.Vec3.test2` (UByte)
+  +0x0099 | 00                      | uint8_t[1] | .                                        | padding
+  +0x009A | 05 00                   | int16_t    | 0x0005 (5)                               | struct field `MyGame.Example.Test.a` (Short)
+  +0x009C | 06                      | uint8_t    | 0x06 (6)                                 | struct field `MyGame.Example.Test.b` (Byte)
+  +0x009D | 00                      | uint8_t[1] | .                                        | padding
+  +0x009E | 00 00                   | uint8_t[2] | ..                                       | padding
+  +0x00A0 | 00 00 00 00             | uint8_t[4] | ....                                     | padding
+  +0x00A4 | A4 01 00 00             | UOffset32  | 0x000001A4 (420) Loc: +0x0248            | offset to field `name` (string)
+  +0x00A8 | 94 01 00 00             | UOffset32  | 0x00000194 (404) Loc: +0x023C            | offset to field `inventory` (vector)
+  +0x00AC | 2C 01 00 00             | UOffset32  | 0x0000012C (300) Loc: +0x01D8            | offset to field `test` (union of type `Monster`)
+  +0x00B0 | 10 01 00 00             | UOffset32  | 0x00000110 (272) Loc: +0x01C0            | offset to field `test4` (vector)
+  +0x00B4 | DC 00 00 00             | UOffset32  | 0x000000DC (220) Loc: +0x0190            | offset to field `testarrayofstring` (vector)
+  +0x00B8 | C4 00 00 00             | UOffset32  | 0x000000C4 (196) Loc: +0x017C            | offset to field `enemy` (table)
+  +0x00BC | 41 C9 79 DD             | uint32_t   | 0xDD79C941 (3715746113)                  | table field `testhashs32_fnv1` (Int)
+  +0x00C0 | 41 C9 79 DD             | uint32_t   | 0xDD79C941 (3715746113)                  | table field `testhashu32_fnv1` (UInt)
+  +0x00C4 | 71 A4 81 8E             | uint32_t   | 0x8E81A471 (2390860913)                  | table field `testhashs32_fnv1a` (Int)
+  +0x00C8 | 71 A4 81 8E             | uint32_t   | 0x8E81A471 (2390860913)                  | table field `testhashu32_fnv1a` (UInt)
+  +0x00CC | A8 00 00 00             | UOffset32  | 0x000000A8 (168) Loc: +0x0174            | offset to field `testarrayofbools` (vector)
+  +0x00D0 | 88 00 00 00             | UOffset32  | 0x00000088 (136) Loc: +0x0158            | offset to field `testarrayofsortedstruct` (vector)
+  +0x00D4 | E0 00 00 00             | UOffset32  | 0x000000E0 (224) Loc: +0x01B4            | offset to field `test5` (vector)
+  +0x00D8 | 34 01 00 00             | UOffset32  | 0x00000134 (308) Loc: +0x020C            | offset to field `vector_of_longs` (vector)
+  +0x00DC | 10 01 00 00             | UOffset32  | 0x00000110 (272) Loc: +0x01EC            | offset to field `vector_of_doubles` (vector)
+  +0x00E0 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: +0x010C             | offset to field `scalar_key_sorted_tables` (vector)
+  +0x00E4 | 01 00                   | int16_t    | 0x0001 (1)                               | struct field `MyGame.Example.Test.a` (Short)
+  +0x00E6 | 02                      | uint8_t    | 0x02 (2)                                 | struct field `MyGame.Example.Test.b` (Byte)
+  +0x00E7 | 00                      | uint8_t[1] | .                                        | padding
+  +0x00E8 | 81 91 7B F2 CD 80 0F 6E | int64_t    | 0x6E0F80CDF27B9181 (7930699090847568257) | table field `testhashs64_fnv1` (Long)
+  +0x00F0 | 81 91 7B F2 CD 80 0F 6E | uint64_t   | 0x6E0F80CDF27B9181 (7930699090847568257) | table field `testhashu64_fnv1` (ULong)
+  +0x00F8 | F1 DD 67 C7 DC 48 F9 43 | int64_t    | 0x43F948DCC767DDF1 (4898026182817603057) | table field `testhashs64_fnv1a` (Long)
+  +0x0100 | F1 DD 67 C7 DC 48 F9 43 | uint64_t   | 0x43F948DCC767DDF1 (4898026182817603057) | table field `testhashu64_fnv1a` (ULong)
+  +0x0108 | 00 00 00 00             | uint8_t[4] | ....                                     | padding
+
+vector (MyGame.Example.Monster.scalar_key_sorted_tables):
+  +0x010C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                           | length of vector (# items)
+  +0x0110 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: +0x0120             | offset to table[0]
+  +0x0114 | 28 00 00 00             | UOffset32  | 0x00000028 (40) Loc: +0x013C             | offset to table[1]
+
+padding:
+  +0x0118 | 00 00                   | uint8_t[2] | ..                                       | padding
+
+vtable (MyGame.Example.Stat):
+  +0x011A | 06 00                   | uint16_t   | 0x0006 (6)                               | size of this vtable
+  +0x011C | 08 00                   | uint16_t   | 0x0008 (8)                               | size of referring table
+  +0x011E | 04 00                   | VOffset16  | 0x0004 (4)                               | offset to field `id` (id: 0)
+
+table (MyGame.Example.Stat):
+  +0x0120 | 06 00 00 00             | SOffset32  | 0x00000006 (6) Loc: +0x011A              | offset to vtable
+  +0x0124 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x0128              | offset to field `id` (string)
+
+string (MyGame.Example.Stat.id):
+  +0x0128 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                           | length of string
+  +0x012C | 6D 69 73 73             | char[4]    | miss                                     | string literal
+  +0x0130 | 00                      | char       | 0x00 (0)                                 | string terminator
+
+vtable (MyGame.Example.Stat):
+  +0x0132 | 0A 00                   | uint16_t   | 0x000A (10)                              | size of this vtable
+  +0x0134 | 14 00                   | uint16_t   | 0x0014 (20)                              | size of referring table
+  +0x0136 | 08 00                   | VOffset16  | 0x0008 (8)                               | offset to field `id` (id: 0)
+  +0x0138 | 0C 00                   | VOffset16  | 0x000C (12)                              | offset to field `val` (id: 1)
+  +0x013A | 06 00                   | VOffset16  | 0x0006 (6)                               | offset to field `count` (id: 2)
+
+table (MyGame.Example.Stat):
+  +0x013C | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: +0x0132             | offset to vtable
+  +0x0140 | 00 00                   | uint8_t[2] | ..                                       | padding
+  +0x0142 | 01 00                   | uint16_t   | 0x0001 (1)                               | table field `count` (UShort)
+  +0x0144 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: +0x0150             | offset to field `id` (string)
+  +0x0148 | 0A 00 00 00 00 00 00 00 | int64_t    | 0x000000000000000A (10)                  | table field `val` (Long)
+
+string (MyGame.Example.Stat.id):
+  +0x0150 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                           | length of string
+  +0x0154 | 68 69 74                | char[3]    | hit                                      | string literal
+  +0x0157 | 00                      | char       | 0x00 (0)                                 | string terminator
+
+vector (MyGame.Example.Monster.testarrayofsortedstruct):
+  +0x0158 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                           | length of vector (# items)
+  +0x015C | 00 00 00 00             | uint32_t   | 0x00000000 (0)                           | struct field `MyGame.Example.Ability.id` (UInt)
+  +0x0160 | 2D 00 00 00             | uint32_t   | 0x0000002D (45)                          | struct field `MyGame.Example.Ability.distance` (UInt)
+  +0x0164 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                           | struct field `MyGame.Example.Ability.id` (UInt)
+  +0x0168 | 15 00 00 00             | uint32_t   | 0x00000015 (21)                          | struct field `MyGame.Example.Ability.distance` (UInt)
+  +0x016C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                           | struct field `MyGame.Example.Ability.id` (UInt)
+  +0x0170 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                          | struct field `MyGame.Example.Ability.distance` (UInt)
+
+vector (MyGame.Example.Monster.testarrayofbools):
+  +0x0174 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                           | length of vector (# items)
+  +0x0178 | 01                      | uint8_t    | 0x01 (1)                                 | value[0]
+  +0x0179 | 00                      | uint8_t    | 0x00 (0)                                 | value[1]
+  +0x017A | 01                      | uint8_t    | 0x01 (1)                                 | value[2]
+
+table (MyGame.Example.Monster):
+  +0x017C | B0 FF FF FF             | SOffset32  | 0xFFFFFFB0 (-80) Loc: +0x01CC            | offset to vtable
+  +0x0180 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x0184              | offset to field `name` (string)
+
+string (MyGame.Example.Monster.name):
+  +0x0184 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                           | length of string
+  +0x0188 | 46 72 65 64             | char[4]    | Fred                                     | string literal
+  +0x018C | 00                      | char       | 0x00 (0)                                 | string terminator
+
+padding:
+  +0x018D | 00 00 00                | uint8_t[3] | ...                                      | padding
+
+vector (MyGame.Example.Monster.testarrayofstring):
+  +0x0190 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                           | length of vector (# items)
+  +0x0194 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: +0x01A8             | offset to string[0]
+  +0x0198 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x019C              | offset to string[1]
+
+string (MyGame.Example.Monster.testarrayofstring):
+  +0x019C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                           | length of string
+  +0x01A0 | 74 65 73 74 32          | char[5]    | test2                                    | string literal
+  +0x01A5 | 00                      | char       | 0x00 (0)                                 | string terminator
+
+padding:
+  +0x01A6 | 00 00                   | uint8_t[2] | ..                                       | padding
+
+string (MyGame.Example.Monster.testarrayofstring):
+  +0x01A8 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                           | length of string
+  +0x01AC | 74 65 73 74 31          | char[5]    | test1                                    | string literal
+  +0x01B1 | 00                      | char       | 0x00 (0)                                 | string terminator
+
+padding:
+  +0x01B2 | 00 00                   | uint8_t[2] | ..                                       | padding
+
+vector (MyGame.Example.Monster.test5):
+  +0x01B4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                           | length of vector (# items)
+  +0x01B8 | 0A 00                   | int16_t    | 0x000A (10)                              | struct field `MyGame.Example.Test.a` (Short)
+  +0x01BA | 14                      | uint8_t    | 0x14 (20)                                | struct field `MyGame.Example.Test.b` (Byte)
+  +0x01BB | 00                      | uint8_t[1] | .                                        | padding
+  +0x01BC | 1E 00                   | int16_t    | 0x001E (30)                              | struct field `MyGame.Example.Test.a` (Short)
+  +0x01BE | 28                      | uint8_t    | 0x28 (40)                                | struct field `MyGame.Example.Test.b` (Byte)
+  +0x01BF | 00                      | uint8_t[1] | .                                        | padding
+
+vector (MyGame.Example.Monster.test4):
+  +0x01C0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                           | length of vector (# items)
+  +0x01C4 | 0A 00                   | int16_t    | 0x000A (10)                              | struct field `MyGame.Example.Test.a` (Short)
+  +0x01C6 | 14                      | uint8_t    | 0x14 (20)                                | struct field `MyGame.Example.Test.b` (Byte)
+  +0x01C7 | 00                      | uint8_t[1] | .                                        | padding
+  +0x01C8 | 1E 00                   | int16_t    | 0x001E (30)                              | struct field `MyGame.Example.Test.a` (Short)
+  +0x01CA | 28                      | uint8_t    | 0x28 (40)                                | struct field `MyGame.Example.Test.b` (Byte)
+  +0x01CB | 00                      | uint8_t[1] | .                                        | padding
+
+vtable (MyGame.Example.Monster):
+  +0x01CC | 0C 00                   | uint16_t   | 0x000C (12)                              | size of this vtable
+  +0x01CE | 08 00                   | uint16_t   | 0x0008 (8)                               | size of referring table
+  +0x01D0 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `pos` (id: 0) <null> (Obj)
+  +0x01D2 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `mana` (id: 1) <defaults to 150> (Short)
+  +0x01D4 | 00 00                   | VOffset16  | 0x0000 (0)                               | offset to field `hp` (id: 2) <defaults to 100> (Short)
+  +0x01D6 | 04 00                   | VOffset16  | 0x0004 (4)                               | offset to field `name` (id: 3)
+
+table (MyGame.Example.Monster):
+  +0x01D8 | 0C 00 00 00             | SOffset32  | 0x0000000C (12) Loc: +0x01CC             | offset to vtable
+  +0x01DC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x01E0              | offset to field `name` (string)
+
+string (MyGame.Example.Monster.name):
+  +0x01E0 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                           | length of string
+  +0x01E4 | 46 72 65 64             | char[4]    | Fred                                     | string literal
+  +0x01E8 | 00                      | char       | 0x00 (0)                                 | string terminator
+
+padding:
+  +0x01E9 | 00 00 00                | uint8_t[3] | ...                                      | padding
+
+vector (MyGame.Example.Monster.vector_of_doubles):
+  +0x01EC | 03 00 00 00             | uint32_t   | 0x00000003 (3)                           | length of vector (# items)
+  +0x01F0 | FF FF FF FF FF FF EF FF | double     | 0xFFEFFFFFFFFFFFFF (-1.79769e+308)       | value[0]
+  +0x01F8 | 00 00 00 00 00 00 00 00 | double     | 0x0000000000000000 (0)                   | value[1]
+  +0x0200 | FF FF FF FF FF FF EF 7F | double     | 0x7FEFFFFFFFFFFFFF (1.79769e+308)        | value[2]
+
+padding:
+  +0x0208 | 00 00 00 00             | uint8_t[4] | ....                                     | padding
+
+vector (MyGame.Example.Monster.vector_of_longs):
+  +0x020C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                           | length of vector (# items)
+  +0x0210 | 01 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000001 (1)                   | value[0]
+  +0x0218 | 64 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000064 (100)                 | value[1]
+  +0x0220 | 10 27 00 00 00 00 00 00 | int64_t    | 0x0000000000002710 (10000)               | value[2]
+  +0x0228 | 40 42 0F 00 00 00 00 00 | int64_t    | 0x00000000000F4240 (1000000)             | value[3]
+  +0x0230 | 00 E1 F5 05 00 00 00 00 | int64_t    | 0x0000000005F5E100 (100000000)           | value[4]
+
+padding:
+  +0x0238 | 00 00 00 00             | uint8_t[4] | ....                                     | padding
+
+vector (MyGame.Example.Monster.inventory):
+  +0x023C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                           | length of vector (# items)
+  +0x0240 | 00                      | uint8_t    | 0x00 (0)                                 | value[0]
+  +0x0241 | 01                      | uint8_t    | 0x01 (1)                                 | value[1]
+  +0x0242 | 02                      | uint8_t    | 0x02 (2)                                 | value[2]
+  +0x0243 | 03                      | uint8_t    | 0x03 (3)                                 | value[3]
+  +0x0244 | 04                      | uint8_t    | 0x04 (4)                                 | value[4]
+
+padding:
+  +0x0245 | 00 00 00                | uint8_t[3] | ...                                      | padding
+
+string (MyGame.Example.Monster.name):
+  +0x0248 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                           | length of string
+  +0x024C | 4D 79 4D 6F 6E 73 74 65 | char[9]    | MyMonste                                 | string literal
+  +0x0254 | 72                      |            | r
+  +0x0255 | 00                      | char       | 0x00 (0)                                 | string terminator
+
+padding:
+  +0x0256 | 00 00                   | uint8_t[2] | ..                                       | padding


### PR DESCRIPTION
Fixed the case in annotated binaries where I wasn't accounting for padding within a structure. This was found when I was annotated the `monster_test.fbs` in `tests/`. 