### PR TITLE
[C#] Rework how sorted vectors are looked up

### DIFF
--- a/tests/MyGame/Example/Referrable.cs
+++ b/tests/MyGame/Example/Referrable.cs
@@ -37,17 +37,21 @@ public struct Referrable : IFlatbufferObject
   }
 
   public static VectorOffset CreateSortedVectorOfReferrable(FlatBufferBuilder builder, Offset<Referrable>[] offsets) {
-    Array.Sort(offsets, (Offset<Referrable> o1, Offset<Referrable> o2) => builder.DataBuffer.GetUlong(Table.__offset(4, o1.Value, builder.DataBuffer)).CompareTo(builder.DataBuffer.GetUlong(Table.__offset(4, o2.Value, builder.DataBuffer))));
+    Array.Sort(offsets,
+      (Offset<Referrable> o1, Offset<Referrable> o2) =>
+        new Referrable().__assign(builder.DataBuffer.Length - o1.Value, builder.DataBuffer).Id.CompareTo(new Referrable().__assign(builder.DataBuffer.Length - o2.Value, builder.DataBuffer).Id));
     return builder.CreateVectorOfTables(offsets);
   }
 
   public static Referrable? __lookup_by_key(int vectorLocation, ulong key, ByteBuffer bb) {
+    Referrable obj_ = new Referrable();
     int span = bb.GetInt(vectorLocation - 4);
     int start = 0;
     while (span != 0) {
       int middle = span / 2;
       int tableOffset = Table.__indirect(vectorLocation + 4 * (start + middle), bb);
-      int comp = bb.GetUlong(Table.__offset(4, bb.Length - tableOffset, bb)).CompareTo(key);
+      obj_.__assign(tableOffset, bb);
+      int comp = obj_.Id.CompareTo(key);
       if (comp > 0) {
         span = middle;
       } else if (comp < 0) {
@@ -55,7 +59,7 @@ public struct Referrable : IFlatbufferObject
         start += middle;
         span -= middle;
       } else {
-        return new Referrable().__assign(tableOffset, bb);
+        return obj_;
       }
     }
     return null;

--- a/tests/MyGame/Example/Stat.cs
+++ b/tests/MyGame/Example/Stat.cs
@@ -52,17 +52,21 @@ public struct Stat : IFlatbufferObject
   }
 
   public static VectorOffset CreateSortedVectorOfStat(FlatBufferBuilder builder, Offset<Stat>[] offsets) {
-    Array.Sort(offsets, (Offset<Stat> o1, Offset<Stat> o2) => builder.DataBuffer.GetUshort(Table.__offset(8, o1.Value, builder.DataBuffer)).CompareTo(builder.DataBuffer.GetUshort(Table.__offset(8, o2.Value, builder.DataBuffer))));
+    Array.Sort(offsets,
+      (Offset<Stat> o1, Offset<Stat> o2) =>
+        new Stat().__assign(builder.DataBuffer.Length - o1.Value, builder.DataBuffer).Count.CompareTo(new Stat().__assign(builder.DataBuffer.Length - o2.Value, builder.DataBuffer).Count));
     return builder.CreateVectorOfTables(offsets);
   }
 
   public static Stat? __lookup_by_key(int vectorLocation, ushort key, ByteBuffer bb) {
+    Stat obj_ = new Stat();
     int span = bb.GetInt(vectorLocation - 4);
     int start = 0;
     while (span != 0) {
       int middle = span / 2;
       int tableOffset = Table.__indirect(vectorLocation + 4 * (start + middle), bb);
-      int comp = bb.GetUshort(Table.__offset(8, bb.Length - tableOffset, bb)).CompareTo(key);
+      obj_.__assign(tableOffset, bb);
+      int comp = obj_.Count.CompareTo(key);
       if (comp > 0) {
         span = middle;
       } else if (comp < 0) {
@@ -70,7 +74,7 @@ public struct Stat : IFlatbufferObject
         start += middle;
         span -= middle;
       } else {
-        return new Stat().__assign(tableOffset, bb);
+        return obj_;
       }
     }
     return null;


### PR DESCRIPTION
When looking up keys, the previous implementation went to the key directly in the buffer to get the value to compare. However, this fails when the value is not in the buffer because it is equal to the default value (e.g., = 0).  This led to some interesting bugs.

The fix is to use the generated code's getter, which already account for defaulted fields.  

Fixes #7380 

We should probably do something similar in #7235, as the Java and C# code share common origin.