### PR TITLE
C++17 `std::variant` getter for Unions

### DIFF
--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -4,6 +4,8 @@
 #ifndef FLATBUFFERS_GENERATED_MONSTERTEST_MYGAME_EXAMPLE_H_
 #define FLATBUFFERS_GENERATED_MONSTERTEST_MYGAME_EXAMPLE_H_
 
+#include <variant>
+
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/flexbuffers.h"
 #include "flatbuffers/flex_flat_util.h"
@@ -251,6 +253,12 @@ template<> struct AnyTraits<MyGame::Example2::Monster> {
   static const Any enum_value = Any::MyGame_Example2_Monster;
 };
 
+using AnyVariant = std::variant<
+  const MyGame::Example2::Monster *,
+  const MyGame::Example::Monster *,
+  const MyGame::Example::TestSimpleTableWithEnum *,
+  std::monostate>;
+
 template<typename T> struct AnyUnionTraits {
   static const Any enum_value = Any::NONE;
 };
@@ -378,6 +386,12 @@ template<> struct AnyUniqueAliasesTraits<MyGame::Example2::Monster> {
   static const AnyUniqueAliases enum_value = AnyUniqueAliases::M2;
 };
 
+using AnyUniqueAliasesVariant = std::variant<
+  const MyGame::Example2::Monster *,
+  const MyGame::Example::Monster *,
+  const MyGame::Example::TestSimpleTableWithEnum *,
+  std::monostate>;
+
 template<typename T> struct AnyUniqueAliasesUnionTraits {
   static const AnyUniqueAliases enum_value = AnyUniqueAliases::NONE;
 };
@@ -488,6 +502,10 @@ inline const char *EnumNameAnyAmbiguousAliases(AnyAmbiguousAliases e) {
   const size_t index = static_cast<size_t>(e);
   return EnumNamesAnyAmbiguousAliases()[index];
 }
+
+using AnyAmbiguousAliasesVariant = std::variant<
+  const MyGame::Example::Monster *,
+  std::monostate>;
 
 struct AnyAmbiguousAliasesUnion {
   AnyAmbiguousAliases type;
@@ -1439,6 +1457,15 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return GetPointer<const void *>(VT_TEST);
   }
   template<typename T> const T *test_as() const;
+  AnyVariant test_variant() const {
+    switch(test_type()) {
+      case MyGame::Example::Any::NONE: break;
+      case MyGame::Example::Any::Monster: return static_cast<const MyGame::Example::Monster *>(test()); 
+      case MyGame::Example::Any::TestSimpleTableWithEnum: return static_cast<const MyGame::Example::TestSimpleTableWithEnum *>(test()); 
+      case MyGame::Example::Any::MyGame_Example2_Monster: return static_cast<const MyGame::Example2::Monster *>(test()); 
+    }
+    return std::monostate{};
+  }
   const MyGame::Example::Monster *test_as_Monster() const {
     return test_type() == MyGame::Example::Any::Monster ? static_cast<const MyGame::Example::Monster *>(test()) : nullptr;
   }
@@ -1670,6 +1697,15 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return GetPointer<const void *>(VT_ANY_UNIQUE);
   }
   template<typename T> const T *any_unique_as() const;
+  AnyUniqueAliasesVariant any_unique_variant() const {
+    switch(any_unique_type()) {
+      case MyGame::Example::AnyUniqueAliases::NONE: break;
+      case MyGame::Example::AnyUniqueAliases::M: return static_cast<const MyGame::Example::Monster *>(any_unique()); 
+      case MyGame::Example::AnyUniqueAliases::TS: return static_cast<const MyGame::Example::TestSimpleTableWithEnum *>(any_unique()); 
+      case MyGame::Example::AnyUniqueAliases::M2: return static_cast<const MyGame::Example2::Monster *>(any_unique()); 
+    }
+    return std::monostate{};
+  }
   const MyGame::Example::Monster *any_unique_as_M() const {
     return any_unique_type() == MyGame::Example::AnyUniqueAliases::M ? static_cast<const MyGame::Example::Monster *>(any_unique()) : nullptr;
   }
