### PR TITLE
Add tests for flatc

### DIFF
--- a/tests/flatc/bar/bar.fbs
+++ b/tests/flatc/bar/bar.fbs
@@ -1,0 +1,5 @@
+include "baz/baz.fbs";
+
+table Bar {
+  baz:Baz;
+}

--- a/tests/flatc/bar/baz/baz.fbs
+++ b/tests/flatc/bar/baz/baz.fbs
@@ -1,0 +1,3 @@
+table Baz {
+  a:int;
+}

--- a/tests/flatc/flatc_cpp_tests.py
+++ b/tests/flatc/flatc_cpp_tests.py
@@ -1,0 +1,154 @@
+# Copyright 2022 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from flatc_test import *
+
+class CppTests():
+
+  def Flatten(self):
+    # Generate just foo with a "flatten" import of bar.
+    flatc(["--cpp", "foo.fbs"])
+
+    # Foo should be generated in place and include bar flatten
+    assert_file_and_contents("foo_generated.h", '#include "bar_generated.h"')
+
+  def FlattenAbsolutePath(self):
+    # Generate just foo with a "flatten" import of bar.
+    flatc(["--cpp", make_absolute("foo.fbs")])
+
+    # Foo should be generated in place and include bar flatten
+    assert_file_and_contents("foo_generated.h", '#include "bar_generated.h"')
+
+  def FlattenSubDirectory(self):
+    # Generate just foo with a "flatten" import of bar.
+    flatc(["--cpp", "bar/bar.fbs"])
+    
+    # Bar should be generated in place and include baz
+    assert_file_and_contents("bar_generated.h", '#include "baz_generated.h"')
+
+  def FlattenOutPath(self):
+    # Generate just foo with a "flatten" import of bar.
+    flatc(["--cpp", "-o", ".tmp", "foo.fbs"])
+
+    # Foo should be generated in the out path and include bar flatten to the out path.
+    assert_file_and_contents(".tmp/foo_generated.h", '#include "bar_generated.h"')
+
+  def FlattenOutPathSuperDirectory(self):
+    # Generate just foo with a "flatten" import of bar.
+    flatc(["--cpp", "-o", "../.tmp", "foo.fbs"])
+
+    # Foo should be generated in the out path and include bar flatten to the out path.
+    assert_file_and_contents("../.tmp/foo_generated.h", '#include "bar_generated.h"')
+
+  def FlattenOutPathSubDirectory(self):
+    # Generate just foo with a "flatten" import of bar.
+    flatc(["--cpp", "-o", ".tmp", "bar/bar.fbs"])
+
+    # Bar should be generated in the out path and include baz flatten to the out path.
+    assert_file_and_contents(".tmp/bar_generated.h", '#include "baz_generated.h"')
+
+  def KeepPrefix(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--keep-prefix", "foo.fbs"])
+
+    assert_file_and_contents("foo_generated.h", '#include "bar/bar_generated.h"')
+
+  def KeepPrefixAbsolutePath(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--keep-prefix", make_absolute("foo.fbs")])
+
+    assert_file_and_contents("foo_generated.h", '#include "bar/bar_generated.h"')
+
+  def KeepPrefixSubDirectory(self):
+    # Generate with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--keep-prefix", "bar/bar.fbs"])
+
+    assert_file_and_contents("bar_generated.h", '#include "baz/baz_generated.h"')
+
+  def KeepPrefixOutPath(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--keep-prefix", "-o", ".tmp", "foo.fbs"])
+
+    assert_file_and_contents(".tmp/foo_generated.h", '#include "bar/bar_generated.h"')
+
+  def KeepPrefixOutPathSubDirectory(self):
+    # Generate with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--keep-prefix", "-o", ".tmp", "bar/bar.fbs"])
+
+    assert_file_and_contents(".tmp/bar_generated.h", '#include "baz/baz_generated.h"')
+
+  def IncludePrefix(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--include-prefix", "test", "foo.fbs"])
+
+    assert_file_and_contents("foo_generated.h", '#include "test/bar_generated.h"')
+
+  def IncludePrefixAbolutePath(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--include-prefix", "test", make_absolute("foo.fbs")])
+
+    assert_file_and_contents("foo_generated.h", '#include "test/bar_generated.h"')
+
+  def IncludePrefixSubDirectory(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--include-prefix", "test", "bar/bar.fbs"])
+
+    assert_file_and_contents("bar_generated.h", '#include "test/baz_generated.h"')
+
+  def IncludePrefixOutPath(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--include-prefix", "test", "-o", ".tmp", "foo.fbs"])
+
+    assert_file_and_contents(".tmp/foo_generated.h", '#include "test/bar_generated.h"')
+
+  def IncludePrefixOutPathSubDirectory(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--include-prefix", "test", "-o", ".tmp", "bar/bar.fbs"])
+
+    assert_file_and_contents(".tmp/bar_generated.h", '#include "test/baz_generated.h"')
+
+  def KeepPrefixIncludePrefix(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", "foo.fbs"])
+
+    # The include prefix should come first, with the kept prefix next.
+    assert_file_and_contents("foo_generated.h", '#include "test/bar/bar_generated.h"')
+
+  def KeepPrefixIncludePrefixAbsolutePath(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", make_absolute("foo.fbs")])
+
+    # The include prefix should come first, with the kept prefix next.
+    assert_file_and_contents("foo_generated.h", '#include "test/bar/bar_generated.h"')
+
+  def KeepPrefixIncludePrefixSubDirectory(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", "bar/bar.fbs"])
+
+    # The include prefix should come first, with the kept prefix next.
+    assert_file_and_contents("bar_generated.h", '#include "test/baz/baz_generated.h"')
+
+  def KeepPrefixIncludePrefixOutPathSubDirectory(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", "-o", ".tmp", "bar/bar.fbs"])
+
+    # The include prefix should come first, with the kept prefix next.
+    assert_file_and_contents(".tmp/bar_generated.h", '#include "test/baz/baz_generated.h"')
+
+  def KeepPrefixIncludePrefixOutPathSuperDirectory(self):
+    # Generate just foo with the import of bar keeping the prefix of where it is located.
+    flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", "-o", "../.tmp", "bar/bar.fbs"])
+
+    # The include prefix should come first, with the kept prefix next.
+    assert_file_and_contents("../.tmp/bar_generated.h", '#include "test/baz/baz_generated.h"')

--- a/tests/flatc/flatc_test.py
+++ b/tests/flatc/flatc_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import filecmp
+import glob
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--flatc",
+    help="path of the Flat C compiler relative to the root directory")
+    
+args = parser.parse_args()
+
+# Get the path where this script is located so we can invoke the script from
+# any directory and have the paths work correctly.
+script_path = Path(__file__).parent.resolve()
+
+# Get the root path as an absolute path, so all derived paths are absolute.
+root_path = script_path.parent.parent.absolute()
+
+# Get the location of the flatc executable, reading from the first command line
+# argument or defaulting to default names.
+flatc_exe = Path(
+    ("flatc" if not platform.system() == "Windows" else "flatc.exe")
+    if not args.flatc
+    else args.flatc
+)
+
+# Find and assert flatc compiler is present.
+if root_path in flatc_exe.parents:
+    flatc_exe = flatc_exe.relative_to(root_path)
+flatc_path = Path(root_path, flatc_exe)
+assert flatc_path.exists(), "Cannot find the flatc compiler " + str(flatc_path)
+
+# Execute the flatc compiler with the specified parameters
+def flatc(options, cwd=script_path):
+    cmd = [str(flatc_path)] + options 
+    result = subprocess.run(cmd, cwd=str(cwd), check=True)
+
+def make_absolute(filename, path=script_path):
+   return Path(path, filename).absolute()
+
+def assert_file_exists(filename, path=script_path):
+    file = Path(path, filename)
+    assert file.exists(), "could not find file: " + filename
+    return file
+
+def assert_file_contains(file, needle):
+    assert needle in open(file).read(), "coudn't find '"+needle+"' in file: "+str(file)
+    return file
+
+def assert_file_and_contents(file, needle, path=script_path):
+    assert_file_contains(assert_file_exists(file, path), needle).unlink()
+
+def run_all(module):
+  methods = [func for func in dir(module) if callable(getattr(module, func)) and not func.startswith("__")]
+  for method in methods:
+      try:
+          print(method)
+          getattr(module, method)(module)
+          print(" [PASSED]")
+      except Exception as e:
+          print(" [FAILED]: " +str(e))

--- a/tests/flatc/foo.fbs
+++ b/tests/flatc/foo.fbs
@@ -1,0 +1,7 @@
+include "bar/bar.fbs";
+
+table Foo {
+  bar:Bar;
+}
+
+root_type Foo;

--- a/tests/flatc/main.py
+++ b/tests/flatc/main.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from flatc_test import run_all
+from flatc_cpp_tests import CppTests
+
+run_all(CppTests)


### PR DESCRIPTION
Added some python based tests that directly work off the generated `flatc` binary to test various flag combinations. I think these will be easier to write and maintain than doing it in C++.

Added C++ tests to look at the generated `#include` statements when using the `--keep-prefix` and `--include-prefix` flags, along with some other things like relative/absolute pathing.

#7354

