### PR TITLE
[optimization] Keep the underlying storage capacity when clearing the FlatBufferBuilder 

### DIFF
--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -127,8 +127,8 @@ public struct FlatBufferBuilder {
   mutating public func clear() {
     _minAlignment = 0
     isNested = false
-    stringOffsetMap = [:]
-    _vtables = []
+    stringOffsetMap.removeAll(keepingCapacity: true)
+    _vtables.removeAll(keepingCapacity: true)
     _vtableStorage.clear()
     _bb.clear()
   }


### PR DESCRIPTION
Hi,

Just tried a short performance benchmark of the Swift implementation and analysed it and could see a simple performance optimisation opportunity in FlatBufferBuilder clearing by simply retaining the underlying buffer.

Have not tried it extensively on many different workloads, but seems it is a reasonable change - please see minimal diff.

Actual performance numbers for my test as reference of encoding 10M smallish messages on my laptop:

C++ 71 ns / message
Swift 173 ns / message

Swift with this patch - retained underlying storage 107 ns / message

We've signed the CLA also.