### PR TITLE
[C#] Add allocation-free GetByKey implementation

### DIFF
--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -190,11 +190,10 @@ namespace FlatBuffers
         }
 
         // Compare string from the ByteBuffer with the string object
-        public static int CompareStrings(int offset_1, byte[] key, ByteBuffer bb)
+        public static int CompareStrings(int offset_1, byte[] key, int len_2, ByteBuffer bb)
         {
             offset_1 += bb.GetInt(offset_1);
             var len_1 = bb.GetInt(offset_1);
-            var len_2 = key.Length;
             var startPos_1 = offset_1 + sizeof(int);
             var len = Math.Min(len_1, len_2);
             for (int i = 0; i < len; i++) {

--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -614,7 +614,7 @@ class CSharpGenerator : public BaseGenerator {
       key_getter += "int comp = Table.";
       key_getter += "CompareStrings(";
       key_getter += GenOffsetGetter(key_field);
-      key_getter += ", byteKey, bb);\n";
+      key_getter += ", byteKey, keyLen, bb);\n";
     } else {
       auto get_val = GenGetterForLookupByKey(key_field, "bb");
       key_getter += "int comp = " + get_val + ".CompareTo(key);\n";
@@ -934,10 +934,15 @@ class CSharpGenerator : public BaseGenerator {
               auto qualified_name = NamespacedName(sd);
               code += "  public " + qualified_name + "? ";
               code += Name(field) + "ByKey(";
-              code += GenTypeGet(key_field.value.type) + " key)";
+              code += GenTypeGet(key_field.value.type) + " key";
+              if (IsString(key_field.value.type)) {
+                code += ", byte[] tmpBuffer = null";
+              }
+              code += ")";
               code += offset_prefix;
               code += qualified_name + ".__lookup_by_key(";
               code += "__p.__vector(o), key, ";
+              if (IsString(key_field.value.type)) { code += "tmpBuffer, "; }
               code += "__p.bb) : null; ";
               code += "}\n";
               break;
@@ -1332,10 +1337,19 @@ class CSharpGenerator : public BaseGenerator {
       code += " __lookup_by_key(";
       code += "int vectorLocation, ";
       code += GenTypeGet(key_field->value.type);
-      code += " key, ByteBuffer bb) {\n";
+      code += " key, ";
+      if (IsString(key_field->value.type)) { code += "byte[] byteKey, "; }
+      code += "ByteBuffer bb) {\n";
       if (IsString(key_field->value.type)) {
-        code += "    byte[] byteKey = ";
+        code += "    int keyLen;\n";
+        code += "    if (byteKey == null) {\n";
+        code += "        byteKey = ";
         code += "System.Text.Encoding.UTF8.GetBytes(key);\n";
+        code += "        keyLen = byteKey.Length;\n";
+        code += "    } else {\n";
+        code += "        keyLen = System.Text.Encoding.UTF8.GetBytes(";
+        code += "key, 0, key.Length, byteKey, 0);\n";
+        code += "    }\n";
       }
       code += "    int span = ";
       code += "bb.GetInt(vectorLocation - 4);\n";

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -57,7 +57,7 @@ public struct Monster : IFlatbufferObject
   /// multiline too
   public MyGame.Example.Monster? Testarrayoftables(int j) { int o = __p.__offset(26); return o != 0 ? (MyGame.Example.Monster?)(new MyGame.Example.Monster()).__assign(__p.__indirect(__p.__vector(o) + j * 4), __p.bb) : null; }
   public int TestarrayoftablesLength { get { int o = __p.__offset(26); return o != 0 ? __p.__vector_len(o) : 0; } }
-  public MyGame.Example.Monster? TestarrayoftablesByKey(string key) { int o = __p.__offset(26); return o != 0 ? MyGame.Example.Monster.__lookup_by_key(__p.__vector(o), key, __p.bb) : null; }
+  public MyGame.Example.Monster? TestarrayoftablesByKey(string key, byte[] tmpBuffer = null) { int o = __p.__offset(26); return o != 0 ? MyGame.Example.Monster.__lookup_by_key(__p.__vector(o), key, tmpBuffer, __p.bb) : null; }
   public MyGame.Example.Monster? Enemy { get { int o = __p.__offset(28); return o != 0 ? (MyGame.Example.Monster?)(new MyGame.Example.Monster()).__assign(__p.__indirect(o + __p.bb_pos), __p.bb) : null; } }
   public byte Testnestedflatbuffer(int j) { int o = __p.__offset(30); return o != 0 ? __p.bb.Get(__p.__vector(o) + j * 1) : (byte)0; }
   public int TestnestedflatbufferLength { get { int o = __p.__offset(30); return o != 0 ? __p.__vector_len(o) : 0; } }
@@ -482,14 +482,20 @@ public struct Monster : IFlatbufferObject
     return builder.CreateVectorOfTables(offsets);
   }
 
-  public static Monster? __lookup_by_key(int vectorLocation, string key, ByteBuffer bb) {
-    byte[] byteKey = System.Text.Encoding.UTF8.GetBytes(key);
+  public static Monster? __lookup_by_key(int vectorLocation, string key, byte[] byteKey, ByteBuffer bb) {
+    int keyLen;
+    if (byteKey == null) {
+        byteKey = System.Text.Encoding.UTF8.GetBytes(key);
+        keyLen = byteKey.Length;
+    } else {
+        keyLen = System.Text.Encoding.UTF8.GetBytes(key, 0, key.Length, byteKey, 0);
+    }
     int span = bb.GetInt(vectorLocation - 4);
     int start = 0;
     while (span != 0) {
       int middle = span / 2;
       int tableOffset = Table.__indirect(vectorLocation + 4 * (start + middle), bb);
-      int comp = Table.CompareStrings(Table.__offset(10, bb.Length - tableOffset, bb), byteKey, bb);
+      int comp = Table.CompareStrings(Table.__offset(10, bb.Length - tableOffset, bb), byteKey, keyLen, bb);
       if (comp > 0) {
         span = middle;
       } else if (comp < 0) {


### PR DESCRIPTION
This is a fix for https://github.com/google/flatbuffers/issues/7288

The current C# implementation of `GetByKey()` had no option for avoiding a `byte[]` allocation from `UTF8.GetBytes(string)`.

This adds an optional `byte[]` parameter that will be used as the buffer for UTF8 encoding the string if passed. The optionality of the parameter preserves backwards compatibility with existing code, but gives users the option to pass in their own scratch buffer and avoid the allocation. There is no safety checking to make sure the `byte[]` is long enough. If an array that is too small is passed, you'll get an exception thrown:
```
ArgumentException: The output byte buffer is too small to contain the encoded data, encoding 'Unicode (UTF-8)' fallback 'System.Text.EncoderReplacementFallback'.
```

This only affects tables where the key is a `String`.