### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR in benchmark cpp path

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -27,7 +27,7 @@ FetchContent_MakeAvailable(
     googlebenchmark
 )
 
-set(CPP_BENCH_DIR cpp)
+set(CPP_BENCH_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cpp)
 set(CPP_FB_BENCH_DIR ${CPP_BENCH_DIR}/flatbuffers)
 set(CPP_RAW_BENCH_DIR ${CPP_BENCH_DIR}/raw)
 set(CPP_BENCH_FBS ${CPP_FB_BENCH_DIR}/bench.fbs)


### PR DESCRIPTION
Use CMAKE_CURRENT_SOURCE_DIR in the cpp benchmark, so that the benchmark CMake can work in the different build paths.

This fixed #7652.