### PR TITLE
[TS/Bazel] Minor improvements to typescript.bzl

### DIFF
--- a/reflection/BUILD.bazel
+++ b/reflection/BUILD.bazel
@@ -1,14 +1,5 @@
-load("//:typescript.bzl", "flatbuffer_ts_library")
-
 filegroup(
     name = "reflection_fbs_schema",
     srcs = ["reflection.fbs"],
-    visibility = ["//visibility:public"],
-)
-
-flatbuffer_ts_library(
-    name = "reflection_ts_fbs",
-    srcs = ["reflection.fbs"],
-    include_reflection = False,
     visibility = ["//visibility:public"],
 )

--- a/reflection/ts/BUILD.bazel
+++ b/reflection/ts/BUILD.bazel
@@ -1,8 +1,16 @@
 load("//:typescript.bzl", "flatbuffer_ts_library")
 
+genrule(
+    name = "copy_schema_to_folder",
+    srcs = ["//reflection:reflection_fbs_schema"],
+    outs = ["reflection.fbs"],
+    cmd = "cp $< $@",
+)
+
 flatbuffer_ts_library(
     name = "reflection_ts_fbs",
-    srcs = ["//reflection:reflection_fbs_schema"],
+    package_name = "flatbuffers_reflection",
+    srcs = [":reflection.fbs"],
     include_reflection = False,
     visibility = ["//visibility:public"],
 )

--- a/reflection/ts/BUILD.bazel
+++ b/reflection/ts/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//:typescript.bzl", "flatbuffer_ts_library")
+
+flatbuffer_ts_library(
+    name = "reflection_ts_fbs",
+    srcs = ["//reflection:reflection_fbs_schema"],
+    include_reflection = False,
+    visibility = ["//visibility:public"],
+)

--- a/typescript.bzl
+++ b/typescript.bzl
@@ -25,7 +25,9 @@ def flatbuffer_ts_library(
         flatc_args = DEFAULT_FLATC_TS_ARGS,
         visibility = None,
         restricted_to = None,
-        include_reflection = True):
+        include_reflection = True,
+        gen_reflections = False,
+        package_name = None):
     """Generates a ts_library rule for a given flatbuffer definition.
 
     Args:
@@ -47,21 +49,47 @@ def flatbuffer_ts_library(
       include_reflection: Optional, Whether to depend on the flatbuffer
         reflection library automatically. Only really relevant for the
         target that builds the reflection library itself.
+      gen_reflections: Optional, if true this will generate the flatbuffer
+        reflection binaries for the schemas.
+      package_name: Optional, Package name to use for the generated code.
     """
     srcs_lib = "%s_srcs" % (name)
-    outs = ["%s_generated.ts" % (s.replace(".fbs", "").split("/")[-1]) for s in srcs]
+    out_base = [s.replace(".fbs", "").split("/")[-1].split(":")[-1] for s in srcs]
+
+    # Because of how we have to manage the bazel rules for typescript,
+    # reflection has to get special-cased to get imported when
+    # run within bazel. As such, generate the code using the _pregenerate
+    # suffix; then do a find/replace to fix-up all the reflection imports.
+    pre_outs = ["%s_pregenerated.ts" % s for s in out_base]
+    outs = ["%s_generated.ts" % s for s in out_base]
     includes = [d + "_includes" for d in deps]
+    reflection_name = "%s_reflection" % name if gen_reflections else ""
     flatbuffer_library_public(
         name = srcs_lib,
         srcs = srcs,
-        outs = outs,
+        outs = pre_outs,
         language_flag = "--ts",
         includes = includes,
         include_paths = include_paths,
-        flatc_args = flatc_args,
+        flatc_args = flatc_args + ["--filename-suffix _pregenerated"],
         compatible_with = compatible_with,
         restricted_to = restricted_to,
+        reflection_name = reflection_name,
+        reflection_visibility = visibility,
         target_compatible_with = target_compatible_with,
+    )
+    fix_import_cmd = " ".join([
+        "SRCS=($(SRCS));",
+        "OUTS=($(OUTS));",
+        "for i in $${!SRCS[@]}; do",
+        "sed \"s/'.*reflection\\/reflection_pregenerated/'flatbuffers_reflection\\/reflection_generated/; s/_pregenerated/_generated/\" $${SRCS[i]} > $${OUTS[i]};",
+        "done",
+    ])
+    native.genrule(
+        name = name + "_reimporter",
+        srcs = pre_outs,
+        outs = outs,
+        cmd = fix_import_cmd,
     )
     ts_project(
         name = name + "_ts",
@@ -86,7 +114,7 @@ def flatbuffer_ts_library(
                 "types": ["node"],
             },
         },
-        deps = deps + ["//ts:flatbuffers"] + (["//reflection/ts:reflection_ts_fbs"] if include_reflection else []),
+        deps = deps + ["@com_github_google_flatbuffers//ts:flatbuffers"] + (["@com_github_google_flatbuffers//reflection/ts:reflection_ts_fbs"] if include_reflection else []),
     )
     js_library(
         name = name,
@@ -95,6 +123,7 @@ def flatbuffer_ts_library(
         restricted_to = restricted_to,
         target_compatible_with = target_compatible_with,
         deps = [name + "_ts"],
+        package_name = package_name,
     )
     native.filegroup(
         name = "%s_includes" % (name),

--- a/typescript.bzl
+++ b/typescript.bzl
@@ -86,7 +86,7 @@ def flatbuffer_ts_library(
                 "types": ["node"],
             },
         },
-        deps = deps + ["//ts:flatbuffers"] + (["//reflection:reflection_ts_fbs"] if include_reflection else []),
+        deps = deps + ["//ts:flatbuffers"] + (["//reflection/ts:reflection_ts_fbs"] if include_reflection else []),
     )
     js_library(
         name = name,


### PR DESCRIPTION
* Uses @...// dependencies so that flatbuffers can actually
  be used as an external repo (had forgotten to upstream this earlier).
* Allows using flatbuffer_ts_library to generate reflection schemas
  in the same way that flatbuffer_cc_library does (but default it
  to off to avoid behavioral changes).
* Pass through a package_name attribute to flatbuffer_ts_library to
  allow non-relative imports of generated typescript code.
* Fix bazel build regression caused by #7342, re-implementing #7342.