### PR TITLE
Add explicit return types to lobster generated code

### DIFF
--- a/samples/monster_generated.lobster
+++ b/samples/monster_generated.lobster
@@ -19,11 +19,11 @@ class Monster
 class Weapon
 
 class Vec3 : flatbuffers_handle
-    def x():
+    def x() -> float:
         return buf_.read_float32_le(pos_ + 0)
-    def y():
+    def y() -> float:
         return buf_.read_float32_le(pos_ + 4)
-    def z():
+    def z() -> float:
         return buf_.read_float32_le(pos_ + 8)
 
 def CreateVec3(b_:flatbuffers_builder, x:float, y:float, z:float):
@@ -34,32 +34,32 @@ def CreateVec3(b_:flatbuffers_builder, x:float, y:float, z:float):
     return b_.Offset()
 
 class Monster : flatbuffers_handle
-    def pos():
+    def pos() -> MyGame_Sample_Vec3?:
         let o = buf_.flatbuffers_field_struct(pos_, 4)
         return if o: MyGame_Sample_Vec3 { buf_, o } else: nil
-    def mana():
+    def mana() -> int:
         return buf_.flatbuffers_field_int16(pos_, 6, 150)
-    def hp():
+    def hp() -> int:
         return buf_.flatbuffers_field_int16(pos_, 8, 100)
-    def name():
+    def name() -> string:
         return buf_.flatbuffers_field_string(pos_, 10)
-    def inventory(i:int):
+    def inventory(i:int) -> int:
         return buf_.read_uint8_le(buf_.flatbuffers_field_vector(pos_, 14) + i * 1)
-    def inventory_length():
+    def inventory_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 14)
-    def color():
+    def color() -> Color:
         return Color(buf_.flatbuffers_field_int8(pos_, 16, 2))
-    def weapons(i:int):
+    def weapons(i:int) -> MyGame_Sample_Weapon:
         return MyGame_Sample_Weapon { buf_, buf_.flatbuffers_indirect(buf_.flatbuffers_field_vector(pos_, 18) + i * 4) }
-    def weapons_length():
+    def weapons_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 18)
-    def equipped_type():
+    def equipped_type() -> Equipment:
         return Equipment(buf_.flatbuffers_field_uint8(pos_, 20, 0))
     def equipped_as_Weapon():
         return MyGame_Sample_Weapon { buf_, buf_.flatbuffers_field_table(pos_, 22) }
-    def path(i:int):
+    def path(i:int) -> MyGame_Sample_Vec3:
         return MyGame_Sample_Vec3 { buf_, buf_.flatbuffers_field_vector(pos_, 24) + i * 12 }
-    def path_length():
+    def path_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 24)
 
 def GetRootAsMonster(buf:string): return Monster { buf, buf.flatbuffers_indirect(0) }
@@ -120,9 +120,9 @@ def MonsterStartPathVector(b_:flatbuffers_builder, n_:int):
     b_.StartVector(12, n_, 4)
 
 class Weapon : flatbuffers_handle
-    def name():
+    def name() -> string:
         return buf_.flatbuffers_field_string(pos_, 4)
-    def damage():
+    def damage() -> int:
         return buf_.flatbuffers_field_int16(pos_, 6, 0)
 
 def GetRootAsWeapon(buf:string): return Weapon { buf, buf.flatbuffers_indirect(0) }

--- a/src/idl_gen_lobster.cpp
+++ b/src/idl_gen_lobster.cpp
@@ -78,6 +78,16 @@ class LobsterGenerator : public BaseGenerator {
     return "int";
   }
 
