### PR TITLE
Remove span ConstIterator/cbegin()/cend().

### DIFF
--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -366,13 +366,9 @@ class span FLATBUFFERS_FINAL_CLASS {
 
   #if !defined(FLATBUFFERS_SPAN_MINIMAL)
     using Iterator = internal::SpanIterator<T>;
-    using ConstIterator = internal::SpanIterator<const T>;
 
     Iterator begin() const { return Iterator(data()); }
     Iterator end() const   { return Iterator(data() + size()); }
-
-    ConstIterator cbegin() const { return ConstIterator(data()); }
-    ConstIterator cend() const  { return ConstIterator(data() + size()); }
   #endif
 
   // Returns a reference to the idx-th element of the sequence.

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -3554,7 +3554,7 @@ void CreateSharedStringTest() {
   TEST_EQ((*a[6]) < (*a[5]), true);
 }
 
-#if !defined(FLATBUFFERS_SPAN_MINIMAL)
+#if !defined(FLATBUFFERS_USE_STD_SPAN) && !defined(FLATBUFFERS_SPAN_MINIMAL)
 void FlatbuffersSpanTest() {
   // Compile-time checking of non-const [] to const [] conversions.
   using flatbuffers::internal::is_span_convertable;
@@ -3941,11 +3941,11 @@ void FixedLengthArraySpanTest() {
     TEST_EQ(2, mutable_d_c.size());
     TEST_EQ(MyGame::Example::TestEnum::C, const_d_c[0]);
     TEST_EQ(MyGame::Example::TestEnum::B, const_d_c[1]);
-    TEST_ASSERT(mutable_d_c.end() == std::copy(const_d_c.cbegin(),
-                                               const_d_c.cend(),
+    TEST_ASSERT(mutable_d_c.end() == std::copy(const_d_c.begin(),
+                                               const_d_c.end(),
                                                mutable_d_c.begin()));
     TEST_ASSERT(
-        std::equal(const_d_c.cbegin(), const_d_c.cend(), mutable_d_c.cbegin()));
+        std::equal(const_d_c.begin(), const_d_c.end(), mutable_d_c.begin()));
   }
   // test little endian array of int32
 #  if FLATBUFFERS_LITTLEENDIAN
@@ -3957,11 +3957,11 @@ void FixedLengthArraySpanTest() {
     TEST_EQ(2, mutable_d_a.size());
     TEST_EQ(-1, const_d_a[0]);
     TEST_EQ(2, const_d_a[1]);
-    TEST_ASSERT(mutable_d_a.end() == std::copy(const_d_a.cbegin(),
-                                               const_d_a.cend(),
+    TEST_ASSERT(mutable_d_a.end() == std::copy(const_d_a.begin(),
+                                               const_d_a.end(),
                                                mutable_d_a.begin()));
     TEST_ASSERT(
-        std::equal(const_d_a.cbegin(), const_d_a.cend(), mutable_d_a.cbegin()));
+        std::equal(const_d_a.begin(), const_d_a.end(), mutable_d_a.begin()));
   }
 #  endif
 }


### PR DESCRIPTION
std::span lacks these; make  the flatbuffers STL emulation and tests
match.  This fixes a compile error in C++20 mode when using std::span.

Bug: chromium:1284275