### PR TITLE
Fix go.mod name

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/google/flatbuffers
+module github.com/google/flatbuffers/go
 
 go 1.19


### PR DESCRIPTION
Fixes go.mod naming issue introduced by #7720.

Module name should be `github.com/google/flatbuffers/go` not `github.com/google/flatbuffers`.

https://pkg.go.dev/github.com/google/flatbuffers/go 
https://google.github.io/flatbuffers/flatbuffers_guide_use_go.html