### PR TITLE
Update documentation to mention enum value attributes

### DIFF
--- a/docs/source/Grammar.md
+++ b/docs/source/Grammar.md
@@ -10,7 +10,7 @@ include = `include` string\_constant `;`
 
 namespace\_decl = `namespace` ident ( `.` ident )* `;`
 
-attribute\_decl = `attribute` ident | `"`ident`"` `;`
+attribute\_decl = `attribute` ident | `"` ident `"` `;`
 
 type\_decl = ( `table` | `struct` ) ident metadata `{` field\_decl+ `}`
 
@@ -31,7 +31,7 @@ type = `bool` | `byte` | `ubyte` | `short` | `ushort` | `int` | `uint` |
 `float32` | `float64` |
 `string` | `[` type `]` | ident
 
-enumval\_decl = ident [ `=` integer\_constant ]
+enumval\_decl = ident [ `=` integer\_constant ] metadata
 
 metadata = [ `(` commasep( ident [ `:` single\_value ] ) `)` ]
 

--- a/docs/source/Schemas.md
+++ b/docs/source/Schemas.md
@@ -309,11 +309,11 @@ in the corresponding C++ code. Multiple such lines per item are allowed.
 
 ### Attributes
 
-Attributes may be attached to a declaration, behind a field, or after
-the name of a table/struct/enum/union. These may either have a value or
-not. Some attributes like `deprecated` are understood by the compiler;
-user defined ones need to be declared with the attribute declaration
-(like `priority` in the example above), and are
+Attributes may be attached to a declaration, behind a field/enum value,
+or after the name of a table/struct/enum/union. These may either have
+a value or not. Some attributes like `deprecated` are understood by
+the compiler; user defined ones need to be declared with the attribute
+declaration (like `priority` in the example above), and are
 available to query if you parse the schema at runtime.
 This is useful if you write your own code generators/editors etc., and
 you wish to add additional information specific to your tool (such as a


### PR DESCRIPTION
Follow-up to my previous merge request. This updates the documentation to mention that attributes are also allowed on enum values.