### PR TITLE
Annotated Binaries emit field names instead of type names

### DIFF
--- a/src/binary_annotator.h
+++ b/src/binary_annotator.h
@@ -273,6 +273,7 @@ class BinaryAnnotator {
                   const reflection::Object *table);
 
   uint64_t BuildStruct(uint64_t offset, std::vector<BinaryRegion> &regions,
+                       const std::string referring_field_name,
                        const reflection::Object *structure);
 
   void BuildString(uint64_t offset, const reflection::Object *table,

--- a/tests/annotated_binary/annotated_binary.afb
+++ b/tests/annotated_binary/annotated_binary.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8     | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t   | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32  | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t    | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t    | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t    | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t    | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t    | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t    | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1] | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32  | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
   +0x0078 | 5C 01 00 00             | UOffset32  | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
@@ -97,7 +97,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3] | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t    | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t    | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
@@ -144,12 +144,12 @@ vector (AnnotatedBinary.Foo.foobars_type):
 
 vector (AnnotatedBinary.Foo.points_of_interest):
   +0x0134 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double     | 0x4045A33333333333 (43.275)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double     | 0xC053875BFF04577E (-78.115)   | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double     | 0x4042B60420F6F08D (37.422)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double     | 0xC05E85614163779F (-122.084)  | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double     | 0xC04B35DC8323358F (-54.4208)  | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double     | 0x400AC58793DD97F6 (3.34645)   | struct field `AnnotatedBinary.Location.longitude` (Double)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double     | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double     | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double     | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double     | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double     | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double     | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
   +0x0168 | 00 00 00 00             | uint8_t[4] | ....                           | padding

--- a/tests/annotated_binary/tests/invalid_string_length.afb
+++ b/tests/annotated_binary/tests/invalid_string_length.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8      | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t     | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t     | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t     | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t     | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t     | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t     | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1]  | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
   +0x0078 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
@@ -95,7 +95,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3]  | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t     | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t     | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
@@ -142,12 +142,12 @@ vector (AnnotatedBinary.Foo.foobars_type):
 
 vector (AnnotatedBinary.Foo.points_of_interest):
   +0x0134 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double      | 0x4045A33333333333 (43.275)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double      | 0xC053875BFF04577E (-78.115)   | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double      | 0x4042B60420F6F08D (37.422)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double      | 0xC05E85614163779F (-122.084)  | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double      | 0xC04B35DC8323358F (-54.4208)  | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double      | 0x400AC58793DD97F6 (3.34645)   | struct field `AnnotatedBinary.Location.longitude` (Double)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double      | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double      | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double      | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double      | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double      | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double      | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
   +0x0168 | 00 00 00 00             | uint8_t[4]  | ....                           | padding

--- a/tests/annotated_binary/tests/invalid_string_length_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_string_length_cut_short.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
   +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
   +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)              | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x70 | 01                      | uint8_t     | 0x01 (1)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x71 | 02                      | uint8_t     | 0x02 (2)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x72 | 03                      | uint8_t     | 0x03 (3)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)              | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x70 | 01                      | uint8_t     | 0x01 (1)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x71 | 02                      | uint8_t     | 0x02 (2)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x72 | 03                      | uint8_t     | 0x03 (3)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x73 | 00                      | uint8_t[1]  | .                            | padding
   +0x74 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x23C | ERROR: offset to field `name`. Invalid offset, points outside the binary.
   +0x78 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x1D4 | ERROR: offset to field `bars`. Invalid offset, points outside the binary.

--- a/tests/annotated_binary/tests/invalid_struct_array_field_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_struct_array_field_cut_short.afb
@@ -65,8 +65,8 @@ root_table (AnnotatedBinary.Foo):
   +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
   +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
   +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x68 | 0C 00                   | ?uint8_t[2] | ..                           | ERROR: array field `AnnotatedBinary.Dimension.values`[1] (Int). Incomplete binary, expected to read 4 bytes.
+  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x68 | 0C 00                   | ?uint8_t[2] | ..                           | ERROR: array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int). Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_struct_field_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_struct_field_cut_short.afb
@@ -65,5 +65,5 @@ root_table (AnnotatedBinary.Foo):
   +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
   +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
   +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x5C | 02 00                   | ?uint8_t[2] | ..                           | ERROR: struct field `AnnotatedBinary.Building.doors` (Int). Incomplete binary, expected to read 4 bytes.
