### PR TITLE
Include <array> in flatbuffer headers

### DIFF
--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -26,6 +26,10 @@
 #include <memory>
 #include <limits>
 
+#if defined(__cpp_lib_array_constexpr)
+  #include <array>
+#endif
+
 #ifndef FLATBUFFERS_USE_STD_OPTIONAL
   // Detect C++17 compatible compiler.
   // __cplusplus >= 201703L - a compiler has support of 'static inline' variables.
@@ -316,7 +320,7 @@ namespace internal {
     SpanIterator(pointer ptr) : ptr_(ptr) {}
     reference operator*() const { return *ptr_; }
     pointer operator->() { return ptr_; }
-    SpanIterator& operator++() { ptr_++; return *this; }  
+    SpanIterator& operator++() { ptr_++; return *this; }
     SpanIterator  operator++(int) { auto tmp = *this; ++(*this); return tmp; }
 
     friend bool operator== (const SpanIterator& lhs, const SpanIterator& rhs) { return lhs.ptr_ == rhs.ptr_; }


### PR DESCRIPTION
This fixes a small inconsistency when using flatbuffers headers with different cpp runtimes.

With the `--cpp-std c++17` and `--cpp-static-reflection` options, the C++ generator emits `std::array` fields as part of the reflection data. When using LLVM's STL, `flatbuffers.h` happens to implicitly include `array` via `span`, but the MS STL forward declares `array` in `span`, and so it needs to be included separately.

(Resolves one of the issues in https://github.com/google/flatbuffers/issues/6898)