@@ -1687,6 +1723,15 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   const void *any_ambiguous() const {
     return GetPointer<const void *>(VT_ANY_AMBIGUOUS);
+  }
+  AnyAmbiguousAliasesVariant any_ambiguous_variant() const {
+    switch(any_ambiguous_type()) {
+      case MyGame::Example::AnyAmbiguousAliases::NONE: break;
+      case MyGame::Example::AnyAmbiguousAliases::M1: return static_cast<const MyGame::Example::Monster *>(any_ambiguous()); 
+      case MyGame::Example::AnyAmbiguousAliases::M2: return static_cast<const MyGame::Example::Monster *>(any_ambiguous()); 
+      case MyGame::Example::AnyAmbiguousAliases::M3: return static_cast<const MyGame::Example::Monster *>(any_ambiguous()); 
+    }
+    return std::monostate{};
   }
   const MyGame::Example::Monster *any_ambiguous_as_M1() const {
     return any_ambiguous_type() == MyGame::Example::AnyAmbiguousAliases::M1 ? static_cast<const MyGame::Example::Monster *>(any_ambiguous()) : nullptr;

--- a/tests/cpp17/generated_cpp17/optional_scalars_generated.h
+++ b/tests/cpp17/generated_cpp17/optional_scalars_generated.h
@@ -4,6 +4,8 @@
 #ifndef FLATBUFFERS_GENERATED_OPTIONALSCALARS_OPTIONAL_SCALARS_H_
 #define FLATBUFFERS_GENERATED_OPTIONALSCALARS_OPTIONAL_SCALARS_H_
 
+#include <variant>
+
 #include "flatbuffers/flatbuffers.h"
 
 // Ensure the included flatbuffers.h is the same version as when this file was

--- a/tests/cpp17/generated_cpp17/union_vector_generated.h
+++ b/tests/cpp17/generated_cpp17/union_vector_generated.h
@@ -4,6 +4,8 @@
 #ifndef FLATBUFFERS_GENERATED_UNIONVECTOR_H_
 #define FLATBUFFERS_GENERATED_UNIONVECTOR_H_
 
+#include <variant>
+
 #include "flatbuffers/flatbuffers.h"
 
 // Ensure the included flatbuffers.h is the same version as when this file was
@@ -87,6 +89,13 @@ inline const char *EnumNameCharacter(Character e) {
   const size_t index = static_cast<size_t>(e);
   return EnumNamesCharacter()[index];
 }
+
+using CharacterVariant = std::variant<
+  const Attacker *,
+  const BookReader *,
+  const Rapunzel *,
+  const flatbuffers::String *,
+  std::monostate>;
 
 struct CharacterUnion {
   Character type;
@@ -205,6 +214,11 @@ template<> struct GadgetTraits<FallingTub> {
 template<> struct GadgetTraits<HandFan> {
   static const Gadget enum_value = Gadget::HandFan;
 };
+
+using GadgetVariant = std::variant<
+  const FallingTub *,
+  const HandFan *,
+  std::monostate>;
 
 template<typename T> struct GadgetUnionTraits {
   static const Gadget enum_value = Gadget::NONE;
@@ -570,6 +584,18 @@ struct Movie FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   const void *main_character() const {
     return GetPointer<const void *>(VT_MAIN_CHARACTER);
+  }
+  CharacterVariant main_character_variant() const {
+    switch(main_character_type()) {
+      case Character::NONE: break;
+      case Character::MuLan: return static_cast<const Attacker *>(main_character()); 
+      case Character::Rapunzel: return static_cast<const Rapunzel *>(main_character()); 
+      case Character::Belle: return static_cast<const BookReader *>(main_character()); 
+      case Character::BookFan: return static_cast<const BookReader *>(main_character()); 
+      case Character::Other: return static_cast<const flatbuffers::String *>(main_character()); 
+      case Character::Unused: return static_cast<const flatbuffers::String *>(main_character()); 
+    }
+    return std::monostate{};
   }
   const Attacker *main_character_as_MuLan() const {
     return main_character_type() == Character::MuLan ? static_cast<const Attacker *>(main_character()) : nullptr;


### PR DESCRIPTION
This adds a `std::variant` getter accessor for tables' union fields. 

This is the idiomatic way to represent a type safe union in C++, and allows one to use `std::visit` on the Union, which adds safety in that each type has to be explicitly visited.

This is only for c++17 builds or newer since variant was only added in that. You have to explicitly enable this feature using `flatc --cpp --cpp-std C++17`.


