### PR TITLE
Enable locale independent functions for Fuchsia

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -262,6 +262,7 @@ namespace flatbuffers {
 #ifndef FLATBUFFERS_LOCALE_INDEPENDENT
   // Enable locale independent functions {strtof_l, strtod_l,strtoll_l, strtoull_l}.
   #if ((defined(_MSC_VER) && _MSC_VER >= 1800)            || \
+       (defined(__Fuchsia__)) || \
        (defined(_XOPEN_VERSION) && (_XOPEN_VERSION>=700)) && (!defined(__ANDROID_API__) || (defined(__ANDROID_API__) && (__ANDROID_API__>=21))))
     #define FLATBUFFERS_LOCALE_INDEPENDENT 1
   #else


### PR DESCRIPTION
Enable the locale independent functions for building with Fuchsia
