### PR TITLE
rust: Introduce a trait for `get_fully_qualified_name`

### DIFF
--- a/rust/flatbuffers/src/primitives.rs
+++ b/rust/flatbuffers/src/primitives.rs
@@ -326,3 +326,12 @@ impl_follow_for_endian_scalar!(i32);
 impl_follow_for_endian_scalar!(i64);
 impl_follow_for_endian_scalar!(f32);
 impl_follow_for_endian_scalar!(f64);
+
+pub trait FullyQualifiedName {
+    /// Returns the fully-qualified name for this table. This will include all namespaces,like
+    /// `MyGame.Monster`.
+    ///
+    /// Use `--gen-name-strings` when running the flatbuffers compile to generate implementations
+    /// of this trait for all tables.
+    fn get_fully_qualified_name() -> &'static str;
+}

--- a/samples/rust_generated/my_game/sample/monster_generated.rs
+++ b/samples/rust_generated/my_game/sample/monster_generated.rs
@@ -156,6 +156,12 @@ impl<'a> Monster<'a> {
 
 }
 
+impl flatbuffers::FullyQualifiedName for Monster<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Sample.Monster"
+  }
+}
+
 impl flatbuffers::Verifiable for Monster<'_> {
   #[inline]
   fn run_verifier(

--- a/samples/rust_generated/my_game/sample/monster_generated.rs
+++ b/samples/rust_generated/my_game/sample/monster_generated.rs
@@ -158,7 +158,7 @@ impl<'a> Monster<'a> {
 
 impl flatbuffers::FullyQualifiedName for Monster<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Sample.Monster"
+    Monster::get_fully_qualified_name()
   }
 }
 

--- a/samples/rust_generated/my_game/sample/vec_3_generated.rs
+++ b/samples/rust_generated/my_game/sample/vec_3_generated.rs
@@ -174,7 +174,7 @@ impl<'a> Vec3 {
 
 impl flatbuffers::FullyQualifiedName for Vec3 {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Sample.Vec3"
+    Vec3::get_fully_qualified_name()
   }
 }
 

--- a/samples/rust_generated/my_game/sample/vec_3_generated.rs
+++ b/samples/rust_generated/my_game/sample/vec_3_generated.rs
@@ -172,6 +172,12 @@ impl<'a> Vec3 {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Vec3 {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Sample.Vec3"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Vec3T {
   pub x: f32,

--- a/samples/rust_generated/my_game/sample/weapon_generated.rs
+++ b/samples/rust_generated/my_game/sample/weapon_generated.rs
@@ -70,7 +70,7 @@ impl<'a> Weapon<'a> {
 
 impl flatbuffers::FullyQualifiedName for Weapon<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Sample.Weapon"
+    Weapon::get_fully_qualified_name()
   }
 }
 

--- a/samples/rust_generated/my_game/sample/weapon_generated.rs
+++ b/samples/rust_generated/my_game/sample/weapon_generated.rs
@@ -68,6 +68,12 @@ impl<'a> Weapon<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Weapon<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Sample.Weapon"
+  }
+}
+
 impl flatbuffers::Verifiable for Weapon<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/arrays_test/my_game/example/array_struct_generated.rs
+++ b/tests/arrays_test/my_game/example/array_struct_generated.rs
@@ -214,6 +214,12 @@ impl<'a> ArrayStruct {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for ArrayStruct {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.ArrayStruct"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ArrayStructT {
   pub a: f32,

--- a/tests/arrays_test/my_game/example/array_struct_generated.rs
+++ b/tests/arrays_test/my_game/example/array_struct_generated.rs
@@ -216,7 +216,7 @@ impl<'a> ArrayStruct {
 
 impl flatbuffers::FullyQualifiedName for ArrayStruct {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.ArrayStruct"
+    ArrayStruct::get_fully_qualified_name()
   }
 }
 

--- a/tests/arrays_test/my_game/example/array_table_generated.rs
+++ b/tests/arrays_test/my_game/example/array_table_generated.rs
@@ -60,6 +60,12 @@ impl<'a> ArrayTable<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for ArrayTable<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.ArrayTable"
+  }
+}
+
 impl flatbuffers::Verifiable for ArrayTable<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/arrays_test/my_game/example/array_table_generated.rs
+++ b/tests/arrays_test/my_game/example/array_table_generated.rs
@@ -62,7 +62,7 @@ impl<'a> ArrayTable<'a> {
 
 impl flatbuffers::FullyQualifiedName for ArrayTable<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.ArrayTable"
+    ArrayTable::get_fully_qualified_name()
   }
 }
 

--- a/tests/arrays_test/my_game/example/nested_struct_generated.rs
+++ b/tests/arrays_test/my_game/example/nested_struct_generated.rs
@@ -160,6 +160,12 @@ impl<'a> NestedStruct {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for NestedStruct {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.NestedStruct"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct NestedStructT {
   pub a: [i32; 2],

