### PR TITLE
Turn on clippy for Rust and fix lints for non-generated code

### DIFF
--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -116,7 +116,7 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
         // memset only the part of the buffer that could be dirty:
         {
             let to_clear = self.owned_buf.len() - self.head;
-            let ptr = (&mut self.owned_buf[self.head..]).as_mut_ptr();
+            let ptr = self.owned_buf[self.head..].as_mut_ptr();
             // Safety:
             // Verified ptr is valid for `to_clear` above
             unsafe {
@@ -150,7 +150,7 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
         self.align(sz, P::alignment());
         self.make_space(sz);
         {
-            let (dst, rest) = (&mut self.owned_buf[self.head..]).split_at_mut(sz);
+            let (dst, rest) = self.owned_buf[self.head..].split_at_mut(sz);
             // Safety:
             // Called make_space above
             unsafe { x.push(dst, rest.len()) };
@@ -605,7 +605,7 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
         }
         // finally, zero out the old end data.
         {
-            let ptr = (&mut self.owned_buf[..middle]).as_mut_ptr();
+            let ptr = self.owned_buf[..middle].as_mut_ptr();
             // Safety:
             // ptr is byte aligned and of length middle
             unsafe {

--- a/rust/flatbuffers/src/endian_scalar.rs
+++ b/rust/flatbuffers/src/endian_scalar.rs
@@ -179,10 +179,6 @@ pub unsafe fn read_scalar<T: EndianScalar>(s: &[u8]) -> T {
 
     let mut mem = core::mem::MaybeUninit::<T::Scalar>::uninit();
     // Since [u8] has alignment 1, we copy it into T which may have higher alignment.
-    core::ptr::copy_nonoverlapping(
-        s.as_ptr(),
-        mem.as_mut_ptr() as *mut u8,
-        size,
-    );
+    core::ptr::copy_nonoverlapping(s.as_ptr(), mem.as_mut_ptr() as *mut u8, size);
     T::from_little_endian(mem.assume_init())
 }

--- a/rust/flexbuffers/src/buffer.rs
+++ b/rust/flexbuffers/src/buffer.rs
@@ -70,7 +70,7 @@ impl<'de> Buffer for &'de [u8] {
     /// Based off of the `empty` function, allows override for optimization purposes.
     #[inline]
     fn empty_str() -> Self::BufferString {
-        &""
+        ""
     }
 
     #[inline]

--- a/rust/flexbuffers/src/builder/map.rs
+++ b/rust/flexbuffers/src/builder/map.rs
@@ -49,7 +49,7 @@ impl<'a> MapBuilder<'a> {
         // Nested vector.
         let start = Some(self.builder.values.len());
         VectorBuilder {
-            builder: &mut self.builder,
+            builder: self.builder,
             start,
         }
     }
@@ -64,7 +64,7 @@ impl<'a> MapBuilder<'a> {
         // Nested map.
         let start = Some(self.builder.values.len());
         MapBuilder {
-            builder: &mut self.builder,
+            builder: self.builder,
             start,
         }
     }

--- a/rust/flexbuffers/src/builder/ser.rs
+++ b/rust/flexbuffers/src/builder/ser.rs
@@ -98,7 +98,7 @@ impl ser::Error for Error {
         Self::Serde(format!("{}", msg))
     }
 }
-impl<'a> ser::SerializeSeq for &mut FlexbufferSerializer {
+impl ser::SerializeSeq for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
@@ -113,14 +113,14 @@ impl<'a> ser::SerializeSeq for &mut FlexbufferSerializer {
 }
 // This is unlike a flexbuffers map which requires CString like keys.
 // Its implemented as alternating keys and values (hopefully).
-impl<'a> ser::SerializeMap for &'a mut FlexbufferSerializer {
+impl ser::SerializeMap for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
     fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
     where
         T: Serialize,
     {
-        key.serialize(MapKeySerializer(&mut **self))
+        key.serialize(MapKeySerializer(self))
     }
     fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
@@ -132,7 +132,7 @@ impl<'a> ser::SerializeMap for &'a mut FlexbufferSerializer {
         self.end_map()
     }
 }
-impl<'a> ser::SerializeTuple for &mut FlexbufferSerializer {
+impl ser::SerializeTuple for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
@@ -145,7 +145,7 @@ impl<'a> ser::SerializeTuple for &mut FlexbufferSerializer {
         self.end_vector()
     }
 }
-impl<'a> ser::SerializeTupleStruct for &mut FlexbufferSerializer {
+impl ser::SerializeTupleStruct for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
@@ -158,7 +158,7 @@ impl<'a> ser::SerializeTupleStruct for &mut FlexbufferSerializer {
         self.end_vector()
     }
 }
