### PR TITLE
Ensure that empty modules can build in TypeScript isolatedModules mode

### DIFF
--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -277,6 +277,13 @@ class TsGenerator : public BaseGenerator {
       for (auto it = imports_all_.begin(); it != imports_all_.end(); it++) {
         code += it->second.export_statement + "\n";
       }
+
+      if (imports_all_.empty()) {
+        // if the file is empty, add an empty export so that tsc doesn't
+        // complain when running under `--isolatedModules` mode
+        code += "export {}";
+      }
+
       const std::string path =
           GeneratedFileName(path_, file_name_, parser_.opts);
       SaveFile(path.c_str(), code, false);


### PR DESCRIPTION
Some cases, like if a .fbs file contains only an enum but does not import anything, will result in the compiler emitting a `foo_generated.ts` file that is empty, which causes `tsc` to error out when running with `--isolatedModules`