### PR TITLE
Use keep case for Rust union discriminant type.

### DIFF
--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1605,7 +1605,7 @@ class RustGenerator : public BaseGenerator {
       code_.SetValue("OFFSET_VALUE", NumToString(field.value.offset));
       code_.SetValue("FIELD", namer_.Field(field));
       code_.SetValue("BLDR_DEF_VAL", GetDefaultValue(field, kBuilder));
-      code_.SetValue("DISCRIMINANT", namer_.Method(field) + "_type");
+      code_.SetValue("DISCRIMINANT", namer_.Field(field) + "_type");
       code_.IncrementIdentLevel();
       cb(field);
       code_.DecrementIdentLevel();


### PR DESCRIPTION
Fixes #7320. (tested locally on the given schema)

I realize that Rust doesn't really follow the Namer convention, since
it uses Field case for methods... that's a future problem.