### PR TITLE
Handle +/-inf in protos

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -492,8 +492,8 @@ CheckedError Parser::Next() {
         if (has_sign) {
           // Check for +/-inf which is considered a float constant.
           if (strncmp(cursor_, "inf", 3) == 0 &&
-              !IsIdentifierStart(cursor_[4])) {
-            attribute_.append(cursor_ - 1, cursor_ + 3);
+              !(IsIdentifierStart(cursor_[4]) || is_digit(cursor_[4]))) {
+            attribute_.assign(cursor_ - 1, cursor_ + 3);
             token_ = kTokenFloatConstant;
             cursor_ += 3;
             return NoError();
@@ -2189,8 +2189,12 @@ template<typename T> void EnumDef::ChangeEnumValue(EnumVal *ev, T new_value) {
 }
 
 namespace EnumHelper {
-template<BaseType E> struct EnumValType { typedef int64_t type; };
-template<> struct EnumValType<BASE_TYPE_ULONG> { typedef uint64_t type; };
+template<BaseType E> struct EnumValType {
+  typedef int64_t type;
+};
+template<> struct EnumValType<BASE_TYPE_ULONG> {
+  typedef uint64_t type;
+};
 }  // namespace EnumHelper
 
 struct EnumValBuilder {

--- a/tests/prototest/test.golden
+++ b/tests/prototest/test.golden
@@ -51,6 +51,9 @@ table ProtoMessage {
   /// doc comment for r.
   r:proto.test.ProtoMessage_.Anonymous0;
   outer_enum:proto.test.ProtoEnum;
+  u:float = +inf;
+  v:float = +inf;
+  w:float = -inf;
 }
 
 namespace proto.test.ProtoMessage_;

--- a/tests/prototest/test.proto
+++ b/tests/prototest/test.proto
@@ -67,4 +67,8 @@ message ProtoMessage {
     OtherMessage t = 18;
   }
   optional ProtoEnum outer_enum = 33;
+  // Tests that `inf` and `+/-inf` can be parsed in proto options.
+  optional float u = 34 [default = inf];
+  optional float v = 35 [default = +inf];
+  optional float w = 36 [default = -inf];
 }

--- a/tests/prototest/test_include.golden
+++ b/tests/prototest/test_include.golden
@@ -49,6 +49,9 @@ table ProtoMessage {
   /// doc comment for r.
   r:proto.test.ProtoMessage_.Anonymous0;
   outer_enum:proto.test.ProtoEnum;
+  u:float = +inf;
+  v:float = +inf;
+  w:float = -inf;
 }
 
 namespace proto.test.ProtoMessage_;

--- a/tests/prototest/test_suffix.golden
+++ b/tests/prototest/test_suffix.golden
@@ -51,6 +51,9 @@ table ProtoMessage {
   /// doc comment for r.
   r:proto.test.test_namespace_suffix.ProtoMessage_.Anonymous0;
   outer_enum:proto.test.test_namespace_suffix.ProtoEnum;
+  u:float = +inf;
+  v:float = +inf;
+  w:float = -inf;
 }
 
 namespace proto.test.test_namespace_suffix.ProtoMessage_;

--- a/tests/prototest/test_union.golden
+++ b/tests/prototest/test_union.golden
@@ -61,6 +61,9 @@ table ProtoMessage {
   /// doc comment for r.
   r:proto.test.ProtoMessage_.RUnion;
   outer_enum:proto.test.ProtoEnum;
+  u:float = +inf;
+  v:float = +inf;
+  w:float = -inf;
 }
 
 namespace proto.test.ProtoMessage_;

--- a/tests/prototest/test_union_include.golden
+++ b/tests/prototest/test_union_include.golden
@@ -59,6 +59,9 @@ table ProtoMessage {
   /// doc comment for r.
   r:proto.test.ProtoMessage_.RUnion;
   outer_enum:proto.test.ProtoEnum;
+  u:float = +inf;
+  v:float = +inf;
+  w:float = -inf;
 }
 
 namespace proto.test.ProtoMessage_;

--- a/tests/prototest/test_union_suffix.golden
+++ b/tests/prototest/test_union_suffix.golden
@@ -61,6 +61,9 @@ table ProtoMessage {
   /// doc comment for r.
   r:proto.test.test_namespace_suffix.ProtoMessage_.RUnion;
   outer_enum:proto.test.test_namespace_suffix.ProtoEnum;
+  u:float = +inf;
+  v:float = +inf;
+  w:float = -inf;
 }
 
 namespace proto.test.test_namespace_suffix.ProtoMessage_;


### PR DESCRIPTION
Protos [allow `inf`, `+inf`, and `-inf`](https://developers.google.com/protocol-buffers/docs/reference/proto2-spec#floating-point-literals) for specifying float constants. The fbs parser was not handling this correctly.