### PR TITLE
Disable RTTI and rework use in idl_gen_ts.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,8 @@ else()
       $<$<BOOL:${FLATBUFFERS_STRICT_MODE}>:
         -Werror   # Treat all compiler warnings as errors
 
+        -fno-rtti # Disable runtime type information
+
         $<$<CXX_COMPILER_ID:GNU>:
           # False positive string overflow
           # https://github.com/google/flatbuffers/issues/7366

--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -38,6 +38,12 @@ struct ImportDefinition {
 };
 
 enum AnnotationType { kParam = 0, kType = 1, kReturns = 2 };
+
+template<typename T> bool SupportsObjectAPI() { return false; }
+
+// Structs can have Object API support.
+template<> bool SupportsObjectAPI<StructDef>() { return true; }
+
 }  // namespace
 
 namespace ts {
@@ -712,9 +718,9 @@ class TsGenerator : public BaseGenerator {
     return symbols_expression;
   }
 
-  template<typename DefintionT>
+  template<typename DefinitionT>
   ImportDefinition AddImport(import_set &imports, const Definition &dependent,
-                             const DefintionT &dependency) {
+                             const DefinitionT &dependency) {
     // The unique name of the dependency, fully qualified in its namespace.
     const std::string unique_name = GetTypeName(
         dependency, /*object_api = */ false, /*force_ns_wrap=*/true);
@@ -748,8 +754,9 @@ class TsGenerator : public BaseGenerator {
                 // Strip the leading //
                 .substr(2);
         flat_file_import_declarations_[file][import_name] = name;
+
         if (parser_.opts.generate_object_based_api &&
-            typeid(dependency) == typeid(StructDef)) {
+            SupportsObjectAPI<DefinitionT>()) {
           flat_file_import_declarations_[file][import_name + "T"] = object_name;
         }
       }


### PR DESCRIPTION
Some dependent projects build with `-fno-rtti` which I recently added in `idl_gen_ts.cpp`. Since there is a better way to do this with template specializations, I switched over to that and also added `-fno-rtti` to our strict mode to catch it in CI.
