### PR TITLE
upgrade conform

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -634,7 +634,6 @@ struct IDLOptions {
   bool json_nested_legacy_flatbuffers;
   bool ts_flat_file;
   bool no_leak_private_annotations;
-
   // Possible options for the more general generator below.
   enum Language {
     kJava = 1 << 0,
@@ -681,6 +680,10 @@ struct IDLOptions {
   // make the flatbuffer more compact.
   bool set_empty_vectors_to_null;
 
+  // If set, deletion of the last fields of each table/struct will be treated as 
+  // unconformable because subsequent added fields will break the conformity with
+  // historical schemas 
+  bool conform_subsequence;
   IDLOptions()
       : gen_jvmstatic(false),
         use_flexbuffers(false),
@@ -740,7 +743,8 @@ struct IDLOptions {
         rust_module_root_file(false),
         lang_to_generate(0),
         set_empty_strings_to_null(true),
-        set_empty_vectors_to_null(true) {}
+        set_empty_vectors_to_null(true),
+        conform_subsequence(false) {}
 };
 
 // This encapsulates where the parser is in the current source file.
@@ -920,9 +924,10 @@ class Parser : public ParserState {
 
   Type *DeserializeType(const reflection::Type *type);
 
-  // Checks that the schema represented by this parser is a safe evolution
-  // of the schema provided. Returns non-empty error on any problems.
-  std::string ConformTo(const Parser &base);
+  // Checks that the schema represented by this parser is a safe evolution of the schema provided. 
+  // If considerSubsequence is true, the check fails when deletion of foot fields occurs.
+  // Returns non-empty error on any problems.
+  std::string ConformTo(const Parser &base, bool consider_subsequence);
 
   // Similar to Parse(), but now only accepts JSON to be parsed into a
   // FlexBuffer.

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -175,6 +175,10 @@ const static FlatCOption options[] = {
     "errors if not." },
   { "", "conform-includes", "PATH",
     "Include path for the schema given with --conform PATH" },
+  { "", "conform-subsequence", "",
+    "Deletion of the foot fields of each table/struct is no longer treated as "
+    "conformable. This enables that subsequent schema changes can conform with "
+    "historical ones."},
   { "", "filename-suffix", "SUFFIX",
     "The suffix appended to the generated file names (Default is "
     "'_generated')." },
@@ -428,6 +432,8 @@ int FlatCompiler::Compile(int argc, const char **argv) {
             flatbuffers::PosixPath(argv[argi]));
         conform_include_directories.push_back(
             include_directories_storage.back().c_str());
+      } else if (arg == "--conform-subsequence") {
+        opts.conform_subsequence = true;
       } else if (arg == "--include-prefix") {
         if (++argi >= argc) Error("missing path following: " + arg, true);
         opts.include_prefix = flatbuffers::ConCatPathFileName(
@@ -786,7 +792,7 @@ int FlatCompiler::Compile(int argc, const char **argv) {
         }
       }
       if ((is_schema || is_binary_schema) && !conform_to_schema.empty()) {
-        auto err = parser->ConformTo(conform_parser);
+        auto err = parser->ConformTo(conform_parser, opts.conform_subsequence);
         if (!err.empty()) Error("schemas don\'t conform: " + err, false);
       }
       if (schema_binary || opts.binary_schema_gen_embed) {

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -4124,24 +4124,26 @@ bool Parser::Deserialize(const reflection::Schema *schema) {
   return true;
 }
 
-std::string Parser::ConformTo(const Parser &base) {
+std::string Parser::ConformTo(const Parser &base, bool consider_subsequence) {
   for (auto sit = structs_.vec.begin(); sit != structs_.vec.end(); ++sit) {
     auto &struct_def = **sit;
     auto qualified_name =
         struct_def.defined_namespace->GetFullyQualifiedName(struct_def.name);
     auto struct_def_base = base.LookupStruct(qualified_name);
     if (!struct_def_base) continue;
+    std::vector<FieldDef*> renamed_fields;
     for (auto fit = struct_def.fields.vec.begin();
          fit != struct_def.fields.vec.end(); ++fit) {
       auto &field = **fit;
       auto field_base = struct_def_base->fields.Lookup(field.name);
+      auto qualified_field_name = qualified_name + "." + field.name;
       if (field_base) {
         if (field.value.offset != field_base->value.offset)
-          return "offsets differ for field: " + field.name;
+          return "offsets differ for field: " + qualified_field_name;
         if (field.value.constant != field_base->value.constant)
-          return "defaults differ for field: " + field.name;
+          return "defaults differ for field: " + qualified_field_name;
         if (!EqualByName(field.value.type, field_base->value.type))
-          return "types differ for field: " + field.name;
+          return "types differ for field: " + qualified_field_name;
       } else {
         // Doesn't have to exist, deleting fields is fine.
         // But we should check if there is a field that has the same offset
@@ -4150,14 +4152,42 @@ std::string Parser::ConformTo(const Parser &base) {
              fbit != struct_def_base->fields.vec.end(); ++fbit) {
           field_base = *fbit;
           if (field.value.offset == field_base->value.offset) {
+            renamed_fields.push_back(field_base);
             if (!EqualByName(field.value.type, field_base->value.type))
-              return "field renamed to different type: " + field.name;
+              return "field renamed to different type: " + qualified_field_name;
             break;
           }
         }
       }
     }
+    if (consider_subsequence) { //deletion of foot fields are not allowed
+      for (auto fit = struct_def_base->fields.vec.begin();
+        fit != struct_def_base->fields.vec.end(); ++fit ) {  
+        auto &field_base = **fit;
+        //not a renamed field
+        if (std::find(renamed_fields.begin(), renamed_fields.end(), &field_base) == renamed_fields.end()) {
+          auto field = struct_def.fields.Lookup(field_base.name);
+          auto qualified_field_name = qualified_name + "." + field_base.name;
+          if (!field) {
+            return "field deleted: " + qualified_field_name;
+          }
+        }
+      }
+    }
   }
+  
+  if (consider_subsequence) {
+    for (auto sit = base.structs_.vec.begin(); sit != base.structs_.vec.end(); ++sit) {
+      auto &base_struct_def = **sit;
+      auto qualified_name =
+          base_struct_def.defined_namespace->GetFullyQualifiedName(base_struct_def.name);
+      auto struct_def = LookupStruct(qualified_name);
+      if (!struct_def) {
+        return "struct deleted: " + qualified_name;
+      }
+    }
+  }
+
   for (auto eit = enums_.vec.begin(); eit != enums_.vec.end(); ++eit) {
     auto &enum_def = **eit;
     auto qualified_name =


### PR DESCRIPTION
add new conform option --conform-subsequence
- when the option is present, conform will fail on deleted fields or structs/tables
- currently there exists cases that subsequent changes conform with the original schema, but fail to conform with its historical ones. 
- It is preferable in a CI/CD system that all subsequent schemas conform with their predecessors.

provide more information with unconformable test;
