### PR TITLE
tests/reflection_test.h: add missing <stdint.h> include

### DIFF
--- a/tests/reflection_test.h
+++ b/tests/reflection_test.h
@@ -1,6 +1,7 @@
 #ifndef TESTS_REFLECTION_TEST_H
 #define TESTS_REFLECTION_TEST_H
 
+#include <stdint.h>
 #include <string>
 
 namespace flatbuffers {


### PR DESCRIPTION
Without the change build fails on weekly `gcc-13` snapshots as:

    In file included from /build/flatbuffers/tests/reflection_test.cpp:1:
    tests/reflection_test.h:9:57: error: 'uint8_t' has not been declared
        9 | void ReflectionTest(const std::string& tests_data_path, uint8_t *flatbuf, size_t length);
          |                                                         ^~~~~~~