--- a/tests/arrays_test/my_game/example/nested_struct_generated.rs
+++ b/tests/arrays_test/my_game/example/nested_struct_generated.rs
@@ -162,7 +162,7 @@ impl<'a> NestedStruct {
 
 impl flatbuffers::FullyQualifiedName for NestedStruct {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.NestedStruct"
+    NestedStruct::get_fully_qualified_name()
   }
 }
 

--- a/tests/include_test1/my_game/other_name_space/table_b_generated.rs
+++ b/tests/include_test1/my_game/other_name_space/table_b_generated.rs
@@ -60,6 +60,12 @@ impl<'a> TableB<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TableB<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.OtherNameSpace.TableB"
+  }
+}
+
 impl flatbuffers::Verifiable for TableB<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/include_test1/my_game/other_name_space/table_b_generated.rs
+++ b/tests/include_test1/my_game/other_name_space/table_b_generated.rs
@@ -62,7 +62,7 @@ impl<'a> TableB<'a> {
 
 impl flatbuffers::FullyQualifiedName for TableB<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.OtherNameSpace.TableB"
+    TableB::get_fully_qualified_name()
   }
 }
 

--- a/tests/include_test1/my_game/other_name_space/unused_generated.rs
+++ b/tests/include_test1/my_game/other_name_space/unused_generated.rs
@@ -118,6 +118,12 @@ impl<'a> Unused {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Unused {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.OtherNameSpace.Unused"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct UnusedT {
   pub a: i32,

--- a/tests/include_test1/my_game/other_name_space/unused_generated.rs
+++ b/tests/include_test1/my_game/other_name_space/unused_generated.rs
@@ -120,7 +120,7 @@ impl<'a> Unused {
 
 impl flatbuffers::FullyQualifiedName for Unused {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.OtherNameSpace.Unused"
+    Unused::get_fully_qualified_name()
   }
 }
 

--- a/tests/include_test1/table_a_generated.rs
+++ b/tests/include_test1/table_a_generated.rs
@@ -62,7 +62,7 @@ impl<'a> TableA<'a> {
 
 impl flatbuffers::FullyQualifiedName for TableA<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "TableA"
+    TableA::get_fully_qualified_name()
   }
 }
 

--- a/tests/include_test1/table_a_generated.rs
+++ b/tests/include_test1/table_a_generated.rs
@@ -60,6 +60,12 @@ impl<'a> TableA<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TableA<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "TableA"
+  }
+}
+
 impl flatbuffers::Verifiable for TableA<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/include_test2/my_game/other_name_space/table_b_generated.rs
+++ b/tests/include_test2/my_game/other_name_space/table_b_generated.rs
@@ -60,6 +60,12 @@ impl<'a> TableB<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TableB<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.OtherNameSpace.TableB"
+  }
+}
+
 impl flatbuffers::Verifiable for TableB<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/include_test2/my_game/other_name_space/table_b_generated.rs
+++ b/tests/include_test2/my_game/other_name_space/table_b_generated.rs
@@ -62,7 +62,7 @@ impl<'a> TableB<'a> {
 
 impl flatbuffers::FullyQualifiedName for TableB<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.OtherNameSpace.TableB"
+    TableB::get_fully_qualified_name()
   }
 }
 

--- a/tests/include_test2/my_game/other_name_space/unused_generated.rs
+++ b/tests/include_test2/my_game/other_name_space/unused_generated.rs
@@ -118,6 +118,12 @@ impl<'a> Unused {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Unused {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.OtherNameSpace.Unused"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct UnusedT {
   pub a: i32,

--- a/tests/include_test2/my_game/other_name_space/unused_generated.rs
+++ b/tests/include_test2/my_game/other_name_space/unused_generated.rs
@@ -120,7 +120,7 @@ impl<'a> Unused {
 
 impl flatbuffers::FullyQualifiedName for Unused {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.OtherNameSpace.Unused"
+    Unused::get_fully_qualified_name()
   }
 }
 

--- a/tests/include_test2/table_a_generated.rs
+++ b/tests/include_test2/table_a_generated.rs
@@ -62,7 +62,7 @@ impl<'a> TableA<'a> {
 
 impl flatbuffers::FullyQualifiedName for TableA<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "TableA"
+    TableA::get_fully_qualified_name()
   }
 }
 

--- a/tests/include_test2/table_a_generated.rs
+++ b/tests/include_test2/table_a_generated.rs
@@ -60,6 +60,12 @@ impl<'a> TableA<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TableA<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "TableA"
+  }
+}
+
 impl flatbuffers::Verifiable for TableA<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/keyword_test/keyword_test/keywords_in_table_generated.rs
