### PR TITLE
Add Ref.AsStringBytes to flatbuffers.flexbuffers Python API

### DIFF
--- a/python/flatbuffers/flexbuffers.py
+++ b/python/flatbuffers/flexbuffers.py
@@ -728,6 +728,15 @@ class Ref:
     return self._type is Type.STRING
 
   @property
+  def AsStringBytes(self):
+    if self.IsString:
+      return String(self._Indirect(), self._byte_width)
+    elif self.IsKey:
+      return self.AsKeyBytes
+    else:
+      raise self._ConvertError(Type.STRING)
+
+  @property
   def AsString(self):
     if self.IsString:
       return str(String(self._Indirect(), self._byte_width))

--- a/python/flatbuffers/flexbuffers.py
+++ b/python/flatbuffers/flexbuffers.py
@@ -730,7 +730,7 @@ class Ref:
   @property
   def AsStringBytes(self):
     if self.IsString:
-      return String(self._Indirect(), self._byte_width)
+      return String(self._Indirect(), self._byte_width).Bytes
     elif self.IsKey:
       return self.AsKeyBytes
     else:


### PR DESCRIPTION
Add Ref.AsStringBytes to flatbuffers.flexbuffers Python API.

This is for handling Ref as raw string bytes (without UTF-8 decoding).