### PR TITLE
Add flatc python tests to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
       run: |
         chmod +x flatc
         ./flatc --version
+    - name: flatc tests
+      run: python3 tests/flatc/main.py
     - name: upload build artifacts
       uses: actions/upload-artifact@v1
       with:

--- a/tests/flatc/flatc_test.py
+++ b/tests/flatc/flatc_test.py
@@ -24,9 +24,9 @@ from pathlib import Path
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    "--flatc",
-    help="path of the Flat C compiler relative to the root directory")
-    
+    "--flatc", help="path of the Flat C compiler relative to the root directory"
+)
+
 args = parser.parse_args()
 
 # Get the path where this script is located so we can invoke the script from
@@ -52,30 +52,47 @@ assert flatc_path.exists(), "Cannot find the flatc compiler " + str(flatc_path)
 
 # Execute the flatc compiler with the specified parameters
 def flatc(options, cwd=script_path):
-    cmd = [str(flatc_path)] + options 
+    cmd = [str(flatc_path)] + options
     result = subprocess.run(cmd, cwd=str(cwd), check=True)
 
+
 def make_absolute(filename, path=script_path):
-   return Path(path, filename).absolute()
+    return Path(path, filename).absolute()
+
 
 def assert_file_exists(filename, path=script_path):
     file = Path(path, filename)
     assert file.exists(), "could not find file: " + filename
     return file
 
+
 def assert_file_contains(file, needle):
-    assert needle in open(file).read(), "coudn't find '"+needle+"' in file: "+str(file)
+    assert needle in open(file).read(), (
+        "coudn't find '" + needle + "' in file: " + str(file)
+    )
     return file
+
 
 def assert_file_and_contents(file, needle, path=script_path):
     assert_file_contains(assert_file_exists(file, path), needle).unlink()
 
+
 def run_all(module):
-  methods = [func for func in dir(module) if callable(getattr(module, func)) and not func.startswith("__")]
-  for method in methods:
-      try:
-          print(method)
-          getattr(module, method)(module)
-          print(" [PASSED]")
-      except Exception as e:
-          print(" [FAILED]: " +str(e))
+    methods = [
+        func
+        for func in dir(module)
+        if callable(getattr(module, func)) and not func.startswith("__")
+    ]
+    failing = 0
+    passing = 0
+    for method in methods:
+        try:
+            print(method)
+            getattr(module, method)(module)
+            print(" [PASSED]")
+            passing = passing + 1
+        except Exception as e:
+            print(" [FAILED]: " + str(e))
+            failing = failing + 1
+    print("{0}: {1} of {2} passsed".format(module.__name__, passing, passing + failing))
+    return passing, failing

--- a/tests/flatc/main.py
+++ b/tests/flatc/main.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 
+import sys;
+
 from flatc_test import run_all
 from flatc_cpp_tests import CppTests
 
-run_all(CppTests)
+passing, failing = run_all(CppTests)
+
+if failing > 0:
+  sys.exit(1)


### PR DESCRIPTION
I recently added some `flatc` tests that invoke `flatc` with some different flags and check that the expected generated files (and their contents) were correct. This now adds this check to the CI.