### PR TITLE
Add some extra warnings, tested on GCC 9.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,8 @@ else()
       -Wnon-virtual-dtor
 
       $<$<CXX_COMPILER_ID:CLANG>:
+        -Wmissing-declarations
+        -Wzero-as-null-pointer-constant
         $<$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,3.8>:
           -Wimplicit-fallthrough
           -Wextra-semi
@@ -391,10 +393,11 @@ else()
         $<$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,4.4>:
           -Wunused-result
           -Wunused-parameter 
-          $<$<BOOL:${FLATBUFFERS_STRICT_MODE}>:
-            -Werror=unused-result           
-            -Werror=unused-parameter
-          >
+          -Werror=unused-parameter
+          -Wmissing-declarations
+        >
+        $<$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,4.7>:
+          -Wzero-as-null-pointer-constant
         >
         $<$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,7.0>:
           -faligned-new 

--- a/grpc/src/compiler/cpp_generator.cc
+++ b/grpc/src/compiler/cpp_generator.cc
@@ -8,23 +8,24 @@
 namespace grpc_cpp_generator {
 namespace {
 
-grpc::string service_header_ext() { return ".grpc.fb.h"; }
+static grpc::string service_header_ext() { return ".grpc.fb.h"; }
 
-template<class T> grpc::string as_string(T x) {
+template<class T>
+static grpc::string as_string(T x) {
   std::ostringstream out;
   out << x;
   return out.str();
 }
 
-inline bool ClientOnlyStreaming(const grpc_generator::Method *method) {
+static inline bool ClientOnlyStreaming(const grpc_generator::Method *method) {
   return method->ClientStreaming() && !method->ServerStreaming();
 }
 
-inline bool ServerOnlyStreaming(const grpc_generator::Method *method) {
+static inline bool ServerOnlyStreaming(const grpc_generator::Method *method) {
   return !method->ClientStreaming() && method->ServerStreaming();
 }
 
-grpc::string FilenameIdentifier(const grpc::string &filename) {
+static grpc::string FilenameIdentifier(const grpc::string &filename) {
   grpc::string result;
   for (unsigned i = 0; i < filename.size(); i++) {
     char c = filename[i];
@@ -39,11 +40,11 @@ grpc::string FilenameIdentifier(const grpc::string &filename) {
   }
   return result;
 }
-}  // namespace
 
-template<class T, size_t N> T *array_end(T (&array)[N]) { return array + N; }
+template<class T, size_t N>
+static T *array_end(T (&array)[N]) { return array + N; }
 
-void PrintIncludes(grpc_generator::Printer *printer,
+static void PrintIncludes(grpc_generator::Printer *printer,
                    const std::vector<grpc::string> &headers,
                    const Parameters &params) {
   std::map<grpc::string, grpc::string> vars;
@@ -62,6 +63,8 @@ void PrintIncludes(grpc_generator::Printer *printer,
     printer->Print(vars, "#include $l$$h$$r$\n");
   }
 }
+
+}  // namespace
 
 grpc::string GetHeaderPrologue(grpc_generator::File *file,
                                const Parameters &params) {
@@ -137,7 +140,10 @@ grpc::string GetHeaderIncludes(grpc_generator::File *file,
   return output;
 }
 
-void PrintHeaderClientMethodInterfaces(
+
+namespace {
+
+static void PrintHeaderClientMethodInterfaces(
     grpc_generator::Printer *printer, const grpc_generator::Method *method,
     std::map<grpc::string, grpc::string> *vars, bool is_public) {
   (*vars)["Method"] = method->name();
@@ -351,7 +357,9 @@ void PrintHeaderClientMethodInterfaces(
   }
 }
 
-void PrintHeaderClientMethod(grpc_generator::Printer *printer,
+
+
+static void PrintHeaderClientMethod(grpc_generator::Printer *printer,
                              const grpc_generator::Method *method,
                              std::map<grpc::string, grpc::string> *vars,
                              bool is_public) {
@@ -554,7 +562,7 @@ void PrintHeaderClientMethod(grpc_generator::Printer *printer,
   }
 }
 
-void PrintHeaderClientMethodData(grpc_generator::Printer *printer,
+static void PrintHeaderClientMethodData(grpc_generator::Printer *printer,
                                  const grpc_generator::Method *method,
                                  std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Method"] = method->name();
@@ -562,7 +570,7 @@ void PrintHeaderClientMethodData(grpc_generator::Printer *printer,
                  "const ::grpc::internal::RpcMethod rpcmethod_$Method$_;\n");
 }
 
-void PrintHeaderServerMethodSync(grpc_generator::Printer *printer,
+static void PrintHeaderServerMethodSync(grpc_generator::Printer *printer,
                                  const grpc_generator::Method *method,
                                  std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Method"] = method->name();
@@ -596,7 +604,7 @@ void PrintHeaderServerMethodSync(grpc_generator::Printer *printer,
   printer->Print(method->GetTrailingComments("//").c_str());
 }
 
-void PrintHeaderServerMethodAsync(grpc_generator::Printer *printer,
+static void PrintHeaderServerMethodAsync(grpc_generator::Printer *printer,
                                   const grpc_generator::Method *method,
                                   std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Method"] = method->name();
@@ -712,7 +720,7 @@ void PrintHeaderServerMethodAsync(grpc_generator::Printer *printer,
   printer->Print(*vars, "};\n");
 }
 
-void PrintHeaderServerMethodStreamedUnary(
+static void PrintHeaderServerMethodStreamedUnary(
     grpc_generator::Printer *printer, const grpc_generator::Method *method,
     std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Method"] = method->name();
@@ -763,7 +771,7 @@ void PrintHeaderServerMethodStreamedUnary(
   }
 }
 
-void PrintHeaderServerMethodSplitStreaming(
+static void PrintHeaderServerMethodSplitStreaming(
     grpc_generator::Printer *printer, const grpc_generator::Method *method,
     std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Method"] = method->name();
@@ -816,7 +824,7 @@ void PrintHeaderServerMethodSplitStreaming(
   }
 }
 
-void PrintHeaderServerMethodGeneric(
+static void PrintHeaderServerMethodGeneric(
     grpc_generator::Printer *printer, const grpc_generator::Method *method,
     std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Method"] = method->name();
@@ -887,7 +895,7 @@ void PrintHeaderServerMethodGeneric(
   printer->Print(*vars, "};\n");
 }
 
-void PrintHeaderService(grpc_generator::Printer *printer,
+static void PrintHeaderService(grpc_generator::Printer *printer,
                         const grpc_generator::Service *service,
                         std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Service"] = service->name();
@@ -1058,6 +1066,8 @@ void PrintHeaderService(grpc_generator::Printer *printer,
   printer->Print(service->GetTrailingComments("//").c_str());
 }
 
+} // namespace
+
 grpc::string GetHeaderServices(grpc_generator::File *file,
                                const Parameters &params) {
   grpc::string output;
@@ -1176,7 +1186,10 @@ grpc::string GetSourceIncludes(grpc_generator::File *file,
   return output;
 }
 
-void PrintSourceClientMethod(grpc_generator::Printer *printer,
+
+namespace {
+
+static void PrintSourceClientMethod(grpc_generator::Printer *printer,
                              const grpc_generator::Method *method,
                              std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Method"] = method->name();
@@ -1320,7 +1333,7 @@ void PrintSourceClientMethod(grpc_generator::Printer *printer,
   }
 }
 
-void PrintSourceServerMethod(grpc_generator::Printer *printer,
+static void PrintSourceServerMethod(grpc_generator::Printer *printer,
                              const grpc_generator::Method *method,
                              std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Method"] = method->name();
@@ -1369,7 +1382,7 @@ void PrintSourceServerMethod(grpc_generator::Printer *printer,
   }
 }
 
-void PrintSourceService(grpc_generator::Printer *printer,
+static void PrintSourceService(grpc_generator::Printer *printer,
                         const grpc_generator::Service *service,
                         std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Service"] = service->name();
@@ -1486,6 +1499,8 @@ void PrintSourceService(grpc_generator::Printer *printer,
   }
 }
 
+} // namespace
+
 grpc::string GetSourceServices(grpc_generator::File *file,
                                const Parameters &params) {
   grpc::string output;
@@ -1588,7 +1603,10 @@ grpc::string GetMockIncludes(grpc_generator::File *file,
   return output;
 }
 
-void PrintMockClientMethods(grpc_generator::Printer *printer,
+
+namespace {
+
+static void PrintMockClientMethods(grpc_generator::Printer *printer,
                             const grpc_generator::Method *method,
                             std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Method"] = method->name();
@@ -1680,7 +1698,7 @@ void PrintMockClientMethods(grpc_generator::Printer *printer,
   }
 }
 
-void PrintMockService(grpc_generator::Printer *printer,
+static void PrintMockService(grpc_generator::Printer *printer,
                       const grpc_generator::Service *service,
                       std::map<grpc::string, grpc::string> *vars) {
   (*vars)["Service"] = service->name();
@@ -1695,6 +1713,8 @@ void PrintMockService(grpc_generator::Printer *printer,
   printer->Outdent();
   printer->Print("};\n");
 }
+
+} // namespace
 
 grpc::string GetMockServices(grpc_generator::File *file,
                              const Parameters &params) {

--- a/grpc/src/compiler/go_generator.cc
+++ b/grpc/src/compiler/go_generator.cc
@@ -19,22 +19,23 @@ inline bool ServerOnlyStreaming(const grpc_generator::Method *method) {
 }
 
 namespace grpc_go_generator {
+namespace {
 
 // Returns string with first letter to lowerCase
-grpc::string unexportName(grpc::string s) {
+static grpc::string unexportName(grpc::string s) {
   if (s.empty()) return s;
   s[0] = static_cast<char>(std::tolower(s[0]));
   return s;
 }
 
 // Returns string with first letter to uppercase
-grpc::string exportName(grpc::string s) {
+static grpc::string exportName(grpc::string s) {
   if (s.empty()) return s;
   s[0] = static_cast<char>(std::toupper(s[0]));
   return s;
 }
 
-void GenerateError(grpc_generator::Printer *printer,
+static void GenerateError(grpc_generator::Printer *printer,
                    std::map<grpc::string, grpc::string> vars,
                    const bool multiple_return = true) {
   printer->Print(vars, "if $Error_Check$ {\n");
@@ -46,7 +47,7 @@ void GenerateError(grpc_generator::Printer *printer,
 }
 
 // Generates imports for the service
-void GenerateImports(grpc_generator::File *file,
+static void GenerateImports(grpc_generator::File *file,
                      grpc_generator::Printer *printer,
                      std::map<grpc::string, grpc::string> vars) {
   vars["filename"] = file->filename();
@@ -66,7 +67,7 @@ void GenerateImports(grpc_generator::File *file,
 }
 
 // Generates Server method signature source
-void GenerateServerMethodSignature(const grpc_generator::Method *method,
+static void GenerateServerMethodSignature(const grpc_generator::Method *method,
                                    grpc_generator::Printer *printer,
                                    std::map<grpc::string, grpc::string> vars) {
   vars["Method"] = exportName(method->name());
@@ -86,7 +87,7 @@ void GenerateServerMethodSignature(const grpc_generator::Method *method,
   }
 }
 
-void GenerateServerMethod(const grpc_generator::Method *method,
+static void GenerateServerMethod(const grpc_generator::Method *method,
                           grpc_generator::Printer *printer,
                           std::map<grpc::string, grpc::string> vars) {
   vars["Method"] = exportName(method->name());
@@ -204,7 +205,7 @@ void GenerateServerMethod(const grpc_generator::Method *method,
 }
 
 // Generates Client method signature source
-void GenerateClientMethodSignature(const grpc_generator::Method *method,
+static void GenerateClientMethodSignature(const grpc_generator::Method *method,
                                    grpc_generator::Printer *printer,
                                    std::map<grpc::string, grpc::string> vars) {
   vars["Method"] = exportName(method->name());
@@ -225,7 +226,7 @@ void GenerateClientMethodSignature(const grpc_generator::Method *method,
 }
 
 // Generates Client method source
-void GenerateClientMethod(const grpc_generator::Method *method,
+static void GenerateClientMethod(const grpc_generator::Method *method,
                           grpc_generator::Printer *printer,
                           std::map<grpc::string, grpc::string> vars) {
   printer->Print(vars, "func (c *$ServiceUnexported$Client) ");
@@ -480,6 +481,7 @@ void GenerateService(const grpc_generator::Service *service,
   printer->Outdent();
   printer->Print("}\n");
 }
+}  // namespace
 
 // Returns source for the service
 grpc::string GenerateServiceSource(grpc_generator::File *file,

--- a/grpc/src/compiler/java_generator.cc
+++ b/grpc/src/compiler/java_generator.cc
@@ -44,8 +44,9 @@ typedef grpc_generator::Method MethodDescriptor;
 
 namespace grpc_java_generator {
 typedef std::string string;
+namespace {
 // Generates imports for the service
-void GenerateImports(grpc_generator::File *file,
+static void GenerateImports(grpc_generator::File *file,
                      grpc_generator::Printer *printer, VARS &vars) {
   vars["filename"] = file->filename();
   printer->Print(vars,
@@ -287,7 +288,7 @@ static void GrpcWriteServiceDocComment(Printer *printer, VARS &vars,
   printer->Print(" */\n");
 }
 
-void GrpcWriteMethodDocComment(Printer *printer, VARS &vars,
+static void GrpcWriteMethodDocComment(Printer *printer, VARS &vars,
                                const MethodDescriptor *method) {
   printer->Print("/**\n");
   std::vector<string> lines = GrpcGetDocLinesForDescriptor(method);
@@ -1029,7 +1030,7 @@ static void PrintService(Printer *p, VARS &vars,
   p->Print("}\n");
 }
 
-void PrintStaticImports(Printer *p) {
+static void PrintStaticImports(Printer *p) {
   p->Print(
       "import java.nio.ByteBuffer;\n"
       "import static "
@@ -1062,7 +1063,7 @@ void PrintStaticImports(Printer *p) {
       "io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;\n\n");
 }
 
-void GenerateService(const grpc_generator::Service *service,
+static void GenerateService(const grpc_generator::Service *service,
                      grpc_generator::Printer *printer, VARS &vars,
                      bool disable_version) {
   // All non-generated classes must be referred by fully qualified names to
@@ -1097,6 +1098,7 @@ void GenerateService(const grpc_generator::Service *service,
 
   PrintService(printer, vars, service, disable_version);
 }
+} // namespace
 
 grpc::string GenerateServiceSource(
     grpc_generator::File *file, const grpc_generator::Service *service,

--- a/grpc/src/compiler/python_generator.cc
+++ b/grpc/src/compiler/python_generator.cc
@@ -23,8 +23,9 @@
 #include "src/compiler/python_generator.h"
 
 namespace grpc_python_generator {
+namespace {
 
-grpc::string GenerateMethodType(const grpc_generator::Method *method) {
+static grpc::string GenerateMethodType(const grpc_generator::Method *method) {
 
   if (method->NoStreaming())
     return "unary_unary";
@@ -131,6 +132,7 @@ void GenerateRegister(const grpc_generator::Service *service,
   printer->Outdent();
   printer->Print("\n");
 }
+} // namespace
 
 grpc::string Generate(grpc_generator::File *file,
                       const grpc_generator::Service *service) {

--- a/grpc/src/compiler/swift_generator.cc
+++ b/grpc/src/compiler/swift_generator.cc
@@ -28,8 +28,9 @@
 #include "src/compiler/swift_generator.h"
 
 namespace grpc_swift_generator {
+namespace {
 
-std::string WrapInNameSpace(const std::vector<std::string> &components,
+static std::string WrapInNameSpace(const std::vector<std::string> &components,
                             const grpc::string &name) {
   std::string qualified_name;
   for (auto it = components.begin(); it != components.end(); ++it)
@@ -37,14 +38,14 @@ std::string WrapInNameSpace(const std::vector<std::string> &components,
   return qualified_name + name;
 }
 
-grpc::string GenerateMessage(const std::vector<std::string> &components,
+static grpc::string GenerateMessage(const std::vector<std::string> &components,
                              const grpc::string &name) {
   return "Message<" + WrapInNameSpace(components, name) + ">";
 }
 
 // MARK: - Client
 
-void GenerateClientFuncName(const grpc_generator::Method *method,
+static void GenerateClientFuncName(const grpc_generator::Method *method,
                             grpc_generator::Printer *printer,
                             std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -82,7 +83,7 @@ void GenerateClientFuncName(const grpc_generator::Method *method,
                  "  ) -> BidirectionalStreamingCall<$Input$, $Output$>");
 }
 
-void GenerateClientFuncBody(const grpc_generator::Method *method,
+static void GenerateClientFuncBody(const grpc_generator::Method *method,
                             grpc_generator::Printer *printer,
                             std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -372,6 +373,7 @@ void GenerateServerProtocol(const grpc_generator::Service *service,
   }
   printer->Print("}");
 }
+} // namespace
 
 grpc::string Generate(grpc_generator::File *file,
                       const grpc_generator::Service *service) {

--- a/grpc/src/compiler/ts_generator.cc
+++ b/grpc/src/compiler/ts_generator.cc
@@ -30,8 +30,9 @@
 #include "src/compiler/schema_interface.h"
 
 namespace grpc_ts_generator {
+namespace {
 
-grpc::string GenerateNamespace(const std::vector<std::string> ns,
+static grpc::string GenerateNamespace(const std::vector<std::string> ns,
                                const std::string filename,
                                const bool include_separator) {
   grpc::string path = "";
@@ -55,7 +56,7 @@ grpc::string GenerateNamespace(const std::vector<std::string> ns,
 
 // MARK: - Shared code
 
-void GenerateImports(const grpc_generator::Service *service,
+static void GenerateImports(const grpc_generator::Service *service,
                      grpc_generator::Printer *printer,
                      std::map<grpc::string, grpc::string> *dictonary,
                      const bool grpc_var_import) {
@@ -104,7 +105,7 @@ void GenerateImports(const grpc_generator::Service *service,
 
 // MARK: - Generate Main GRPC Code
 
-void GetStreamType(grpc_generator::Printer *printer,
+static void GetStreamType(grpc_generator::Printer *printer,
                    const grpc_generator::Method *method,
                    std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -116,7 +117,7 @@ void GetStreamType(grpc_generator::Printer *printer,
   printer->Print(vars, "responseStream: $ServerStreaming$,\n");
 }
 
-void GenerateSerializeMethod(grpc_generator::Printer *printer,
+static void GenerateSerializeMethod(grpc_generator::Printer *printer,
                              std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
   printer->Print(vars, "function serialize_$Type$(buffer_args) {\n");
@@ -132,7 +133,7 @@ void GenerateSerializeMethod(grpc_generator::Printer *printer,
   printer->Print("}\n\n");
 }
 
-void GenerateDeserializeMethod(
+static void GenerateDeserializeMethod(
     grpc_generator::Printer *printer,
     std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -145,7 +146,7 @@ void GenerateDeserializeMethod(
   printer->Print("}\n\n");
 }
 
-void GenerateMethods(const grpc_generator::Service *service,
+static void GenerateMethods(const grpc_generator::Service *service,
                      grpc_generator::Printer *printer,
                      std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -177,7 +178,7 @@ void GenerateMethods(const grpc_generator::Service *service,
   }
 }
 
-void GenerateService(const grpc_generator::Service *service,
+static void GenerateService(const grpc_generator::Service *service,
                      grpc_generator::Printer *printer,
                      std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -212,6 +213,8 @@ void GenerateService(const grpc_generator::Service *service,
                  "grpc.makeGenericClientConstructor($NAME$);");
 }
 
+} // namespace
+
 grpc::string Generate(grpc_generator::File *file,
                       const grpc_generator::Service *service,
                       const grpc::string &filename) {
@@ -233,9 +236,11 @@ grpc::string Generate(grpc_generator::File *file,
   return output;
 }
 
+namespace {
+
 // MARK: - Generate Interface
 
-void FillInterface(grpc_generator::Printer *printer,
+static void FillInterface(grpc_generator::Printer *printer,
                    std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
   printer->Print(vars,
@@ -253,7 +258,7 @@ void FillInterface(grpc_generator::Printer *printer,
   printer->Print("}\n");
 }
 
-void GenerateInterfaces(const grpc_generator::Service *service,
+static void GenerateInterfaces(const grpc_generator::Service *service,
                         grpc_generator::Printer *printer,
                         std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -275,7 +280,7 @@ void GenerateInterfaces(const grpc_generator::Service *service,
   }
 }
 
-void GenerateExportedInterface(
+static void GenerateExportedInterface(
     const grpc_generator::Service *service, grpc_generator::Printer *printer,
     std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -319,7 +324,7 @@ void GenerateExportedInterface(
   printer->Print("}\n");
 }
 
-void GenerateMainInterface(const grpc_generator::Service *service,
+static void GenerateMainInterface(const grpc_generator::Service *service,
                            grpc_generator::Printer *printer,
                            std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -344,11 +349,11 @@ void GenerateMainInterface(const grpc_generator::Service *service,
   GenerateExportedInterface(service, printer, &vars);
 }
 
-grpc::string GenerateMetaData() { return "metadata: grpc.Metadata"; }
+static grpc::string GenerateMetaData() { return "metadata: grpc.Metadata"; }
 
-grpc::string GenerateOptions() { return "options: Partial<grpc.CallOptions>"; }
+static grpc::string GenerateOptions() { return "options: Partial<grpc.CallOptions>"; }
 
-void GenerateUnaryClientInterface(
+static void GenerateUnaryClientInterface(
     grpc_generator::Printer *printer,
     std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -363,7 +368,7 @@ void GenerateUnaryClientInterface(
   printer->Print(vars, (main + meta_data + options + callback).c_str());
 }
 
-void GenerateClientWriteStreamInterface(
+static void GenerateClientWriteStreamInterface(
     grpc_generator::Printer *printer,
     std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -380,7 +385,7 @@ void GenerateClientWriteStreamInterface(
   printer->Print(vars, (main + meta_data + options + callback).c_str());
 }
 
-void GenerateClientReadableStreamInterface(
+static void GenerateClientReadableStreamInterface(
     grpc_generator::Printer *printer,
     std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -392,7 +397,7 @@ void GenerateClientReadableStreamInterface(
   printer->Print(vars, (main + options + end_function).c_str());
 }
 
-void GenerateDepluxStreamInterface(
+static void GenerateDepluxStreamInterface(
     grpc_generator::Printer *printer,
     std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -408,7 +413,7 @@ void GenerateDepluxStreamInterface(
                            .c_str());
 }
 
-void GenerateClientInterface(const grpc_generator::Service *service,
+static void GenerateClientInterface(const grpc_generator::Service *service,
                              grpc_generator::Printer *printer,
                              std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -446,7 +451,7 @@ void GenerateClientInterface(const grpc_generator::Service *service,
   printer->Print("}\n");
 }
 
-void GenerateClientClassInterface(
+static void GenerateClientClassInterface(
     const grpc_generator::Service *service, grpc_generator::Printer *printer,
     std::map<grpc::string, grpc::string> *dictonary) {
   auto vars = *dictonary;
@@ -487,6 +492,8 @@ void GenerateClientClassInterface(
   printer->Outdent();
   printer->Print("}\n");
 }
+} // namespace
+
 
 grpc::string GenerateInterface(grpc_generator::File *file,
                                const grpc_generator::Service *service,

--- a/src/bfbs_gen.h
+++ b/src/bfbs_gen.h
@@ -24,19 +24,21 @@
 
 namespace flatbuffers {
 
-void ForAllEnums(
+namespace {
+
+static void ForAllEnums(
     const flatbuffers::Vector<flatbuffers::Offset<reflection::Enum>> *enums,
     std::function<void(const reflection::Enum *)> func) {
   for (auto it = enums->cbegin(); it != enums->cend(); ++it) { func(*it); }
 }
 
-void ForAllObjects(
+static void ForAllObjects(
     const flatbuffers::Vector<flatbuffers::Offset<reflection::Object>> *objects,
     std::function<void(const reflection::Object *)> func) {
   for (auto it = objects->cbegin(); it != objects->cend(); ++it) { func(*it); }
 }
 
-void ForAllEnumValues(const reflection::Enum *enum_def,
+static void ForAllEnumValues(const reflection::Enum *enum_def,
                       std::function<void(const reflection::EnumVal *)> func) {
   for (auto it = enum_def->values()->cbegin(); it != enum_def->values()->cend();
        ++it) {
@@ -44,7 +46,7 @@ void ForAllEnumValues(const reflection::Enum *enum_def,
   }
 }
 
-void ForAllDocumentation(
+static void ForAllDocumentation(
     const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>
         *documentation,
     std::function<void(const flatbuffers::String *)> func) {
@@ -88,6 +90,8 @@ static bool IsSingleByte(const reflection::BaseType base_type) {
 static bool IsVector(const reflection::BaseType base_type) {
   return base_type == reflection::Vector;
 }
+
+} // namespace
 
 // A concrete base Flatbuffer Generator that specific language generators can
 // derive from.

--- a/src/code_generators.cpp
+++ b/src/code_generators.cpp
@@ -299,7 +299,10 @@ std::string SimpleFloatConstantGenerator::NaN(float v) const {
   return this->NaN(static_cast<double>(v));
 }
 
-std::string JavaCSharpMakeRule(const bool java, const Parser &parser,
+
+namespace {
+
+static std::string JavaCSharpMakeRule(const bool java, const Parser &parser,
                                const std::string &path,
                                const std::string &file_name) {
   const std::string file_extension = java ? ".java" : ".cs";
@@ -331,6 +334,9 @@ std::string JavaCSharpMakeRule(const bool java, const Parser &parser,
   return make_rule;
 }
 
+} // namespace
+
+
 std::string JavaMakeRule(const Parser &parser, const std::string &path,
                          const std::string &file_name) {
   return JavaCSharpMakeRule(true, parser, path, file_name);
@@ -340,11 +346,15 @@ std::string CSharpMakeRule(const Parser &parser, const std::string &path,
   return JavaCSharpMakeRule(false, parser, path, file_name);
 }
 
-std::string BinaryFileName(const Parser &parser, const std::string &path,
+namespace {
+
+static std::string BinaryFileName(const Parser &parser, const std::string &path,
                            const std::string &file_name) {
   auto ext = parser.file_extension_.length() ? parser.file_extension_ : "bin";
   return path + file_name + "." + ext;
 }
+
+} // namespace
 
 bool GenerateBinary(const Parser &parser, const std::string &path,
                     const std::string &file_name) {

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -25,7 +25,7 @@
 
 namespace flatbuffers {
 
-const char *FLATC_VERSION() { return FLATBUFFERS_VERSION(); }
+static const char *FLATC_VERSION() { return FLATBUFFERS_VERSION(); }
 
 void FlatCompiler::ParseFile(
     flatbuffers::Parser &parser, const std::string &filename,

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -27,7 +27,9 @@ namespace flatbuffers {
 
 namespace dart {
 
-Namer::Config DartDefaultConfig() {
+namespace {
+
+static Namer::Config DartDefaultConfig() {
   return { /*types=*/Case::kUpperCamel,
            /*constants=*/Case::kScreamingSnake,
            /*methods=*/Case::kLowerCamel,
@@ -50,7 +52,7 @@ Namer::Config DartDefaultConfig() {
            /*filename_extension=*/".dart" };
 }
 
-std::set<std::string> DartKeywords() {
+static std::set<std::string> DartKeywords() {
   // see https://www.dartlang.org/guides/language/language-tour#keywords
   // yield*, async*, and sync* shouldn't be proble
   return {
@@ -67,6 +69,7 @@ std::set<std::string> DartKeywords() {
     "dynamic",  "implements", "set",
   };
 }
+} // namespace
 
 const std::string _kFb = "fb";
 

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -38,8 +38,10 @@ namespace flatbuffers {
 
 namespace go {
 
+namespace {
+
 // see https://golang.org/ref/spec#Keywords
-std::set<std::string> GoKeywords() {
+static std::set<std::string> GoKeywords() {
   return {
     "break",    "default",     "func",   "interface", "select",
     "case",     "defer",       "go",     "map",       "struct",
@@ -49,7 +51,7 @@ std::set<std::string> GoKeywords() {
   };
 }
 
-Namer::Config GoDefaultConfig() {
+static Namer::Config GoDefaultConfig() {
   // Note that the functions with user defined types in the name use
   // upper camel case for all but the user defined type itself, which is keep
   // cased. Despite being a function, we interpret it as a Type.
@@ -74,6 +76,8 @@ Namer::Config GoDefaultConfig() {
            /*filename_suffix=*/"",
            /*filename_extension=*/".go" };
 }
+
+} // namespace
 
 class GoGenerator : public BaseGenerator {
  public:

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -25,7 +25,9 @@
 namespace flatbuffers {
 namespace java {
 
-Namer::Config JavaDefaultConfig() {
+namespace {
+
+static Namer::Config JavaDefaultConfig() {
   return {
     /*types=*/Case::kKeep,
     /*constants=*/Case::kScreamingSnake,
@@ -50,7 +52,7 @@ Namer::Config JavaDefaultConfig() {
   };
 }
 
-std::set<std::string> JavaKeywords() {
+static std::set<std::string> JavaKeywords() {
   return {
     "abstract", "continue", "for",        "new",       "switch",
     "assert",   "default",  "goto",       "package",   "synchronized",
@@ -65,15 +67,17 @@ std::set<std::string> JavaKeywords() {
   };
 }
 
-static TypedFloatConstantGenerator JavaFloatGen("Double.", "Float.", "NaN",
+static const TypedFloatConstantGenerator JavaFloatGen("Double.", "Float.", "NaN",
                                                 "POSITIVE_INFINITY",
                                                 "NEGATIVE_INFINITY");
 
-static CommentConfig comment_config = {
+static const CommentConfig comment_config = {
   "/**",
   " *",
   " */",
 };
+
+} // namespace
 
 class JavaGenerator : public BaseGenerator {
   struct FieldArrayLength {

--- a/src/idl_gen_json_schema.cpp
+++ b/src/idl_gen_json_schema.cpp
@@ -24,7 +24,10 @@ namespace flatbuffers {
 
 namespace jsons {
 
-template<class T> std::string GenFullName(const T *enum_def) {
+namespace {
+
+template<class T>
+static std::string GenFullName(const T *enum_def) {
   std::string full_name;
   const auto &name_spaces = enum_def->defined_namespace->components;
   for (auto ns = name_spaces.cbegin(); ns != name_spaces.cend(); ++ns) {
@@ -34,15 +37,16 @@ template<class T> std::string GenFullName(const T *enum_def) {
   return full_name;
 }
 
-template<class T> std::string GenTypeRef(const T *enum_def) {
+template<class T>
+static std::string GenTypeRef(const T *enum_def) {
   return "\"$ref\" : \"#/definitions/" + GenFullName(enum_def) + "\"";
 }
 
-std::string GenType(const std::string &name) {
+static std::string GenType(const std::string &name) {
   return "\"type\" : \"" + name + "\"";
 }
 
-std::string GenType(BaseType type) {
+static std::string GenType(BaseType type) {
   switch (type) {
     case BASE_TYPE_BOOL: return "\"type\" : \"boolean\"";
     case BASE_TYPE_CHAR:
@@ -84,13 +88,13 @@ std::string GenType(BaseType type) {
   }
 }
 
-std::string GenBaseType(const Type &type) {
+static std::string GenBaseType(const Type &type) {
   if (type.struct_def != nullptr) { return GenTypeRef(type.struct_def); }
   if (type.enum_def != nullptr) { return GenTypeRef(type.enum_def); }
   return GenType(type.base_type);
 }
 
-std::string GenArrayType(const Type &type) {
+static std::string GenArrayType(const Type &type) {
   std::string element_type;
   if (type.struct_def != nullptr) {
     element_type = GenTypeRef(type.struct_def);
@@ -103,7 +107,7 @@ std::string GenArrayType(const Type &type) {
   return "\"type\" : \"array\", \"items\" : {" + element_type + "}";
 }
 
-std::string GenType(const Type &type) {
+static std::string GenType(const Type &type) {
   switch (type.base_type) {
     case BASE_TYPE_ARRAY: FLATBUFFERS_FALLTHROUGH();  // fall thru
     case BASE_TYPE_VECTOR: {
@@ -135,6 +139,8 @@ std::string GenType(const Type &type) {
     }
   }
 }
+
+} // namespace
 
 class JsonSchemaGenerator : public BaseGenerator {
  private:

--- a/src/idl_gen_kotlin.cpp
+++ b/src/idl_gen_kotlin.cpp
@@ -29,6 +29,8 @@ namespace flatbuffers {
 
 namespace kotlin {
 
+namespace {
+
 typedef std::map<std::string, std::pair<std::string, std::string> > FbbParamMap;
 static TypedFloatConstantGenerator KotlinFloatGen("Double.", "Float.", "NaN",
                                                   "POSITIVE_INFINITY",
@@ -36,7 +38,7 @@ static TypedFloatConstantGenerator KotlinFloatGen("Double.", "Float.", "NaN",
 
 static const CommentConfig comment_config = { "/**", " *", " */" };
 static const std::string ident_pad = "    ";
-std::set<std::string> KotlinKeywords() {
+static std::set<std::string> KotlinKeywords() {
   return { "package",  "as",     "typealias", "class",  "this",   "super",
            "val",      "var",    "fun",       "for",    "null",   "true",
            "false",    "is",     "in",        "throw",  "return", "break",
@@ -44,7 +46,7 @@ std::set<std::string> KotlinKeywords() {
            "do",       "when",   "interface", "typeof", "Any",    "Character" };
 }
 
-Namer::Config KotlinDefaultConfig() {
+static Namer::Config KotlinDefaultConfig() {
   return { /*types=*/Case::kKeep,
            /*constants=*/Case::kKeep,
            /*methods=*/Case::kLowerCamel,
@@ -66,6 +68,7 @@ Namer::Config KotlinDefaultConfig() {
            /*filename_suffix=*/"",
            /*filename_extension=*/".kt" };
 }
+} // namespace
 
 class KotlinGenerator : public BaseGenerator {
  public:

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -31,7 +31,9 @@
 namespace flatbuffers {
 namespace python {
 
-std::set<std::string> PythonKeywords() {
+namespace {
+
+static std::set<std::string> PythonKeywords() {
   return { "False", "None",   "True",     "and",   "as",     "assert",
            "break", "class",  "continue", "def",   "del",    "elif",
            "else",  "except", "finally",  "for",   "from",   "global",
@@ -40,7 +42,7 @@ std::set<std::string> PythonKeywords() {
            "while", "with",   "yield" };
 }
 
-Namer::Config PythonDefaultConfig() {
+static Namer::Config PythonDefaultConfig() {
   return { /*types=*/Case::kKeep,
            /*constants=*/Case::kScreamingSnake,
            /*methods=*/Case::kUpperCamel,
@@ -64,8 +66,10 @@ Namer::Config PythonDefaultConfig() {
 }
 
 // Hardcode spaces per indentation.
-const CommentConfig def_comment = { nullptr, "#", nullptr };
-const std::string Indent = "    ";
+static const CommentConfig def_comment = { nullptr, "#", nullptr };
+static const std::string Indent = "    ";
+
+} // namespace
 
 class PythonGenerator : public BaseGenerator {
  public:

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -23,8 +23,9 @@
 #include "idl_namer.h"
 
 namespace flatbuffers {
+namespace {
 
-Namer::Config RustDefaultConfig() {
+static Namer::Config RustDefaultConfig() {
   // Historical note: We've been using "keep" casing since the original
   // implementation, presumably because Flatbuffers schema style and Rust style
   // roughly align. We are not going to enforce proper casing since its an
@@ -51,7 +52,7 @@ Namer::Config RustDefaultConfig() {
            /*filename_extension=*/".rs" };
 }
 
-std::set<std::string> RustKeywords() {
+static std::set<std::string> RustKeywords() {
   return {
     // https://doc.rust-lang.org/book/second-edition/appendix-01-keywords.html
     "as",
@@ -173,7 +174,7 @@ enum FullType {
 };
 
 // Convert a Type to a FullType (exhaustive).
-FullType GetFullType(const Type &type) {
+static FullType GetFullType(const Type &type) {
   // N.B. The order of these conditionals matters for some types.
 
   if (IsString(type)) {
@@ -263,15 +264,16 @@ FullType GetFullType(const Type &type) {
   return ftBool;
 }
 
-bool IsBitFlagsEnum(const EnumDef &enum_def) {
+static bool IsBitFlagsEnum(const EnumDef &enum_def) {
   return enum_def.attributes.Lookup("bit_flags") != nullptr;
 }
 
 // TableArgs make required non-scalars "Option<_>".
 // TODO(cneo): Rework how we do defaults and stuff.
-bool IsOptionalToBuilder(const FieldDef &field) {
+static bool IsOptionalToBuilder(const FieldDef &field) {
   return field.IsOptional() || !IsScalar(field.value.type.base_type);
 }
+} // namespace
 
 bool GenerateRustModuleRootFile(const Parser &parser,
                                 const std::string &output_dir) {

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -27,7 +27,9 @@ namespace flatbuffers {
 
 namespace swift {
 
-Namer::Config SwiftDefaultConfig() {
+namespace {
+
+static Namer::Config SwiftDefaultConfig() {
   return { /*types=*/Case::kKeep,
            /*constants=*/Case::kLowerCamel,
            /*methods=*/Case::kLowerCamel,
@@ -50,7 +52,7 @@ Namer::Config SwiftDefaultConfig() {
            /*filename_extension=*/".swift" };
 }
 
-std::set<std::string> SwiftKeywords() {
+static std::set<std::string> SwiftKeywords() {
   return {
     "associatedtype",
     "class",
@@ -134,15 +136,17 @@ std::set<std::string> SwiftKeywords() {
   };
 }
 
-inline std::string GenIndirect(const std::string &reading) {
+static std::string GenIndirect(const std::string &reading) {
   return "{{ACCESS}}.indirect(" + reading + ")";
 }
 
-inline std::string GenArrayMainBody(const std::string &optional) {
+static std::string GenArrayMainBody(const std::string &optional) {
   return "{{ACCESS_TYPE}} func {{FIELDMETHOD}}(at index: Int32) -> "
          "{{VALUETYPE}}" +
          optional + " { ";
 }
+
+} // namespace
 
 class SwiftGenerator : public BaseGenerator {
  private:

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -36,7 +36,11 @@ const char *FLATBUFFERS_VERSION() {
   // clang-format on
 }
 
-const double kPi = 3.14159265358979323846;
+namespace {
+
+static const double kPi = 3.14159265358979323846;
+
+} // namespace
 
 // clang-format off
 const char *const kTypeNames[] = {
@@ -54,6 +58,9 @@ const char kTypeSizes[] = {
   #undef FLATBUFFERS_TD
 };
 // clang-format on
+
+
+namespace {
 
 // The enums in the reflection schema should match the ones we use internally.
 // Compare the last element to check if these go out of sync.
@@ -93,12 +100,14 @@ static bool IsLowerSnakeCase(const std::string &str) {
   return true;
 }
 
-void DeserializeDoc(std::vector<std::string> &doc,
+static void DeserializeDoc(std::vector<std::string> &doc,
                     const Vector<Offset<String>> *documentation) {
   if (documentation == nullptr) return;
   for (uoffset_t index = 0; index < documentation->size(); index++)
     doc.push_back(documentation->Get(index)->str());
 }
+
+} // namespace
 
 void Parser::Message(const std::string &msg) {
   if (!error_.empty()) error_ += "\n";  // log all warnings and errors
@@ -128,7 +137,11 @@ CheckedError Parser::Error(const std::string &msg) {
   return CheckedError(true);
 }
 
-inline CheckedError NoError() { return CheckedError(false); }
+namespace {
+
+static CheckedError NoError() { return CheckedError(false); }
+
+} // namespace
 
 CheckedError Parser::RecurseError() {
   return Error("maximum parsing depth " + NumToString(parse_depth_counter_) +
@@ -164,26 +177,38 @@ class Parser::ParseDepthGuard {
   const int caller_depth_;
 };
 
-template<typename T> std::string TypeToIntervalString() {
+
+namespace {
+
+template<typename T>
+static std::string TypeToIntervalString() {
   return "[" + NumToString((flatbuffers::numeric_limits<T>::lowest)()) + "; " +
          NumToString((flatbuffers::numeric_limits<T>::max)()) + "]";
 }
 
+} // namespace
+
+
+
+namespace {
+
+
 // atot: template version of atoi/atof: convert a string to an instance of T.
 template<typename T>
-bool atot_scalar(const char *s, T *val, bool_constant<false>) {
+static bool atot_scalar(const char *s, T *val, bool_constant<false>) {
   return StringToNumber(s, val);
 }
 
 template<typename T>
-bool atot_scalar(const char *s, T *val, bool_constant<true>) {
+static bool atot_scalar(const char *s, T *val, bool_constant<true>) {
   // Normalize NaN parsed from fbs or json to unsigned NaN.
   if (false == StringToNumber(s, val)) return false;
   *val = (*val != *val) ? std::fabs(*val) : *val;
   return true;
 }
 
-template<typename T> CheckedError atot(const char *s, Parser &parser, T *val) {
+template<typename T>
+static CheckedError atot(const char *s, Parser &parser, T *val) {
   auto done = atot_scalar(s, val, bool_constant<is_floating_point<T>::value>());
   if (done) return NoError();
   if (0 == *val)
@@ -193,12 +218,14 @@ template<typename T> CheckedError atot(const char *s, Parser &parser, T *val) {
                         ", constant does not fit " + TypeToIntervalString<T>());
 }
 template<>
-inline CheckedError atot<Offset<void>>(const char *s, Parser &parser,
+CheckedError atot<Offset<void>>(const char *s, Parser &parser,
                                        Offset<void> *val) {
   (void)parser;
   *val = Offset<void>(atoi(s));
   return NoError();
 }
+
+} // namespace
 
 std::string Namespace::GetFullyQualifiedName(const std::string &name,
                                              size_t max_components) const {
@@ -217,8 +244,12 @@ std::string Namespace::GetFullyQualifiedName(const std::string &name,
   return stream_str;
 }
 
+
+namespace {
+
+
 template<typename T>
-T *LookupTableByName(const SymbolTable<T> &table, const std::string &name,
+static T *LookupTableByName(const SymbolTable<T> &table, const std::string &name,
                      const Namespace &current_namespace, size_t skip_top) {
   const auto &components = current_namespace.components;
   if (table.dict.empty()) return nullptr;
@@ -278,6 +309,9 @@ static std::string TokenToString(int t) {
 }
 // clang-format on
 
+} // namespace
+
+
 std::string Parser::TokenToStringId(int t) const {
   return t == kTokenIdentifier ? attribute_ : TokenToString(t);
 }
@@ -307,9 +341,13 @@ CheckedError Parser::SkipByteOrderMark() {
   return NoError();
 }
 
-static inline bool IsIdentifierStart(char c) {
+namespace {
+
+static bool IsIdentifierStart(char c) {
   return is_alpha(c) || (c == '_');
 }
+
+} // namespace
 
 CheckedError Parser::Next() {
   doc_comment_.clear();
@@ -1410,6 +1448,9 @@ CheckedError Parser::ParseVectorDelimiters(uoffset_t &count, F body) {
   return NoError();
 }
 
+
+namespace {
+
 static bool CompareSerializedScalars(const uint8_t *a, const uint8_t *b,
                                      const FieldDef &key) {
   switch (key.value.type.base_type) {
@@ -1477,7 +1518,7 @@ static void SwapSerializedTables(Offset<Table> *a, Offset<Table> *b) {
 
 // See below for why we need our own sort :(
 template<typename T, typename F, typename S>
-void SimpleQsort(T *begin, T *end, size_t width, F comparator, S swapper) {
+static void SimpleQsort(T *begin, T *end, size_t width, F comparator, S swapper) {
   if (end - begin <= static_cast<ptrdiff_t>(width)) return;
   auto l = begin + width;
   auto r = end;
@@ -1494,6 +1535,11 @@ void SimpleQsort(T *begin, T *end, size_t width, F comparator, S swapper) {
   SimpleQsort(begin, l, width, comparator, swapper);
   SimpleQsort(r, end, width, comparator, swapper);
 }
+
+
+
+} // namespace
+
 
 CheckedError Parser::ParseAlignAttribute(const std::string &align_constant,
                                          size_t min_align, size_t *align) {
@@ -1821,21 +1867,27 @@ CheckedError Parser::TokenError() {
   return Error("cannot parse value starting with: " + TokenToStringId(token_));
 }
 
+namespace {
+
 // Re-pack helper (ParseSingleValue) to normalize defaults of scalars.
-template<typename T> inline void SingleValueRepack(Value &e, T val) {
+template<typename T>
+static inline void SingleValueRepack(Value &e, T val) {
   // Remove leading zeros.
   if (IsInteger(e.type.base_type)) { e.constant = NumToString(val); }
 }
+
 #if defined(FLATBUFFERS_HAS_NEW_STRTOD) && (FLATBUFFERS_HAS_NEW_STRTOD > 0)
 // Normalize defaults NaN to unsigned quiet-NaN(0) if value was parsed from
 // hex-float literal.
-static inline void SingleValueRepack(Value &e, float val) {
+static void SingleValueRepack(Value &e, float val) {
   if (val != val) e.constant = "nan";
 }
-static inline void SingleValueRepack(Value &e, double val) {
+static void SingleValueRepack(Value &e, double val) {
   if (val != val) e.constant = "nan";
 }
 #endif
+
+} // namespace
 
 CheckedError Parser::ParseFunction(const std::string *name, Value &e) {
   ParseDepthGuard depth_guard(this);
@@ -2108,12 +2160,16 @@ const EnumVal *EnumDef::MaxValue() const {
   return vals.vec.empty() ? nullptr : vals.vec.back();
 }
 
+namespace {
+
 template<typename T> static uint64_t EnumDistanceImpl(T e1, T e2) {
   if (e1 < e2) { std::swap(e1, e2); }  // use std for scalars
   // Signed overflow may occur, use unsigned calculation.
   // The unsigned overflow is well-defined by C++ standard (modulo 2^n).
   return static_cast<uint64_t>(e1) - static_cast<uint64_t>(e2);
 }
+
+} // namespace
 
 uint64_t EnumDef::Distance(const EnumVal *v1, const EnumVal *v2) const {
   return IsUInt64() ? EnumDistanceImpl(v1->GetAsUInt64(), v2->GetAsUInt64())
@@ -2535,11 +2591,15 @@ std::string Parser::UnqualifiedName(const std::string &full_qualified_name) {
   return full_qualified_name.substr(previous, current - previous);
 }
 
+namespace {
+
 static bool compareFieldDefs(const FieldDef *a, const FieldDef *b) {
   auto a_id = atoi(a->attributes.Lookup("id")->constant.c_str());
   auto b_id = atoi(b->attributes.Lookup("id")->constant.c_str());
   return a_id < b_id;
 }
+
+} // namespace
 
 CheckedError Parser::ParseDecl(const char *filename) {
   std::vector<std::string> dc = doc_comment_;
@@ -3349,6 +3409,9 @@ CheckedError Parser::CheckPrivatelyLeakedFields(const Definition &def,
   return NoError();
 }
 
+
+namespace {
+
 // Generate a unique hash for a file based on its name and contents (if any).
 static uint64_t HashFile(const char *source_filename, const char *source) {
   uint64_t hash = 0;
@@ -3360,6 +3423,9 @@ static uint64_t HashFile(const char *source_filename, const char *source) {
 
   return hash;
 }
+
+} // namespace
+
 
 CheckedError Parser::DoParse(const char *source, const char **include_paths,
                              const char *source_filename,
@@ -3574,17 +3640,23 @@ std::set<std::string> Parser::GetIncludedFilesRecursive(
 
 // Schema serialization functionality:
 
-template<typename T> bool compareName(const T *a, const T *b) {
+namespace {
+
+template<typename T>
+static bool compareName(const T *a, const T *b) {
   return a->defined_namespace->GetFullyQualifiedName(a->name) <
          b->defined_namespace->GetFullyQualifiedName(b->name);
 }
 
-template<typename T> void AssignIndices(const std::vector<T *> &defvec) {
+template<typename T>
+static void AssignIndices(const std::vector<T *> &defvec) {
   // Pre-sort these vectors, such that we can set the correct indices for them.
   auto vec = defvec;
   std::sort(vec.begin(), vec.end(), compareName<T>);
   for (int i = 0; i < static_cast<int>(vec.size()); i++) vec[i]->index = i;
 }
+
+} // namespace
 
 void Parser::Serialize() {
   builder_.Clear();
@@ -3655,6 +3727,8 @@ void Parser::Serialize() {
   }
 }
 
+namespace {
+
 static Namespace *GetNamespace(
     const std::string &qualified_name, std::vector<Namespace *> &namespaces,
     std::map<std::string, Namespace *> &namespaces_index) {
@@ -3680,6 +3754,9 @@ static Namespace *GetNamespace(
 
   return ns;
 }
+
+} // namespace
+
 
 Offset<reflection::Object> StructDef::Serialize(FlatBufferBuilder *builder,
                                                 const Parser &parser) const {

--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -384,12 +384,18 @@ const uint8_t *AddFlatBuffer(std::vector<uint8_t> &flatbuf,
   return flatbuf.data() + insertion_point + root_offset;
 }
 
-void CopyInline(FlatBufferBuilder &fbb, const reflection::Field &fielddef,
+namespace {
+
+static void CopyInline(FlatBufferBuilder &fbb, const reflection::Field &fielddef,
                 const Table &table, size_t align, size_t size) {
   fbb.Align(align);
   fbb.PushBytes(table.GetStruct<const uint8_t *>(fielddef.offset()), size);
   fbb.TrackField(fielddef.offset(), fbb.GetSize());
 }
+
+} // namespace
+
+
 
 Offset<const Table *> CopyTable(FlatBufferBuilder &fbb,
                                 const reflection::Schema &schema,
@@ -515,7 +521,9 @@ Offset<const Table *> CopyTable(FlatBufferBuilder &fbb,
   }
 }
 
-bool VerifyStruct(flatbuffers::Verifier &v,
+namespace {
+
+static bool VerifyStruct(flatbuffers::Verifier &v,
                   const flatbuffers::Table &parent_table,
                   voffset_t field_offset, const reflection::Object &obj,
                   bool required) {
@@ -527,7 +535,7 @@ bool VerifyStruct(flatbuffers::Verifier &v,
                              offset, obj.bytesize(), obj.minalign());
 }
 
-bool VerifyVectorOfStructs(flatbuffers::Verifier &v,
+static bool VerifyVectorOfStructs(flatbuffers::Verifier &v,
                            const flatbuffers::Table &parent_table,
                            voffset_t field_offset,
                            const reflection::Object &obj, bool required) {
@@ -538,11 +546,11 @@ bool VerifyVectorOfStructs(flatbuffers::Verifier &v,
 }
 
 // forward declare to resolve cyclic deps between VerifyObject and VerifyVector
-bool VerifyObject(flatbuffers::Verifier &v, const reflection::Schema &schema,
+static bool VerifyObject(flatbuffers::Verifier &v, const reflection::Schema &schema,
                   const reflection::Object &obj,
                   const flatbuffers::Table *table, bool required);
 
-bool VerifyUnion(flatbuffers::Verifier &v, const reflection::Schema &schema,
+static bool VerifyUnion(flatbuffers::Verifier &v, const reflection::Schema &schema,
                  uint8_t utype, const uint8_t *elem,
                  const reflection::Field &union_field) {
   if (!utype) return true;  // Not present.
@@ -567,7 +575,7 @@ bool VerifyUnion(flatbuffers::Verifier &v, const reflection::Schema &schema,
   }
 }
 
-bool VerifyVector(flatbuffers::Verifier &v, const reflection::Schema &schema,
+static bool VerifyVector(flatbuffers::Verifier &v, const reflection::Schema &schema,
                   const flatbuffers::Table &table,
                   const reflection::Field &vec_field) {
   FLATBUFFERS_ASSERT(vec_field.type()->base_type() == reflection::Vector);
@@ -645,7 +653,7 @@ bool VerifyVector(flatbuffers::Verifier &v, const reflection::Schema &schema,
   }
 }
 
-bool VerifyObject(flatbuffers::Verifier &v, const reflection::Schema &schema,
+static bool VerifyObject(flatbuffers::Verifier &v, const reflection::Schema &schema,
                   const reflection::Object &obj,
                   const flatbuffers::Table *table, bool required) {
   if (!table) return !required;
@@ -734,6 +742,9 @@ bool VerifyObject(flatbuffers::Verifier &v, const reflection::Schema &schema,
 
   return true;
 }
+
+
+} // namespace
 
 bool Verify(const reflection::Schema &schema, const reflection::Object &root,
             const uint8_t *const buf, const size_t length,

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -56,12 +56,14 @@
 
 namespace flatbuffers {
 
-bool FileExistsRaw(const char *name) {
+namespace {
+
+static bool FileExistsRaw(const char *name) {
   std::ifstream ifs(name);
   return ifs.good();
 }
 
-bool LoadFileRaw(const char *name, bool binary, std::string *buf) {
+static bool LoadFileRaw(const char *name, bool binary, std::string *buf) {
   if (DirExists(name)) return false;
   std::ifstream ifs(name, binary ? std::ifstream::binary : std::ifstream::in);
   if (!ifs.is_open()) return false;
@@ -81,8 +83,10 @@ bool LoadFileRaw(const char *name, bool binary, std::string *buf) {
   return !ifs.bad();
 }
 
-static LoadFileFunction g_load_file_function = LoadFileRaw;
-static FileExistsFunction g_file_exists_function = FileExistsRaw;
+LoadFileFunction g_load_file_function = LoadFileRaw;
+FileExistsFunction g_file_exists_function = FileExistsRaw;
+
+} // namespace
 
 bool LoadFile(const char *name, bool binary, std::string *buf) {
   FLATBUFFERS_ASSERT(g_load_file_function);
@@ -365,14 +369,14 @@ static std::string ToSnakeCase(const std::string &input, bool screaming) {
   return s;
 }
 
-static std::string ToAll(const std::string &input,
+std::string ToAll(const std::string &input,
                          std::function<char(const char)> transform) {
   std::string s;
   for (size_t i = 0; i < input.length(); i++) { s += transform(input[i]); }
   return s;
 }
 
-static std::string CamelToSnake(const std::string &input) {
+std::string CamelToSnake(const std::string &input) {
   std::string s;
   for (size_t i = 0; i < input.length(); i++) {
     if (i == 0) {
@@ -391,7 +395,7 @@ static std::string CamelToSnake(const std::string &input) {
   return s;
 }
 
-static std::string DasherToSnake(const std::string &input) {
+std::string DasherToSnake(const std::string &input) {
   std::string s;
   for (size_t i = 0; i < input.length(); i++) {
     if (input[i] == '-') {
@@ -403,7 +407,7 @@ static std::string DasherToSnake(const std::string &input) {
   return s;
 }
 
-static std::string ToDasher(const std::string &input) {
+std::string ToDasher(const std::string &input) {
   std::string s;
   char p = 0;
   for (size_t i = 0; i < input.length(); i++) {
@@ -424,10 +428,9 @@ static std::string ToDasher(const std::string &input) {
   return s;
 }
 
-}  // namespace
 
 // Converts foo_bar_123baz_456 to foo_bar123_baz456
-static std::string SnakeToSnake2(const std::string &s) {
+std::string SnakeToSnake2(const std::string &s) {
   if (s.length() <= 1) return s;
   std::string result;
   result.reserve(s.size());
@@ -446,6 +449,8 @@ static std::string SnakeToSnake2(const std::string &s) {
 
   return result;
 }
+
+} // namespace
 
 std::string ConvertCase(const std::string &input, Case output_case,
                         Case input_case) {

--- a/tests/cpp17/test_cpp17.cpp
+++ b/tests/cpp17/test_cpp17.cpp
@@ -47,6 +47,7 @@ using ::cpp17::MyGame::Example::Vec3;
 /*******************************************************************************
 ** Build some FB objects.
 *******************************************************************************/
+namespace {
 const Monster *BuildMonster(flatbuffers::FlatBufferBuilder &fbb) {
   using ::cpp17::MyGame::Example::Color;
   using ::cpp17::MyGame::Example::MonsterBuilder;
@@ -250,6 +251,7 @@ int FlatBufferCpp17Tests() {
   StringifyAnyFlatbuffersTypeTest();
   return 0;
 }
+} // namespace
 
 int main(int /*argc*/, const char * /*argv*/[]) {
   InitTestEngine();

--- a/tests/fuzzer/test_init.h
+++ b/tests/fuzzer/test_init.h
@@ -11,7 +11,7 @@ struct OneTimeTestInit {
   // This hook terminate program both in Debug and Release.
   static bool TestFailListener(const char *expval, const char *val,
                                const char *exp, const char *file, int line,
-                               const char *func = 0) {
+                               const char *func = nullptr) {
     (void)expval;
     (void)val;
     (void)exp;

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -42,6 +42,10 @@
 #include "native_type_test_generated.h"
 #include "test_assert.h"
 
+void FlatBufferBuilderTest();
+
+namespace {
+
 // clang-format off
 // Check that char* and uint8_t* are interoperable types.
 // The reinterpret_cast<> between the pointers are used to simplify data loading.
@@ -62,8 +66,6 @@ static const auto infinity_f = std::numeric_limits<float>::infinity();
 static const auto infinity_d = std::numeric_limits<double>::infinity();
 
 using namespace MyGame::Example;
-
-void FlatBufferBuilderTest();
 
 // Include simple random number generator to ensure results will be the
 // same cross platform.
@@ -776,19 +778,19 @@ template<typename T, typename U, U qnan_base> bool is_quiet_nan_impl(T v) {
   return ((b & qnan_base) == qnan_base);
 }
 #  if defined(__mips__) || defined(__hppa__)
-static bool is_quiet_nan(float v) {
+bool is_quiet_nan(float v) {
   return is_quiet_nan_impl<float, uint32_t, 0x7FC00000u>(v) ||
          is_quiet_nan_impl<float, uint32_t, 0x7FBFFFFFu>(v);
 }
-static bool is_quiet_nan(double v) {
+bool is_quiet_nan(double v) {
   return is_quiet_nan_impl<double, uint64_t, 0x7FF8000000000000ul>(v) ||
          is_quiet_nan_impl<double, uint64_t, 0x7FF7FFFFFFFFFFFFu>(v);
 }
 #  else
-static bool is_quiet_nan(float v) {
+bool is_quiet_nan(float v) {
   return is_quiet_nan_impl<float, uint32_t, 0x7FC00000u>(v);
 }
-static bool is_quiet_nan(double v) {
+bool is_quiet_nan(double v) {
   return is_quiet_nan_impl<double, uint64_t, 0x7FF8000000000000ul>(v);
 }
 #  endif
@@ -4722,6 +4724,7 @@ int FlatBufferTests() {
   ErrorTest();
   ValueTest();
   EnumValueTest();
+  NestedListTest();
   EnumStringsTest();
   EnumNamesTest();
   EnumOutOfRangeTest();
@@ -4775,6 +4778,7 @@ int FlatBufferTests() {
   VectorSpanTest();
   return 0;
 }
+} // namespace
 
 int main(int argc, const char *argv[]) {
   for (int argi = 1; argi < argc; argi++) {

--- a/tests/test_builder.cpp
+++ b/tests/test_builder.cpp
@@ -117,6 +117,9 @@ bool release_n_verify(flatbuffers::FlatBufferBuilder &fbb,
   return verify(buf, expected_name, color);
 }
 
+// forward-declared in test.cpp
+void FlatBufferBuilderTest();
+
 void FlatBufferBuilderTest() {
   using flatbuffers::FlatBufferBuilder;
 
@@ -137,6 +140,9 @@ void FlatBufferBuilderTest() {
   BuilderReuseTests<GrpcLikeMessageBuilder, GrpcLikeMessageBuilder>::run_tests(
       TestSelector(tests, tests + 4));
 }
+
+// forward-declared in test_builder.h
+void CheckTestGeneratedIsValid(const MyGame::Example::Color&);
 
 // Link-time check using pointer type.
 void CheckTestGeneratedIsValid(const MyGame::Example::Color &) {}


### PR DESCRIPTION
For resolving bug #7200
not sure how I'm supposed to link this to the bug more directly, is that correct?

Added:
-Wmissing-declarations
-Wzero-as-null-pointer-constant

Added a lot of 'static' declarations in front of functions,
to satisfy -Wmissing-declarations

Adjusted the CPP code generator to output nullptr where appropriate,
to satisfy -Wzero-as-null-pointer-constant

-------

Note that I did NOT run `sh scripts/clang-format-git.sh`
as that introduced changes not relevant to this PR.

Also note that I haven't tested on any compilers except GCC 9.4.0

And I'm not sure if I've put the new warning flags in the correct place in CMakeLists.txt
I am not sure, but I think -Wzero-as-null-pointer-constant was only added in more modern GCC compilers, not sure what version, but this is why I put it in the > 7.0 section.