### PR TITLE
Eliminate UB in ReadScalar/WriteScalar

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -405,7 +405,9 @@ template<typename T>
 // UBSAN: C++ aliasing type rules, see std::bit_cast<> for details.
 __supress_ubsan__("alignment")
 T ReadScalar(const void *p) {
-  return EndianScalar(*reinterpret_cast<const T *>(p));
+  T ret;
+  memcpy(&ret, p, sizeof(T));
+  return EndianScalar(ret);
 }
 
 // See https://github.com/google/flatbuffers/issues/5950
@@ -416,15 +418,15 @@ T ReadScalar(const void *p) {
 #endif
 
 template<typename T>
-// UBSAN: C++ aliasing type rules, see std::bit_cast<> for details.
-__supress_ubsan__("alignment")
 void WriteScalar(void *p, T t) {
-  *reinterpret_cast<T *>(p) = EndianScalar(t);
+  t = EndianScalar(t);
+  memcpy(p, &t, sizeof(T));
 }
 
 template<typename T> struct Offset;
 template<typename T> __supress_ubsan__("alignment") void WriteScalar(void *p, Offset<T> t) {
-  *reinterpret_cast<uoffset_t *>(p) = EndianScalar(t.o);
+  uoffset_t o = static_cast<uoffset_t>(EndianScalar(t.o));
+  memcpy(p, &o, sizeof(uoffset_t));
 }
 
 #if (FLATBUFFERS_GCC >= 100000) && (FLATBUFFERS_GCC < 110000)


### PR DESCRIPTION
`clang-tidy` picks up on the UB from the bitcast usage of `reinterpret_cast` here. `clang-tidy` seems to only trigger the diagnostic when analyzing code that loops and traverses through a `flexbuffers::Reference` or similar construct, i.e. such as iteratively descending through keyed structures following some keypath.

```
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii.orig:95846:10: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage,-warnings-as-errors]
  return EndianScalar(*reinterpret_cast<const T *>(p));
  ^
```

Removing the call to `EndianScalar` returns a similar but different diagnostic which is more explicit:
```
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:95846:3: note: Undefined or garbage value returned to caller
  return *reinterpret_cast<const T *>(p);
  ^
```

I've creduce'd the full repro and attached it and the full preprocessed repro files. They are preprocessed by clang++-12 in an Ubuntu VM in WSL.

For visibility, the sample code that triggers this looks like this, although (for reasons unknown) is insufficient to raise the diagnostic in strict isolation.

```
static void advance_jsin( flexbuffers::Reference root, const JsonPath &path )
{
    for( uint16_t idx : path ) {
        if( root.IsMap() ) {
            std::string member = root.AsMap().Keys()[ idx ].AsString().str();
            // std::cout << "Descending through member " << member << std::endl;
            root = root.AsVector()[ idx ];
        } else if( root.IsAnyVector() ) {
            // std::cout << "Descending through index " << idx << std::endl;
            root = root.AsVector()[ idx ];
        } else {
          /* do something */
          return;
        }
    }
}
```

The full diagnostic stack is
```
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:95846:10: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage,-warnings-as-errors]
  return EndianScalar(*reinterpret_cast<const T *>(p));
         ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109957:5: note: Calling 'JsonObject::throw_error_at'
    throw_error_at( member.c_str(), err );
    ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109963:9: note: Assuming the condition is true
    if( member_opt.has_value() ) {
        ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109963:5: note: Taking true branch
    if( member_opt.has_value() ) {
    ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109964:9: note: Calling 'JsonValue::throw_error'
        ( *member_opt ).throw_error( err );
        ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:107480:13: note: Calling 'JsonValue::throw_error'
            throw_error( 0, message );
            ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:107485:17: note: Assuming field 'parent_path_' is null
            if( parent_path_ ) {
                ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:107485:13: note: Taking false branch
            if( parent_path_ ) {
            ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:107488:13: note: Calling 'Json::throw_error'
            throw_error( p, offset, message );
            ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109708:5: note: Calling 'advance_jsin'
    advance_jsin( &jsin, flexbuffer_root_from_storage( root_->get_storage() ), path );
    ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109673:35: note: Assuming '__begin1' is not equal to '__end1'
    for( JsonPath::index_type idx : path ) {
                                  ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109674:9: note: Taking false branch
        if( root.IsMap() ) {
        ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109684:16: note: Taking true branch
        } else if( root.IsAnyVector() ) {
               ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109686:32: note: Assuming 'i' is >= 'idx'
            for( size_t i = 0; i < idx && !jsin->end_array(); ++i ) {
                               ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109686:40: note: Left side of '&&' is false
            for( size_t i = 0; i < idx && !jsin->end_array(); ++i ) {
                                       ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109674:9: note: Taking true branch
        if( root.IsMap() ) {
        ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:109675:34: note: Calling 'Reference::AsMap'
            std::string member = root.AsMap().Keys()[ idx ].AsString().str();
                                 ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:97379:9: note: Field 'type_' is equal to FBT_MAP
    if (type_ == FBT_MAP) {
        ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:97379:5: note: Taking true branch
    if (type_ == FBT_MAP) {
    ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:97380:18: note: Calling 'Reference::Indirect'
      return Map(Indirect(), byte_width_);
                 ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:97466:12: note: Calling 'Indirect'
    return flexbuffers::Indirect(data_, parent_width_);
           ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:96909:19: note: Calling 'ReadUInt64'
  return offset - ReadUInt64(offset, byte_width);
                  ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:96897:12: note: Calling 'ReadSizedScalar<unsigned long, unsigned char, unsigned short, unsigned int, unsigned long>'
    return ReadSizedScalar<uint64_t, uint8_t, uint16_t, uint32_t, uint64_t>(
           ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:96881:10: note: 'byte_width' is < 4
  return byte_width < 4
         ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:96881:10: note: '?' condition is true
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:96882:17: note: 'byte_width' is < 2
             ? (byte_width < 2
                ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:96882:17: note: '?' condition is true
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:96883:38: note: Calling 'ReadScalar<unsigned char>'
                    ? static_cast<R>(flatbuffers::ReadScalar<T1>(data))
                                     ^
/home/akrieger/Cataclysm-DDA/flexbuffer_json.ii:95846:10: note: 1st function call argument is an uninitialized value
  return EndianScalar(*reinterpret_cast<const T *>(p));
         ^
```

I ran the full source through godbolt before/after my fix and the generated x86 asm is identical. However, I'm a bit rusty on my endianness handling and I'm not 100% certain my standard-blessed solution does it correctly.

[reduced.ii.txt](https://github.com/google/flatbuffers/files/9096013/reduced.ii.txt)
[full.ii.txt](https://github.com/google/flatbuffers/files/9096016/full.ii.txt)

