### PR TITLE
Only include direct included files

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -911,6 +911,11 @@ class Parser : public ParserState {
   // @param opts Options used to parce a schema and generate code.
   static bool SupportsOptionalScalars(const flatbuffers::IDLOptions &opts);
 
+  // Get the set of included files that are directly referenced by the file
+  // being parsed. This does not include files that are transitively included by
+  // others includes.
+  std::vector<std::string> GetIncludedFiles() const;
+
  private:
   class ParseDepthGuard;
 

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2189,12 +2189,8 @@ template<typename T> void EnumDef::ChangeEnumValue(EnumVal *ev, T new_value) {
 }
 
 namespace EnumHelper {
-template<BaseType E> struct EnumValType {
-  typedef int64_t type;
-};
-template<> struct EnumValType<BASE_TYPE_ULONG> {
-  typedef uint64_t type;
-};
+template<BaseType E> struct EnumValType { typedef int64_t type; };
+template<> struct EnumValType<BASE_TYPE_ULONG> { typedef uint64_t type; };
 }  // namespace EnumHelper
 
 struct EnumValBuilder {
@@ -2462,6 +2458,13 @@ CheckedError Parser::CheckClash(std::vector<FieldDef *> &fields,
     }
   }
   return NoError();
+}
+
+std::vector<std::string> Parser::GetIncludedFiles() const {
+  const auto it = files_included_per_file_.find(file_being_parsed_);
+  if (it == files_included_per_file_.end()) { return {}; }
+
+  return { it->second.cbegin(), it->second.cend() };
 }
 
 bool Parser::SupportsOptionalScalars(const flatbuffers::IDLOptions &opts) {
@@ -3332,8 +3335,8 @@ CheckedError Parser::CheckPrivatelyLeakedFields(const Definition &def,
   const auto is_field_private = value_type.attributes.Lookup("private");
   if (!is_private && is_field_private) {
     return Error(
-      "Leaking private implementation, verify all objects have similar "
-      "annotations");
+        "Leaking private implementation, verify all objects have similar "
+        "annotations");
   }
   return NoError();
 }


### PR DESCRIPTION
Addresses #7311

Previously, we were using the include files of all parsed files, even if file `A` only referenced file `C` via a intermediary file `B`. Instead, just get the included files that are directly referenced by the file being parsed. 