### PR TITLE
Uses swift build command directly in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -431,7 +431,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: test
       working-directory: tests/swift/tests
-      run: sh SwiftTest.sh
+      run: |
+        swift build --build-tests
+        swift test
 
   build-swift-wasm:
     name: Build Swift Wasm


### PR DESCRIPTION
The following PR changes the CI from using `SwiftTests.sh` to building the binary directly within the CI so that it fails. Currently the swift lib is failing to [build](https://github.com/google/flatbuffers/issues/7633) which is perfect to test this.