+  std::string LobsterReturnType(const Type &type) {
+    if (IsFloat(type.base_type)) return "float";
+    if (IsBool(type.base_type)) return "bool";
+    if (IsString(type)) return "string";
+    if (IsScalar(type.base_type) && type.enum_def)
+      return NormalizedName(*type.enum_def);
+    if (!IsScalar(type.base_type)) return "flatbuffers_offset";
+    return "int";
+  }
+
   // Returns the method name for use with add/put calls.
   std::string GenMethod(const Type &type) {
     return IsScalar(type.base_type)
@@ -121,16 +131,17 @@ class LobsterGenerator : public BaseGenerator {
         acc = NormalizedName(*field.value.type.enum_def) + "(" + acc + ")";
       if (field.IsOptional())
         acc += ", buf_.flatbuffers_field_present(pos_, " + offsets + ")";
-      code += def + "():\n        return " + acc + "\n";
+      code += def + "()->" + LobsterReturnType(field.value.type) + ":\n        return " + acc + "\n";
       return;
     }
     switch (field.value.type.base_type) {
       case BASE_TYPE_STRUCT: {
         auto name = NamespacedName(*field.value.type.struct_def);
-        code += def + "():\n        ";
         if (struct_def.fixed) {
+          code += def + "()->" + name+":\n        ";
           code += "return " + name + "{ buf_, pos_ + " + offsets + " }\n";
         } else {
+          code += def + "()->" + name+"?:\n        ";
           code += std::string("let o = buf_.flatbuffers_field_") +
                   (field.value.type.struct_def->fixed ? "struct" : "table") +
                   "(pos_, " + offsets + ")\n        return if o: " + name +
@@ -140,25 +151,28 @@ class LobsterGenerator : public BaseGenerator {
       }
       case BASE_TYPE_STRING:
         code += def +
-                "():\n        return buf_.flatbuffers_field_string(pos_, " +
+                "()->string:\n        return buf_.flatbuffers_field_string(pos_, " +
                 offsets + ")\n";
         break;
       case BASE_TYPE_VECTOR: {
         auto vectortype = field.value.type.VectorType();
-        code += def + "(i:int):\n        return ";
         if (vectortype.base_type == BASE_TYPE_STRUCT) {
           auto start = "buf_.flatbuffers_field_vector(pos_, " + offsets +
                        ") + i * " + NumToString(InlineSize(vectortype));
           if (!(vectortype.struct_def->fixed)) {
             start = "buf_.flatbuffers_indirect(" + start + ")";
           }
+          code += def + "(i:int)->" + NamespacedName(*field.value.type.struct_def) + ":\n        return ";
           code += NamespacedName(*field.value.type.struct_def) + " { buf_, " +
                   start + " }\n";
         } else {
-          if (IsString(vectortype))
+          if (IsString(vectortype)) {
+            code += def + "(i:int)->string:\n        return ";
             code += "buf_.flatbuffers_string";
-          else
+          } else {
+            code += def + "(i:int)->" + LobsterReturnType(vectortype) + ":\n        return ";
             code += "buf_.read_" + GenTypeName(vectortype) + "_le";
+          }
           code += "(buf_.flatbuffers_field_vector(pos_, " + offsets +
                   ") + i * " + NumToString(InlineSize(vectortype)) + ")\n";
         }
@@ -181,7 +195,7 @@ class LobsterGenerator : public BaseGenerator {
     }
     if (IsVector(field.value.type)) {
       code += def +
-              "_length():\n        return "
+              "_length()->int:\n        return "
               "buf_.flatbuffers_field_vector_len(pos_, " +
               offsets + ")\n";
     }

--- a/tests/monster_test_generated.lobster
+++ b/tests/monster_test_generated.lobster
@@ -102,9 +102,9 @@ struct MonsterBuilder:
 namespace MyGame_Example
 
 class Test : flatbuffers_handle
-    def a():
+    def a() -> int:
         return buf_.read_int16_le(pos_ + 0)
-    def b():
+    def b() -> int:
         return buf_.read_int8_le(pos_ + 2)
 
 def CreateTest(b_:flatbuffers_builder, a:int, b:int):
@@ -115,7 +115,7 @@ def CreateTest(b_:flatbuffers_builder, a:int, b:int):
     return b_.Offset()
 
 class TestSimpleTableWithEnum : flatbuffers_handle
-    def color():
+    def color() -> Color:
         return Color(buf_.flatbuffers_field_uint8(pos_, 4, 2))
 
 def GetRootAsTestSimpleTableWithEnum(buf:string): return TestSimpleTableWithEnum { buf, buf.flatbuffers_indirect(0) }
@@ -132,17 +132,17 @@ struct TestSimpleTableWithEnumBuilder:
         return b_.EndObject()
 
 class Vec3 : flatbuffers_handle
-    def x():
+    def x() -> float:
         return buf_.read_float32_le(pos_ + 0)
-    def y():
+    def y() -> float:
         return buf_.read_float32_le(pos_ + 4)
-    def z():
+    def z() -> float:
         return buf_.read_float32_le(pos_ + 8)
-    def test1():
+    def test1() -> float:
         return buf_.read_float64_le(pos_ + 16)
-    def test2():
+    def test2() -> Color:
         return Color(buf_.read_uint8_le(pos_ + 24))
-    def test3():
+    def test3() -> MyGame_Example_Test:
         return MyGame_Example_Test{ buf_, pos_ + 26 }
 
 def CreateVec3(b_:flatbuffers_builder, x:float, y:float, z:float, test1:float, test2:Color, test3_a:int, test3_b:int):
@@ -162,9 +162,9 @@ def CreateVec3(b_:flatbuffers_builder, x:float, y:float, z:float, test1:float, t
     return b_.Offset()
 
 class Ability : flatbuffers_handle
-    def id():
+    def id() -> int:
         return buf_.read_uint32_le(pos_ + 0)
-    def distance():
+    def distance() -> int:
         return buf_.read_uint32_le(pos_ + 4)
 
 def CreateAbility(b_:flatbuffers_builder, id:int, distance:int):
@@ -174,11 +174,11 @@ def CreateAbility(b_:flatbuffers_builder, id:int, distance:int):
     return b_.Offset()
 
 class StructOfStructs : flatbuffers_handle
-    def a():
+    def a() -> MyGame_Example_Ability:
         return MyGame_Example_Ability{ buf_, pos_ + 0 }
-    def b():
+    def b() -> MyGame_Example_Test:
         return MyGame_Example_Test{ buf_, pos_ + 8 }
-    def c():
+    def c() -> MyGame_Example_Ability:
         return MyGame_Example_Ability{ buf_, pos_ + 12 }
 
 def CreateStructOfStructs(b_:flatbuffers_builder, a_id:int, a_distance:int, b_a:int, b_b:int, c_id:int, c_distance:int):
@@ -196,7 +196,7 @@ def CreateStructOfStructs(b_:flatbuffers_builder, a_id:int, a_distance:int, b_a:
     return b_.Offset()
 
 class StructOfStructsOfStructs : flatbuffers_handle
-    def a():
+    def a() -> MyGame_Example_StructOfStructs:
         return MyGame_Example_StructOfStructs{ buf_, pos_ + 0 }
 
 def CreateStructOfStructsOfStructs(b_:flatbuffers_builder, a_a_id:int, a_a_distance:int, a_b_a:int, a_b_b:int, a_c_id:int, a_c_distance:int):
@@ -215,11 +215,11 @@ def CreateStructOfStructsOfStructs(b_:flatbuffers_builder, a_a_id:int, a_a_dista
     return b_.Offset()
 
 class Stat : flatbuffers_handle
-    def id():
+    def id() -> string:
         return buf_.flatbuffers_field_string(pos_, 4)
-    def val():
+    def val() -> int:
         return buf_.flatbuffers_field_int64(pos_, 6, 0)
-    def count():
+    def count() -> int:
         return buf_.flatbuffers_field_uint16(pos_, 8, 0)
 
 def GetRootAsStat(buf:string): return Stat { buf, buf.flatbuffers_indirect(0) }
@@ -242,7 +242,7 @@ struct StatBuilder:
         return b_.EndObject()
 
 class Referrable : flatbuffers_handle
-    def id():
+    def id() -> int:
         return buf_.flatbuffers_field_uint64(pos_, 4, 0)
 
 def GetRootAsReferrable(buf:string): return Referrable { buf, buf.flatbuffers_indirect(0) }
@@ -260,22 +260,22 @@ struct ReferrableBuilder:
 
 /// an example documentation comment: "monster object"
 class Monster : flatbuffers_handle
-    def pos():
+    def pos() -> MyGame_Example_Vec3?:
         let o = buf_.flatbuffers_field_struct(pos_, 4)
         return if o: MyGame_Example_Vec3 { buf_, o } else: nil
-    def mana():
+    def mana() -> int:
         return buf_.flatbuffers_field_int16(pos_, 6, 150)
-    def hp():
+    def hp() -> int:
         return buf_.flatbuffers_field_int16(pos_, 8, 100)
-    def name():
+    def name() -> string:
         return buf_.flatbuffers_field_string(pos_, 10)
-    def inventory(i:int):
+    def inventory(i:int) -> int:
         return buf_.read_uint8_le(buf_.flatbuffers_field_vector(pos_, 14) + i * 1)
-    def inventory_length():
+    def inventory_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 14)
-    def color():
+    def color() -> Color:
         return Color(buf_.flatbuffers_field_uint8(pos_, 16, 8))
-    def test_type():
+    def test_type() -> Any:
         return Any(buf_.flatbuffers_field_uint8(pos_, 18, 0))
     def test_as_Monster():
         return MyGame_Example_Monster { buf_, buf_.flatbuffers_field_table(pos_, 20) }
@@ -283,112 +283,112 @@ class Monster : flatbuffers_handle
         return MyGame_Example_TestSimpleTableWithEnum { buf_, buf_.flatbuffers_field_table(pos_, 20) }
     def test_as_MyGame_Example2_Monster():
         return MyGame_Example2_Monster { buf_, buf_.flatbuffers_field_table(pos_, 20) }
-    def test4(i:int):
+    def test4(i:int) -> MyGame_Example_Test:
         return MyGame_Example_Test { buf_, buf_.flatbuffers_field_vector(pos_, 22) + i * 4 }
-    def test4_length():
+    def test4_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 22)
-    def testarrayofstring(i:int):
+    def testarrayofstring(i:int) -> string:
         return buf_.flatbuffers_string(buf_.flatbuffers_field_vector(pos_, 24) + i * 4)
-    def testarrayofstring_length():
+    def testarrayofstring_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 24)
     /// an example documentation comment: this will end up in the generated code
     /// multiline too
-    def testarrayoftables(i:int):
+    def testarrayoftables(i:int) -> MyGame_Example_Monster:
         return MyGame_Example_Monster { buf_, buf_.flatbuffers_indirect(buf_.flatbuffers_field_vector(pos_, 26) + i * 4) }
-    def testarrayoftables_length():
+    def testarrayoftables_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 26)
-    def enemy():
+    def enemy() -> MyGame_Example_Monster?:
         let o = buf_.flatbuffers_field_table(pos_, 28)
         return if o: MyGame_Example_Monster { buf_, o } else: nil
-    def testnestedflatbuffer(i:int):
+    def testnestedflatbuffer(i:int) -> int:
         return buf_.read_uint8_le(buf_.flatbuffers_field_vector(pos_, 30) + i * 1)
-    def testnestedflatbuffer_length():
+    def testnestedflatbuffer_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 30)
-    def testempty():
+    def testempty() -> MyGame_Example_Stat?:
         let o = buf_.flatbuffers_field_table(pos_, 32)
         return if o: MyGame_Example_Stat { buf_, o } else: nil
-    def testbool():
-        return buf_.flatbuffers_field_int8(pos_, 34, 0)
-    def testhashs32_fnv1():
+    def testbool() -> bool:
+        return bool(buf_.flatbuffers_field_int8(pos_, 34, 0))
+    def testhashs32_fnv1() -> int:
         return buf_.flatbuffers_field_int32(pos_, 36, 0)
-    def testhashu32_fnv1():
+    def testhashu32_fnv1() -> int:
         return buf_.flatbuffers_field_uint32(pos_, 38, 0)
-    def testhashs64_fnv1():
+    def testhashs64_fnv1() -> int:
         return buf_.flatbuffers_field_int64(pos_, 40, 0)
-    def testhashu64_fnv1():
+    def testhashu64_fnv1() -> int:
         return buf_.flatbuffers_field_uint64(pos_, 42, 0)
-    def testhashs32_fnv1a():
+    def testhashs32_fnv1a() -> int:
         return buf_.flatbuffers_field_int32(pos_, 44, 0)
-    def testhashu32_fnv1a():
+    def testhashu32_fnv1a() -> int:
         return buf_.flatbuffers_field_uint32(pos_, 46, 0)
-    def testhashs64_fnv1a():
+    def testhashs64_fnv1a() -> int:
         return buf_.flatbuffers_field_int64(pos_, 48, 0)
-    def testhashu64_fnv1a():
+    def testhashu64_fnv1a() -> int:
         return buf_.flatbuffers_field_uint64(pos_, 50, 0)
-    def testarrayofbools(i:int):
+    def testarrayofbools(i:int) -> bool:
         return buf_.read_int8_le(buf_.flatbuffers_field_vector(pos_, 52) + i * 1)
-    def testarrayofbools_length():
+    def testarrayofbools_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 52)
-    def testf():
+    def testf() -> float:
         return buf_.flatbuffers_field_float32(pos_, 54, 3.14159)
-    def testf2():
+    def testf2() -> float:
         return buf_.flatbuffers_field_float32(pos_, 56, 3.0)
-    def testf3():
+    def testf3() -> float:
         return buf_.flatbuffers_field_float32(pos_, 58, 0.0)
-    def testarrayofstring2(i:int):
+    def testarrayofstring2(i:int) -> string:
         return buf_.flatbuffers_string(buf_.flatbuffers_field_vector(pos_, 60) + i * 4)
-    def testarrayofstring2_length():
+    def testarrayofstring2_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 60)
-    def testarrayofsortedstruct(i:int):
+    def testarrayofsortedstruct(i:int) -> MyGame_Example_Ability:
         return MyGame_Example_Ability { buf_, buf_.flatbuffers_field_vector(pos_, 62) + i * 8 }
-    def testarrayofsortedstruct_length():
+    def testarrayofsortedstruct_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 62)
-    def flex(i:int):
+    def flex(i:int) -> int:
         return buf_.read_uint8_le(buf_.flatbuffers_field_vector(pos_, 64) + i * 1)