+++ b/tests/keyword_test/keyword_test/keywords_in_table_generated.rs
@@ -84,7 +84,7 @@ impl<'a> KeywordsInTable<'a> {
 
 impl flatbuffers::FullyQualifiedName for KeywordsInTable<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "KeywordTest.KeywordsInTable"
+    KeywordsInTable::get_fully_qualified_name()
   }
 }
 

--- a/tests/keyword_test/keyword_test/keywords_in_table_generated.rs
+++ b/tests/keyword_test/keyword_test/keywords_in_table_generated.rs
@@ -82,6 +82,12 @@ impl<'a> KeywordsInTable<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for KeywordsInTable<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "KeywordTest.KeywordsInTable"
+  }
+}
+
 impl flatbuffers::Verifiable for KeywordsInTable<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test/my_game/example/ability_generated.rs
+++ b/tests/monster_test/my_game/example/ability_generated.rs
@@ -155,6 +155,12 @@ impl<'a> Ability {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Ability {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Ability"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct AbilityT {
   pub id: u32,

--- a/tests/monster_test/my_game/example/ability_generated.rs
+++ b/tests/monster_test/my_game/example/ability_generated.rs
@@ -157,7 +157,7 @@ impl<'a> Ability {
 
 impl flatbuffers::FullyQualifiedName for Ability {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Ability"
+    Ability::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/example/monster_generated.rs
+++ b/tests/monster_test/my_game/example/monster_generated.rs
@@ -690,6 +690,12 @@ impl<'a> Monster<'a> {
 
 }
 
+impl flatbuffers::FullyQualifiedName for Monster<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Monster"
+  }
+}
+
 impl flatbuffers::Verifiable for Monster<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test/my_game/example/monster_generated.rs
+++ b/tests/monster_test/my_game/example/monster_generated.rs
@@ -692,7 +692,7 @@ impl<'a> Monster<'a> {
 
 impl flatbuffers::FullyQualifiedName for Monster<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Monster"
+    Monster::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/example/referrable_generated.rs
+++ b/tests/monster_test/my_game/example/referrable_generated.rs
@@ -70,7 +70,7 @@ impl<'a> Referrable<'a> {
 
 impl flatbuffers::FullyQualifiedName for Referrable<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Referrable"
+    Referrable::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/example/referrable_generated.rs
+++ b/tests/monster_test/my_game/example/referrable_generated.rs
@@ -68,6 +68,12 @@ impl<'a> Referrable<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Referrable<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Referrable"
+  }
+}
+
 impl flatbuffers::Verifiable for Referrable<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test/my_game/example/stat_generated.rs
+++ b/tests/monster_test/my_game/example/stat_generated.rs
@@ -88,7 +88,7 @@ impl<'a> Stat<'a> {
 
 impl flatbuffers::FullyQualifiedName for Stat<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Stat"
+    Stat::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/example/stat_generated.rs
+++ b/tests/monster_test/my_game/example/stat_generated.rs
@@ -86,6 +86,12 @@ impl<'a> Stat<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Stat<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Stat"
+  }
+}
+
 impl flatbuffers::Verifiable for Stat<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test/my_game/example/struct_of_structs_generated.rs
+++ b/tests/monster_test/my_game/example/struct_of_structs_generated.rs
@@ -130,6 +130,12 @@ impl<'a> StructOfStructs {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for StructOfStructs {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.StructOfStructs"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct StructOfStructsT {
   pub a: AbilityT,

