### PR TITLE
Fix "'flatbuffers::FieldDef* field' shadows a parameter"

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -501,7 +501,9 @@ class GoGenerator : public BaseGenerator {
     auto &vector_struct_fields = vectortype.struct_def->fields.vec;
     auto kit =
         std::find_if(vector_struct_fields.begin(), vector_struct_fields.end(),
-                     [&](FieldDef *field) { return field->key; });
+                     [&](FieldDef *vector_struct_field) {
+                       return vector_struct_field->key;
+                     });
 
     auto &key_field = **kit;
     FLATBUFFERS_ASSERT(key_field.key);


### PR DESCRIPTION
Recent additions make gcc grouchy:

```
/usr/**********/flatbuffers/src/idl_gen_go.cpp: In lambda function:
/usr/**********/flatbuffers/src/idl_gen_go.cpp:506:41: error: declaration of 'flatbuffers::FieldDef* field' shadows a parameter [-Werror=shadow]
                      [&](FieldDef *field) { return field->key; });
                                         ^
/usr/**********/flatbuffers/src/idl_gen_go.cpp:497:55: note: shadowed declaration is here
                                       const FieldDef &field,
                                       ~~~~~~~~~~~~~~~~^~~~~
```

This change provides a fully local name for the lambda parameter.