### PR TITLE
[C++] generate sorted #include directives

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -236,7 +236,7 @@ class CppGenerator : public BaseGenerator {
       if (it->second.empty()) continue;
       include_files.push_back(it->second);
     }
-    std::sort(include_files.begin(), include_files.end());
+    std::stable_sort(include_files.begin(), include_files.end());
 
     for (auto it = include_files.begin(); it != include_files.end(); ++it) {
       auto noext = flatbuffers::StripExtension(*it);

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -229,10 +229,17 @@ class CppGenerator : public BaseGenerator {
         num_includes++;
       }
     }
+
+    std::vector<std::string> include_files;
     for (auto it = parser_.included_files_.begin();
          it != parser_.included_files_.end(); ++it) {
       if (it->second.empty()) continue;
-      auto noext = flatbuffers::StripExtension(it->second);
+      include_files.push_back(it->second);
+    }
+    std::sort(include_files.begin(), include_files.end());
+
+    for (auto it = include_files.begin(); it != include_files.end(); ++it) {
+      auto noext = flatbuffers::StripExtension(*it);
       auto basename = flatbuffers::StripPath(noext);
       auto includeName =
           GeneratedFileName(opts_.include_prefix,


### PR DESCRIPTION
Lets flatc generate the #include directives from schema-includes in a sorted order.

Currently the order of the include directives changes even after pure whitespace changes in the schema files, which makes comparing the generated headers unnecessarily complicated. We store the generated header files in a source control repository, so that we can see the impact of schema changes, flatc options, flatc updates, but often times many header files changed and the only change is the include order.

Sorting the include directives would lead to less header file changes, but should not have a negative effect, because the order of include directives should be irrelevant.