### PR TITLE
`keep-prefix` keeps relative pathing

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -577,7 +577,7 @@ struct IDLOptions {
   bool allow_non_utf8;
   bool natural_utf8;
   std::string include_prefix;
-  bool keep_include_path;
+  bool keep_prefix;
   bool binary_schema_comments;
   bool binary_schema_builtins;
   bool binary_schema_gen_embed;
@@ -683,7 +683,7 @@ struct IDLOptions {
         union_value_namespacing(true),
         allow_non_utf8(false),
         natural_utf8(false),
-        keep_include_path(false),
+        keep_prefix(false),
         binary_schema_comments(false),
         binary_schema_builtins(false),
         binary_schema_gen_embed(false),
@@ -1054,10 +1054,10 @@ class Parser : public ParserState {
 
   uint64_t advanced_features_;
 
+  std::string file_being_parsed_;
+
  private:
   const char *source_;
-
-  std::string file_being_parsed_;
 
   std::vector<std::pair<Value, FieldDef *>> field_stack_;
 

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -448,6 +448,9 @@ std::string StripPath(const std::string &filepath);
 // Strip the last component of the path + separator.
 std::string StripFileName(const std::string &filepath);
 
+std::string StripPrefix(const std::string &filepath,
+                        const std::string &prefix_to_remove);
+
 // Concatenates a path with a filename, regardless of whether the path
 // ends in a separator or not.
 std::string ConCatPathFileName(const std::string &path,

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -433,7 +433,7 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         opts.include_prefix = flatbuffers::ConCatPathFileName(
             flatbuffers::PosixPath(argv[argi]), "");
       } else if (arg == "--keep-prefix") {
-        opts.keep_include_path = true;
+        opts.keep_prefix = true;
       } else if (arg == "--strict-json") {
         opts.strict_json = true;
       } else if (arg == "--allow-non-utf8") {

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -235,13 +235,20 @@ class CppGenerator : public BaseGenerator {
     // interdependence between them.
     std::stable_sort(included_files.begin(), included_files.end());
 
+    // Get any prefix of the file being parsed, so that included filed can be
+    // properly stripped.
+    auto prefix = flatbuffers::StripFileName(parser_.file_being_parsed_) +
+                  flatbuffers::kPathSeparator;
+
     for (const std::string &included_file : included_files) {
-      auto noext = flatbuffers::StripExtension(included_file);
+      auto file_without_extension = flatbuffers::StripExtension(included_file);
       code_ +=
           "#include \"" +
           GeneratedFileName(
               opts_.include_prefix,
-              opts_.keep_include_path ? noext : flatbuffers::StripPath(noext),
+              opts_.keep_prefix
+                  ? flatbuffers::StripPrefix(file_without_extension, prefix)
+                  : flatbuffers::StripPath(file_without_extension),
               opts_) +
           "\"";
     }

--- a/src/idl_gen_fbs.cpp
+++ b/src/idl_gen_fbs.cpp
@@ -82,7 +82,7 @@ std::string GenerateFBS(const Parser &parser, const std::string &file_name) {
       if (it->second.empty())
         continue;
       std::string basename;
-      if(parser.opts.keep_include_path) {
+      if(parser.opts.keep_prefix) {
         basename = flatbuffers::StripExtension(it->second);
       } else {
         basename = flatbuffers::StripPath(

--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -234,7 +234,7 @@ class TsGenerator : public BaseGenerator {
         std::string basename = flatbuffers::StripPath(noext);
         std::string include_file = GeneratedFileName(
             parser_.opts.include_prefix,
-            parser_.opts.keep_include_path ? noext : basename, parser_.opts);
+            parser_.opts.keep_prefix ? noext : basename, parser_.opts);
         // TODO: what is the right behavior when different include flags are
         // specified here? Should we always be adding the "./" for a relative
         // path or turn it off if --include-prefix is specified, or something

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -17,6 +17,7 @@
 // clang-format off
 // Dont't remove `format off`, it prevent reordering of win-includes.
 
+#include <cstring>
 #if defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__) || \
     defined(__QNXNTO__)
 #  define _POSIX_C_SOURCE 200809L
@@ -46,8 +47,8 @@
 
 #include <clocale>
 #include <cstdlib>
-#include <functional>
 #include <fstream>
+#include <functional>
 
 #include "flatbuffers/base.h"
 
@@ -153,6 +154,15 @@ std::string StripPath(const std::string &filepath) {
 std::string StripFileName(const std::string &filepath) {
   size_t i = filepath.find_last_of(PathSeparatorSet);
   return i != std::string::npos ? filepath.substr(0, i) : "";
+}
+
+std::string StripPrefix(const std::string &filepath,
+                        const std::string &prefix_to_remove) {
+  if (!strncmp(filepath.c_str(), prefix_to_remove.c_str(),
+               prefix_to_remove.size())) {
+    return filepath.substr(prefix_to_remove.size());
+  }
+  return filepath;
 }
 
 std::string ConCatPathFileName(const std::string &path,


### PR DESCRIPTION
Addresses: #7354

The logic now looks at the file being parsed and gets its path, and strips that path off the included files when `keep-prefix` is specified.

