### PR TITLE
Specialize CreateVector with std::initializer_list

### DIFF
--- a/include/flatbuffers/flatbuffer_builder.h
+++ b/include/flatbuffers/flatbuffer_builder.h
@@ -18,6 +18,7 @@
 #define FLATBUFFERS_FLATBUFFER_BUILDER_H_
 
 #include <functional>
+#include <initializer_list>
 
 #include "flatbuffers/allocator.h"
 #include "flatbuffers/array.h"
@@ -653,6 +654,16 @@ class FlatBufferBuilder {
   /// where the vector is stored.
   template<typename T, class C> Offset<Vector<T>> CreateVector(const C &array) {
     return CreateVector(array.data(), array.size());
+  }
+
+  /// @brief Serialize an initializer list into a FlatBuffer `vector`.
+  /// @tparam T The data type of the initializer list elements.
+  /// @param[in] v The value of the initializer list.
+  /// @return Returns a typed `Offset` into the serialized data indicating
+  /// where the vector is stored.
+  template<typename T>
+  Offset<Vector<T>> CreateVector(std::initializer_list<T> v) {
+    return CreateVector(v.begin(), v.size());
   }
 
   template<typename T>

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <stdint.h>
+
 #include <cmath>
 #include <string>
 
@@ -86,8 +88,9 @@ flatbuffers::DetachedBuffer CreateFlatBufferTest(std::string &buffer) {
 
   auto name = builder.CreateString("MyMonster");
 
-  unsigned char inv_data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-  auto inventory = builder.CreateVector(inv_data, 10);
+  // Use the initializer_list specialization of CreateVector.
+  auto inventory =
+      builder.CreateVector<uint8_t>({ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
 
   // Alternatively, create the vector first, and fill in data later:
   // unsigned char *inv_buf = nullptr;


### PR DESCRIPTION
This adds a specialization of `CreateVector` to take in an std::initializer_list. This was needed since in C+11 the `.data()` member function is not present: https://en.cppreference.com/w/cpp/utility/initializer_list