### PR TITLE
Move reflection_ts_fbs into a separate directory

### DIFF
--- a/reflection/BUILD.bazel
+++ b/reflection/BUILD.bazel
@@ -1,14 +1,5 @@
-load("//:typescript.bzl", "flatbuffer_ts_library")
-
 filegroup(
     name = "reflection_fbs_schema",
     srcs = ["reflection.fbs"],
-    visibility = ["//visibility:public"],
-)
-
-flatbuffer_ts_library(
-    name = "reflection_ts_fbs",
-    srcs = ["reflection.fbs"],
-    include_reflection = False,
     visibility = ["//visibility:public"],
 )

--- a/reflection/ts/BUILD.bazel
+++ b/reflection/ts/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//:typescript.bzl", "flatbuffer_ts_library")
+
+flatbuffer_ts_library(
+    name = "reflection_ts_fbs",
+    srcs = ["//reflection:reflection_fbs_schema"],
+    include_reflection = False,
+    visibility = ["//visibility:public"],
+)

--- a/typescript.bzl
+++ b/typescript.bzl
@@ -85,7 +85,7 @@ def flatbuffer_ts_library(
                 "types": ["node"],
             },
         },
-        deps = deps + ["//ts:flatbuffers"] + (["//reflection:reflection_ts_fbs"] if include_reflection else []),
+        deps = deps + ["//ts:flatbuffers"] + (["//reflection/ts:reflection_ts_fbs"] if include_reflection else []),
     )
     js_library(
         name = name,


### PR DESCRIPTION
Right now, reflection_ts_fbs target is in reflection/BUILD.bazel.

This is not ideal because reflection:reflection_fbs_schema is referenced
from :flatc in the root. Thus, for any Bazel projects that want to
include flatbuffers, they need to include npm / yarn_install and nodejs
support all because reflection/BUILD.bazel loads typescript.bzl and that
requires all TypeScript things.

This PR separated that target into a different subdirectory, freeing
root BUILD.bazel from that dependency.