--- a/tests/monster_test/my_game/example/struct_of_structs_generated.rs
+++ b/tests/monster_test/my_game/example/struct_of_structs_generated.rs
@@ -132,7 +132,7 @@ impl<'a> StructOfStructs {
 
 impl flatbuffers::FullyQualifiedName for StructOfStructs {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.StructOfStructs"
+    StructOfStructs::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/example/struct_of_structs_of_structs_generated.rs
+++ b/tests/monster_test/my_game/example/struct_of_structs_of_structs_generated.rs
@@ -106,7 +106,7 @@ impl<'a> StructOfStructsOfStructs {
 
 impl flatbuffers::FullyQualifiedName for StructOfStructsOfStructs {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.StructOfStructsOfStructs"
+    StructOfStructsOfStructs::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/example/struct_of_structs_of_structs_generated.rs
+++ b/tests/monster_test/my_game/example/struct_of_structs_of_structs_generated.rs
@@ -104,6 +104,12 @@ impl<'a> StructOfStructsOfStructs {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for StructOfStructsOfStructs {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.StructOfStructsOfStructs"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct StructOfStructsOfStructsT {
   pub a: StructOfStructsT,

--- a/tests/monster_test/my_game/example/test_generated.rs
+++ b/tests/monster_test/my_game/example/test_generated.rs
@@ -145,6 +145,12 @@ impl<'a> Test {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Test {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Test"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct TestT {
   pub a: i16,

--- a/tests/monster_test/my_game/example/test_generated.rs
+++ b/tests/monster_test/my_game/example/test_generated.rs
@@ -147,7 +147,7 @@ impl<'a> Test {
 
 impl flatbuffers::FullyQualifiedName for Test {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Test"
+    Test::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/example/test_simple_table_with_enum_generated.rs
+++ b/tests/monster_test/my_game/example/test_simple_table_with_enum_generated.rs
@@ -60,7 +60,7 @@ impl<'a> TestSimpleTableWithEnum<'a> {
 
 impl flatbuffers::FullyQualifiedName for TestSimpleTableWithEnum<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.TestSimpleTableWithEnum"
+    TestSimpleTableWithEnum::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/example/test_simple_table_with_enum_generated.rs
+++ b/tests/monster_test/my_game/example/test_simple_table_with_enum_generated.rs
@@ -58,6 +58,12 @@ impl<'a> TestSimpleTableWithEnum<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TestSimpleTableWithEnum<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.TestSimpleTableWithEnum"
+  }
+}
+
 impl flatbuffers::Verifiable for TestSimpleTableWithEnum<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test/my_game/example/type_aliases_generated.rs
+++ b/tests/monster_test/my_game/example/type_aliases_generated.rs
@@ -150,6 +150,12 @@ impl<'a> TypeAliases<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TypeAliases<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.TypeAliases"
+  }
+}
+
 impl flatbuffers::Verifiable for TypeAliases<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test/my_game/example/type_aliases_generated.rs
+++ b/tests/monster_test/my_game/example/type_aliases_generated.rs
@@ -152,7 +152,7 @@ impl<'a> TypeAliases<'a> {
 
 impl flatbuffers::FullyQualifiedName for TypeAliases<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.TypeAliases"
+    TypeAliases::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/example/vec_3_generated.rs
+++ b/tests/monster_test/my_game/example/vec_3_generated.rs
@@ -241,7 +241,7 @@ impl<'a> Vec3 {
 
 impl flatbuffers::FullyQualifiedName for Vec3 {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Vec3"
+    Vec3::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/example/vec_3_generated.rs
+++ b/tests/monster_test/my_game/example/vec_3_generated.rs
@@ -239,6 +239,12 @@ impl<'a> Vec3 {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Vec3 {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Vec3"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Vec3T {
   pub x: f32,

--- a/tests/monster_test/my_game/example_2/monster_generated.rs
+++ b/tests/monster_test/my_game/example_2/monster_generated.rs
@@ -49,6 +49,12 @@ impl<'a> Monster<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Monster<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example2.Monster"
+  }
+}
+
 impl flatbuffers::Verifiable for Monster<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test/my_game/example_2/monster_generated.rs
+++ b/tests/monster_test/my_game/example_2/monster_generated.rs
@@ -51,7 +51,7 @@ impl<'a> Monster<'a> {
 
 impl flatbuffers::FullyQualifiedName for Monster<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example2.Monster"
+    Monster::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/in_parent_namespace_generated.rs
+++ b/tests/monster_test/my_game/in_parent_namespace_generated.rs
@@ -49,6 +49,12 @@ impl<'a> InParentNamespace<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for InParentNamespace<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.InParentNamespace"
+  }
+}
+
 impl flatbuffers::Verifiable for InParentNamespace<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test/my_game/in_parent_namespace_generated.rs
+++ b/tests/monster_test/my_game/in_parent_namespace_generated.rs
@@ -51,7 +51,7 @@ impl<'a> InParentNamespace<'a> {
 
 impl flatbuffers::FullyQualifiedName for InParentNamespace<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.InParentNamespace"
+    InParentNamespace::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/other_name_space/table_b_generated.rs
+++ b/tests/monster_test/my_game/other_name_space/table_b_generated.rs
@@ -60,6 +60,12 @@ impl<'a> TableB<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TableB<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.OtherNameSpace.TableB"
+  }
+}
+
 impl flatbuffers::Verifiable for TableB<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test/my_game/other_name_space/table_b_generated.rs
