### PR TITLE
[vector] Allow to iterate with mutables

### DIFF
--- a/include/flatbuffers/array.h
+++ b/include/flatbuffers/array.h
@@ -35,7 +35,7 @@ template<typename T, uint16_t length> class Array {
  public:
   typedef uint16_t size_type;
   typedef typename IndirectHelper<IndirectHelperType>::return_type return_type;
-  typedef VectorIterator<T, return_type> const_iterator;
+  typedef VectorConstIterator<T, return_type> const_iterator;
   typedef VectorReverseIterator<const_iterator> const_reverse_iterator;
 
   // If T is a LE-scalar or a struct (!scalar_tag::value).

--- a/include/flatbuffers/buffer.h
+++ b/include/flatbuffers/buffer.h
@@ -76,6 +76,9 @@ template<typename T> struct IndirectHelper {
   static return_type Read(const uint8_t *p, uoffset_t i) {
     return EndianScalar((reinterpret_cast<const T *>(p))[i]);
   }
+  static return_type Read(uint8_t *p, uoffset_t i) {
+    return Read(const_cast<const uint8_t *>(p), i);
+  }
 };
 template<typename T> struct IndirectHelper<Offset<T>> {
   typedef const T *return_type;
@@ -85,13 +88,20 @@ template<typename T> struct IndirectHelper<Offset<T>> {
     p += i * sizeof(uoffset_t);
     return reinterpret_cast<return_type>(p + ReadScalar<uoffset_t>(p));
   }
+  static mutable_return_type Read(uint8_t *p, uoffset_t i) {
+    p += i * sizeof(uoffset_t);
+    return reinterpret_cast<mutable_return_type>(p + ReadScalar<uoffset_t>(p));
+  }
 };
 template<typename T> struct IndirectHelper<const T *> {
   typedef const T *return_type;
   typedef T *mutable_return_type;
   static const size_t element_stride = sizeof(T);
   static return_type Read(const uint8_t *p, uoffset_t i) {
-    return reinterpret_cast<const T *>(p + i * sizeof(T));
+    return reinterpret_cast<return_type>(p + i * sizeof(T));
+  }
+  static mutable_return_type Read(uint8_t *p, uoffset_t i) {
+    return reinterpret_cast<mutable_return_type>(p + i * sizeof(T));
   }
 };
 

--- a/include/flatbuffers/vector.h
+++ b/include/flatbuffers/vector.h
@@ -27,14 +27,15 @@ struct String;
 
 // An STL compatible iterator implementation for Vector below, effectively
 // calling Get() for every element.
-template<typename T, typename IT> struct VectorIterator {
+template<typename T, typename IT, typename Data = uint8_t *>
+struct VectorIterator {
   typedef std::random_access_iterator_tag iterator_category;
   typedef IT value_type;
   typedef ptrdiff_t difference_type;
   typedef IT *pointer;
   typedef IT &reference;
 
-  VectorIterator(const uint8_t *data, uoffset_t i)
+  VectorIterator(Data data, uoffset_t i)
       : data_(data + IndirectHelper<T>::element_stride * i) {}
   VectorIterator(const VectorIterator &other) : data_(other.data_) {}
   VectorIterator() : data_(nullptr) {}
@@ -116,8 +117,11 @@ template<typename T, typename IT> struct VectorIterator {
   }
 
  private:
-  const uint8_t *data_;
+  Data data_;
 };
+
+template<typename T, typename IT>
+using VectorConstIterator = VectorIterator<T, IT, const uint8_t *>;
 
 template<typename Iterator>
 struct VectorReverseIterator : public std::reverse_iterator<Iterator> {
@@ -145,7 +149,7 @@ template<typename T> class Vector {
  public:
   typedef VectorIterator<T, typename IndirectHelper<T>::mutable_return_type>
       iterator;
-  typedef VectorIterator<T, typename IndirectHelper<T>::return_type>
+  typedef VectorConstIterator<T, typename IndirectHelper<T>::return_type>
       const_iterator;
   typedef VectorReverseIterator<iterator> reverse_iterator;
   typedef VectorReverseIterator<const_iterator> const_reverse_iterator;


### PR DESCRIPTION
When using mutable buffers it is currently impossible to deference iterators without having a compiler error due to `struct IndirectHelper::Read` returning `return_type` instead of `mutable_return_type`:

```cpp
struct VectorIterator {
  ...
  // compiler error: failed to convert const value (IndirectHelper<T>::return_type)
  // to non const value (IndirectHelper<T>::mutable_return_type, aka IT)
  IT operator*() const { return IndirectHelper<T>::Read(data_, 0); }
  IT operator->() const { return IndirectHelper<T>::Read(data_, 0); }
  ...
};
```

The main idea behind this PR is to have an `VectorIterator` using `uint8_t *` and `VectorConstIterator` using `const uint8_t *` as data to use the correct overload of `IndirectHelper<T>::Read`

So `VectorIterator` has a new template parameter to switch from const_iterator to iterator. Side effect, as array was also using `VectorIterator` it is now using `VectorConstIterator`.

This will fix issue #4674