### PR TITLE
[golang] Perform keyword escaping after case conversion

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -61,7 +61,7 @@ Namer::Config GoDefaultConfig() {
            /*variables=*/Case::kLowerCamel,
            /*variants=*/Case::kKeep,
            /*enum_variant_seperator=*/"",  // I.e. Concatenate.
-           /*escape_keywords=*/Namer::Config::Escape::BeforeConvertingCase,
+           /*escape_keywords=*/Namer::Config::Escape::AfterConvertingCase,
            /*namespaces=*/Case::kKeep,
            /*namespace_seperator=*/"__",
            /*object_prefix=*/"",


### PR DESCRIPTION
Change config.escape_keywords to AfterConvertingCase.

It avoids unecessay escaping since the generated native
structs have fields starting with a uppercase letter
and Go's keywords start with lowercase letters.

See also issue #7420 
