### PR TITLE
Swift update performance benchmark infrastructure

### DIFF
--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -127,8 +127,8 @@ public struct FlatBufferBuilder {
   mutating public func clear() {
     _minAlignment = 0
     isNested = false
-    stringOffsetMap = [:]
-    _vtables = []
+    stringOffsetMap.removeAll(keepingCapacity: true)
+    _vtables.removeAll(keepingCapacity: true)
     _vtableStorage.clear()
     _bb.clear()
   }

--- a/tests/FlatBuffers.Benchmarks.swift/Package.swift
+++ b/tests/FlatBuffers.Benchmarks.swift/Package.swift
@@ -24,9 +24,11 @@ let package = Package(
   ],
   dependencies: [
     .package(path: "../../swift"),
+    .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
   ],
   targets: [
     .target(
       name: "FlatBuffers.Benchmarks.swift",
-      dependencies: ["FlatBuffers"]),
+      dependencies: ["FlatBuffers",
+                     .product(name: "Benchmark", package: "swift-benchmark")]),
   ])


### PR DESCRIPTION
Added dependency of [Google's Swift benchmark library](https://github.com/google/swift-benchmark) to the performance benchmark to provide more consistent results (it dynamically adjusts number of iterations depending on hardware) - also simplifies the benchmark as all supporting code could be removed as its provided for free by the package.

Sample output:

```
hassila@max ~/D/G/p/f/t/FlatBuffers.Benchmarks.swift (swift-update-performance-benchmark)> swift run -c release
Building for production...
Build complete! (0.07s)
running 10Strings... done! (1586.81 ms)
running 100Strings... done! (1668.91 ms)
running FlatBufferBuilder.add... done! (2332.52 ms)
running structs... done! (2263.61 ms)

name                  time            std        iterations
-----------------------------------------------------------
10Strings             14303124.500 ns ±   4.91 %         98
100Strings            28040333.000 ns ±   3.72 %         47
FlatBufferBuilder.add 82922708.000 ns ±   0.38 %         17
structs               80600250.000 ns ±   0.74 %         17
```

We also gain some tuning options:
```
hassila@max ~/D/G/p/f/t/FlatBuffers.Benchmarks.swift (swift-update-performance-benchmark)> .build/debug/FlatBuffers.Benchmarks.swift --help
USAGE: benchmark-command [--allow-debug-build] [--filter <filter>] [--filter-not <filter-not>] [--iterations <iterations>] [--warmup-iterations <warmup-iterations>] [--min-time <min-time>] [--max-iterations <max-iterations>] [--time-unit <time-unit>] [--inverse-time-unit <inverse-time-unit>] [--columns <columns>] [--format <format>] [--quiet]

OPTIONS:
  --allow-debug-build     Overrides check to verify optimized build.
  --filter <filter>       Run only benchmarks whose names match the regular expression.
  --filter-not <filter-not>
                          Exclude benchmarks whose names match the regular expression.
  --iterations <iterations>
                          Number of iterations to run.
  --warmup-iterations <warmup-iterations>
                          Number of warm-up iterations to run.
  --min-time <min-time>   Minimal time to run when automatically detecting number iterations.
  --max-iterations <max-iterations>
                          Maximum number of iterations to run when automatically detecting number iterations.
  --time-unit <time-unit> Time unit used to report the timing results.
  --inverse-time-unit <inverse-time-unit>
                          Inverse time unit used to report throughput results.
  --columns <columns>     Comma-separated list of column names to show.
  --format <format>       Output format (valid values are: json, csv, console, none).
  --quiet                 Only print final benchmark results.
  -h, --help              Show help information.
```

But also most importantly gives support for simple A/B performance comparisons:
```
hassila@max ~/D/G/p/f/t/FlatBuffers.Benchmarks.swift (swift-update-performance-benchmark) [64]> swift run -c release FlatBuffers.Benchmarks.swift --format json > a.json
Building for production...
Build complete! (0.07s)
running 10Strings... done! (1470.36 ms)
running 100Strings... done! (1706.32 ms)
running FlatBufferBuilder.add... done! (2325.53 ms)
running structs... done! (2249.58 ms)
hassila@max ~/D/G/p/f/t/FlatBuffers.Benchmarks.swift (swift-update-performance-benchmark)> swift run -c release FlatBuffers.Benchmarks.swift --format json > b.json
Building for production...
Build complete! (0.07s)
running 10Strings... done! (1518.49 ms)
running 100Strings... done! (1708.88 ms)
running FlatBufferBuilder.add... done! (2270.06 ms)
running structs... done! (2339.86 ms)
hassila@max ~/D/G/p/f/t/FlatBuffers.Benchmarks.swift (swift-update-performance-benchmark)> python3 ./compare.py a.json b.json
benchmark             column               a           b       %
----------------------------------------------------------------
10Strings             time       14333792.00 14212333.00    0.85
10Strings             std               4.74        3.67   22.48
10Strings             iterations       89.00       94.00   -5.62
100Strings            time       28220979.00 28556167.00   -1.19
100Strings            std               4.58        4.33    5.48
100Strings            iterations       48.00       48.00    0.00
FlatBufferBuilder.add time       82689750.00 82971666.50   -0.34
FlatBufferBuilder.add std               0.63        1.57 -150.56
FlatBufferBuilder.add iterations       17.00       16.00    5.88
structs               time       80078416.00 82826750.00   -3.43
structs               std               0.36        2.66 -629.54
structs               iterations       17.00       17.00    0.00
----------------------------------------------------------------
                      time                                 -1.02
                      std                                 -91.30
                      iterations                            0.15
```
(compare.py is here: https://github.com/google/swift-benchmark/blob/main/Scripts/compare.py )
 