### PR TITLE
[Go] Fix bug where `bytes` wasn't being imported when using --gen-onefile flag

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -103,10 +103,12 @@ class GoGenerator : public BaseGenerator {
     bool needs_imports = false;
     for (auto it = parser_.enums_.vec.begin(); it != parser_.enums_.vec.end();
          ++it) {
-      tracked_imported_namespaces_.clear();
-      needs_math_import_ = false;
-      needs_bytes_import_ = false;
-      needs_imports = false;
+      if (!parser_.opts.one_file) {
+        tracked_imported_namespaces_.clear();
+        needs_math_import_ = false;
+        needs_bytes_import_ = false;
+        needs_imports = false;
+      }
       std::string enumcode;
       GenEnum(**it, &enumcode);
       if ((*it)->is_union && parser_.opts.generate_object_based_api) {
@@ -124,9 +126,11 @@ class GoGenerator : public BaseGenerator {
 
     for (auto it = parser_.structs_.vec.begin();
          it != parser_.structs_.vec.end(); ++it) {
-      tracked_imported_namespaces_.clear();
-      needs_math_import_ = false;
-      needs_bytes_import_ = false;
+      if (!parser_.opts.one_file) {
+        tracked_imported_namespaces_.clear();
+        needs_math_import_ = false;
+        needs_bytes_import_ = false;
+      }
       std::string declcode;
       GenStruct(**it, &declcode);
       if (parser_.opts.one_file) {
@@ -915,6 +919,7 @@ class GoGenerator : public BaseGenerator {
     code += "buf []byte) bool {\n";
     code += "\tspan := flatbuffers.GetUOffsetT(buf[vectorLocation - 4:])\n";
     code += "\tstart := flatbuffers.UOffsetT(0)\n";
+    if (IsString(field.value.type)) code += "\tbKey := []byte(key)\n";
     code += "\tfor span != 0 {\n";
     code += "\t\tmiddle := span / 2\n";
     code += "\t\ttableOffset := flatbuffers.GetIndirectOffset(buf, ";
@@ -924,7 +929,6 @@ class GoGenerator : public BaseGenerator {
     code += "\t\tobj.Init(buf, tableOffset)\n";
 
     if (IsString(field.value.type)) {
-      code += "\t\tbKey := []byte(key)\n";
       needs_bytes_import_ = true;
       code +=
           "\t\tcomp := bytes.Compare(obj." + namer_.Function(field.name) + "()";

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -104,10 +104,8 @@ class GoGenerator : public BaseGenerator {
     for (auto it = parser_.enums_.vec.begin(); it != parser_.enums_.vec.end();
          ++it) {
       if (!parser_.opts.one_file) {
-        tracked_imported_namespaces_.clear();
-        needs_math_import_ = false;
-        needs_bytes_import_ = false;
         needs_imports = false;
+        ResetImports();
       }
       std::string enumcode;
       GenEnum(**it, &enumcode);
@@ -126,11 +124,7 @@ class GoGenerator : public BaseGenerator {
 
     for (auto it = parser_.structs_.vec.begin();
          it != parser_.structs_.vec.end(); ++it) {
-      if (!parser_.opts.one_file) {
-        tracked_imported_namespaces_.clear();
-        needs_math_import_ = false;
-        needs_bytes_import_ = false;
-      }
+      if (!parser_.opts.one_file) { ResetImports(); }
       std::string declcode;
       GenStruct(**it, &declcode);
       if (parser_.opts.one_file) {
@@ -919,7 +913,7 @@ class GoGenerator : public BaseGenerator {
     code += "buf []byte) bool {\n";
     code += "\tspan := flatbuffers.GetUOffsetT(buf[vectorLocation - 4:])\n";
     code += "\tstart := flatbuffers.UOffsetT(0)\n";
-    if (IsString(field.value.type)) code += "\tbKey := []byte(key)\n";
+    if (IsString(field.value.type)) { code += "\tbKey := []byte(key)\n"; }
     code += "\tfor span != 0 {\n";
     code += "\t\tmiddle := span / 2\n";
     code += "\t\ttableOffset := flatbuffers.GetIndirectOffset(buf, ";
@@ -1466,6 +1460,7 @@ class GoGenerator : public BaseGenerator {
     StructBuilderBody(struct_def, "", code_ptr);
     EndBuilderBody(code_ptr);
   }
+
   // Begin by declaring namespace and imports.
   void BeginFile(const std::string &name_space_name, const bool needs_imports,
                  const bool is_enum, std::string *code_ptr) {
@@ -1505,6 +1500,13 @@ class GoGenerator : public BaseGenerator {
         code += "import \"math\"\n\n";
       }
     }
+  }
+
+  // Resets the needed imports before generating a new file.
+  void ResetImports() {
+    tracked_imported_namespaces_.clear();
+    needs_bytes_import_ = false;
+    needs_math_import_ = false;
   }
 
   // Save out the generated code for a Go Table type.

--- a/tests/MyGame/Example/Monster.go
+++ b/tests/MyGame/Example/Monster.go
@@ -579,12 +579,12 @@ func MonsterKeyCompare(o1, o2 flatbuffers.UOffsetT, buf []byte) bool {
 func (rcv *Monster) LookupByKey(key string, vectorLocation flatbuffers.UOffsetT, buf []byte) bool {
 	span := flatbuffers.GetUOffsetT(buf[vectorLocation - 4:])
 	start := flatbuffers.UOffsetT(0)
+	bKey := []byte(key)
 	for span != 0 {
 		middle := span / 2
 		tableOffset := flatbuffers.GetIndirectOffset(buf, vectorLocation+ 4 * (start + middle))
 		obj := &Monster{}
 		obj.Init(buf, tableOffset)
-		bKey := []byte(key)
 		comp := bytes.Compare(obj.Name(), bKey)
 		if comp > 0 {
 			span = middle


### PR DESCRIPTION
Fix for discussion in #7460.

Currently, the go generator resets the state of needed imports each time we process an enum or struct. This works  fine when we want each enum and struct to be in their own files.

However, this will lead to an error if an `fbs` file is defined like the following.

```
namespace example;

table Foo {
  name: string (key);
}

table Bar {
  id: int;
}
```

When processing the `Foo` table the `needs_bytes_import` will be set to `true` because of the key field. Then when processing the `Bar` table the `needs_bytes_import` will be reset to `false` resulting in the final output file to not import the `bytes` package.

When we want all code to be in the same file we shouldn't reset the needed imports as we iterate through the structs/enums.

**Additional Changes**
For the lookup function I moved the declaration of `bKey` outside of the for loop to reduce unnecessary casting.