### PR TITLE
[Java][FlexBuffers] throwing exception for untyped fixed vectors

### DIFF
--- a/java/com/google/flatbuffers/FlexBuffersBuilder.java
+++ b/java/com/google/flatbuffers/FlexBuffersBuilder.java
@@ -502,7 +502,9 @@ public class FlexBuffersBuilder {
      * @return Value representing the created vector
      */
     private Value createVector(int key, int start, int length, boolean typed, boolean fixed, Value keys) {
-        assert (!fixed || typed); // typed=false, fixed=true combination is not supported.
+        if (fixed & !typed)
+            throw new UnsupportedOperationException("Untyped fixed vector is not supported");
+
         // Figure out smallest bit width we can store this vector with.
         int bitWidth = Math.max(WIDTH_8, widthUInBits(length));
         int prefixElems = 1;


### PR DESCRIPTION
Untyped fixed vectors are not supported in FlexBuffers. There
was an assert to check for it, but on java, asserts are optional. This
change converts the assertion into a runtime exception.

Fixes #7358