-    def flex_length():
+    def flex_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 64)
-    def test5(i:int):
+    def test5(i:int) -> MyGame_Example_Test:
         return MyGame_Example_Test { buf_, buf_.flatbuffers_field_vector(pos_, 66) + i * 4 }
-    def test5_length():
+    def test5_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 66)
-    def vector_of_longs(i:int):
+    def vector_of_longs(i:int) -> int:
         return buf_.read_int64_le(buf_.flatbuffers_field_vector(pos_, 68) + i * 8)
-    def vector_of_longs_length():
+    def vector_of_longs_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 68)
-    def vector_of_doubles(i:int):
+    def vector_of_doubles(i:int) -> float:
         return buf_.read_float64_le(buf_.flatbuffers_field_vector(pos_, 70) + i * 8)
-    def vector_of_doubles_length():
+    def vector_of_doubles_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 70)
-    def parent_namespace_test():
+    def parent_namespace_test() -> MyGame_InParentNamespace?:
         let o = buf_.flatbuffers_field_table(pos_, 72)
         return if o: MyGame_InParentNamespace { buf_, o } else: nil
-    def vector_of_referrables(i:int):
+    def vector_of_referrables(i:int) -> MyGame_Example_Referrable:
         return MyGame_Example_Referrable { buf_, buf_.flatbuffers_indirect(buf_.flatbuffers_field_vector(pos_, 74) + i * 4) }
