### PR TITLE
Stop using __has_trivial_copy on recent clang versions.

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -640,7 +640,8 @@ void SizePrefixedTest() {
 
 void TriviallyCopyableTest() {
   // clang-format off
-  #if __GNUG__ && __GNUC__ < 5
+  #if __GNUG__ && __GNUC__ < 5 && \
+      !(defined(__clang__) && __clang_major__ >= 16)
     TEST_EQ(__has_trivial_copy(Vec3), true);
   #else
     #if __cplusplus >= 201103L


### PR DESCRIPTION
Starting from https://reviews.llvm.org/D129170, clang has started to emit a warning on usage of deprecated builtins like __has_trivial_copy. This PR makes clang 16 and later versions avoid to use the __has_trivial_copy and instead enter the branch where std::is_trivially_copyable is used.
