### PR TITLE
[C++] Set StructDef::has_key property when deserializing from binary …

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -3720,6 +3720,14 @@ bool StructDef::Deserialize(Parser &parser, const reflection::Object *object) {
       delete field_def;
       return false;
     }
+    if (field_def->key) {
+      if (has_key) {
+        // only one field may be set as key
+        delete field_def;
+        return false;
+      }
+      has_key = true;
+    }
     if (fixed) {
       // Recompute padding since that's currently not serialized.
       auto size = InlineSize(field_def->value.type);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -4550,6 +4550,28 @@ void PrivateAnnotationsLeaks() {
   }
 }
 
+void JsonUnsortedArrayTest()
+{
+  flatbuffers::Parser parser;
+  TEST_EQ(parser.Deserialize(MyGame::Example::MonsterBinarySchema::data(), MyGame::Example::MonsterBinarySchema::size()), true);
+  auto jsonStr = R"(
+  {
+    "name": "lookupTest",
+    "testarrayoftables": [
+      { "name": "aaa" },
+      { "name": "ccc" },
+      { "name": "bbb" }
+    ]
+  }
+  )";
+  TEST_EQ(parser.ParseJson(jsonStr), true);
+  auto monster = flatbuffers::GetRoot<MyGame::Example::Monster>(parser.builder_.GetBufferPointer());
+
+  TEST_NOTNULL(monster->testarrayoftables()->LookupByKey("aaa"));
+  TEST_NOTNULL(monster->testarrayoftables()->LookupByKey("bbb"));
+  TEST_NOTNULL(monster->testarrayoftables()->LookupByKey("ccc"));
+}
+
 int FlatBufferTests() {
   // clang-format off
 
@@ -4655,6 +4677,7 @@ int FlatBufferTests() {
   WarningsAsErrorsTest();
   NestedVerifierTest();
   PrivateAnnotationsLeaks();
+  JsonUnsortedArrayTest();
   return 0;
 }
 


### PR DESCRIPTION
This is a fix for #7386 