-    def vector_of_referrables_length():
+    def vector_of_referrables_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 74)
-    def single_weak_reference():
+    def single_weak_reference() -> int:
         return buf_.flatbuffers_field_uint64(pos_, 76, 0)
-    def vector_of_weak_references(i:int):
+    def vector_of_weak_references(i:int) -> int:
         return buf_.read_uint64_le(buf_.flatbuffers_field_vector(pos_, 78) + i * 8)
-    def vector_of_weak_references_length():
+    def vector_of_weak_references_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 78)
-    def vector_of_strong_referrables(i:int):
+    def vector_of_strong_referrables(i:int) -> MyGame_Example_Referrable:
         return MyGame_Example_Referrable { buf_, buf_.flatbuffers_indirect(buf_.flatbuffers_field_vector(pos_, 80) + i * 4) }
-    def vector_of_strong_referrables_length():
+    def vector_of_strong_referrables_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 80)
-    def co_owning_reference():
+    def co_owning_reference() -> int:
         return buf_.flatbuffers_field_uint64(pos_, 82, 0)
-    def vector_of_co_owning_references(i:int):
+    def vector_of_co_owning_references(i:int) -> int:
         return buf_.read_uint64_le(buf_.flatbuffers_field_vector(pos_, 84) + i * 8)