+  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x5C | 02 00                   | ?uint8_t[2] | ..                           | ERROR: struct field `home.doors` of 'AnnotatedBinary.Building' (Int). Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_table_field_offset.afb
+++ b/tests/annotated_binary/tests/invalid_table_field_offset.afb
@@ -56,15 +56,15 @@ root_table (AnnotatedBinary.Foo):
   +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
   +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
   +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)              | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x70 | 01                      | uint8_t     | 0x01 (1)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x71 | 02                      | uint8_t     | 0x02 (2)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x72 | 03                      | uint8_t     | 0x03 (3)                     | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)              | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x70 | 01                      | uint8_t     | 0x01 (1)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x71 | 02                      | uint8_t     | 0x02 (2)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x72 | 03                      | uint8_t     | 0x03 (3)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x73 | 00                      | uint8_t[1]  | .                            | padding
   +0x74 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x23C | ERROR: offset to field `name`. Invalid offset, points outside the binary.
   +0x78 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x1D4 | ERROR: offset to field `bars`. Invalid offset, points outside the binary.

--- a/tests/annotated_binary/tests/invalid_union_type_value.afb
+++ b/tests/annotated_binary/tests/invalid_union_type_value.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
@@ -97,7 +97,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
@@ -144,12 +144,12 @@ vector (AnnotatedBinary.Foo.foobars_type):
 
 vector (AnnotatedBinary.Foo.points_of_interest):
   +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `AnnotatedBinary.Location.longitude` (Double)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
   +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding

--- a/tests/annotated_binary/tests/invalid_vector_length_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_length_cut_short.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
@@ -97,7 +97,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)

--- a/tests/annotated_binary/tests/invalid_vector_scalars_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_scalars_cut_short.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
@@ -97,7 +97,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
@@ -138,12 +138,12 @@ vector (AnnotatedBinary.Foo.foobars_type):
 
 vector (AnnotatedBinary.Foo.points_of_interest):
   +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `AnnotatedBinary.Location.longitude` (Double)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
   +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding

--- a/tests/annotated_binary/tests/invalid_vector_strings_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_strings_cut_short.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
@@ -97,7 +97,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
@@ -138,12 +138,12 @@ vector (AnnotatedBinary.Foo.foobars_type):
 
 vector (AnnotatedBinary.Foo.points_of_interest):
   +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `AnnotatedBinary.Location.longitude` (Double)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
   +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding

--- a/tests/annotated_binary/tests/invalid_vector_structs_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_structs_cut_short.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
@@ -97,7 +97,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)

--- a/tests/annotated_binary/tests/invalid_vector_tables_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_tables_cut_short.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
@@ -97,7 +97,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
@@ -138,12 +138,12 @@ vector (AnnotatedBinary.Foo.foobars_type):
 
 vector (AnnotatedBinary.Foo.points_of_interest):
   +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `AnnotatedBinary.Location.longitude` (Double)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
   +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding

--- a/tests/annotated_binary/tests/invalid_vector_union_type_value.afb
+++ b/tests/annotated_binary/tests/invalid_vector_union_type_value.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8      | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t     | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t     | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t     | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t     | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t     | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t     | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1]  | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
   +0x0078 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
@@ -97,7 +97,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3]  | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t     | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t     | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
@@ -140,12 +140,12 @@ vector (AnnotatedBinary.Foo.foobars_type):
 
 vector (AnnotatedBinary.Foo.points_of_interest):
   +0x0134 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double      | 0x4045A33333333333 (43.275)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double      | 0xC053875BFF04577E (-78.115)   | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double      | 0x4042B60420F6F08D (37.422)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double      | 0xC05E85614163779F (-122.084)  | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double      | 0xC04B35DC8323358F (-54.4208)  | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double      | 0x400AC58793DD97F6 (3.34645)   | struct field `AnnotatedBinary.Location.longitude` (Double)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double      | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double      | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double      | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double      | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double      | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double      | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
   +0x0168 | 00 00 00 00             | uint8_t[4]  | ....                           | padding

--- a/tests/annotated_binary/tests/invalid_vector_unions_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_unions_cut_short.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
@@ -97,7 +97,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
@@ -138,12 +138,12 @@ vector (AnnotatedBinary.Foo.foobars_type):
 
 vector (AnnotatedBinary.Foo.points_of_interest):
   +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `AnnotatedBinary.Location.longitude` (Double)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
   +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding

