### PR TITLE
Rust: fix a name conflict when building with "no_std" feature

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatbuffers"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2018"
 authors = ["Robert Winslow <hello@rwinslow.com>", "FlatBuffers Maintainers"]
 license = "Apache-2.0"

--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -6,7 +6,8 @@ use crate::follow::Follow;
 use crate::{ForwardsUOffset, SOffsetT, SkipSizePrefix, UOffsetT, VOffsetT, Vector, SIZE_UOFFSET};
 
 #[cfg(feature="no_std")]
-extern crate thiserror_core2 as thiserror;
+use thiserror_core2::Error;
+#[cfg(not(feature="no_std"))]
 use thiserror::Error;
 
 /// Traces the location of data errors. Not populated for Dos detecting errors.


### PR DESCRIPTION
`thiserror` was ambiguous when `no_std` is enabled, leading to a build failure. This PR resolves the ambiguity by gating the `thiserror` v1 import.
