### PR TITLE
[C++] stl_emulation span::count_ is not const anymore (#7226)

### DIFF
--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -466,7 +466,7 @@ class span FLATBUFFERS_FINAL_CLASS {
  private:
   // This is a naive implementation with 'count_' member even if (Extent != dynamic_extent).
   pointer const data_;
-  const size_type count_;
+  size_type count_;
 };
 #endif  // defined(FLATBUFFERS_USE_STD_SPAN)
 


### PR DESCRIPTION
In C++ we cannot have both assignment operator and const member.
Since span::operator= is defined, span::count_ constness must be removed.

This fixes a build issue with C++ IAR compiler 
