### PR TITLE
[C#] Add allocation-free GetByKey implementation

### DIFF
--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -190,19 +190,18 @@ namespace FlatBuffers
         }
 
         // Compare string from the ByteBuffer with the string object
-        public static int CompareStrings(int offset_1, byte[] key, ByteBuffer bb)
+        public static int CompareStrings(int offset_1, byte[] key, int key_length, ByteBuffer bb)
         {
             offset_1 += bb.GetInt(offset_1);
             var len_1 = bb.GetInt(offset_1);
-            var len_2 = key.Length;
             var startPos_1 = offset_1 + sizeof(int);
-            var len = Math.Min(len_1, len_2);
+            var len = Math.Min(len_1, key_length);
             for (int i = 0; i < len; i++) {
                 byte b = bb.Get(i + startPos_1);
                 if (b != key[i])
                     return b - key[i];
             }
-            return len_1 - len_2;
+            return len_1 - key_length;
         }
     }
 }

--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -57,7 +57,7 @@ public struct Monster : IFlatbufferObject
   /// multiline too
   public MyGame.Example.Monster? Testarrayoftables(int j) { int o = __p.__offset(26); return o != 0 ? (MyGame.Example.Monster?)(new MyGame.Example.Monster()).__assign(__p.__indirect(__p.__vector(o) + j * 4), __p.bb) : null; }
   public int TestarrayoftablesLength { get { int o = __p.__offset(26); return o != 0 ? __p.__vector_len(o) : 0; } }
-  public MyGame.Example.Monster? TestarrayoftablesByKey(string key) { int o = __p.__offset(26); return o != 0 ? MyGame.Example.Monster.__lookup_by_key(__p.__vector(o), key, __p.bb) : null; }
+  public MyGame.Example.Monster? TestarrayoftablesByKey(string key, byte[] tmpBuffer = null) { int o = __p.__offset(26); return o != 0 ? MyGame.Example.Monster.__lookup_by_key(__p.__vector(o), key, tmpBuffer, __p.bb) : null; }
   public MyGame.Example.Monster? Enemy { get { int o = __p.__offset(28); return o != 0 ? (MyGame.Example.Monster?)(new MyGame.Example.Monster()).__assign(__p.__indirect(o + __p.bb_pos), __p.bb) : null; } }
   public byte Testnestedflatbuffer(int j) { int o = __p.__offset(30); return o != 0 ? __p.bb.Get(__p.__vector(o) + j * 1) : (byte)0; }
   public int TestnestedflatbufferLength { get { int o = __p.__offset(30); return o != 0 ? __p.__vector_len(o) : 0; } }
@@ -482,14 +482,20 @@ public struct Monster : IFlatbufferObject
     return builder.CreateVectorOfTables(offsets);
   }
 
-  public static Monster? __lookup_by_key(int vectorLocation, string key, ByteBuffer bb) {
-    byte[] byteKey = System.Text.Encoding.UTF8.GetBytes(key);
+  public static Monster? __lookup_by_key(int vectorLocation, string key, byte[] byteKey, ByteBuffer bb) {
+    int keyLen;
+    if (byteKey == null) {
+        byteKey = System.Text.Encoding.UTF8.GetBytes(key);
+        keyLen = byteKey.Length;
+    } else {
+        keyLen = System.Text.Encoding.UTF8.GetBytes(key, 0, key.Length, byteKey, 0);
+    }
     int span = bb.GetInt(vectorLocation - 4);
     int start = 0;
     while (span != 0) {
       int middle = span / 2;
       int tableOffset = Table.__indirect(vectorLocation + 4 * (start + middle), bb);
-      int comp = Table.CompareStrings(Table.__offset(10, bb.Length - tableOffset, bb), byteKey, bb);
+      int comp = Table.CompareStrings(Table.__offset(10, bb.Length - tableOffset, bb), byteKey, keyLen, bb);
       if (comp > 0) {
         span = middle;
       } else if (comp < 0) {


### PR DESCRIPTION
This is a fix for https://github.com/google/flatbuffers/issues/7288

The current C# implementation of `GetByKey()` had no option for avoiding a `byte[]` allocation from `UTF8.GetBytes(string)`.

This adds an optional `byte[]` parameter that will be used as the buffer for UTF8 encoding the string if passed. The optionality of the parameter preserves backwards compatibility with existing code, but gives users the option to pass in their own scratch buffer and avoid the allocation. There is no safety checking to make sure the `byte[]` is long enough. If an array that is too small is passed, you'll get an exception thrown:
```
ArgumentException: The output byte buffer is too small to contain the encoded data, encoding 'Unicode (UTF-8)' fallback 'System.Text.EncoderReplacementFallback'.
```

This only affects tables where the key is a `String`.