### PR TITLE
make_span overloads for pointer to vector (#7374)

### DIFF
--- a/include/flatbuffers/vector.h
+++ b/include/flatbuffers/vector.h
@@ -327,6 +327,24 @@ FLATBUFFERS_CONSTEXPR_CPP11 flatbuffers::span<const uint8_t> make_bytes_span(
   return span<const uint8_t>(vec.Data(), vec.size() * sizeof(U));
 }
 
+// Convenient helper functions to get a span of any vector, regardless
+// of whether it is null or not (the field is not set).
+template<class U>
+FLATBUFFERS_CONSTEXPR_CPP11 flatbuffers::span<U> make_span(Vector<U> *ptr)
+    FLATBUFFERS_NOEXCEPT {
+  static_assert(Vector<U>::is_span_observable,
+                "wrong type U, only LE-scalar, or byte types are allowed");
+  return ptr ? make_span(*ptr) : span<U>();
+}
+
+template<class U>
+FLATBUFFERS_CONSTEXPR_CPP11 flatbuffers::span<const U> make_span(
+    const Vector<U> *ptr) FLATBUFFERS_NOEXCEPT {
+  static_assert(Vector<U>::is_span_observable,
+                "wrong type U, only LE-scalar, or byte types are allowed");
+  return ptr ? make_span(*ptr) : span<const U>();
+}
+
 // Represent a vector much like the template above, but in this case we
 // don't know what the element types are (used with reflection.h).
 class VectorOfAny {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -4584,45 +4584,61 @@ void VectorSpanTest() {
   auto monster = GetMonster(builder.GetBufferPointer());
   auto mutable_monster = GetMutableMonster(builder.GetBufferPointer());
 
-  TEST_NOTNULL(monster->inventory());
+  { // using references
+    TEST_NOTNULL(monster->inventory());
 
-  {  // using references
-
-    auto const_inventory = flatbuffers::make_span(*monster->inventory());
+    flatbuffers::span<const uint8_t> const_inventory =
+        flatbuffers::make_span(*monster->inventory());
     TEST_EQ(const_inventory.size(), 10);
     TEST_EQ(const_inventory[0], 0);
     TEST_EQ(const_inventory[9], 9);
 
-    auto mutable_inventory = flatbuffers::make_span(*mutable_monster->inventory());
+    flatbuffers::span<uint8_t> mutable_inventory =
+        flatbuffers::make_span(*mutable_monster->mutable_inventory());
     TEST_EQ(mutable_inventory.size(), 10);
     TEST_EQ(mutable_inventory[0], 0);
     TEST_EQ(mutable_inventory[9], 9);
+
+    mutable_inventory[0] = 42;
+    TEST_EQ(mutable_inventory[0], 42);
+
+    mutable_inventory[0] = 0;
+    TEST_EQ(mutable_inventory[0], 0);
   }
 
   { // using pointers
     TEST_EQ(flatbuffers::VectorLength(monster->inventory()), 10);
 
-    auto const_inventory = flatbuffers::make_span(monster->inventory());
+    flatbuffers::span<const uint8_t> const_inventory =
+        flatbuffers::make_span(monster->inventory());
     TEST_EQ(const_inventory.size(), 10);
     TEST_EQ(const_inventory[0], 0);
     TEST_EQ(const_inventory[9], 9);
 
-    auto mutable_inventory = flatbuffers::make_span(mutable_monster->inventory());
+    flatbuffers::span<uint8_t> mutable_inventory =
+        flatbuffers::make_span(mutable_monster->mutable_inventory());
     TEST_EQ(mutable_inventory.size(), 10);
     TEST_EQ(mutable_inventory[0], 0);
     TEST_EQ(mutable_inventory[9], 9);
+
+    mutable_inventory[0] = 42;
+    TEST_EQ(mutable_inventory[0], 42);
+
+    mutable_inventory[0] = 0;
+    TEST_EQ(mutable_inventory[0], 0);
   }
 
-  TEST_ASSERT(nullptr == monster->testnestedflatbuffer());
-
   {
+    TEST_ASSERT(nullptr == monster->testnestedflatbuffer());
+
     TEST_EQ(flatbuffers::VectorLength(monster->testnestedflatbuffer()), 0);
 
-    auto const_nested = flatbuffers::make_span(monster->testnestedflatbuffer());
+    flatbuffers::span<const uint8_t> const_nested =
+        flatbuffers::make_span(monster->testnestedflatbuffer());
     TEST_ASSERT(const_nested.empty());
 
-    auto mutable_nested =
-        flatbuffers::make_span(monster->testnestedflatbuffer());
+    flatbuffers::span<uint8_t> mutable_nested =
+        flatbuffers::make_span(mutable_monster->mutable_testnestedflatbuffer());
     TEST_ASSERT(mutable_nested.empty());
   }
 }


### PR DESCRIPTION
I added an overload for make_span for pointer to vector to get a span of any vector, regardless
of whether it is null or not (the field is not set).
