### PR TITLE
Added option to not requires an EoF token when parsing JSON

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -642,6 +642,7 @@ struct IDLOptions {
   bool json_nested_legacy_flatbuffers;
   bool ts_flat_file;
   bool no_leak_private_annotations;
+  bool require_json_eof;
 
   // Possible options for the more general generator below.
   enum Language {
@@ -743,6 +744,7 @@ struct IDLOptions {
         json_nested_legacy_flatbuffers(false),
         ts_flat_file(false),
         no_leak_private_annotations(false),
+        require_json_eof(true),
         mini_reflect(IDLOptions::kNone),
         require_explicit_ids(false),
         rust_serialize(false),
@@ -905,6 +907,9 @@ class Parser : public ParserState {
 
   bool ParseJson(const char *json, const char *json_filename = nullptr);
 
+  // Returns the number of characters were consumed when parsing a JSON string.
+  std::ptrdiff_t BytesConsumed() const;
+   
   // Set the root type. May override the one set in the schema.
   bool SetRootType(const char *name);
 

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -3264,6 +3264,10 @@ bool Parser::ParseJson(const char *json, const char *json_filename) {
   return done;
 }
 
+std::ptrdiff_t Parser::BytesConsumed() const {
+  return std::distance(source_, cursor_);
+}
+
 CheckedError Parser::StartParseFile(const char *source,
                                     const char *source_filename) {
   file_being_parsed_ = source_filename ? source_filename : "";
@@ -3601,9 +3605,11 @@ CheckedError Parser::DoParseJson() {
                                                : nullptr);
     }
   }
-  // Check that JSON file doesn't contain more objects or IDL directives.
-  // Comments after JSON are allowed.
-  EXPECT(kTokenEof);
+  if (opts.require_json_eof) {
+    // Check that JSON file doesn't contain more objects or IDL directives.
+    // Comments after JSON are allowed.
+    EXPECT(kTokenEof);
+  }
   return NoError();
 }
 


### PR DESCRIPTION
Previously when parsing a JSON representation of a Flatbuffer, the parser required that the input string contain one and only one root table. This change adds a flag that removes that requirement, so that if a Flatbuffer table is embedded in some larger string the parser will simply stop parsing once it reaches the end of the root table, and does not validate that it has reached the end of the string.

This change also adds a BytesConsumed function, which returns the number of bytes the parser consumed. This is useful if the table embedded in some larger string that is being parsed, and that outer parser needs to know how many bytes the table was so that it can step over it.
