### PR TITLE
updated method generation to be independent of renaming code

### DIFF
--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -387,8 +387,7 @@ class TsGenerator : public BaseGenerator {
         return GenBBAccess() + ".__union_with_string" + arguments;
       case BASE_TYPE_VECTOR: return GenGetter(type.VectorType(), arguments);
       default: {
-        auto getter = GenBBAccess() + "." +
-                      namer_.Method("read_" + GenType(type)) + arguments;
+        auto getter = GenBBAccess() + "." + "read" + GenType(type) + arguments;
         if (type.base_type == BASE_TYPE_BOOL) { getter = "!!" + getter; }
         return getter;
       }


### PR DESCRIPTION
The TypeScript generator creates the accessors for built-in dataview methods [here](https://github.com/google/flatbuffers/blob/6f895f54c25aa19f5d84ac6cf7fa8bc955a14e1d/src/idl_gen_ts.cpp#L391), for methods like `readUint8` of [https://github.com/google/flatbuffers/blob/master/ts/byte-buffer.ts](ByteBuffer) which are natively in lowerCamelCase.  However, it depends on the TypeScriptDefaultConfig conversion rules [for Methods](https://github.com/google/flatbuffers/blob/6f895f54c25aa19f5d84ac6cf7fa8bc955a14e1d/src/idl_gen_ts.cpp#L45), and if these change will not match the actual method names that need to be called.

Removing the underscore / namer method call fixes this problem as the generated names will now always match.