### PR TITLE
[Java] Shallow unused return value in Pack method

### DIFF
--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -1658,11 +1658,15 @@ class JavaGenerator : public BaseGenerator {
                 field.value.type.struct_def == nullptr
                     ? "builder.add" + GenMethod(field.value.type.VectorType()) +
                           "(" + variable + "[_j]);"
-                    : type_name + ".pack(builder, " + variable + "[_j]);";
+                    : "_unused_offset = " + type_name + ".pack(builder, " +
+                          variable + "[_j]);";
             code += "    int _" + field_name + " = 0;\n";
             code += "    " + element_type_name + "[] " + variable + " = _o." +
                     get_field + "();\n";
             code += "    if (" + variable + " != null) {\n";
+            if (field.value.type.struct_def != nullptr) {
+              code += "      int _unused_offset = 0;\n";
+            }
             code += "      " + namer_.Method("start", field) +
                     "Vector(builder, " + variable + ".length);\n";
             code += "      for (int _j = " + variable +

--- a/tests/MyGame/Example/Monster.java
+++ b/tests/MyGame/Example/Monster.java
@@ -549,8 +549,9 @@ public final class Monster extends Table {
     int _test4 = 0;
     MyGame.Example.TestT[] _oTest4 = _o.getTest4();
     if (_oTest4 != null) {
+      int _unused_offset = 0;
       startTest4Vector(builder, _oTest4.length);
-      for (int _j = _oTest4.length - 1; _j >=0; _j--) { MyGame.Example.Test.pack(builder, _oTest4[_j]);}
+      for (int _j = _oTest4.length - 1; _j >=0; _j--) { _unused_offset = MyGame.Example.Test.pack(builder, _oTest4[_j]);}
       _test4 = builder.endVector();
     }
     int _testarrayofstring = 0;
@@ -590,8 +591,9 @@ public final class Monster extends Table {
     int _testarrayofsortedstruct = 0;
     MyGame.Example.AbilityT[] _oTestarrayofsortedstruct = _o.getTestarrayofsortedstruct();
     if (_oTestarrayofsortedstruct != null) {
+      int _unused_offset = 0;
       startTestarrayofsortedstructVector(builder, _oTestarrayofsortedstruct.length);
-      for (int _j = _oTestarrayofsortedstruct.length - 1; _j >=0; _j--) { MyGame.Example.Ability.pack(builder, _oTestarrayofsortedstruct[_j]);}
+      for (int _j = _oTestarrayofsortedstruct.length - 1; _j >=0; _j--) { _unused_offset = MyGame.Example.Ability.pack(builder, _oTestarrayofsortedstruct[_j]);}
       _testarrayofsortedstruct = builder.endVector();
     }
     int _flex = 0;
@@ -604,8 +606,9 @@ public final class Monster extends Table {
     int _test5 = 0;
     MyGame.Example.TestT[] _oTest5 = _o.getTest5();
     if (_oTest5 != null) {
+      int _unused_offset = 0;
       startTest5Vector(builder, _oTest5.length);
-      for (int _j = _oTest5.length - 1; _j >=0; _j--) { MyGame.Example.Test.pack(builder, _oTest5[_j]);}
+      for (int _j = _oTest5.length - 1; _j >=0; _j--) { _unused_offset = MyGame.Example.Test.pack(builder, _oTest5[_j]);}
       _test5 = builder.endVector();
     }
     int _vectorOfLongs = 0;


### PR DESCRIPTION
When packing a vector of structs, the struct's pack method returns an offset. This offset isn't used since the structs are included inline in the vector. To appease some error checking for unused return values, this PR captures the returned offset into a local unused variable.
