### PR TITLE
Make type conversions explicit.

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,6 @@
         <testExcludes>
           <testExclude>**/LongEnum.java</testExclude>
           <testExclude>MyGame/Example/MonsterStorageGrpc.java</testExclude>
-          <testExclude>MyGame/Example/StructOfStructs**</testExclude>
           <testExclude>MyGame/OtherNameSpace/TableBT.java</testExclude>
         </testExcludes>
       </configuration>

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -1889,6 +1889,7 @@ class JavaGenerator : public BaseGenerator {
           }
         } else {
           code += " " + name + " = ";
+          code += SourceCast(field_type);
           code += "_o";
           for (size_t i = 0; i < array_lengths.size(); ++i) {
             code += "." + namer_.Method("get", array_lengths[i].name) + "()";

--- a/tests/MyGame/Example/StructOfStructs.java
+++ b/tests/MyGame/Example/StructOfStructs.java
@@ -52,12 +52,12 @@ public final class StructOfStructs extends Struct {
   }
   public static int pack(FlatBufferBuilder builder, StructOfStructsT _o) {
     if (_o == null) return 0;
-    int _a_id = _o.getA().getId();
-    int _a_distance = _o.getA().getDistance();
+    int _a_id = (int) _o.getA().getId();
+    int _a_distance = (int) _o.getA().getDistance();
     short _b_a = _o.getB().getA();
     byte _b_b = _o.getB().getB();
-    int _c_id = _o.getC().getId();
-    int _c_distance = _o.getC().getDistance();
+    int _c_id = (int) _o.getC().getId();
+    int _c_distance = (int) _o.getC().getDistance();
     return createStructOfStructs(
       builder,
       _a_id,

--- a/tests/MyGame/Example/StructOfStructsOfStructs.java
+++ b/tests/MyGame/Example/StructOfStructsOfStructs.java
@@ -47,12 +47,12 @@ public final class StructOfStructsOfStructs extends Struct {
   }
   public static int pack(FlatBufferBuilder builder, StructOfStructsOfStructsT _o) {
     if (_o == null) return 0;
-    int _a_a_id = _o.getA().getA().getId();
-    int _a_a_distance = _o.getA().getA().getDistance();
+    int _a_a_id = (int) _o.getA().getA().getId();
+    int _a_a_distance = (int) _o.getA().getA().getDistance();
     short _a_b_a = _o.getA().getB().getA();
     byte _a_b_b = _o.getA().getB().getB();
-    int _a_c_id = _o.getA().getC().getId();
-    int _a_c_distance = _o.getA().getC().getDistance();
+    int _a_c_id = (int) _o.getA().getC().getId();
+    int _a_c_distance = (int) _o.getA().getC().getDistance();
     return createStructOfStructsOfStructs(
       builder,
       _a_a_id,


### PR DESCRIPTION
As Java does not support unsigned integer types, the value types are "rounded up" (an uint32 is represented as a long) but persisted correctly (an uint32 is persisted as 4 bytes).

This CL makes a cast operation explicit so that the compiler does not throw warning messages.

This should fix issue #7594.