### PR TITLE
Reworked keep prefix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
     - name: test
       run: Release\flattests.exe
     - name: flatc tests
-      run: python3 tests/flatc/main.py
+      run: python3 tests/flatc/main.py --flatc Release\flatc.exe
     - name: upload build artifacts
       uses: actions/upload-artifact@v1
       with:
@@ -184,7 +184,7 @@ jobs:
         chmod +x _build/Release/flatc
         ./_build/Release/flatc --version
     - name: flatc tests
-      run: python3 tests/flatc/main.py
+      run: python3 tests/flatc/main.py --flatc ./_build/Release/flatc
     - name: upload build artifacts
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,8 @@ jobs:
       run: msbuild.exe FlatBuffers.sln /p:Configuration=Release /p:Platform=x64
     - name: test
       run: Release\flattests.exe
+    - name: flatc tests
+      run: python3 tests/flatc/main.py
     - name: upload build artifacts
       uses: actions/upload-artifact@v1
       with:
@@ -181,6 +183,8 @@ jobs:
       run: |
         chmod +x _build/Release/flatc
         ./_build/Release/flatc --version
+    - name: flatc tests
+      run: python3 tests/flatc/main.py
     - name: upload build artifacts
       uses: actions/upload-artifact@v1
       with:

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -16,7 +16,6 @@
 
 // independent from idl_parser, since this code is not needed for most clients
 
-#include <iostream>
 #include <string>
 #include <unordered_set>
 

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -16,6 +16,7 @@
 
 // independent from idl_parser, since this code is not needed for most clients
 
+#include <iostream>
 #include <string>
 #include <unordered_set>
 