-    def vector_of_co_owning_references_length():
+    def vector_of_co_owning_references_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 84)
-    def non_owning_reference():
+    def non_owning_reference() -> int:
         return buf_.flatbuffers_field_uint64(pos_, 86, 0)
-    def vector_of_non_owning_references(i:int):
+    def vector_of_non_owning_references(i:int) -> int:
         return buf_.read_uint64_le(buf_.flatbuffers_field_vector(pos_, 88) + i * 8)
-    def vector_of_non_owning_references_length():
+    def vector_of_non_owning_references_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 88)
-    def any_unique_type():
+    def any_unique_type() -> AnyUniqueAliases:
         return AnyUniqueAliases(buf_.flatbuffers_field_uint8(pos_, 90, 0))
     def any_unique_as_M():
         return MyGame_Example_Monster { buf_, buf_.flatbuffers_field_table(pos_, 92) }
@@ -396,7 +396,7 @@ class Monster : flatbuffers_handle
         return MyGame_Example_TestSimpleTableWithEnum { buf_, buf_.flatbuffers_field_table(pos_, 92) }
     def any_unique_as_M2():
         return MyGame_Example2_Monster { buf_, buf_.flatbuffers_field_table(pos_, 92) }
-    def any_ambiguous_type():
+    def any_ambiguous_type() -> AnyAmbiguousAliases:
         return AnyAmbiguousAliases(buf_.flatbuffers_field_uint8(pos_, 94, 0))
     def any_ambiguous_as_M1():
         return MyGame_Example_Monster { buf_, buf_.flatbuffers_field_table(pos_, 96) }
