### PR TITLE
[Swift] usableFromInline attribute for _minAlignment

### DIFF
--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -50,7 +50,7 @@ public struct FlatBufferBuilder {
   private var serializeDefaults: Bool
 
   /// Current alignment for the buffer
-  var _minAlignment: Int = 0 {
+  @usableFromInline var _minAlignment: Int = 0 {
     didSet {
       _bb.alignment = _minAlignment
     }


### PR DESCRIPTION
Swift Code generator does not generate setter and getter unless the variable is marked with attribute.
Mainly while generating XCFramework and interfaces for different architectures.

- The generated build/framework generally works if the build is built only for one architecture ( because the compiler maybe generated the code properly for the particular architecture

- While generating XCFramework - compiler doesn't know or cannot resolve during runtime - Hence the interface needs to generate the appropriate getters and setter to provide the compiler the appropriate clues.