--- a/tests/annotated_binary/tests/invalid_vtable_field_offset.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_field_offset.afb
@@ -52,15 +52,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | ?uint8_t[4]  | (...                           | WARN: nothing refers to this section.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
@@ -98,7 +98,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
@@ -145,12 +145,12 @@ vector (AnnotatedBinary.Foo.foobars_type):
 
 vector (AnnotatedBinary.Foo.points_of_interest):
   +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `AnnotatedBinary.Location.longitude` (Double)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
   +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding

--- a/tests/annotated_binary/tests/invalid_vtable_ref_table_size.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_ref_table_size.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1]   | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
   +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
@@ -160,7 +160,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
@@ -207,12 +207,12 @@ vector (AnnotatedBinary.Foo.foobars_type):
 
 vector (AnnotatedBinary.Foo.points_of_interest):
   +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `AnnotatedBinary.Location.longitude` (Double)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
   +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding

--- a/tests/annotated_binary/tests/invalid_vtable_ref_table_size_short.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_ref_table_size_short.afb
@@ -51,15 +51,15 @@ root_table (AnnotatedBinary.Foo):
   +0x004F | 01                      | UType8     | 0x01 (1)                       | table field `anything_type` (UType)
   +0x0050 | D2 04 00 00             | uint32_t   | 0x000004D2 (1234)              | table field `counter` (Int)
   +0x0054 | 28 02 00 00             | UOffset32  | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                 | struct field `AnnotatedBinary.Building.floors` (Int)
