### PR TITLE
[TS] fix incorrect reverse order when writting array of structs

### DIFF
--- a/tests/JavaScriptTest.js
+++ b/tests/JavaScriptTest.js
@@ -4,7 +4,7 @@ import fs from 'fs'
 import * as flatbuffers from 'flatbuffers'
 
 import { Monster, MonsterT } from './my-game/example/monster'
-import { Test } from './my-game/example/test'
+import { Test, TestT } from './my-game/example/test'
 import { Stat } from './my-game/example/stat'
 import { Vec3 } from './my-game/example/vec3'
 import { Color } from './my-game/example/color';
@@ -47,6 +47,7 @@ function main() {
   fuzzTest1();
   testNullStrings();
   testSharedStrings();
+  testVectorOfStructs();
 
   console.log('FlatBuffers test: completed successfully');
 }
@@ -456,6 +457,24 @@ function testNullStrings() {
   assert.strictEqual(builder.createSharedString(null), 0);
   assert.strictEqual(builder.createString(undefined), 0);
   assert.strictEqual(builder.createSharedString(undefined), 0);
+}
+
+function testVectorOfStructs() {
+  let monster = new MonsterT();
+  monster.name = 'testVectorOfStructs';
+  monster.test4 = [
+    new TestT(1, 2),
+    new TestT(3, 4)
+  ];
+
+  let builder = new flatbuffers.Builder();
+  builder.finish(monster.pack(builder));
+
+  let decodedMonster = Monster.getRootAsMonster(builder.dataBuffer()).unpack();
+  assert.strictEqual(decodedMonster.test4[0].a, 1);
+  assert.strictEqual(decodedMonster.test4[0].b, 2);
+  assert.strictEqual(decodedMonster.test4[1].a, 3);
+  assert.strictEqual(decodedMonster.test4[1].b, 4);
 }
 
 main();

--- a/ts/builder.ts
+++ b/ts/builder.ts
@@ -617,7 +617,7 @@ export class Builder {
   
     createStructOffsetList(list: string[] | any[], startFunc: (builder: Builder, length: number) => void): Offset {
       startFunc(this, list.length);
-      this.createObjectOffsetList(list);
+      this.createObjectOffsetList(list.slice().reverse());
       return this.endVector();
     }
   }


### PR DESCRIPTION
When writting array of structs to flatbuffer in TS, structs will be written in reverse order.

Example code:
```
struct Vec3 {
    x: float;
    y: float;
    z: float;
}

table Pos {
    vecs: [Vec3];
}
```
```ts
import { Pos, PosT } from './pos'
import { Vec3T } from './vec3'
import * as flatbuffers from 'flatbuffers'

let origin = new PosT();
origin.vecs = [
    new Vec3T(1, 2, 3),
    new Vec3T(4, 5, 6)
];

console.log('origin:', origin);

let builder = new flatbuffers.Builder();
builder.finish(origin.pack(builder));

let decoded = Pos.getRootAsPos(builder.dataBuffer()).unpack();
console.log('decoded:', decoded);
```

Will output:

```
origin: PosT {
  vecs: [ Vec3T { x: 1, y: 2, z: 3 }, Vec3T { x: 4, y: 5, z: 6 } ]
}
decoded: PosT {
  vecs: [ Vec3T { x: 4, y: 5, z: 6 }, Vec3T { x: 1, y: 2, z: 3 } ]
}
```

Because `createObjectOffsetList` writes data in reverse order, and many generated codes depend on it. So we need to reverse `createStructOffsetList`’s input to make the structs order correct.