+++ b/tests/monster_test/my_game/other_name_space/table_b_generated.rs
@@ -62,7 +62,7 @@ impl<'a> TableB<'a> {
 
 impl flatbuffers::FullyQualifiedName for TableB<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.OtherNameSpace.TableB"
+    TableB::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/my_game/other_name_space/unused_generated.rs
+++ b/tests/monster_test/my_game/other_name_space/unused_generated.rs
@@ -118,6 +118,12 @@ impl<'a> Unused {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Unused {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.OtherNameSpace.Unused"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct UnusedT {
   pub a: i32,

--- a/tests/monster_test/my_game/other_name_space/unused_generated.rs
+++ b/tests/monster_test/my_game/other_name_space/unused_generated.rs
@@ -120,7 +120,7 @@ impl<'a> Unused {
 
 impl flatbuffers::FullyQualifiedName for Unused {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.OtherNameSpace.Unused"
+    Unused::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/table_a_generated.rs
+++ b/tests/monster_test/table_a_generated.rs
@@ -62,7 +62,7 @@ impl<'a> TableA<'a> {
 
 impl flatbuffers::FullyQualifiedName for TableA<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "TableA"
+    TableA::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test/table_a_generated.rs
+++ b/tests/monster_test/table_a_generated.rs
@@ -60,6 +60,12 @@ impl<'a> TableA<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TableA<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "TableA"
+  }
+}
+
 impl flatbuffers::Verifiable for TableA<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test_serialize/my_game/example/ability_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/ability_generated.rs
@@ -171,7 +171,7 @@ impl<'a> Ability {
 
 impl flatbuffers::FullyQualifiedName for Ability {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Ability"
+    Ability::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/ability_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/ability_generated.rs
@@ -169,6 +169,12 @@ impl<'a> Ability {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Ability {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Ability"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct AbilityT {
   pub id: u32,

--- a/tests/monster_test_serialize/my_game/example/monster_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/monster_generated.rs
@@ -694,7 +694,7 @@ impl<'a> Monster<'a> {
 
 impl flatbuffers::FullyQualifiedName for Monster<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Monster"
+    Monster::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/monster_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/monster_generated.rs
@@ -692,6 +692,12 @@ impl<'a> Monster<'a> {
 
 }
 
+impl flatbuffers::FullyQualifiedName for Monster<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Monster"
+  }
+}
+
 impl flatbuffers::Verifiable for Monster<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test_serialize/my_game/example/referrable_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/referrable_generated.rs
@@ -70,6 +70,12 @@ impl<'a> Referrable<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Referrable<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Referrable"
+  }
+}
+
 impl flatbuffers::Verifiable for Referrable<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test_serialize/my_game/example/referrable_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/referrable_generated.rs
@@ -72,7 +72,7 @@ impl<'a> Referrable<'a> {
 
 impl flatbuffers::FullyQualifiedName for Referrable<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Referrable"
+    Referrable::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/stat_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/stat_generated.rs
@@ -88,6 +88,12 @@ impl<'a> Stat<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Stat<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Stat"
+  }
+}
+
 impl flatbuffers::Verifiable for Stat<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test_serialize/my_game/example/stat_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/stat_generated.rs
