### PR TITLE
Fixed Parser error when using predecl nested structs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,8 @@ set(FlatBuffers_Tests_SRCS
   tests/native_type_test_impl.cpp
   tests/alignment_test.h
   tests/alignment_test.cpp
+  tests/nested_predecl_struct_test.h
+  tests/nested_predecl_struct_test.cpp
   include/flatbuffers/code_generators.h
   src/code_generators.cpp
   # file generate by running compiler on tests/monster_test.fbs

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -351,7 +351,8 @@ struct StructDef : public Definition {
         sortbysize(true),
         has_key(false),
         minalign(1),
-        bytesize(0) {}
+        bytesize(0),
+        should_check(false) {}
 
   void PadLastField(size_t min_align) {
     auto padding = PaddingBytes(bytesize, min_align);
@@ -374,6 +375,7 @@ struct StructDef : public Definition {
   size_t bytesize;  // Size if fixed.
 
   flatbuffers::unique_ptr<std::string> original_location;
+  bool should_check; // If it should be checked later because of struct field constraint
 };
 
 struct EnumDef;
@@ -471,6 +473,10 @@ inline bool IsString(const Type &type) {
 
 inline bool IsStruct(const Type &type) {
   return type.base_type == BASE_TYPE_STRUCT && type.struct_def->fixed;
+}
+
+inline bool IsPredeclStruct(const Type &type) {
+  return type.base_type == BASE_TYPE_STRUCT && type.struct_def->predecl;
 }
 
 inline bool IsTable(const Type &type) {
@@ -988,6 +994,7 @@ class Parser : public ParserState {
                                      const std::string &name, const Type &type,
                                      FieldDef **dest);
   FLATBUFFERS_CHECKED_ERROR ParseField(StructDef &struct_def);
+  FLATBUFFERS_CHECKED_ERROR CheckStructField(const Type &type);
   FLATBUFFERS_CHECKED_ERROR ParseString(Value &val, bool use_string_pooling);
   FLATBUFFERS_CHECKED_ERROR ParseComma();
   FLATBUFFERS_CHECKED_ERROR ParseAnyValue(Value &val, FieldDef *field,

--- a/tests/nested_predecl_struct_test.cpp
+++ b/tests/nested_predecl_struct_test.cpp
@@ -1,0 +1,47 @@
+#include "flatbuffers/idl.h"
+#include "flatbuffers/flatbuffers.h"
+#include "test_assert.h"
+#include "nested_predecl_struct_test.h"
+
+namespace flatbuffers {
+namespace tests {
+
+void NestedPredeclStructTest()
+{
+    const char* nested_predecl_struct = R"(
+        // This struct contains a "predecl" nested struct
+        struct NestedStructTest
+        {
+            a: Vec3;
+        }
+
+        struct Vec3
+        {
+            x: float;
+            y: float;
+            z: float;
+        }
+    )";
+    flatbuffers::Parser p;
+    TEST_ASSERT(p.Parse(nested_predecl_struct));
+
+    const char* nested_predecl_table = R"(
+        // This struct contains a "predecl" nested struct
+        struct NestedStructTest
+        {
+            a: Vec3;
+        }
+
+        table Vec3
+        {
+            x: float;
+            y: float;
+            z: float;
+        }
+    )";
+    flatbuffers::Parser p2;
+    TEST_EQ(p2.Parse(nested_predecl_table), false);
+}
+
+}
+}

--- a/tests/nested_predecl_struct_test.h
+++ b/tests/nested_predecl_struct_test.h
@@ -1,0 +1,12 @@
+
+#ifndef NESTED_PREDECL_STRUCT_TEST_H
+#define NESTED_PREDECL_STRUCT_TEST_H
+
+#include "flatbuffers/idl.h"
+namespace flatbuffers {
+namespace tests {
+    void NestedPredeclStructTest();
+}
+}
+
+#endif

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -37,6 +37,7 @@
 #include "parser_test.h"
 #include "proto_test.h"
 #include "reflection_test.h"
+#include "nested_predecl_struct_test.h"
 #include "union_vector/union_vector_generated.h"
 #if !defined(_MSC_VER) || _MSC_VER >= 1700
 #  include "arrays_test_generated.h"
@@ -1565,6 +1566,7 @@ int FlatBufferTests(const std::string &tests_data_path) {
   VectorSpanTest();
   NativeInlineTableVectorTest();
   FixedSizedScalarKeyInStructTest();
+  NestedPredeclStructTest();
   return 0;
 }
 }  // namespace


### PR DESCRIPTION
When using nested struct with pre-declaration, such as:

``` 
struct A { a: B;}
struct B { b: int;}
```

Parser will emit an error: 

> structs may contain only scalar or struct fields

Because at this time, Parser has no infomation about if this struct is fixed.

As a workaround, we should check it later when we get its declaration.