@@ -404,26 +404,26 @@ class Monster : flatbuffers_handle
         return MyGame_Example_Monster { buf_, buf_.flatbuffers_field_table(pos_, 96) }
     def any_ambiguous_as_M3():
         return MyGame_Example_Monster { buf_, buf_.flatbuffers_field_table(pos_, 96) }
-    def vector_of_enums(i:int):
+    def vector_of_enums(i:int) -> Color:
         return buf_.read_uint8_le(buf_.flatbuffers_field_vector(pos_, 98) + i * 1)
-    def vector_of_enums_length():
+    def vector_of_enums_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 98)
-    def signed_enum():
+    def signed_enum() -> Race:
         return Race(buf_.flatbuffers_field_int8(pos_, 100, -1))
-    def testrequirednestedflatbuffer(i:int):
+    def testrequirednestedflatbuffer(i:int) -> int:
         return buf_.read_uint8_le(buf_.flatbuffers_field_vector(pos_, 102) + i * 1)
-    def testrequirednestedflatbuffer_length():
+    def testrequirednestedflatbuffer_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 102)
-    def scalar_key_sorted_tables(i:int):
+    def scalar_key_sorted_tables(i:int) -> MyGame_Example_Stat:
         return MyGame_Example_Stat { buf_, buf_.flatbuffers_indirect(buf_.flatbuffers_field_vector(pos_, 104) + i * 4) }
-    def scalar_key_sorted_tables_length():
+    def scalar_key_sorted_tables_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 104)
-    def native_inline():
+    def native_inline() -> MyGame_Example_Test?:
         let o = buf_.flatbuffers_field_struct(pos_, 106)
         return if o: MyGame_Example_Test { buf_, o } else: nil
-    def long_enum_non_enum_default():
+    def long_enum_non_enum_default() -> LongEnum:
         return LongEnum(buf_.flatbuffers_field_uint64(pos_, 108, 0))
-    def long_enum_normal_default():
+    def long_enum_normal_default() -> LongEnum:
         return LongEnum(buf_.flatbuffers_field_uint64(pos_, 110, 2))
 
 def GetRootAsMonster(buf:string): return Monster { buf, buf.flatbuffers_indirect(0) }
@@ -475,7 +475,7 @@ struct MonsterBuilder:
     def add_testempty(testempty:flatbuffers_offset):
         b_.PrependUOffsetTRelativeSlot(14, testempty)
         return this
-    def add_testbool(testbool:int):
+    def add_testbool(testbool:bool):
         b_.PrependBoolSlot(15, testbool, 0)
         return this
     def add_testhashs32_fnv1(testhashs32_fnv1:int):
@@ -628,7 +628,7 @@ def MonsterCreateTestnestedflatbufferVector(b_:flatbuffers_builder, v_:[int]):
 
 def MonsterStartTestarrayofboolsVector(b_:flatbuffers_builder, n_:int):
     b_.StartVector(1, n_, 1)
-def MonsterCreateTestarrayofboolsVector(b_:flatbuffers_builder, v_:[int]):
+def MonsterCreateTestarrayofboolsVector(b_:flatbuffers_builder, v_:[bool]):
     b_.StartVector(1, v_.length, 1)
     reverse(v_) e_: b_.PrependBool(e_)
     return b_.EndVector(v_.length)