@@ -90,7 +90,7 @@ impl<'a> Stat<'a> {
 
 impl flatbuffers::FullyQualifiedName for Stat<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Stat"
+    Stat::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/struct_of_structs_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/struct_of_structs_generated.rs
@@ -147,7 +147,7 @@ impl<'a> StructOfStructs {
 
 impl flatbuffers::FullyQualifiedName for StructOfStructs {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.StructOfStructs"
+    StructOfStructs::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/struct_of_structs_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/struct_of_structs_generated.rs
@@ -145,6 +145,12 @@ impl<'a> StructOfStructs {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for StructOfStructs {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.StructOfStructs"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct StructOfStructsT {
   pub a: AbilityT,

--- a/tests/monster_test_serialize/my_game/example/struct_of_structs_of_structs_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/struct_of_structs_of_structs_generated.rs
@@ -119,7 +119,7 @@ impl<'a> StructOfStructsOfStructs {
 
 impl flatbuffers::FullyQualifiedName for StructOfStructsOfStructs {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.StructOfStructsOfStructs"
+    StructOfStructsOfStructs::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/struct_of_structs_of_structs_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/struct_of_structs_of_structs_generated.rs
@@ -117,6 +117,12 @@ impl<'a> StructOfStructsOfStructs {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for StructOfStructsOfStructs {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.StructOfStructsOfStructs"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct StructOfStructsOfStructsT {
   pub a: StructOfStructsT,

--- a/tests/monster_test_serialize/my_game/example/test_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/test_generated.rs
@@ -161,7 +161,7 @@ impl<'a> Test {
 
 impl flatbuffers::FullyQualifiedName for Test {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Test"
+    Test::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/test_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/test_generated.rs
@@ -159,6 +159,12 @@ impl<'a> Test {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Test {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Test"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct TestT {
   pub a: i16,

--- a/tests/monster_test_serialize/my_game/example/test_simple_table_with_enum_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/test_simple_table_with_enum_generated.rs
@@ -62,7 +62,7 @@ impl<'a> TestSimpleTableWithEnum<'a> {
 
 impl flatbuffers::FullyQualifiedName for TestSimpleTableWithEnum<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.TestSimpleTableWithEnum"
+    TestSimpleTableWithEnum::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/test_simple_table_with_enum_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/test_simple_table_with_enum_generated.rs
@@ -60,6 +60,12 @@ impl<'a> TestSimpleTableWithEnum<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TestSimpleTableWithEnum<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.TestSimpleTableWithEnum"
+  }
+}
+
 impl flatbuffers::Verifiable for TestSimpleTableWithEnum<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test_serialize/my_game/example/type_aliases_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/type_aliases_generated.rs
@@ -152,6 +152,12 @@ impl<'a> TypeAliases<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TypeAliases<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.TypeAliases"
+  }
+}
+
 impl flatbuffers::Verifiable for TypeAliases<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test_serialize/my_game/example/type_aliases_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/type_aliases_generated.rs
@@ -154,7 +154,7 @@ impl<'a> TypeAliases<'a> {
 
 impl flatbuffers::FullyQualifiedName for TypeAliases<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.TypeAliases"
+    TypeAliases::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/vec_3_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/vec_3_generated.rs
@@ -259,7 +259,7 @@ impl<'a> Vec3 {
 
 impl flatbuffers::FullyQualifiedName for Vec3 {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example.Vec3"
+    Vec3::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/vec_3_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/vec_3_generated.rs
@@ -257,6 +257,12 @@ impl<'a> Vec3 {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Vec3 {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example.Vec3"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Vec3T {
   pub x: f32,

--- a/tests/monster_test_serialize/my_game/example_2/monster_generated.rs
+++ b/tests/monster_test_serialize/my_game/example_2/monster_generated.rs
@@ -53,7 +53,7 @@ impl<'a> Monster<'a> {
 
 impl flatbuffers::FullyQualifiedName for Monster<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.Example2.Monster"
+    Monster::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example_2/monster_generated.rs
+++ b/tests/monster_test_serialize/my_game/example_2/monster_generated.rs
@@ -51,6 +51,12 @@ impl<'a> Monster<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Monster<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.Example2.Monster"
+  }
+}
+
 impl flatbuffers::Verifiable for Monster<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test_serialize/my_game/in_parent_namespace_generated.rs
+++ b/tests/monster_test_serialize/my_game/in_parent_namespace_generated.rs
@@ -53,7 +53,7 @@ impl<'a> InParentNamespace<'a> {
 
 impl flatbuffers::FullyQualifiedName for InParentNamespace<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.InParentNamespace"
+    InParentNamespace::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/in_parent_namespace_generated.rs
+++ b/tests/monster_test_serialize/my_game/in_parent_namespace_generated.rs
@@ -51,6 +51,12 @@ impl<'a> InParentNamespace<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for InParentNamespace<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.InParentNamespace"
+  }
+}
+
 impl flatbuffers::Verifiable for InParentNamespace<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test_serialize/my_game/other_name_space/table_b_generated.rs
+++ b/tests/monster_test_serialize/my_game/other_name_space/table_b_generated.rs
@@ -62,6 +62,12 @@ impl<'a> TableB<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TableB<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.OtherNameSpace.TableB"
+  }
+}
+
 impl flatbuffers::Verifiable for TableB<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/monster_test_serialize/my_game/other_name_space/table_b_generated.rs
+++ b/tests/monster_test_serialize/my_game/other_name_space/table_b_generated.rs
@@ -64,7 +64,7 @@ impl<'a> TableB<'a> {
 
 impl flatbuffers::FullyQualifiedName for TableB<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.OtherNameSpace.TableB"
+    TableB::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/my_game/other_name_space/unused_generated.rs
+++ b/tests/monster_test_serialize/my_game/other_name_space/unused_generated.rs
@@ -131,6 +131,12 @@ impl<'a> Unused {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Unused {
+  fn get_fully_qualified_name() -> &'static str {
+    "MyGame.OtherNameSpace.Unused"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct UnusedT {
   pub a: i32,

--- a/tests/monster_test_serialize/my_game/other_name_space/unused_generated.rs
+++ b/tests/monster_test_serialize/my_game/other_name_space/unused_generated.rs
@@ -133,7 +133,7 @@ impl<'a> Unused {
 
 impl flatbuffers::FullyQualifiedName for Unused {
   fn get_fully_qualified_name() -> &'static str {
-    "MyGame.OtherNameSpace.Unused"
+    Unused::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/table_a_generated.rs
+++ b/tests/monster_test_serialize/table_a_generated.rs
@@ -64,7 +64,7 @@ impl<'a> TableA<'a> {
 
 impl flatbuffers::FullyQualifiedName for TableA<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "TableA"
+    TableA::get_fully_qualified_name()
   }
 }
 

--- a/tests/monster_test_serialize/table_a_generated.rs
+++ b/tests/monster_test_serialize/table_a_generated.rs
@@ -62,6 +62,12 @@ impl<'a> TableA<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TableA<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "TableA"
+  }
+}
+
 impl flatbuffers::Verifiable for TableA<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/more_defaults/more_defaults_generated.rs
