### PR TITLE
rust: Add Follow with a different lifetime

### DIFF
--- a/rust/flatbuffers/src/follow.rs
+++ b/rust/flatbuffers/src/follow.rs
@@ -53,3 +53,7 @@ impl<'a, T: Follow<'a>> Follow<'a> for FollowStart<T> {
         T::follow(buf, loc)
     }
 }
+
+pub trait FollowWith<'a> {
+    type Inner: Follow<'a>;
+}

--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -51,7 +51,7 @@ pub use crate::builder::FlatBufferBuilder;
 pub use crate::endian_scalar::{
     byte_swap_f32, byte_swap_f64, emplace_scalar, read_scalar, read_scalar_at, EndianScalar,
 };
-pub use crate::follow::{Follow, FollowStart};
+pub use crate::follow::{Follow, FollowStart, FollowWith};
 pub use crate::primitives::*;
 pub use crate::push::Push;
 pub use crate::table::{buffer_has_identifier, Table};

--- a/samples/rust_generated/my_game/sample/monster_generated.rs
+++ b/samples/rust_generated/my_game/sample/monster_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Monster<'b> {
+  type Inner = Monster<'a>;
+}
+
 impl<'a> Monster<'a> {
   pub const VT_POS: flatbuffers::VOffsetT = 4;
   pub const VT_MANA: flatbuffers::VOffsetT = 6;

--- a/samples/rust_generated/my_game/sample/weapon_generated.rs
+++ b/samples/rust_generated/my_game/sample/weapon_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for Weapon<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Weapon<'b> {
+  type Inner = Weapon<'a>;
+}
+
 impl<'a> Weapon<'a> {
   pub const VT_NAME: flatbuffers::VOffsetT = 4;
   pub const VT_DAMAGE: flatbuffers::VOffsetT = 6;

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1655,6 +1655,10 @@ class RustGenerator : public BaseGenerator {
     code_ += "  }";
     code_ += "}";
     code_ += "";
+    code_ += "impl<'a, 'b> flatbuffers::FollowWith<'a> for {{STRUCT_TY}}<'b> {";
+    code_ += "  type Inner = {{STRUCT_TY}}<'a>;";
+    code_ += "}";
+    code_ += "";
     code_ += "impl<'a> {{STRUCT_TY}}<'a> {";
 
     // Generate field id constants.

--- a/tests/arrays_test/my_game/example/array_table_generated.rs
+++ b/tests/arrays_test/my_game/example/array_table_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for ArrayTable<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for ArrayTable<'b> {
+  type Inner = ArrayTable<'a>;
+}
+
 impl<'a> ArrayTable<'a> {
   pub const VT_A: flatbuffers::VOffsetT = 4;
 

--- a/tests/include_test1/my_game/other_name_space/table_b_generated.rs
+++ b/tests/include_test1/my_game/other_name_space/table_b_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for TableB<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TableB<'b> {
+  type Inner = TableB<'a>;
+}
+
 impl<'a> TableB<'a> {
   pub const VT_A: flatbuffers::VOffsetT = 4;
 

--- a/tests/include_test1/table_a_generated.rs
+++ b/tests/include_test1/table_a_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for TableA<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TableA<'b> {
+  type Inner = TableA<'a>;
+}
+
 impl<'a> TableA<'a> {
   pub const VT_B: flatbuffers::VOffsetT = 4;
 

--- a/tests/include_test2/my_game/other_name_space/table_b_generated.rs
+++ b/tests/include_test2/my_game/other_name_space/table_b_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for TableB<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TableB<'b> {
+  type Inner = TableB<'a>;
+}
+
 impl<'a> TableB<'a> {
   pub const VT_A: flatbuffers::VOffsetT = 4;
 

--- a/tests/include_test2/table_a_generated.rs
+++ b/tests/include_test2/table_a_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for TableA<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TableA<'b> {
+  type Inner = TableA<'a>;
+}
+
 impl<'a> TableA<'a> {
   pub const VT_B: flatbuffers::VOffsetT = 4;
 

--- a/tests/keyword_test/keyword_test/keywords_in_table_generated.rs
+++ b/tests/keyword_test/keyword_test/keywords_in_table_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for KeywordsInTable<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for KeywordsInTable<'b> {
+  type Inner = KeywordsInTable<'a>;
+}
+
 impl<'a> KeywordsInTable<'a> {
   pub const VT_IS: flatbuffers::VOffsetT = 4;
   pub const VT_PRIVATE: flatbuffers::VOffsetT = 6;

--- a/tests/monster_test/my_game/example/monster_generated.rs
+++ b/tests/monster_test/my_game/example/monster_generated.rs
@@ -25,6 +25,10 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Monster<'b> {
+  type Inner = Monster<'a>;
+}
+
 impl<'a> Monster<'a> {
   pub const VT_POS: flatbuffers::VOffsetT = 4;
   pub const VT_MANA: flatbuffers::VOffsetT = 6;

--- a/tests/monster_test/my_game/example/referrable_generated.rs
+++ b/tests/monster_test/my_game/example/referrable_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for Referrable<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Referrable<'b> {
+  type Inner = Referrable<'a>;
+}
+
 impl<'a> Referrable<'a> {
   pub const VT_ID: flatbuffers::VOffsetT = 4;
 

--- a/tests/monster_test/my_game/example/stat_generated.rs
+++ b/tests/monster_test/my_game/example/stat_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for Stat<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Stat<'b> {
+  type Inner = Stat<'a>;
+}
+
 impl<'a> Stat<'a> {
   pub const VT_ID: flatbuffers::VOffsetT = 4;
   pub const VT_VAL: flatbuffers::VOffsetT = 6;

--- a/tests/monster_test/my_game/example/test_simple_table_with_enum_generated.rs
+++ b/tests/monster_test/my_game/example/test_simple_table_with_enum_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for TestSimpleTableWithEnum<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TestSimpleTableWithEnum<'b> {
+  type Inner = TestSimpleTableWithEnum<'a>;
+}
+
 impl<'a> TestSimpleTableWithEnum<'a> {
   pub const VT_COLOR: flatbuffers::VOffsetT = 4;
 

--- a/tests/monster_test/my_game/example/type_aliases_generated.rs
+++ b/tests/monster_test/my_game/example/type_aliases_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for TypeAliases<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TypeAliases<'b> {
+  type Inner = TypeAliases<'a>;
+}
+
 impl<'a> TypeAliases<'a> {
   pub const VT_I8_: flatbuffers::VOffsetT = 4;
   pub const VT_U8_: flatbuffers::VOffsetT = 6;

--- a/tests/monster_test/my_game/example_2/monster_generated.rs
+++ b/tests/monster_test/my_game/example_2/monster_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Monster<'b> {
+  type Inner = Monster<'a>;
+}
+
 impl<'a> Monster<'a> {
 
   pub const fn get_fully_qualified_name() -> &'static str {

--- a/tests/monster_test/my_game/in_parent_namespace_generated.rs
+++ b/tests/monster_test/my_game/in_parent_namespace_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for InParentNamespace<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for InParentNamespace<'b> {
+  type Inner = InParentNamespace<'a>;
+}
+
 impl<'a> InParentNamespace<'a> {
 
   pub const fn get_fully_qualified_name() -> &'static str {

--- a/tests/monster_test/my_game/other_name_space/table_b_generated.rs
+++ b/tests/monster_test/my_game/other_name_space/table_b_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for TableB<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TableB<'b> {
+  type Inner = TableB<'a>;
+}
+
 impl<'a> TableB<'a> {
   pub const VT_A: flatbuffers::VOffsetT = 4;
 

--- a/tests/monster_test/table_a_generated.rs
+++ b/tests/monster_test/table_a_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for TableA<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TableA<'b> {
+  type Inner = TableA<'a>;
+}
+
 impl<'a> TableA<'a> {
   pub const VT_B: flatbuffers::VOffsetT = 4;
 

--- a/tests/monster_test_serialize/my_game/example/monster_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/monster_generated.rs
@@ -27,6 +27,10 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Monster<'b> {
+  type Inner = Monster<'a>;
+}
+
 impl<'a> Monster<'a> {
   pub const VT_POS: flatbuffers::VOffsetT = 4;
   pub const VT_MANA: flatbuffers::VOffsetT = 6;

--- a/tests/monster_test_serialize/my_game/example/referrable_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/referrable_generated.rs
@@ -26,6 +26,10 @@ impl<'a> flatbuffers::Follow<'a> for Referrable<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Referrable<'b> {
+  type Inner = Referrable<'a>;
+}
+
 impl<'a> Referrable<'a> {
   pub const VT_ID: flatbuffers::VOffsetT = 4;
 

--- a/tests/monster_test_serialize/my_game/example/stat_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/stat_generated.rs
@@ -26,6 +26,10 @@ impl<'a> flatbuffers::Follow<'a> for Stat<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Stat<'b> {
+  type Inner = Stat<'a>;
+}
+
 impl<'a> Stat<'a> {
   pub const VT_ID: flatbuffers::VOffsetT = 4;
   pub const VT_VAL: flatbuffers::VOffsetT = 6;

--- a/tests/monster_test_serialize/my_game/example/test_simple_table_with_enum_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/test_simple_table_with_enum_generated.rs
@@ -26,6 +26,10 @@ impl<'a> flatbuffers::Follow<'a> for TestSimpleTableWithEnum<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TestSimpleTableWithEnum<'b> {
+  type Inner = TestSimpleTableWithEnum<'a>;
+}
+
 impl<'a> TestSimpleTableWithEnum<'a> {
   pub const VT_COLOR: flatbuffers::VOffsetT = 4;
 

--- a/tests/monster_test_serialize/my_game/example/type_aliases_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/type_aliases_generated.rs
@@ -26,6 +26,10 @@ impl<'a> flatbuffers::Follow<'a> for TypeAliases<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TypeAliases<'b> {
+  type Inner = TypeAliases<'a>;
+}
+
 impl<'a> TypeAliases<'a> {
   pub const VT_I8_: flatbuffers::VOffsetT = 4;
   pub const VT_U8_: flatbuffers::VOffsetT = 6;

--- a/tests/monster_test_serialize/my_game/example_2/monster_generated.rs
+++ b/tests/monster_test_serialize/my_game/example_2/monster_generated.rs
@@ -26,6 +26,10 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Monster<'b> {
+  type Inner = Monster<'a>;
+}
+
 impl<'a> Monster<'a> {
 
   pub const fn get_fully_qualified_name() -> &'static str {

--- a/tests/monster_test_serialize/my_game/in_parent_namespace_generated.rs
+++ b/tests/monster_test_serialize/my_game/in_parent_namespace_generated.rs
@@ -26,6 +26,10 @@ impl<'a> flatbuffers::Follow<'a> for InParentNamespace<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for InParentNamespace<'b> {
+  type Inner = InParentNamespace<'a>;
+}
+
 impl<'a> InParentNamespace<'a> {
 
   pub const fn get_fully_qualified_name() -> &'static str {

--- a/tests/monster_test_serialize/my_game/other_name_space/table_b_generated.rs
+++ b/tests/monster_test_serialize/my_game/other_name_space/table_b_generated.rs
@@ -26,6 +26,10 @@ impl<'a> flatbuffers::Follow<'a> for TableB<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TableB<'b> {
+  type Inner = TableB<'a>;
+}
+
 impl<'a> TableB<'a> {
   pub const VT_A: flatbuffers::VOffsetT = 4;
 

--- a/tests/monster_test_serialize/table_a_generated.rs
+++ b/tests/monster_test_serialize/table_a_generated.rs
@@ -26,6 +26,10 @@ impl<'a> flatbuffers::Follow<'a> for TableA<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TableA<'b> {
+  type Inner = TableA<'a>;
+}
+
 impl<'a> TableA<'a> {
   pub const VT_B: flatbuffers::VOffsetT = 4;
 

--- a/tests/more_defaults/more_defaults_generated.rs
+++ b/tests/more_defaults/more_defaults_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for MoreDefaults<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for MoreDefaults<'b> {
+  type Inner = MoreDefaults<'a>;
+}
+
 impl<'a> MoreDefaults<'a> {
   pub const VT_INTS: flatbuffers::VOffsetT = 4;
   pub const VT_FLOATS: flatbuffers::VOffsetT = 6;

--- a/tests/namespace_test/namespace_a/namespace_b/table_in_nested_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/namespace_b/table_in_nested_ns_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for TableInNestedNS<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TableInNestedNS<'b> {
+  type Inner = TableInNestedNS<'a>;
+}
+
 impl<'a> TableInNestedNS<'a> {
   pub const VT_FOO: flatbuffers::VOffsetT = 4;
 

--- a/tests/namespace_test/namespace_a/second_table_in_a_generated.rs
+++ b/tests/namespace_test/namespace_a/second_table_in_a_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for SecondTableInA<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for SecondTableInA<'b> {
+  type Inner = SecondTableInA<'a>;
+}
+
 impl<'a> SecondTableInA<'a> {
   pub const VT_REFER_TO_C: flatbuffers::VOffsetT = 4;
 

--- a/tests/namespace_test/namespace_a/table_in_first_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/table_in_first_ns_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for TableInFirstNS<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TableInFirstNS<'b> {
+  type Inner = TableInFirstNS<'a>;
+}
+
 impl<'a> TableInFirstNS<'a> {
   pub const VT_FOO_TABLE: flatbuffers::VOffsetT = 4;
   pub const VT_FOO_ENUM: flatbuffers::VOffsetT = 6;

--- a/tests/namespace_test/namespace_c/table_in_c_generated.rs
+++ b/tests/namespace_test/namespace_c/table_in_c_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for TableInC<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for TableInC<'b> {
+  type Inner = TableInC<'a>;
+}
+
 impl<'a> TableInC<'a> {
   pub const VT_REFER_TO_A1: flatbuffers::VOffsetT = 4;
   pub const VT_REFER_TO_A2: flatbuffers::VOffsetT = 6;

--- a/tests/optional_scalars/optional_scalars/scalar_stuff_generated.rs
+++ b/tests/optional_scalars/optional_scalars/scalar_stuff_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for ScalarStuff<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for ScalarStuff<'b> {
+  type Inner = ScalarStuff<'a>;
+}
+
 impl<'a> ScalarStuff<'a> {
   pub const VT_JUST_I8: flatbuffers::VOffsetT = 4;
   pub const VT_MAYBE_I8: flatbuffers::VOffsetT = 6;

--- a/tests/private_annotation_test/annotations_generated.rs
+++ b/tests/private_annotation_test/annotations_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for Annotations<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Annotations<'b> {
+  type Inner = Annotations<'a>;
+}
+
 impl<'a> Annotations<'a> {
   pub const VT_VALUE: flatbuffers::VOffsetT = 4;
 

--- a/tests/private_annotation_test/game_generated.rs
+++ b/tests/private_annotation_test/game_generated.rs
@@ -24,6 +24,10 @@ impl<'a> flatbuffers::Follow<'a> for Game<'a> {
   }
 }
 
+impl<'a, 'b> flatbuffers::FollowWith<'a> for Game<'b> {
+  type Inner = Game<'a>;
+}
+
 impl<'a> Game<'a> {
   pub const VT_VALUE: flatbuffers::VOffsetT = 4;
 


### PR DESCRIPTION
This adds a FollowWith trait, which allows accessing a table type with a different lifetime in generic code. This is necessary for writing generic containers that own flatbuffers.

I'm using this (with a flatbuffers fork that already includes this change) at
https://github.com/frc971/971-Robot-Code/blob/f4cae52cf7d990572e157ced324aee43cf89c523/aos/flatbuffers.rs. I would be happy to move this to flatbuffers itself if there's interested, but I think generating the small amount of code in this commit to allow writing wrappers like that is independently valuable.

I think this is what was discussed in google/flatbuffers#5749, for reference.