-  +0x005C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                 | struct field `AnnotatedBinary.Building.doors` (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | struct field `AnnotatedBinary.Building.windows` (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                | array field `AnnotatedBinary.Dimension.values`[0] (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | array field `AnnotatedBinary.Dimension.values`[1] (Int)
-  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)                | array field `AnnotatedBinary.Dimension.values`[2] (Int)
-  +0x0070 | 01                      | uint8_t    | 0x01 (1)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0071 | 02                      | uint8_t    | 0x02 (2)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
-  +0x0072 | 03                      | uint8_t    | 0x03 (3)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x0058 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t    | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t    | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t    | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
   +0x0073 | 00                      | uint8_t[1] | .                              | padding
   +0x0074 | C8 01 00 00             | UOffset32  | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
   +0x0078 | 5C 01 00 00             | UOffset32  | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
@@ -97,7 +97,7 @@ table (AnnotatedBinary.Bar):
   +0x00D0 | 00 00 00                | uint8_t[3] | ...                            | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t    | 0x05 (5)                       | struct field `AnnotatedBinary.Tolerance.width` (UByte)
+  +0x00D3 | 05                      | uint8_t    | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
   +0x00D4 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
@@ -144,12 +144,12 @@ vector (AnnotatedBinary.Foo.foobars_type):
 
 vector (AnnotatedBinary.Foo.points_of_interest):
   +0x0134 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double     | 0x4045A33333333333 (43.275)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double     | 0xC053875BFF04577E (-78.115)   | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double     | 0x4042B60420F6F08D (37.422)    | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double     | 0xC05E85614163779F (-122.084)  | struct field `AnnotatedBinary.Location.longitude` (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double     | 0xC04B35DC8323358F (-54.4208)  | struct field `AnnotatedBinary.Location.latitude` (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double     | 0x400AC58793DD97F6 (3.34645)   | struct field `AnnotatedBinary.Location.longitude` (Double)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double     | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double     | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double     | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double     | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double     | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double     | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
   +0x0168 | 00 00 00 00             | uint8_t[4] | ....                           | padding

--- a/tests/monsterdata_test.afb
+++ b/tests/monsterdata_test.afb
@@ -71,15 +71,15 @@ root_table (MyGame.Example.Monster):
   +0x007C | 01                      | UType8     | 0x01 (1)                                 | table field `test_type` (UType)
   +0x007D | 01                      | uint8_t    | 0x01 (1)                                 | table field `testbool` (Bool)
   +0x007E | 50 00                   | int16_t    | 0x0050 (80)                              | table field `hp` (Short)
-  +0x0080 | 00 00 80 3F             | float      | 0x3F800000 (1)                           | struct field `MyGame.Example.Vec3.x` (Float)
-  +0x0084 | 00 00 00 40             | float      | 0x40000000 (2)                           | struct field `MyGame.Example.Vec3.y` (Float)
-  +0x0088 | 00 00 40 40             | float      | 0x40400000 (3)                           | struct field `MyGame.Example.Vec3.z` (Float)
+  +0x0080 | 00 00 80 3F             | float      | 0x3F800000 (1)                           | struct field `pos.x` of 'MyGame.Example.Vec3' (Float)
+  +0x0084 | 00 00 00 40             | float      | 0x40000000 (2)                           | struct field `pos.y` of 'MyGame.Example.Vec3' (Float)
+  +0x0088 | 00 00 40 40             | float      | 0x40400000 (3)                           | struct field `pos.z` of 'MyGame.Example.Vec3' (Float)
   +0x008C | 00 00 00 00             | uint8_t[4] | ....                                     | padding
-  +0x0090 | 00 00 00 00 00 00 08 40 | double     | 0x4008000000000000 (3)                   | struct field `MyGame.Example.Vec3.test1` (Double)
-  +0x0098 | 02                      | uint8_t    | 0x02 (2)                                 | struct field `MyGame.Example.Vec3.test2` (UByte)
+  +0x0090 | 00 00 00 00 00 00 08 40 | double     | 0x4008000000000000 (3)                   | struct field `pos.test1` of 'MyGame.Example.Vec3' (Double)
+  +0x0098 | 02                      | uint8_t    | 0x02 (2)                                 | struct field `pos.test2` of 'MyGame.Example.Vec3' (UByte)
   +0x0099 | 00                      | uint8_t[1] | .                                        | padding
-  +0x009A | 05 00                   | int16_t    | 0x0005 (5)                               | struct field `MyGame.Example.Test.a` (Short)
-  +0x009C | 06                      | uint8_t    | 0x06 (6)                                 | struct field `MyGame.Example.Test.b` (Byte)
+  +0x009A | 05 00                   | int16_t    | 0x0005 (5)                               | struct field `pos.test3.a` of 'MyGame.Example.Test' (Short)
+  +0x009C | 06                      | uint8_t    | 0x06 (6)                                 | struct field `pos.test3.b` of 'MyGame.Example.Test' (Byte)
   +0x009D | 00                      | uint8_t[1] | .                                        | padding
   +0x009E | 00 00                   | uint8_t[2] | ..                                       | padding
   +0x00A0 | 00 00 00 00             | uint8_t[4] | ....                                     | padding
@@ -99,8 +99,8 @@ root_table (MyGame.Example.Monster):
   +0x00D8 | 34 01 00 00             | UOffset32  | 0x00000134 (308) Loc: +0x020C            | offset to field `vector_of_longs` (vector)
   +0x00DC | 10 01 00 00             | UOffset32  | 0x00000110 (272) Loc: +0x01EC            | offset to field `vector_of_doubles` (vector)
   +0x00E0 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: +0x010C             | offset to field `scalar_key_sorted_tables` (vector)
-  +0x00E4 | 01 00                   | int16_t    | 0x0001 (1)                               | struct field `MyGame.Example.Test.a` (Short)
-  +0x00E6 | 02                      | uint8_t    | 0x02 (2)                                 | struct field `MyGame.Example.Test.b` (Byte)
+  +0x00E4 | 01 00                   | int16_t    | 0x0001 (1)                               | struct field `native_inline.a` of 'MyGame.Example.Test' (Short)
+  +0x00E6 | 02                      | uint8_t    | 0x02 (2)                                 | struct field `native_inline.b` of 'MyGame.Example.Test' (Byte)
   +0x00E7 | 00                      | uint8_t[1] | .                                        | padding
   +0x00E8 | 81 91 7B F2 CD 80 0F 6E | int64_t    | 0x6E0F80CDF27B9181 (7930699090847568257) | table field `testhashs64_fnv1` (Long)
   +0x00F0 | 81 91 7B F2 CD 80 0F 6E | uint64_t   | 0x6E0F80CDF27B9181 (7930699090847568257) | table field `testhashu64_fnv1` (ULong)
@@ -151,12 +151,12 @@ string (MyGame.Example.Stat.id):
 
 vector (MyGame.Example.Monster.testarrayofsortedstruct):
   +0x0158 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                           | length of vector (# items)
-  +0x015C | 00 00 00 00             | uint32_t   | 0x00000000 (0)                           | struct field `MyGame.Example.Ability.id` (UInt)
-  +0x0160 | 2D 00 00 00             | uint32_t   | 0x0000002D (45)                          | struct field `MyGame.Example.Ability.distance` (UInt)
-  +0x0164 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                           | struct field `MyGame.Example.Ability.id` (UInt)
-  +0x0168 | 15 00 00 00             | uint32_t   | 0x00000015 (21)                          | struct field `MyGame.Example.Ability.distance` (UInt)
-  +0x016C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                           | struct field `MyGame.Example.Ability.id` (UInt)
-  +0x0170 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                          | struct field `MyGame.Example.Ability.distance` (UInt)
+  +0x015C | 00 00 00 00             | uint32_t   | 0x00000000 (0)                           | struct field `[0].id` of 'MyGame.Example.Ability' (UInt)
+  +0x0160 | 2D 00 00 00             | uint32_t   | 0x0000002D (45)                          | struct field `[0].distance` of 'MyGame.Example.Ability' (UInt)
+  +0x0164 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                           | struct field `[1].id` of 'MyGame.Example.Ability' (UInt)
+  +0x0168 | 15 00 00 00             | uint32_t   | 0x00000015 (21)                          | struct field `[1].distance` of 'MyGame.Example.Ability' (UInt)
+  +0x016C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                           | struct field `[2].id` of 'MyGame.Example.Ability' (UInt)
+  +0x0170 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                          | struct field `[2].distance` of 'MyGame.Example.Ability' (UInt)
 
 vector (MyGame.Example.Monster.testarrayofbools):
   +0x0174 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                           | length of vector (# items)
@@ -199,20 +199,20 @@ padding:
 
 vector (MyGame.Example.Monster.test5):
   +0x01B4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                           | length of vector (# items)
-  +0x01B8 | 0A 00                   | int16_t    | 0x000A (10)                              | struct field `MyGame.Example.Test.a` (Short)
-  +0x01BA | 14                      | uint8_t    | 0x14 (20)                                | struct field `MyGame.Example.Test.b` (Byte)
+  +0x01B8 | 0A 00                   | int16_t    | 0x000A (10)                              | struct field `[0].a` of 'MyGame.Example.Test' (Short)
+  +0x01BA | 14                      | uint8_t    | 0x14 (20)                                | struct field `[0].b` of 'MyGame.Example.Test' (Byte)
   +0x01BB | 00                      | uint8_t[1] | .                                        | padding
-  +0x01BC | 1E 00                   | int16_t    | 0x001E (30)                              | struct field `MyGame.Example.Test.a` (Short)
-  +0x01BE | 28                      | uint8_t    | 0x28 (40)                                | struct field `MyGame.Example.Test.b` (Byte)
+  +0x01BC | 1E 00                   | int16_t    | 0x001E (30)                              | struct field `[1].a` of 'MyGame.Example.Test' (Short)
+  +0x01BE | 28                      | uint8_t    | 0x28 (40)                                | struct field `[1].b` of 'MyGame.Example.Test' (Byte)
   +0x01BF | 00                      | uint8_t[1] | .                                        | padding
 
 vector (MyGame.Example.Monster.test4):
   +0x01C0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                           | length of vector (# items)
-  +0x01C4 | 0A 00                   | int16_t    | 0x000A (10)                              | struct field `MyGame.Example.Test.a` (Short)
-  +0x01C6 | 14                      | uint8_t    | 0x14 (20)                                | struct field `MyGame.Example.Test.b` (Byte)
+  +0x01C4 | 0A 00                   | int16_t    | 0x000A (10)                              | struct field `[0].a` of 'MyGame.Example.Test' (Short)
+  +0x01C6 | 14                      | uint8_t    | 0x14 (20)                                | struct field `[0].b` of 'MyGame.Example.Test' (Byte)
   +0x01C7 | 00                      | uint8_t[1] | .                                        | padding
-  +0x01C8 | 1E 00                   | int16_t    | 0x001E (30)                              | struct field `MyGame.Example.Test.a` (Short)
-  +0x01CA | 28                      | uint8_t    | 0x28 (40)                                | struct field `MyGame.Example.Test.b` (Byte)
+  +0x01C8 | 1E 00                   | int16_t    | 0x001E (30)                              | struct field `[1].a` of 'MyGame.Example.Test' (Short)
+  +0x01CA | 28                      | uint8_t    | 0x28 (40)                                | struct field `[1].b` of 'MyGame.Example.Test' (Byte)
   +0x01CB | 00                      | uint8_t[1] | .                                        | padding
 
 vtable (MyGame.Example.Monster):


### PR DESCRIPTION
Replaces #7735 due to a push conflict.