### PR TITLE
fix: byte_width_ = 1U << static_cast<BitWidth>(packed_type & 3) implicit-int-conversion fix.

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -384,7 +384,7 @@ class Reference {
 
   Reference(const uint8_t *data, uint8_t parent_width, uint8_t packed_type)
       : data_(data), parent_width_(parent_width) {
-    byte_width_ = 1U << static_cast<BitWidth>(packed_type & 3);
+    byte_width_ = static_cast<BitWidth>(1U << (packed_type & 3));
     type_ = static_cast<Type>(packed_type >> 2);
   }
 


### PR DESCRIPTION
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/22816236/205821153-6afda4b5-d4c5-4d6f-8f12-cc721e0bfa43.png">

flexbuffers.h:361:22: error: implicit conversion loses integer precision: 'unsigned int' to 'uint8_t' (aka 'unsigned char') [-Werror,-Wimplicit-int-conversion]
    byte_width_ = 1U << static_cast<BitWidth>(packed_type & 3);
                ~ ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.

while enable warning as error, this code will compile error by [-Werror,-Wimplicit-int-conversion]