### PR TITLE
Fix LongEnum definitions

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -63,7 +63,6 @@
       <configuration>
         <release>8</release>
         <testExcludes>
-          <testExclude>**/LongEnum.java</testExclude>
           <testExclude>MyGame/Example/MonsterStorageGrpc.java</testExclude>
           <testExclude>MyGame/Example/StructOfStructs**</testExclude>
           <testExclude>MyGame/OtherNameSpace/TableBT.java</testExclude>

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -397,6 +397,10 @@ class JavaGenerator : public BaseGenerator {
       code += " ";
       code += namer_.Variant(ev) + " = ";
       code += enum_def.ToString(ev);
+      if (enum_def.underlying_type.base_type == BASE_TYPE_LONG ||
+          enum_def.underlying_type.base_type == BASE_TYPE_ULONG) {
+        code += "L";
+      }
       code += ";\n";
     }
 

--- a/tests/MyGame/Example/LongEnum.java
+++ b/tests/MyGame/Example/LongEnum.java
@@ -5,8 +5,8 @@ package MyGame.Example;
 @SuppressWarnings("unused")
 public final class LongEnum {
   private LongEnum() { }
-  public static final long LongOne = 2;
-  public static final long LongTwo = 4;
-  public static final long LongBig = 1099511627776;
+  public static final long LongOne = 2L;
+  public static final long LongTwo = 4L;
+  public static final long LongBig = 1099511627776L;
 }
 


### PR DESCRIPTION
The MyGame/Example/LongEnum.java class did not compile because Java expects an "L" suffix for literals of type long.

This CL fixes the code generation to include such a suffix.

This fixes issue #7593 