### PR TITLE
enabled cpp17 tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,10 +82,14 @@ jobs:
         CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles" 
         -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON 
         -DFLATBUFFERS_CPP_STD=${{ matrix.std }}
+        -DFLATBUFFERS_BUILD_CPP17=${{ matrix.std >= 17 && 'On' || 'Off'}}
     - name: build
       run: make -j
     - name: test
       run: ./flattests
+    - name: test C++17
+      if: matrix.std >= 17
+      run: ./flattests_cpp17
 
   build-windows-cpp-std:
     name: Build Windows C++
@@ -103,10 +107,14 @@ jobs:
         cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release 
         -DFLATBUFFERS_STRICT_MODE=ON 
         -DFLATBUFFERS_CPP_STD=${{ matrix.std }}
+        -DFLATBUFFERS_BUILD_CPP17=${{ matrix.std >= 17 && 'On' || 'Off'}}
     - name: build
       run: msbuild.exe FlatBuffers.sln /p:Configuration=Release /p:Platform=x64
     - name: test
       run: Release\flattests.exe
+    - name: test C++17
+      if: matrix.std >= 17
+      run: Release\flattests_cpp17.exe
 
   build-windows:
     permissions:

--- a/tests/cpp17/test_cpp17.cpp
+++ b/tests/cpp17/test_cpp17.cpp
@@ -146,6 +146,8 @@ void StringifyAnyFlatbuffersTypeTest() {
         any_unique_type = 0
         any_ambiguous_type = 0
         signed_enum = -1
+        long_enum_non_enum_default = 0
+        long_enum_normal_default = 2
       })";
 
   // Call a generic function that has no specific knowledge of the flatbuffer we
@@ -251,7 +253,7 @@ int FlatBufferCpp17Tests() {
   StringifyAnyFlatbuffersTypeTest();
   return 0;
 }
-} // namespace
+}  // namespace
 
 int main(int /*argc*/, const char * /*argv*/[]) {
   InitTestEngine();


### PR DESCRIPTION
I was trying to add some C++17-only tests, and I noticed `flattest_cpp17` was failing. So we are missing coverage on CI. This fixes the test and adds CI coverage.