+++ b/tests/more_defaults/more_defaults_generated.rs
@@ -116,6 +116,12 @@ impl<'a> MoreDefaults<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for MoreDefaults<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "MoreDefaults"
+  }
+}
+
 impl flatbuffers::Verifiable for MoreDefaults<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/more_defaults/more_defaults_generated.rs
+++ b/tests/more_defaults/more_defaults_generated.rs
@@ -118,7 +118,7 @@ impl<'a> MoreDefaults<'a> {
 
 impl flatbuffers::FullyQualifiedName for MoreDefaults<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "MoreDefaults"
+    MoreDefaults::get_fully_qualified_name()
   }
 }
 

--- a/tests/namespace_test/namespace_a/namespace_b/struct_in_nested_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/namespace_b/struct_in_nested_ns_generated.rs
@@ -147,7 +147,7 @@ impl<'a> StructInNestedNS {
 
 impl flatbuffers::FullyQualifiedName for StructInNestedNS {
   fn get_fully_qualified_name() -> &'static str {
-    "NamespaceA.NamespaceB.StructInNestedNS"
+    StructInNestedNS::get_fully_qualified_name()
   }
 }
 

--- a/tests/namespace_test/namespace_a/namespace_b/struct_in_nested_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/namespace_b/struct_in_nested_ns_generated.rs
@@ -145,6 +145,12 @@ impl<'a> StructInNestedNS {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for StructInNestedNS {
+  fn get_fully_qualified_name() -> &'static str {
+    "NamespaceA.NamespaceB.StructInNestedNS"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct StructInNestedNST {
   pub a: i32,

--- a/tests/namespace_test/namespace_a/namespace_b/table_in_nested_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/namespace_b/table_in_nested_ns_generated.rs
@@ -60,7 +60,7 @@ impl<'a> TableInNestedNS<'a> {
 
 impl flatbuffers::FullyQualifiedName for TableInNestedNS<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "NamespaceA.NamespaceB.TableInNestedNS"
+    TableInNestedNS::get_fully_qualified_name()
   }
 }
 

--- a/tests/namespace_test/namespace_a/namespace_b/table_in_nested_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/namespace_b/table_in_nested_ns_generated.rs
@@ -58,6 +58,12 @@ impl<'a> TableInNestedNS<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TableInNestedNS<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "NamespaceA.NamespaceB.TableInNestedNS"
+  }
+}
+
 impl flatbuffers::Verifiable for TableInNestedNS<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/namespace_test/namespace_a/second_table_in_a_generated.rs
+++ b/tests/namespace_test/namespace_a/second_table_in_a_generated.rs
@@ -60,6 +60,12 @@ impl<'a> SecondTableInA<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for SecondTableInA<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "NamespaceA.SecondTableInA"
+  }
+}
+
 impl flatbuffers::Verifiable for SecondTableInA<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/namespace_test/namespace_a/second_table_in_a_generated.rs
+++ b/tests/namespace_test/namespace_a/second_table_in_a_generated.rs
@@ -62,7 +62,7 @@ impl<'a> SecondTableInA<'a> {
 
 impl flatbuffers::FullyQualifiedName for SecondTableInA<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "NamespaceA.SecondTableInA"
+    SecondTableInA::get_fully_qualified_name()
   }
 }
 

--- a/tests/namespace_test/namespace_a/table_in_first_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/table_in_first_ns_generated.rs
@@ -112,7 +112,7 @@ impl<'a> TableInFirstNS<'a> {
 
 impl flatbuffers::FullyQualifiedName for TableInFirstNS<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "NamespaceA.TableInFirstNS"
+    TableInFirstNS::get_fully_qualified_name()
   }
 }
 

--- a/tests/namespace_test/namespace_a/table_in_first_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/table_in_first_ns_generated.rs
@@ -110,6 +110,12 @@ impl<'a> TableInFirstNS<'a> {
 
 }
 
+impl flatbuffers::FullyQualifiedName for TableInFirstNS<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "NamespaceA.TableInFirstNS"
+  }
+}
+
 impl flatbuffers::Verifiable for TableInFirstNS<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/namespace_test/namespace_c/table_in_c_generated.rs
+++ b/tests/namespace_test/namespace_c/table_in_c_generated.rs
@@ -72,7 +72,7 @@ impl<'a> TableInC<'a> {
 
 impl flatbuffers::FullyQualifiedName for TableInC<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "NamespaceC.TableInC"
+    TableInC::get_fully_qualified_name()
   }
 }
 

