### PR TITLE
[TypeScript] Fix namespaceless schema generation

### DIFF
--- a/tests/flatc/flatc_test.py
+++ b/tests/flatc/flatc_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright 2022 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,23 +57,30 @@ def flatc(options, cwd=script_path):
 def make_absolute(filename, path=script_path):
     return Path(path, filename).absolute()
 
-
 def assert_file_exists(filename, path=script_path):
     file = Path(path, filename)
     assert file.exists(), "could not find file: " + filename
     return file
 
+def assert_file_doesnt_exists(filename, path=script_path):
+    file = Path(path, filename)
+    assert not file.exists(), "file exists but shouldn't: " + filename
+    return file
 
-def assert_file_contains(file, needle):
-    assert needle in open(file).read(), (
-        "coudn't find '" + needle + "' in file: " + str(file)
-    )
+def assert_file_contains(file, needles):
+    with open(file) as file:
+        contents = file.read();
+        for needle in [needles] if isinstance(needles, str) else needles:
+            assert needle in contents, (
+                "coudn't find '" + needle + "' in file: " + str(file)
+            )
     return file
 
 
-def assert_file_and_contents(file, needle, path=script_path):
-    assert_file_contains(assert_file_exists(file, path), needle).unlink()
-
+def assert_file_and_contents(file, needle, path=script_path, unlink=True):
+    assert_file_contains(assert_file_exists(file, path), needle)
+    if unlink:
+        Path(path, file).unlink()
 
 def run_all(module):
     methods = [
@@ -90,6 +95,7 @@ def run_all(module):
             print(method)
             getattr(module, method)(module)
             print(" [PASSED]")
+
             passing = passing + 1
         except Exception as e:
             print(" [FAILED]: " + str(e))

--- a/tests/flatc/flatc_test.py
+++ b/tests/flatc/flatc_test.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import argparse
-import filecmp
-import glob
 import platform
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -51,25 +48,28 @@ assert flatc_path.exists(), "Cannot find the flatc compiler " + str(flatc_path)
 # Execute the flatc compiler with the specified parameters
 def flatc(options, cwd=script_path):
     cmd = [str(flatc_path)] + options
-    result = subprocess.run(cmd, cwd=str(cwd), check=True)
+    subprocess.check_call(cmd, cwd=str(cwd))
 
 
 def make_absolute(filename, path=script_path):
     return Path(path, filename).absolute()
+
 
 def assert_file_exists(filename, path=script_path):
     file = Path(path, filename)
     assert file.exists(), "could not find file: " + filename
     return file
 
+
 def assert_file_doesnt_exists(filename, path=script_path):
     file = Path(path, filename)
     assert not file.exists(), "file exists but shouldn't: " + filename
     return file
 
+
 def assert_file_contains(file, needles):
     with open(file) as file:
-        contents = file.read();
+        contents = file.read()
         for needle in [needles] if isinstance(needles, str) else needles:
             assert needle in contents, (
                 "coudn't find '" + needle + "' in file: " + str(file)
@@ -82,23 +82,32 @@ def assert_file_and_contents(file, needle, path=script_path, unlink=True):
     if unlink:
         Path(path, file).unlink()
 
-def run_all(module):
-    methods = [
-        func
-        for func in dir(module)
-        if callable(getattr(module, func)) and not func.startswith("__")
-    ]
+
+def run_all(*modules):
     failing = 0
     passing = 0
-    for method in methods:
-        try:
-            print(method)
-            getattr(module, method)(module)
-            print(" [PASSED]")
-
-            passing = passing + 1
-        except Exception as e:
-            print(" [FAILED]: " + str(e))
-            failing = failing + 1
-    print("{0}: {1} of {2} passsed".format(module.__name__, passing, passing + failing))
+    for module in modules:
+        methods = [
+            func
+            for func in dir(module)
+            if callable(getattr(module, func)) and not func.startswith("__")
+        ]
+        module_failing = 0
+        module_passing = 0
+        for method in methods:
+            try:
+                print("{0}.{1}".format(module.__name__, method))
+                getattr(module, method)(module)
+                print(" [PASSED]")
+                module_passing = module_passing + 1
+            except Exception as e:
+                print(" [FAILED]: " + str(e))
+                failingmodule_failing = failingmodule_failing + 1
+        print(
+            "{0}: {1} of {2} passsed".format(
+                module.__name__, module_passing, module_passing + module_failing
+            )
+        )
+        passing = passing + module_passing
+        failing = failing + module_failing
     return passing, failing

--- a/tests/flatc/flatc_ts_tests.py
+++ b/tests/flatc/flatc_ts_tests.py
@@ -14,8 +14,8 @@
 
 from flatc_test import *
 
+class TsTests():
 
-class TsTests:
     def Base(self):
         # Generate just foo with no extra arguments
         flatc(["--ts", "foo.fbs"])

--- a/tests/flatc/flatc_ts_tests.py
+++ b/tests/flatc/flatc_ts_tests.py
@@ -14,12 +14,56 @@
 
 from flatc_test import *
 
-class TsTests():
 
-  def Flatten(self):
-    # Generate just foo with a "flatten" import of bar.
-    flatc(["--ts", "foo.fbs"])
+class TsTests:
+    def Base(self):
+        # Generate just foo with no extra arguments
+        flatc(["--ts", "foo.fbs"])
 
-    # Foo should be generated in place and include bar flatten
-    assert_file_and_contents("foo_generated.ts", '#import "bar_generated.h"')
+        # Should generate the module that exports both foo and its direct
+        # include, bar.
+        assert_file_and_contents(
+            "foo_generated.ts",
+            ["export { Bar } from './bar';", "export { Foo } from './foo';"],
+        )
 
+        # Foo should be generated in place and exports the Foo table.
+        assert_file_and_contents("foo.ts", "export class Foo {")
+
+        # Included files, like bar, should not be generated.
+        assert_file_doesnt_exists("bar.ts")
+
+    def BaseWithNamespace(self):
+        # Generate foo with namespacing, with no extra arguments
+        flatc(["--ts", "foo_with_ns.fbs"])
+
+        # Should generate the module that exports both foo in its namespace
+        # directory and its direct include, bar.
+        assert_file_and_contents(
+            "foo_with_ns_generated.ts",
+            ["export { Bar } from './bar';", "export { Foo } from './something/foo';"],
+        )
+
+        # Foo should be placed in the namespaced directory. It should export
+        # Foo, and the import of Bar should be relative to its location.
+        assert_file_and_contents(
+            "something/foo.ts",
+            ["export class Foo {", "import { Bar } from '../bar';"],
+        )
+
+        # Included files, like bar, should not be generated.
+        assert_file_doesnt_exists("bar.ts")
+
+    def FlatFiles(self):
+        # Generate just foo the flat files option
+        flatc(["--ts", "--ts-flat-files", "foo.fbs"])
+
+        # Should generate a single file that imports bar as a single file, and]
+        # exports the Foo table.
+        assert_file_and_contents(
+            "foo_generated.ts",
+            ["import {Bar as Bar} from './bar_generated';", "export class Foo {"],
+        )
+
+        # The root type Foo should not be generated in its own file.
+        assert_file_doesnt_exists("foo.ts")

--- a/tests/flatc/flatc_ts_tests.py
+++ b/tests/flatc/flatc_ts_tests.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from flatc_test import *
+
+class TsTests():
+
+  def Flatten(self):
+    # Generate just foo with a "flatten" import of bar.
+    flatc(["--ts", "foo.fbs"])
+
+    # Foo should be generated in place and include bar flatten
+    assert_file_and_contents("foo_generated.ts", '#import "bar_generated.h"')
+

--- a/tests/flatc/foo_with_ns.fbs
+++ b/tests/flatc/foo_with_ns.fbs
@@ -1,0 +1,9 @@
+include "bar/bar.fbs";
+
+namespace something;
+
+table Foo {
+  bar:Bar;
+}
+
+root_type Foo;

--- a/tests/flatc/main.py
+++ b/tests/flatc/main.py
@@ -4,8 +4,10 @@ import sys;
 
 from flatc_test import run_all
 from flatc_cpp_tests import CppTests
+from flatc_ts_tests import TsTests
 
 passing, failing = run_all(CppTests)
+passing, failing = run_all(TsTests)
 
 if failing > 0:
   sys.exit(1)

--- a/tests/flatc/main.py
+++ b/tests/flatc/main.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+#
+# Copyright 2022 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys;
 

--- a/tests/flatc/main.py
+++ b/tests/flatc/main.py
@@ -14,14 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys;
+import sys
 
 from flatc_test import run_all
 from flatc_cpp_tests import CppTests
 from flatc_ts_tests import TsTests
 
-passing, failing = run_all(CppTests)
-passing, failing = run_all(TsTests)
+passing, failing = run_all(CppTests, TsTests)
+
+print("")
+print("{0} of {1} tests passed".format(passing, passing + failing))
 
 if failing > 0:
-  sys.exit(1)
+    sys.exit(1)

--- a/tests/monster_test_generated.ts
+++ b/tests/monster_test_generated.ts
@@ -1,0 +1,18 @@
+export { Monster } from './my-game/example/monster';
+export { Monster as MyGameExample2Monster, MonsterT as MyGameExample2MonsterT } from './my-game/example2/monster';
+export { Ability, AbilityT } from './my-game/example/ability';
+export { Any, unionToAny, unionListToAny } from './my-game/example/any';
+export { AnyAmbiguousAliases, unionToAnyAmbiguousAliases, unionListToAnyAmbiguousAliases } from './my-game/example/any-ambiguous-aliases';
+export { AnyUniqueAliases, unionToAnyUniqueAliases, unionListToAnyUniqueAliases } from './my-game/example/any-unique-aliases';
+export { Color } from './my-game/example/color';
+export { Monster, MonsterT } from './my-game/example/monster';
+export { Race } from './my-game/example/race';
+export { Referrable, ReferrableT } from './my-game/example/referrable';
+export { Stat, StatT } from './my-game/example/stat';
+export { StructOfStructs, StructOfStructsT } from './my-game/example/struct-of-structs';
+export { StructOfStructsOfStructs, StructOfStructsOfStructsT } from './my-game/example/struct-of-structs-of-structs';
+export { Test, TestT } from './my-game/example/test';
+export { TestSimpleTableWithEnum, TestSimpleTableWithEnumT } from './my-game/example/test-simple-table-with-enum';
+export { TypeAliases, TypeAliasesT } from './my-game/example/type-aliases';
+export { Vec3, Vec3T } from './my-game/example/vec3';
+export { InParentNamespace, InParentNamespaceT } from './my-game/in-parent-namespace';

--- a/tests/optional_scalars_generated.ts
+++ b/tests/optional_scalars_generated.ts
@@ -1,0 +1,2 @@
+export { ScalarStuff } from './optional-scalars/scalar-stuff';
+export { OptionalByte } from './optional-scalars/optional-byte';

--- a/tests/union_vector/union_vector_generated.ts
+++ b/tests/union_vector/union_vector_generated.ts
@@ -1,0 +1,8 @@
+export { Attacker, AttackerT } from './attacker';
+export { BookReader, BookReaderT } from './book-reader';
+export { Character, unionToCharacter, unionListToCharacter } from './character';
+export { FallingTub, FallingTubT } from './falling-tub';
+export { Gadget, unionToGadget, unionListToGadget } from './gadget';
+export { HandFan, HandFanT } from './hand-fan';
+export { Movie, MovieT } from './movie';
+export { Rapunzel, RapunzelT } from './rapunzel';


### PR DESCRIPTION
There was a bug if you have a namespaceless schema:

`foo.fbs:`
```
table Foo {
  a:int;
}

root_type Foo;
```

and generated `flatc --ts foo.fbs` the output wouldn't include the code for foo. This was because the module that exports all the types was named the same as the type file that was just written. 

Added new tests to verify that this works with and without namespaces, as well as added a test for `--ts-flat-files`.

Fixes: #7190 #7098
