### PR TITLE
cpp_generator: comment out unused parameter to avoid warnings

### DIFF
--- a/grpc/src/compiler/cpp_generator.cc
+++ b/grpc/src/compiler/cpp_generator.cc
@@ -648,7 +648,7 @@ void PrintHeaderServerMethodAsync(grpc_generator::Printer *printer,
         "::grpc::Status $Method$("
         "::grpc::ServerContext* /*context*/, "
         "::grpc::ServerReader< $Request$>* /*reader*/, "
-        "$Response$* response) final override {\n"
+        "$Response$* /*response*/) final override {\n"
         "  abort();\n"
         "  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, \"\");\n"
         "}\n");

--- a/tests/monster_test.grpc.fb.h
+++ b/tests/monster_test.grpc.fb.h
@@ -201,7 +201,7 @@ class MonsterStorage final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status GetMaxHitPoint(::grpc::ServerContext* /*context*/, ::grpc::ServerReader< flatbuffers::grpc::Message<Monster>>* /*reader*/, flatbuffers::grpc::Message<Stat>* response) final override {
+    ::grpc::Status GetMaxHitPoint(::grpc::ServerContext* /*context*/, ::grpc::ServerReader< flatbuffers::grpc::Message<Monster>>* /*reader*/, flatbuffers::grpc::Message<Stat>* /*response*/) final override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }


### PR DESCRIPTION
Presently flatc generates a placeholder for the unused synchronous varient of client-side streaming gRPCs which includes the name of an unused parameter in the method.

To avoid warnings, comment out the parameter name.

Fixes #7382

