### PR TITLE
Fix help output for --gen-includes

### DIFF
--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -88,7 +88,7 @@ const static FlatCOption options[] = {
     "--no-prefix." },
   { "", "swift-implementation-only", "",
     "Adds a @_implementationOnly to swift imports" },
-  { "", "gen-inclues", "",
+  { "", "gen-includes", "",
     "(deprecated), this is the default behavior. If the original behavior is "
     "required (no include statements) use --no-includes." },
   { "", "no-includes", "",


### PR DESCRIPTION
Fixes the `--help` output documenting the deprecated `--gen-includes` option, in which the option name contained a typo (`--gen-inclues`).