### PR TITLE
Make Java namespaces keep case by default

### DIFF
--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -36,7 +36,7 @@ Namer::Config JavaDefaultConfig() {
     /*variants=*/Case::kKeep,
     /*enum_variant_seperator=*/".",
     /*escape_keywords=*/Namer::Config::Escape::AfterConvertingCase,
-    /*namespaces=*/Case::kUpperCamel,
+    /*namespaces=*/Case::kKeep,
     /*namespace_seperator=*/".",
     /*object_prefix=*/"",
     /*object_suffix=*/"T",


### PR DESCRIPTION
@dbaileychess 