@@ -724,33 +724,33 @@ def MonsterCreateScalarKeySortedTablesVector(b_:flatbuffers_builder, v_:[flatbuf
     return b_.EndVector(v_.length)
 
 class TypeAliases : flatbuffers_handle
-    def i8():
+    def i8() -> int:
         return buf_.flatbuffers_field_int8(pos_, 4, 0)
-    def u8():
+    def u8() -> int:
         return buf_.flatbuffers_field_uint8(pos_, 6, 0)
-    def i16():
+    def i16() -> int:
         return buf_.flatbuffers_field_int16(pos_, 8, 0)
-    def u16():
+    def u16() -> int:
         return buf_.flatbuffers_field_uint16(pos_, 10, 0)
-    def i32():
+    def i32() -> int:
         return buf_.flatbuffers_field_int32(pos_, 12, 0)
-    def u32():
+    def u32() -> int:
         return buf_.flatbuffers_field_uint32(pos_, 14, 0)
-    def i64():
+    def i64() -> int:
         return buf_.flatbuffers_field_int64(pos_, 16, 0)
-    def u64():
+    def u64() -> int:
         return buf_.flatbuffers_field_uint64(pos_, 18, 0)
-    def f32():
+    def f32() -> float:
         return buf_.flatbuffers_field_float32(pos_, 20, 0.0)
-    def f64():
+    def f64() -> float:
         return buf_.flatbuffers_field_float64(pos_, 22, 0.0)
-    def v8(i:int):
+    def v8(i:int) -> int:
         return buf_.read_int8_le(buf_.flatbuffers_field_vector(pos_, 24) + i * 1)
-    def v8_length():
+    def v8_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 24)
-    def vf64(i:int):
+    def vf64(i:int) -> float:
         return buf_.read_float64_le(buf_.flatbuffers_field_vector(pos_, 26) + i * 8)
-    def vf64_length():
+    def vf64_length() -> int:
         return buf_.flatbuffers_field_vector_len(pos_, 26)
 
 def GetRootAsTypeAliases(buf:string): return TypeAliases { buf, buf.flatbuffers_indirect(0) }

--- a/tests/optional_scalars_generated.lobster
+++ b/tests/optional_scalars_generated.lobster
@@ -11,77 +11,77 @@ enum OptionalByte:
 class ScalarStuff
 
 class ScalarStuff : flatbuffers_handle
-    def just_i8():
+    def just_i8() -> int:
         return buf_.flatbuffers_field_int8(pos_, 4, 0)
-    def maybe_i8():
+    def maybe_i8() -> int, bool:
         return buf_.flatbuffers_field_int8(pos_, 6, 0), buf_.flatbuffers_field_present(pos_, 6)
-    def default_i8():
+    def default_i8() -> int:
         return buf_.flatbuffers_field_int8(pos_, 8, 42)
-    def just_u8():
+    def just_u8() -> int:
         return buf_.flatbuffers_field_uint8(pos_, 10, 0)
-    def maybe_u8():
+    def maybe_u8() -> int, bool:
         return buf_.flatbuffers_field_uint8(pos_, 12, 0), buf_.flatbuffers_field_present(pos_, 12)
-    def default_u8():
+    def default_u8() -> int:
         return buf_.flatbuffers_field_uint8(pos_, 14, 42)
-    def just_i16():
+    def just_i16() -> int:
         return buf_.flatbuffers_field_int16(pos_, 16, 0)
-    def maybe_i16():
+    def maybe_i16() -> int, bool:
         return buf_.flatbuffers_field_int16(pos_, 18, 0), buf_.flatbuffers_field_present(pos_, 18)
-    def default_i16():
+    def default_i16() -> int:
         return buf_.flatbuffers_field_int16(pos_, 20, 42)
-    def just_u16():
+    def just_u16() -> int:
         return buf_.flatbuffers_field_uint16(pos_, 22, 0)
-    def maybe_u16():
+    def maybe_u16() -> int, bool:
         return buf_.flatbuffers_field_uint16(pos_, 24, 0), buf_.flatbuffers_field_present(pos_, 24)
-    def default_u16():
+    def default_u16() -> int:
         return buf_.flatbuffers_field_uint16(pos_, 26, 42)
-    def just_i32():
+    def just_i32() -> int:
         return buf_.flatbuffers_field_int32(pos_, 28, 0)
-    def maybe_i32():
+    def maybe_i32() -> int, bool:
         return buf_.flatbuffers_field_int32(pos_, 30, 0), buf_.flatbuffers_field_present(pos_, 30)
-    def default_i32():
+    def default_i32() -> int:
         return buf_.flatbuffers_field_int32(pos_, 32, 42)
-    def just_u32():
+    def just_u32() -> int:
         return buf_.flatbuffers_field_uint32(pos_, 34, 0)
-    def maybe_u32():
+    def maybe_u32() -> int, bool:
         return buf_.flatbuffers_field_uint32(pos_, 36, 0), buf_.flatbuffers_field_present(pos_, 36)
-    def default_u32():
+    def default_u32() -> int:
         return buf_.flatbuffers_field_uint32(pos_, 38, 42)
-    def just_i64():
+    def just_i64() -> int:
         return buf_.flatbuffers_field_int64(pos_, 40, 0)
-    def maybe_i64():
+    def maybe_i64() -> int, bool:
         return buf_.flatbuffers_field_int64(pos_, 42, 0), buf_.flatbuffers_field_present(pos_, 42)
-    def default_i64():
+    def default_i64() -> int:
         return buf_.flatbuffers_field_int64(pos_, 44, 42)
-    def just_u64():
+    def just_u64() -> int:
         return buf_.flatbuffers_field_uint64(pos_, 46, 0)
-    def maybe_u64():
+    def maybe_u64() -> int, bool:
         return buf_.flatbuffers_field_uint64(pos_, 48, 0), buf_.flatbuffers_field_present(pos_, 48)
-    def default_u64():
+    def default_u64() -> int:
         return buf_.flatbuffers_field_uint64(pos_, 50, 42)
-    def just_f32():
+    def just_f32() -> float:
         return buf_.flatbuffers_field_float32(pos_, 52, 0.0)
-    def maybe_f32():
+    def maybe_f32() -> float, bool:
         return buf_.flatbuffers_field_float32(pos_, 54, 0), buf_.flatbuffers_field_present(pos_, 54)
-    def default_f32():
+    def default_f32() -> float:
         return buf_.flatbuffers_field_float32(pos_, 56, 42.0)
-    def just_f64():
+    def just_f64() -> float:
         return buf_.flatbuffers_field_float64(pos_, 58, 0.0)
-    def maybe_f64():
+    def maybe_f64() -> float, bool:
         return buf_.flatbuffers_field_float64(pos_, 60, 0), buf_.flatbuffers_field_present(pos_, 60)
-    def default_f64():
+    def default_f64() -> float:
         return buf_.flatbuffers_field_float64(pos_, 62, 42.0)
-    def just_bool():
-        return buf_.flatbuffers_field_int8(pos_, 64, 0)
-    def maybe_bool():
-        return buf_.flatbuffers_field_int8(pos_, 66, 0), buf_.flatbuffers_field_present(pos_, 66)
-    def default_bool():
-        return buf_.flatbuffers_field_int8(pos_, 68, 1)
-    def just_enum():
+    def just_bool() -> bool:
+        return bool(buf_.flatbuffers_field_int8(pos_, 64, 0))
+    def maybe_bool() -> bool, bool:
+        return bool(buf_.flatbuffers_field_int8(pos_, 66, 0)), buf_.flatbuffers_field_present(pos_, 66)
+    def default_bool() -> bool:
+        return bool(buf_.flatbuffers_field_int8(pos_, 68, 1))
+    def just_enum() -> OptionalByte:
         return OptionalByte(buf_.flatbuffers_field_int8(pos_, 70, 0))
-    def maybe_enum():
+    def maybe_enum() -> OptionalByte, bool:
         return OptionalByte(buf_.flatbuffers_field_int8(pos_, 72, 0)), buf_.flatbuffers_field_present(pos_, 72)
-    def default_enum():
+    def default_enum() -> OptionalByte:
         return OptionalByte(buf_.flatbuffers_field_int8(pos_, 74, 1))
 
 def GetRootAsScalarStuff(buf:string): return ScalarStuff { buf, buf.flatbuffers_indirect(0) }
@@ -181,13 +181,13 @@ struct ScalarStuffBuilder:
     def add_default_f64(default_f64:float):
         b_.PrependFloat64Slot(29, default_f64, 42.0)
         return this
-    def add_just_bool(just_bool:int):
+    def add_just_bool(just_bool:bool):
         b_.PrependBoolSlot(30, just_bool, 0)
         return this
-    def add_maybe_bool(maybe_bool:int):
+    def add_maybe_bool(maybe_bool:bool):
         b_.PrependBoolSlot(31, maybe_bool)
         return this
-    def add_default_bool(default_bool:int):
+    def add_default_bool(default_bool:bool):
         b_.PrependBoolSlot(32, default_bool, 1)
         return this
     def add_just_enum(just_enum:OptionalByte):


### PR DESCRIPTION
Adds explicit return type signatures to the generated lobster bindings as discussed with @aardappel 