### PR TITLE
update grpc version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --cxxopt=-std=c++14

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,7 +56,7 @@ http_archive(
 )
 
 ##### GRPC
-_GRPC_VERSION = "1.48.0"  # https://github.com/grpc/grpc/releases/tag/v1.48.0
+_GRPC_VERSION = "1.49.0"  # https://github.com/grpc/grpc/releases/tag/v1.49.0
 
 http_archive(
     name = "com_github_grpc_grpc",


### PR DESCRIPTION
update grpc to the latest version to enable the flag flip for `--incompatible_use_platforms_repo_for_constraints` https://github.com/bazelbuild/continuous-integration/issues/1404