### PR TITLE
Moves swift package to root of repository so it can be used directly …

### DIFF
--- a/FlatBuffers.podspec
+++ b/FlatBuffers.podspec
@@ -11,11 +11,11 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://github.com/google/flatbuffers'
   s.license          = { :type => 'Apache2.0', :file => 'LICENSE' }
   s.author           = { 'mustii' => 'mustii@mmk.one' }
-  s.source           = { :git => 'https://github.com/mustiikhalil/flatbuffers.git', :tag => s.version.to_s, :submodules => true }
+  s.source           = { :git => 'https://github.com/google/flatbuffers.git', :tag => s.version.to_s, :submodules => true }
 
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.14'
 
   s.swift_version = '5.0'
-  s.source_files = 'Sources/Flatbuffers/*.swift'
+  s.source_files = 'swift/Sources/Flatbuffers/*.swift'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -32,5 +32,6 @@ let package = Package(
     .target(
       name: "FlatBuffers",
       dependencies: [],
+      path: "swift/Sources",
       exclude: ["Documentation.docc/Resources/code/swift"]),
   ])

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -31,6 +31,7 @@ let package = Package(
   targets: [
     .target(
       name: "FlatBuffers",
-      dependencies: []),
+      dependencies: [],
+      path: "swift/Sources")
   ])
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -1,14 +1,10 @@
 FlatBuffers swift can be found in both SPM
 
-`.package(url: "https://github.com/mustiikhalil/flatbuffers.git", from: "X.Y.Z"),`
+`.package(url: "https://github.com/google/flatbuffers.git", from: "X.Y.Z"),`
 
 and Cocoapods
 
 `pod 'FlatBuffers'`
-
-### Notes
-
-1- To report any error please use the main repository.
 
 ### Contribute
 

--- a/tests/swift/Wasm.tests/Package.swift
+++ b/tests/swift/Wasm.tests/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     .macOS(.v10_14),
   ],
   dependencies: [
-    .package(path: "../../../swift"),
+    .package(path: "../../.."),
   ],
   targets: [
     .target(

--- a/tests/swift/benchmarks/Package.swift
+++ b/tests/swift/benchmarks/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     .macOS(.v10_14),
   ],
   dependencies: [
-    .package(path: "../../../swift"),
+    .package(path: "../../.."),
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
   ],
   targets: [

--- a/tests/swift/tests/Package.swift
+++ b/tests/swift/tests/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     .macOS(.v10_14),
   ],
   dependencies: [
-    .package(path: "../../../swift"),
+    .package(path: "../../.."),
     .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.4.1"),
   ],
   targets: [


### PR DESCRIPTION
Moves swift packages to root directory, so it can be used directly from the main repository instead of it being maintained somewhere else

@Keith since you added Bazel, would love to know if this change will affect it