-impl<'a> ser::SerializeStruct for &mut FlexbufferSerializer {
+impl ser::SerializeStruct for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
     fn serialize_field<T: ?Sized>(
@@ -176,7 +176,7 @@ impl<'a> ser::SerializeStruct for &mut FlexbufferSerializer {
         self.end_map()
     }
 }
-impl<'a> ser::SerializeTupleVariant for &mut FlexbufferSerializer {
+impl ser::SerializeTupleVariant for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
@@ -190,7 +190,7 @@ impl<'a> ser::SerializeTupleVariant for &mut FlexbufferSerializer {
         self.end_map()
     }
 }
-impl<'a> ser::SerializeStructVariant for &mut FlexbufferSerializer {
+impl ser::SerializeStructVariant for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
     fn serialize_field<T: ?Sized>(

--- a/rust/flexbuffers/src/builder/vector.rs
+++ b/rust/flexbuffers/src/builder/vector.rs
@@ -39,7 +39,7 @@ impl<'a> VectorBuilder<'a> {
     pub fn start_vector(&mut self) -> VectorBuilder {
         let start = Some(self.builder.values.len());
         VectorBuilder {
-            builder: &mut self.builder,
+            builder: self.builder,
             start,
         }
     }
@@ -48,7 +48,7 @@ impl<'a> VectorBuilder<'a> {
     pub fn start_map(&mut self) -> MapBuilder {
         let start = Some(self.builder.values.len());
         MapBuilder {
-            builder: &mut self.builder,
+            builder: self.builder,
             start,
         }
     }

--- a/rust/flexbuffers/src/lib.rs
+++ b/rust/flexbuffers/src/lib.rs
@@ -29,7 +29,7 @@
 //             Serde with maps - field names and type names.
 
 // Until flat/flexbuffers is on Rust v1.42, we cannot use the previously unstable matches! macro.
-#![allow(clippy::unknown_clippy_lints)]
+#![allow(unknown_lints)]
 #![allow(clippy::match_like_matches_macro)]
 
 #[macro_use]

--- a/rust/flexbuffers/src/reader/mod.rs
+++ b/rust/flexbuffers/src/reader/mod.rs
@@ -380,7 +380,7 @@ impl<B: Buffer> Reader<B> {
     }
 
     pub fn as_blob(&self) -> Blob<B> {
-        self.get_blob().unwrap_or(Blob(B::empty()))
+        self.get_blob().unwrap_or_else(|_| Blob(B::empty()))
     }
 
     /// Retrieves str pointer, errors if invalid UTF-8, or the provided index
@@ -580,8 +580,8 @@ impl<B: Buffer> Reader<B> {
     /// Returns empty string if you're not trying to read a string.
     pub fn as_str(&self) -> B::BufferString {
         match self.fxb_type {
-            FlexBufferType::String => self.get_str().unwrap_or(B::empty_str()),
-            FlexBufferType::Key => self.get_key().unwrap_or(B::empty_str()),
+            FlexBufferType::String => self.get_str().unwrap_or_else(|_| B::empty_str()),
+            FlexBufferType::Key => self.get_key().unwrap_or_else(|_| B::empty_str()),
             _ => B::empty_str(),
         }
     }

--- a/samples/sample_binary.rs
+++ b/samples/sample_binary.rs
@@ -19,7 +19,7 @@ extern crate flatbuffers;
 
 // import the generated code
 #[allow(dead_code, unused_imports)]
-#[allow(clippy::approx_constant)]  // We use low precision PI as a default value.
+#[allow(clippy::all)]
 mod rust_generated;
 pub use rust_generated::my_game::sample::{Color, Equipment,
                                              Monster, MonsterArgs,

--- a/tests/RustTest.sh
+++ b/tests/RustTest.sh
@@ -48,13 +48,9 @@ check_test_result "Rust flatbuffers heap alloc test"
 cargo run $TARGET_FLAG --bin=flexbuffers_alloc_check
 check_test_result "Rust flexbuffers heap alloc test"
 
-# TODO(caspern): Fix this.
-#   Temporarily disabled due to error in upstream configuration
-#   https://github.com/google/flatbuffers/issues/6491
-#
-# rustup component add clippy
-# cargo clippy $TARGET_FLAG
-# check_test_result "No Cargo clippy lints test"
+rustup component add clippy
+cargo clippy $TARGET_FLAG
+check_test_result "No Cargo clippy lints test"
 
 cargo bench $TARGET_FLAG
 

--- a/tests/rust_usage_test/bin/flatbuffers_alloc_check.rs
+++ b/tests/rust_usage_test/bin/flatbuffers_alloc_check.rs
@@ -3,6 +3,7 @@
 // global variable).
 use std::alloc::{GlobalAlloc, Layout, System};
 
+
 static mut N_ALLOCS: usize = 0;
 
 struct TrackingAllocator;
@@ -30,15 +31,15 @@ static A: TrackingAllocator = TrackingAllocator;
 // import the flatbuffers generated code:
 extern crate flatbuffers;
 
-#[allow(dead_code, unused_imports)]
+#[allow(dead_code, unused_imports, clippy::all)]
 #[path = "../../include_test1/mod.rs"]
 pub mod include_test1_generated;
 
-#[allow(dead_code, unused_imports)]
+#[allow(dead_code, unused_imports, clippy::all)]
 #[path = "../../include_test2/mod.rs"]
 pub mod include_test2_generated;
 
-#[allow(dead_code, unused_imports, clippy::approx_constant)]
+#[allow(dead_code, unused_imports, clippy::all)]
 #[path = "../../monster_test/mod.rs"]
 mod monster_test_generated;
 

--- a/tests/rust_usage_test/bin/monster_example.rs
+++ b/tests/rust_usage_test/bin/monster_example.rs
@@ -1,4 +1,6 @@
+#![allow(clippy::derivable_impls, clippy::all)]
 extern crate flatbuffers;
+
 
 #[allow(dead_code, unused_imports)]
 #[path = "../../include_test1/mod.rs"]

--- a/tests/rust_usage_test/outdir/build.rs
+++ b/tests/rust_usage_test/outdir/build.rs
@@ -32,6 +32,7 @@ fn main() {
         .arg("-o")
         .arg(&out_dir)
         .arg("--rust")
+        .arg("--rust-module-root-file")
         .arg(&sample_schema)
         .output()
         .expect("Failed to generate file");

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -48,28 +48,28 @@ mod flexbuffers_tests;
 mod more_defaults_test;
 mod optional_scalars_test;
 
-#[allow(dead_code, unused_imports)]
+#[allow(dead_code, unused_imports, clippy::all)]
 #[path = "../../include_test1/mod.rs"]
 pub mod include_test1_generated;
 
-#[allow(dead_code, unused_imports)]
+#[allow(dead_code, unused_imports, clippy::all)]
 #[path = "../../include_test2/mod.rs"]
 pub mod include_test2_generated;
 
-#[allow(dead_code, unused_imports)]
+#[allow(dead_code, unused_imports, clippy::all)]
 #[path = "../../namespace_test/mod.rs"]
 pub mod namespace_test_generated;
 
-#[allow(dead_code, unused_imports)]
+#[allow(dead_code, unused_imports, clippy::all)]
 #[path = "../../monster_test/mod.rs"]
 mod monster_test_generated;
 pub use monster_test_generated::my_game;
 
-#[allow(dead_code, unused_imports)]
+#[allow(dead_code, unused_imports, clippy::all)]
 #[path = "../../optional_scalars/mod.rs"]
 mod optional_scalars_generated;
 
-#[allow(dead_code, unused_imports)]
+#[allow(dead_code, unused_imports, clippy::all)]
 #[path = "../../arrays_test/mod.rs"]
 mod arrays_test_generated;
 


### PR DESCRIPTION
Fixing lints for generated code would take more effort