### PR TITLE
[swift] Make swift module public

### DIFF
--- a/swift/BUILD.bazel
+++ b/swift/BUILD.bazel
@@ -4,4 +4,5 @@ swift_library(
     name = "swift",
     srcs = glob(["Sources/FlatBuffers/*.swift"]),
     module_name = "FlatBuffers",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Previously this could not be depended on directly from other projects.