### PR TITLE
Fix: arduino platform build

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -32,7 +32,7 @@
 #include <cstdlib>
 #include <cstring>
 
-#if defined(ARDUINO) && !defined(ARDUINOSTL_M_H)
+#if defined(ARDUINO) && !defined(ARDUINOSTL_M_H) && defined(__AVR__)
   #include <utility.h>
 #else
   #include <utility>


### PR DESCRIPTION

[#if defined(ARDUINO) && !defined(ARDUINOSTL_M_H)](https://github.com/google/flatbuffers/blob/214cc94681f0c0ceb11ac98ce3879928f92e539f/include/flatbuffers/base.h#L35)

It will case comiple error(I'm using ESP32 and ESP8266 with Arduino SDK):
```
include/flatbuffers/base.h:36:12: fatal error: utility.h: No such file or directory
```
I have already read the issue: https://github.com/google/flatbuffers/issues/4357 and I think it should only apply to AVR.

Because: 
```cpp
#include <utility>
```
this include is allowed on most platform(even mcu toolchains), e.g: esp32/esp8266/stm32. and arduino framework is works too.
