### PR TITLE
Defined CodeGenerator Interface and implement C++

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -44,6 +44,7 @@ filegroup(
         "include/flatbuffers/bfbs_generator.h",
         "include/flatbuffers/buffer.h",
         "include/flatbuffers/buffer_ref.h",
+        "include/flatbuffers/code_generator.h",
         "include/flatbuffers/code_generators.h",
         "include/flatbuffers/default_allocator.h",
         "include/flatbuffers/detached_buffer.h",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ set(FlatBuffers_Library_SRCS
   include/flatbuffers/buffer_ref.h
   include/flatbuffers/default_allocator.h
   include/flatbuffers/detached_buffer.h
+  include/flatbuffers/code_generator.h
   include/flatbuffers/flatbuffer_builder.h
   include/flatbuffers/flatbuffers.h
   include/flatbuffers/flexbuffers.h

--- a/include/flatbuffers/code_generator.h
+++ b/include/flatbuffers/code_generator.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLATBUFFERS_CODE_GENERATOR_H_
+#define FLATBUFFERS_CODE_GENERATOR_H_
+
+#include <string>
+
+#include "flatbuffers/idl.h"
+
+namespace flatbuffers {
+
+// An code generator interface for producing converting flatbuffer schema into
+// code.
+class CodeGenerator {
+ public:
+  virtual ~CodeGenerator() = default;
+
+  enum Status {
+    OK = 0,
+    ERROR = 1,
+    NOT_IMPLEMENTED = 2,
+  };
+
+  // Generate code from the provided `parser`.
+  //
+  // DEPRECATED: prefer using the other overload of GenerateCode for bfbs.
+  virtual Status GenerateCode(const Parser &parser, const std::string &path,
+                              const std::string &filename) = 0;
+
+  // Generate code from the provided `buffer` of given `length`. The buffer is a
+  // serialized reflection.fbs.
+  virtual Status GenerateCode(const uint8_t *buffer, int64_t length) = 0;
+
+  virtual Status GenerateMakeRule(const Parser &parser, const std::string &path,
+                                  const std::string &filename,
+                                  std::string &output) = 0;
+
+  virtual Status GenerateGrpcCode(const Parser &parser, const std::string &path,
+                                  const std::string &filename) = 0;
+
+  virtual bool IsSchemaOnly() const = 0;
+
+  virtual bool SupportsBfbsGeneration() const = 0;
+
+  virtual IDLOptions::Language Language() const = 0;
+  virtual std::string LanguageName() const = 0;
+
+ protected:
+  CodeGenerator() = default;
+
+ private:
+  // Copying is not supported.
+  CodeGenerator(const CodeGenerator &) = delete;
+  CodeGenerator &operator=(const CodeGenerator &) = delete;
+};
+
+}  // namespace flatbuffers
+
+#endif  // FLATBUFFERS_CODE_GENERATOR_H_

--- a/src/flatc_main.cpp
+++ b/src/flatc_main.cpp
@@ -20,8 +20,11 @@
 #include "bfbs_gen_lua.h"
 #include "bfbs_gen_nim.h"
 #include "flatbuffers/base.h"
+#include "flatbuffers/code_generator.h"
 #include "flatbuffers/flatc.h"
 #include "flatbuffers/util.h"
+
+
 
 static const char *g_program_name = nullptr;
 
@@ -158,6 +161,12 @@ int main(int argc, const char *argv[]) {
   params.error_fn = Error;
 
   flatbuffers::FlatCompiler flatc(params);
+
+  std::shared_ptr<flatbuffers::CodeGenerator> cpp_generator =
+      flatbuffers::NewCppCodeGenerator();
+
+  flatc.RegisterCodeGenerator("--cpp", cpp_generator);
+  flatc.RegisterCodeGenerator("-c", cpp_generator);
 
   // Create the FlatC options by parsing the command line arguments.
   const flatbuffers::FlatCOptions &options =


### PR DESCRIPTION
This makes a new `CodeGenerator` interface that has individual methods for generating code, GRPC, makefiles, etc.. This is to consolidate all the logic of a given code generator in a single location, instead of the current design with free functions.

This is part of a general refactoring of the `FlatC`.