--- a/tests/namespace_test/namespace_c/table_in_c_generated.rs
+++ b/tests/namespace_test/namespace_c/table_in_c_generated.rs
@@ -70,6 +70,12 @@ impl<'a> TableInC<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for TableInC<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "NamespaceC.TableInC"
+  }
+}
+
 impl flatbuffers::Verifiable for TableInC<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/optional_scalars/optional_scalars/scalar_stuff_generated.rs
+++ b/tests/optional_scalars/optional_scalars/scalar_stuff_generated.rs
@@ -338,6 +338,12 @@ impl<'a> ScalarStuff<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for ScalarStuff<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "optional_scalars.ScalarStuff"
+  }
+}
+
 impl flatbuffers::Verifiable for ScalarStuff<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/optional_scalars/optional_scalars/scalar_stuff_generated.rs
+++ b/tests/optional_scalars/optional_scalars/scalar_stuff_generated.rs
@@ -340,7 +340,7 @@ impl<'a> ScalarStuff<'a> {
 
 impl flatbuffers::FullyQualifiedName for ScalarStuff<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "optional_scalars.ScalarStuff"
+    ScalarStuff::get_fully_qualified_name()
   }
 }
 

--- a/tests/private_annotation_test/annotations_generated.rs
+++ b/tests/private_annotation_test/annotations_generated.rs
@@ -60,7 +60,7 @@ impl<'a> Annotations<'a> {
 
 impl flatbuffers::FullyQualifiedName for Annotations<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "Annotations"
+    Annotations::get_fully_qualified_name()
   }
 }
 

--- a/tests/private_annotation_test/annotations_generated.rs
+++ b/tests/private_annotation_test/annotations_generated.rs
@@ -58,6 +58,12 @@ impl<'a> Annotations<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Annotations<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "Annotations"
+  }
+}
+
 impl flatbuffers::Verifiable for Annotations<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/private_annotation_test/game_generated.rs
+++ b/tests/private_annotation_test/game_generated.rs
@@ -60,7 +60,7 @@ impl<'a> Game<'a> {
 
 impl flatbuffers::FullyQualifiedName for Game<'_> {
   fn get_fully_qualified_name() -> &'static str {
-    "Game"
+    Game::get_fully_qualified_name()
   }
 }
 

--- a/tests/private_annotation_test/game_generated.rs
+++ b/tests/private_annotation_test/game_generated.rs
@@ -58,6 +58,12 @@ impl<'a> Game<'a> {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Game<'_> {
+  fn get_fully_qualified_name() -> &'static str {
+    "Game"
+  }
+}
+
 impl flatbuffers::Verifiable for Game<'_> {
   #[inline]
   fn run_verifier(

--- a/tests/private_annotation_test/object_generated.rs
+++ b/tests/private_annotation_test/object_generated.rs
@@ -120,7 +120,7 @@ impl<'a> Object {
 
 impl flatbuffers::FullyQualifiedName for Object {
   fn get_fully_qualified_name() -> &'static str {
-    "Object"
+    Object::get_fully_qualified_name()
   }
 }
 

--- a/tests/private_annotation_test/object_generated.rs
+++ b/tests/private_annotation_test/object_generated.rs
@@ -118,6 +118,12 @@ impl<'a> Object {
   }
 }
 
+impl flatbuffers::FullyQualifiedName for Object {
+  fn get_fully_qualified_name() -> &'static str {
+    "Object"
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub(crate) struct ObjectT {
   pub value: i32,

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -3232,6 +3232,19 @@ mod fully_qualified_name {
         assert!(check_eq!(super::my_game::example::Vec3::get_fully_qualified_name(), "MyGame.Example.Vec3").is_ok());
         assert!(check_eq!(super::my_game::example::Ability::get_fully_qualified_name(), "MyGame.Example.Ability").is_ok());
     }
+
+    #[test]
+    fn fully_qualified_name_generated_trait() {
+        fn check_fully_qualified_name_trait<T: flatbuffers::FullyQualifiedName>(expected: &str) {
+            assert!(check_eq!(T::get_fully_qualified_name(), expected).is_ok());
+        }
+
+        check_fully_qualified_name_trait::<super::my_game::example::Monster>("MyGame.Example.Monster");
+        check_fully_qualified_name_trait::<super::my_game::example_2::Monster>("MyGame.Example2.Monster");
+
+        check_fully_qualified_name_trait::<super::my_game::example::Vec3>("MyGame.Example.Vec3");
+        check_fully_qualified_name_trait::<super::my_game::example::Ability>("MyGame.Example.Ability");
+    }
 }
 
 // this is not technically a test, but we want to always keep this generated


### PR DESCRIPTION
This allows retrieving the name of a generic flatbuffer table type, which can be handy.