### PR TITLE
Emit internal enums when swift_implementation_only

### DIFF
--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -1198,7 +1198,8 @@ class SwiftGenerator : public BaseGenerator {
 
   void GenEnum(const EnumDef &enum_def) {
     if (enum_def.generated) return;
-    const auto is_private_access = enum_def.attributes.Lookup("private");
+    const bool is_private_access = parser_.opts.swift_implementation_only ||
+       enum_def.attributes.Lookup("private") != nullptr;
     code_.SetValue("ENUM_TYPE",
                    enum_def.is_union ? "UnionEnum" : "Enum, Verifiable");
     code_.SetValue("ACCESS_TYPE", is_private_access ? "internal" : "public");


### PR DESCRIPTION
- Copy the same pattern as structs and tables
- Fixes google#7542
