### PR TITLE
[Kotlin] Remove download benchmark files dependency

### DIFF
--- a/kotlin/benchmark/build.gradle.kts
+++ b/kotlin/benchmark/build.gradle.kts
@@ -76,7 +76,3 @@ tasks.register<de.undercouch.gradle.tasks.download.Download>("downloadMultipleFi
   dest(File("${project.projectDir.absolutePath}/src/jvmMain/resources"))
   overwrite(false)
 }
-
-project.tasks.named("compileKotlinJvm") {
-  dependsOn("downloadMultipleFiles")
-}


### PR DESCRIPTION
There was a step in the compilation process where benchmark data is
downloaded before starting the kotlin compilation process.

Since we are not running benchmark on CI anymore, we remove the
dependency. To run benchmarks the download task needs to be executed
manually.

Related to #7204

