### PR TITLE
[FlexBuffers Dart] Fix a bug where a floating point number was cast to int and the value…

### DIFF
--- a/dart/lib/src/types.dart
+++ b/dart/lib/src/types.dart
@@ -9,7 +9,7 @@ class BitWidthUtil {
   }
 
   static BitWidth width(num value) {
-    if (value.toInt() == value) {
+    if (value is int) {
       var v = value.toInt().abs();
       if (v >> 7 == 0) return BitWidth.width8;
       if (v >> 15 == 0) return BitWidth.width16;

--- a/dart/test/flex_builder_test.dart
+++ b/dart/test/flex_builder_test.dart
@@ -41,6 +41,10 @@ void main() {
       expect(flx.finish(), [255, 251, 5, 2]);
     }
     {
+      var builder = Builder()..addDouble(1.0);
+      expect(builder.finish(), [0, 0, 128, 63, 14, 4]);
+    }
+    {
       var flx = Builder();
       flx.addDouble(0.1);
       expect(flx.finish(), [154, 153, 153, 153, 153, 153, 185, 63, 15, 8]);

--- a/dart/test/flex_reader_test.dart
+++ b/dart/test/flex_reader_test.dart
@@ -37,6 +37,7 @@ void main() {
 //      expect(FlxValue.fromBuffer(b([255, 255, 255, 255, 255, 255, 255, 255, 11, 8])).intValue, 18446744073709551615);
   });
   test('double value', () {
+    expect(Reference.fromBuffer(b([0, 0, 128, 63, 14, 4])).doubleValue, 1.0);
     expect(Reference.fromBuffer(b([0, 0, 144, 64, 14, 4])).doubleValue, 4.5);
     expect(Reference.fromBuffer(b([205, 204, 204, 61, 14, 4])).doubleValue,
         closeTo(.1, .001));


### PR DESCRIPTION
… was stored incorrectly because of low byte width.

Reported in https://github.com/google/flatbuffers/issues/7690
