### PR TITLE
Use full project version as SOVERSION for the shared library

### DIFF
--- a/CMake/CMakeLists_legacy.cmake.in
+++ b/CMake/CMakeLists_legacy.cmake.in
@@ -438,14 +438,12 @@ endif()
 if(FLATBUFFERS_BUILD_SHAREDLIB)
   add_library(flatbuffers_shared SHARED ${FlatBuffers_Library_SRCS})
 
-  # Shared object version: "major.minor.micro"
-  # - micro updated every release when there is no API/ABI changes
-  # - minor updated when there are additions in API/ABI
-  # - major (ABI number) updated when there are changes in ABI (or removals)
-  set(FlatBuffers_Library_SONAME_MAJOR ${VERSION_MAJOR})
-  set(FlatBuffers_Library_SONAME_FULL "${FlatBuffers_Library_SONAME_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+  # FlatBuffers use calendar-based versioning and do not provide any ABI
+  # stability guarantees. Therefore, always use the full version as SOVERSION
+  # in order to avoid breaking reverse dependencies on upgrades.
+  set(FlatBuffers_Library_SONAME_FULL "${PROJECT_VERSION}")
   set_target_properties(flatbuffers_shared PROPERTIES OUTPUT_NAME flatbuffers
-                        SOVERSION "${FlatBuffers_Library_SONAME_MAJOR}"
+                        SOVERSION "${FlatBuffers_Library_SONAME_FULL}"
                         VERSION "${FlatBuffers_Library_SONAME_FULL}")
   if(FLATBUFFERS_ENABLE_PCH)
     add_pch_to_target(flatbuffers_shared include/flatbuffers/pch/pch.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,14 +525,12 @@ endif()
 if(FLATBUFFERS_BUILD_SHAREDLIB)
   add_library(flatbuffers_shared SHARED ${FlatBuffers_Library_SRCS})
   target_link_libraries(flatbuffers_shared PRIVATE $<BUILD_INTERFACE:ProjectConfig>)
-  # Shared object version: "major.minor.micro"
-  # - micro updated every release when there is no API/ABI changes
-  # - minor updated when there are additions in API/ABI
-  # - major (ABI number) updated when there are changes in ABI (or removals)
-  set(FlatBuffers_Library_SONAME_MAJOR ${VERSION_MAJOR})
-  set(FlatBuffers_Library_SONAME_FULL "${FlatBuffers_Library_SONAME_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+  # FlatBuffers use calendar-based versioning and do not provide any ABI
+  # stability guarantees. Therefore, always use the full version as SOVERSION
+  # in order to avoid breaking reverse dependencies on upgrades.
+  set(FlatBuffers_Library_SONAME_FULL "${PROJECT_VERSION}")
   set_target_properties(flatbuffers_shared PROPERTIES OUTPUT_NAME flatbuffers
-                        SOVERSION "${FlatBuffers_Library_SONAME_MAJOR}"
+                        SOVERSION "${FlatBuffers_Library_SONAME_FULL}"
                         VERSION "${FlatBuffers_Library_SONAME_FULL}")
   if(FLATBUFFERS_ENABLE_PCH)
     add_pch_to_target(flatbuffers_shared include/flatbuffers/pch/pch.h)


### PR DESCRIPTION
Since flatbuffers is using calendar versioning and does not provide any ABI stability guarantees, use the complete version as SOVERSION for the shared library rather than just the major component. This prevents breaking reverse dependencies on incompatible upgrades.

Fixes #7759