### PR TITLE
Use schema include name for keep-prefix

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2545,7 +2545,7 @@ CheckedError Parser::CheckClash(std::vector<FieldDef *> &fields,
   return NoError();
 }
 
-std::vector<std::string> Parser::GetIncludedFiles() const {
+std::vector<IncludedFile> Parser::GetIncludedFiles() const {
   const auto it = files_included_per_file_.find(file_being_parsed_);
   if (it == files_included_per_file_.end()) { return {}; }
 
@@ -3435,7 +3435,7 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
 
     if (included_files_.find(source_hash) == included_files_.end()) {
       included_files_[source_hash] = include_filename ? include_filename : "";
-      files_included_per_file_[source_filename] = std::set<std::string>();
+      files_included_per_file_[source_filename] = std::set<IncludedFile>();
     } else {
       return NoError();
     }
@@ -3483,8 +3483,12 @@ CheckedError Parser::DoParse(const char *source, const char **include_paths,
       }
       if (filepath.empty())
         return Error("unable to locate include file: " + name);
-      if (source_filename)
-        files_included_per_file_[source_filename].insert(filepath);
+      if (source_filename) {
+        IncludedFile included_file;
+        included_file.filename = filepath;
+        included_file.schema_name = name;
+        files_included_per_file_[source_filename].insert(included_file);
+      }
 
       std::string contents;
       bool file_loaded = LoadFile(filepath.c_str(), true, &contents);
@@ -3621,11 +3625,11 @@ std::set<std::string> Parser::GetIncludedFilesRecursive(
 
     // Workaround the lack of const accessor in C++98 maps.
     auto &new_files =
-        (*const_cast<std::map<std::string, std::set<std::string>> *>(
+        (*const_cast<std::map<std::string, std::set<IncludedFile>> *>(
             &files_included_per_file_))[current];
     for (auto it = new_files.begin(); it != new_files.end(); ++it) {
-      if (included_files.find(*it) == included_files.end())
-        to_process.push_back(*it);
+      if (included_files.find(it->filename) == included_files.end())
+        to_process.push_back(it->filename);
     }
   }
 
@@ -3675,7 +3679,7 @@ void Parser::Serialize() {
           RelativeToRootPath(opts.project_root, f->first));
       for (auto i = f->second.begin(); i != f->second.end(); i++) {
         included_files.push_back(builder_.CreateSharedString(
-            RelativeToRootPath(opts.project_root, *i)));
+            RelativeToRootPath(opts.project_root, i->filename)));
       }
       const auto included_files__ = builder_.CreateVector(included_files);
       included_files.clear();
@@ -4107,7 +4111,9 @@ bool Parser::Deserialize(const reflection::Schema *schema) {
          ++s) {
       for (auto f = s->included_filenames()->begin();
            f != s->included_filenames()->end(); ++f) {
-        files_included_per_file_[s->filename()->str()].insert(f->str());
+        IncludedFile included_file;
+        included_file.filename = f->str();
+        files_included_per_file_[s->filename()->str()].insert(included_file);
       }
     }
 


### PR DESCRIPTION
This has been more complicated than I like. There was a subtle difference between what was stored in the parser `included_files` and the `files_included_per_file`. The former stored the schema-defined name of the include, while the later stored the relative file path. In most cases, this was the same and things worked OK, but there were cases when `flatc` is invoked with include paths (`-I ...` ) which caused the relative file path to include more prefix than expected. My fix in #7456 fixed some of those, but made an exception for files in super directories, which wasn't always right.

So all of that lead me to examine this code in depth and more clearly detail what each piece is.  Instead of storing a string to represented included files, I store a struct with clearly labelled fields. Hopefully this will reduce the confusion going forward.
