### PR TITLE
[TS] Don't generate self-imports with --ts-flat-file

### DIFF
--- a/typescript.bzl
+++ b/typescript.bzl
@@ -81,6 +81,7 @@ def flatbuffer_ts_library(
                 ],
                 "module": "commonjs",
                 "moduleResolution": "node",
+                "noUnusedLocals": True,
                 "strict": True,
                 "types": ["node"],
             },


### PR DESCRIPTION
The logic to manage generating typescript in a single file was
generating self imports and unused local names, which triggered some
linters.

This resolves #7191