### PR TITLE
fix clang format plus implicit cast error in flexbuffer

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -385,9 +385,8 @@ class Reference {
   Reference(const uint8_t *data, uint8_t parent_width, uint8_t packed_type)
       : data_(data),
         parent_width_(parent_width),
-        byte_width_(1 << (packed_type & 3)),
-        type_(static_cast<Type>(packed_type >> 2)) {
-  }
+        byte_width_(static_cast<uint8_t>(1 << (packed_type & 3))),
+        type_(static_cast<Type>(packed_type >> 2)) {}
 
   Type GetType() const { return type_; }
 


### PR DESCRIPTION
According to this pr https://github.com/google/flatbuffers/pull/7697