@@ -235,22 +236,34 @@ class CppGenerator : public BaseGenerator {
     // interdependence between them.
     std::stable_sort(included_files.begin(), included_files.end());
 
-    // Get any prefix of the file being parsed, so that included filed can be
-    // properly stripped.
-    auto prefix = flatbuffers::StripFileName(parser_.file_being_parsed_) +
-                  flatbuffers::kPathSeparator;
+    // The absolute path of the file being parsed.
+    const std::string parsed_path =
+        flatbuffers::StripFileName(AbsolutePath(parser_.file_being_parsed_));
 
     for (const std::string &included_file : included_files) {
-      auto file_without_extension = flatbuffers::StripExtension(included_file);
-      code_ +=
-          "#include \"" +
-          GeneratedFileName(
-              opts_.include_prefix,
-              opts_.keep_prefix
-                  ? flatbuffers::StripPrefix(file_without_extension, prefix)
-                  : flatbuffers::StripPath(file_without_extension),
-              opts_) +
-          "\"";
+      // The base name of the file, without path or extensions.
+      std::string basename =
+          flatbuffers::StripPath(flatbuffers::StripExtension(included_file));
+
+      // If we are keeping the prefix
+      if (opts_.keep_prefix) {
+        // The absolute path of the included file.
+        const std::string included_path =
+            flatbuffers::StripFileName(AbsolutePath(included_file));
+
+        // The relative path of the parsed file to the included file.
+        const std::string relative_path =
+            RelativeToRootPath(parsed_path, included_path).substr(2);
+
+        // Only consider cases where the included path is a subdirectory of the
+        // parsed path.
+        if (strncmp("..", relative_path.c_str(), 2) != 0) {
+          basename = relative_path + kPathSeparator + basename;
+        }
+      }
+
+      code_ += "#include \"" +
+               GeneratedFileName(opts_.include_prefix, basename, opts_) + "\"";
     }
 
     if (!parser_.native_included_files_.empty() || !included_files.empty()) {

--- a/tests/flatc/bar/bar_with_foo.fbs
+++ b/tests/flatc/bar/bar_with_foo.fbs
@@ -1,0 +1,5 @@
+include "foo.fbs";
+
+table BarWithFoo {
+  foo:Foo;
+}

--- a/tests/flatc/bar/bar_with_foo.fbs
+++ b/tests/flatc/bar/bar_with_foo.fbs
@@ -1,4 +1,5 @@
 include "foo.fbs";
+include "baz/baz.fbs";
 
 table BarWithFoo {
   foo:Foo;

--- a/tests/flatc/flatc_cpp_tests.py
+++ b/tests/flatc/flatc_cpp_tests.py
@@ -12,143 +12,236 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from math import fabs
 from flatc_test import *
 
-class CppTests():
 
-  def Flatten(self):
-    # Generate just foo with a "flatten" import of bar.
-    flatc(["--cpp", "foo.fbs"])
+class CppTests:
+    def Flatten(self):
+        # Generate just foo with a "flatten" import of bar.
+        flatc(["--cpp", "foo.fbs"])
 
-    # Foo should be generated in place and include bar flatten
-    assert_file_and_contents("foo_generated.h", '#include "bar_generated.h"')
+        # Foo should be generated in place and include bar flatten
+        assert_file_and_contents("foo_generated.h", '#include "bar_generated.h"')
 
-  def FlattenAbsolutePath(self):
-    # Generate just foo with a "flatten" import of bar.
-    flatc(["--cpp", make_absolute("foo.fbs")])
+    def FlattenAbsolutePath(self):
+        # Generate just foo with a "flatten" import of bar.
+        flatc(["--cpp", make_absolute("foo.fbs")])
 
-    # Foo should be generated in place and include bar flatten
-    assert_file_and_contents("foo_generated.h", '#include "bar_generated.h"')
+        # Foo should be generated in place and include bar flatten
+        assert_file_and_contents("foo_generated.h", '#include "bar_generated.h"')
 
-  def FlattenSubDirectory(self):
-    # Generate just foo with a "flatten" import of bar.
-    flatc(["--cpp", "bar/bar.fbs"])
-    
-    # Bar should be generated in place and include baz
-    assert_file_and_contents("bar_generated.h", '#include "baz_generated.h"')
+    def FlattenSubDirectory(self):
+        # Generate just foo with a "flatten" import of bar.
+        flatc(["--cpp", "bar/bar.fbs"])
 
-  def FlattenOutPath(self):
-    # Generate just foo with a "flatten" import of bar.
-    flatc(["--cpp", "-o", ".tmp", "foo.fbs"])
+        # Bar should be generated in place and include baz
+        assert_file_and_contents("bar_generated.h", '#include "baz_generated.h"')
 
-    # Foo should be generated in the out path and include bar flatten to the out path.
-    assert_file_and_contents(".tmp/foo_generated.h", '#include "bar_generated.h"')
+    def FlattenOutPath(self):
+        # Generate just foo with a "flatten" import of bar.
+        flatc(["--cpp", "-o", ".tmp", "foo.fbs"])
 
-  def FlattenOutPathSuperDirectory(self):
-    # Generate just foo with a "flatten" import of bar.
-    flatc(["--cpp", "-o", "../.tmp", "foo.fbs"])
+        # Foo should be generated in the out path and include bar flatten to the out path.
+        assert_file_and_contents(".tmp/foo_generated.h", '#include "bar_generated.h"')
 
-    # Foo should be generated in the out path and include bar flatten to the out path.
-    assert_file_and_contents("../.tmp/foo_generated.h", '#include "bar_generated.h"')
+    def FlattenOutPathSuperDirectory(self):
+        # Generate just foo with a "flatten" import of bar.
+        flatc(["--cpp", "-o", "../.tmp", "foo.fbs"])
 
-  def FlattenOutPathSubDirectory(self):
-    # Generate just foo with a "flatten" import of bar.
-    flatc(["--cpp", "-o", ".tmp", "bar/bar.fbs"])
+        # Foo should be generated in the out path and include bar flatten to the out path.
+        assert_file_and_contents(
+            "../.tmp/foo_generated.h", '#include "bar_generated.h"'
+        )
 
-    # Bar should be generated in the out path and include baz flatten to the out path.
-    assert_file_and_contents(".tmp/bar_generated.h", '#include "baz_generated.h"')
+    def FlattenOutPathSubDirectory(self):
+        # Generate just foo with a "flatten" import of bar.
+        flatc(["--cpp", "-o", ".tmp", "bar/bar.fbs"])
 
-  def KeepPrefix(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--keep-prefix", "foo.fbs"])
+        # Bar should be generated in the out path and include baz flatten to the out path.
+        assert_file_and_contents(".tmp/bar_generated.h", '#include "baz_generated.h"')
 
-    assert_file_and_contents("foo_generated.h", '#include "bar/bar_generated.h"')
+    def KeepPrefix(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--keep-prefix", "foo.fbs"])
 
-  def KeepPrefixAbsolutePath(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--keep-prefix", make_absolute("foo.fbs")])
+        assert_file_and_contents("foo_generated.h", '#include "bar/bar_generated.h"')
 
-    assert_file_and_contents("foo_generated.h", '#include "bar/bar_generated.h"')
+    def KeepPrefixAbsolutePath(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--keep-prefix", make_absolute("foo.fbs")])
 
-  def KeepPrefixSubDirectory(self):
-    # Generate with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--keep-prefix", "bar/bar.fbs"])
+        assert_file_and_contents("foo_generated.h", '#include "bar/bar_generated.h"')
 
-    assert_file_and_contents("bar_generated.h", '#include "baz/baz_generated.h"')
+    def KeepPrefixSubDirectory(self):
+        # Generate with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--keep-prefix", "bar/bar.fbs"])
 
-  def KeepPrefixOutPath(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--keep-prefix", "-o", ".tmp", "foo.fbs"])
+        assert_file_and_contents("bar_generated.h", '#include "baz/baz_generated.h"')
 
-    assert_file_and_contents(".tmp/foo_generated.h", '#include "bar/bar_generated.h"')
+    def KeepPrefixOutPath(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--keep-prefix", "-o", ".tmp", "foo.fbs"])
 
-  def KeepPrefixOutPathSubDirectory(self):
-    # Generate with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--keep-prefix", "-o", ".tmp", "bar/bar.fbs"])
+        assert_file_and_contents(
+            ".tmp/foo_generated.h", '#include "bar/bar_generated.h"',
+        )
 
-    assert_file_and_contents(".tmp/bar_generated.h", '#include "baz/baz_generated.h"')
+    def KeepPrefixOutPathSubDirectory(self):
+        # Generate with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--keep-prefix", "-o", ".tmp", "bar/bar.fbs"])
 
-  def IncludePrefix(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--include-prefix", "test", "foo.fbs"])
+        assert_file_and_contents(
+            ".tmp/bar_generated.h", '#include "baz/baz_generated.h"'
+        )
 
-    assert_file_and_contents("foo_generated.h", '#include "test/bar_generated.h"')
+    def IncludePrefix(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--include-prefix", "test", "foo.fbs"])
 
-  def IncludePrefixAbolutePath(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--include-prefix", "test", make_absolute("foo.fbs")])
+        assert_file_and_contents("foo_generated.h", '#include "test/bar_generated.h"')
 
-    assert_file_and_contents("foo_generated.h", '#include "test/bar_generated.h"')
+    def IncludePrefixAbolutePath(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--include-prefix", "test", make_absolute("foo.fbs")])
 
-  def IncludePrefixSubDirectory(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--include-prefix", "test", "bar/bar.fbs"])
+        assert_file_and_contents("foo_generated.h", '#include "test/bar_generated.h"')
 
-    assert_file_and_contents("bar_generated.h", '#include "test/baz_generated.h"')
+    def IncludePrefixSubDirectory(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--include-prefix", "test", "bar/bar.fbs"])
 
-  def IncludePrefixOutPath(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--include-prefix", "test", "-o", ".tmp", "foo.fbs"])
+        assert_file_and_contents("bar_generated.h", '#include "test/baz_generated.h"')
 
-    assert_file_and_contents(".tmp/foo_generated.h", '#include "test/bar_generated.h"')
+    def IncludePrefixOutPath(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--include-prefix", "test", "-o", ".tmp", "foo.fbs"])
 
-  def IncludePrefixOutPathSubDirectory(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--include-prefix", "test", "-o", ".tmp", "bar/bar.fbs"])
+        assert_file_and_contents(
+            ".tmp/foo_generated.h", '#include "test/bar_generated.h"'
+        )
 
-    assert_file_and_contents(".tmp/bar_generated.h", '#include "test/baz_generated.h"')
+    def IncludePrefixOutPathSubDirectory(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--include-prefix", "test", "-o", ".tmp", "bar/bar.fbs"])
 
-  def KeepPrefixIncludePrefix(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", "foo.fbs"])
+        assert_file_and_contents(
+            ".tmp/bar_generated.h", '#include "test/baz_generated.h"'
+        )
 
-    # The include prefix should come first, with the kept prefix next.
-    assert_file_and_contents("foo_generated.h", '#include "test/bar/bar_generated.h"')
+    def KeepPrefixIncludePrefix(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", "foo.fbs"])
 
-  def KeepPrefixIncludePrefixAbsolutePath(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", make_absolute("foo.fbs")])
+        # The include prefix should come first, with the kept prefix next.
+        assert_file_and_contents(
+            "foo_generated.h", '#include "test/bar/bar_generated.h"'
+        )
 
-    # The include prefix should come first, with the kept prefix next.
-    assert_file_and_contents("foo_generated.h", '#include "test/bar/bar_generated.h"')
+    def KeepPrefixIncludePrefixAbsolutePath(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(
+            [
+                "--cpp",
+                "--keep-prefix",
+                "--include-prefix",
+                "test",
+                make_absolute("foo.fbs"),
+            ]
+        )
 
-  def KeepPrefixIncludePrefixSubDirectory(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", "bar/bar.fbs"])
+        # The include prefix should come first, with the kept prefix next.
+        assert_file_and_contents(
+            "foo_generated.h", '#include "test/bar/bar_generated.h"'
+        )
 
-    # The include prefix should come first, with the kept prefix next.
-    assert_file_and_contents("bar_generated.h", '#include "test/baz/baz_generated.h"')
+    def KeepPrefixIncludePrefixSubDirectory(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", "bar/bar.fbs"])
 
-  def KeepPrefixIncludePrefixOutPathSubDirectory(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", "-o", ".tmp", "bar/bar.fbs"])
+        # The include prefix should come first, with the kept prefix next.
+        assert_file_and_contents(
+            "bar_generated.h", '#include "test/baz/baz_generated.h"'
+        )
 
-    # The include prefix should come first, with the kept prefix next.
-    assert_file_and_contents(".tmp/bar_generated.h", '#include "test/baz/baz_generated.h"')
+    def KeepPrefixIncludePrefixOutPathSubDirectory(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(
+            [
+                "--cpp",
+                "--keep-prefix",
+                "--include-prefix",
+                "test",
+                "-o",
+                ".tmp",
+                "bar/bar.fbs",
+            ]
+        )
 
-  def KeepPrefixIncludePrefixOutPathSuperDirectory(self):
-    # Generate just foo with the import of bar keeping the prefix of where it is located.
-    flatc(["--cpp", "--keep-prefix", "--include-prefix", "test", "-o", "../.tmp", "bar/bar.fbs"])
+        # The include prefix should come first, with the kept prefix next.
+        assert_file_and_contents(
+            ".tmp/bar_generated.h", '#include "test/baz/baz_generated.h"'
+        )
 
-    # The include prefix should come first, with the kept prefix next.
-    assert_file_and_contents("../.tmp/bar_generated.h", '#include "test/baz/baz_generated.h"')
+    def KeepPrefixIncludePrefixOutPathSuperDirectory(self):
+        # Generate just foo with the import of bar keeping the prefix of where it is located.
+        flatc(
+            [
+                "--cpp",
+                "--keep-prefix",
+                "--include-prefix",
+                "test",
+                "-o",
+                "../.tmp",
+                "bar/bar.fbs",
+            ]
+        )
+
+        # The include prefix should come first, with the kept prefix next.
+        assert_file_and_contents(
+            "../.tmp/bar_generated.h", '#include "test/baz/baz_generated.h"'
+        )
+
+    def KeepPrefixIncludePrefixoutPathAbsoluePaths_SuperDirectoryReference(self):
+        # Generate bar_with_foo that references a type in a super directory.
+        flatc(
+            [
+                "--cpp",
+                "--keep-prefix",
+                "--include-prefix",
+                "generated",
+                "-I",
+                script_path.absolute(),
+                "-o",
+                Path(script_path, ".tmp").absolute(),
+                Path(script_path, "bar/bar_with_foo.fbs").absolute(),
+            ]
+        )
+
+        # The include prefix should come first, with the kept prefix next.
+        assert_file_and_contents(
+            ".tmp/bar_with_foo_generated.h",
+            '#include "generated/foo_generated.h"',
+        )
+
+    def KeepPrefixIncludePrefixoutPath_SuperDirectoryReference(self):
+        # Generate bar_with_foo that references a type in a super directory.
+        flatc(
+            [
+                "--cpp",
+                "--keep-prefix",
+                "--include-prefix",
+                "generated",
+                "-I",
+                "./",
+                "-o",
+                ".tmp",
+                "bar/bar_with_foo.fbs",
+            ]
+        )
+
+        # The include prefix should come first, with the kept prefix next.
+        assert_file_and_contents(
+            ".tmp/bar_with_foo_generated.h",
+            '#include "generated/foo_generated.h"',
+        )

--- a/tests/flatc/flatc_cpp_tests.py
+++ b/tests/flatc/flatc_cpp_tests.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from math import fabs
 from flatc_test import *
 
 

--- a/tests/flatc/flatc_cpp_tests.py
+++ b/tests/flatc/flatc_cpp_tests.py
@@ -83,7 +83,8 @@ class CppTests:
         flatc(["--cpp", "--keep-prefix", "-o", ".tmp", "foo.fbs"])
 
         assert_file_and_contents(
-            ".tmp/foo_generated.h", '#include "bar/bar_generated.h"',
+            ".tmp/foo_generated.h",
+            '#include "bar/bar_generated.h"',
         )
 
     def KeepPrefixOutPathSubDirectory(self):
@@ -210,17 +211,20 @@ class CppTests:
                 "--include-prefix",
                 "generated",
                 "-I",
-                script_path.absolute(),
+                str(script_path.absolute()),
                 "-o",
-                Path(script_path, ".tmp").absolute(),
-                Path(script_path, "bar/bar_with_foo.fbs").absolute(),
+                str(Path(script_path, ".tmp").absolute()),
+                str(Path(script_path, "bar/bar_with_foo.fbs").absolute()),
             ]
         )
 
         # The include prefix should come first, with the kept prefix next.
         assert_file_and_contents(
             ".tmp/bar_with_foo_generated.h",
-            '#include "generated/foo_generated.h"',
+            [
+                '#include "generated/baz/baz_generated.h"',
+                '#include "generated/foo_generated.h"',
+            ],
         )
 
     def KeepPrefixIncludePrefixoutPath_SuperDirectoryReference(self):
@@ -242,5 +246,9 @@ class CppTests:
         # The include prefix should come first, with the kept prefix next.
         assert_file_and_contents(
             ".tmp/bar_with_foo_generated.h",
-            '#include "generated/foo_generated.h"',
+            [
+                '#include "generated/baz/baz_generated.h"',
+                '#include "generated/foo_generated.h"',
+            ],
+            unlink=False,
         )

--- a/tests/flatc/flatc_test.py
+++ b/tests/flatc/flatc_test.py
@@ -52,7 +52,7 @@ def flatc(options, cwd=script_path):
 
 
 def make_absolute(filename, path=script_path):
-    return Path(path, filename).absolute()
+    return str(Path(path, filename).absolute())
 
 
 def assert_file_exists(filename, path=script_path):

--- a/tests/flatc/main.py
+++ b/tests/flatc/main.py
@@ -27,5 +27,3 @@ print("{0} of {1} tests passed".format(passing, passing + failing))
 
 if failing > 0:
     sys.exit(1)
-
-# TsTests().Base()


### PR DESCRIPTION
There was a bug in how absolute paths were being handled in the generation of the include file names.

