### PR TITLE
Fixed vtable duplication for binary annotator

### DIFF
--- a/src/annotated_binary_text_gen.cpp
+++ b/src/annotated_binary_text_gen.cpp
@@ -131,7 +131,7 @@ static std::string ToValueString(const BinaryRegion &region,
   // value.
   // TODO(dbaileychess): It might be nicer to put this in the comment field.
   if (IsOffset(region.type)) {
-    s += " Loc: +0x";
+    s += " Loc: 0x";
     s += ToHex(region.points_to_offset, output_config.offset_max_char);
   }
   return s;

--- a/src/binary_annotator.cpp
+++ b/src/binary_annotator.cpp
@@ -196,14 +196,22 @@ uint64_t BinaryAnnotator::BuildHeader(const uint64_t header_offset) {
   return root_table_offset.value();
 }
 
-void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
-                                  const reflection::Object *const table,
-                                  const uint64_t offset_of_referring_table) {
-  // First see if we have used this vtable before, if so skip building it again.
-  auto it = vtables_.find(vtable_offset);
-  if (it != vtables_.end()) { return; }
+BinaryAnnotator::VTable *BinaryAnnotator::GetOrBuildVTable(
+    const uint64_t vtable_offset, const reflection::Object *const table,
+    const uint64_t offset_of_referring_table) {
+  // Get a list of vtables (if any) already defined at this offset.
+  std::list<VTable> &vtables = vtables_[vtable_offset];
 
-  if (ContainsSection(vtable_offset)) { return; }
+  // See if this vtable for the table type has been generated before.
+  for (VTable &vtable : vtables) {
+    if (vtable.referring_table == table) { return &vtable; }
+  }
+
+  // If we are trying to make a new vtable and it is already encompassed by
+  // another binary section, something is corrupted.
+  if (vtables.empty() && ContainsSection(vtable_offset)) { return nullptr; }
+
+  const std::string referring_table_name = table->name()->str();
 
   BinaryRegionComment vtable_size_comment;
   vtable_size_comment.type = BinaryRegionCommentType::VTableSize;
@@ -217,11 +225,11 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
 
     AddSection(vtable_offset,
                MakeSingleRegionBinarySection(
-                   table->name()->str(), BinarySectionType::VTable,
+                   referring_table_name, BinarySectionType::VTable,
                    MakeBinaryRegion(vtable_offset, remaining,
                                     BinaryRegionType::Unknown, remaining, 0,
                                     vtable_size_comment)));
-    return;
+    return nullptr;
   }
 
   // Vtables start with the size of the vtable
@@ -232,23 +240,23 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
     // The vtable_size points to off the end of the binary.
     AddSection(vtable_offset,
                MakeSingleRegionBinarySection(
-                   table->name()->str(), BinarySectionType::VTable,
+                   referring_table_name, BinarySectionType::VTable,
                    MakeBinaryRegion(vtable_offset, sizeof(uint16_t),
                                     BinaryRegionType::Uint16, 0, 0,
                                     vtable_size_comment)));
 
-    return;
+    return nullptr;
   } else if (vtable_size < 2 * sizeof(uint16_t)) {
     SetError(vtable_size_comment, BinaryRegionStatus::ERROR_LENGTH_TOO_SHORT,
              "4");
     // The size includes itself and the table size which are both uint16_t.
     AddSection(vtable_offset,
                MakeSingleRegionBinarySection(
-                   table->name()->str(), BinarySectionType::VTable,
+                   referring_table_name, BinarySectionType::VTable,
                    MakeBinaryRegion(vtable_offset, sizeof(uint16_t),
                                     BinaryRegionType::Uint16, 0, 0,
                                     vtable_size_comment)));
-    return;
+    return nullptr;
   }
 
   std::vector<BinaryRegion> regions;
@@ -272,11 +280,11 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
              "2");
 
     AddSection(offset, MakeSingleRegionBinarySection(
-                           table->name()->str(), BinarySectionType::VTable,
+                           referring_table_name, BinarySectionType::VTable,
                            MakeBinaryRegion(
                                offset, remaining, BinaryRegionType::Unknown,
                                remaining, 0, ref_table_len_comment)));
-    return;
+    return nullptr;
   }
 
   // Then they have the size of the table they reference.
@@ -395,7 +403,7 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
       (vtable_size - sizeof(uint16_t) - sizeof(uint16_t)) / sizeof(uint16_t);
 
   // Prevent a bad binary from declaring a really large vtable_size, that we can
-  // not indpendently verify.
+  // not independently verify.
   expectant_vtable_fields = std::min(
       static_cast<uint16_t>(fields_processed * 3), expectant_vtable_fields);
 
@@ -427,15 +435,26 @@ void BinaryAnnotator::BuildVTable(const uint64_t vtable_offset,
                                        field_comment));
   }
 
-  sections_[vtable_offset] = MakeBinarySection(
-      table->name()->str(), BinarySectionType::VTable, std::move(regions));
+  // If we have never added this vtable before record the Binary section.
+  if (vtables.empty()) {
+    sections_[vtable_offset] = MakeBinarySection(
+        referring_table_name, BinarySectionType::VTable, std::move(regions));
+  } else {
+    // Add the current table name to the name of the section.
+    sections_[vtable_offset].name += ", " + referring_table_name;
+  }
 
   VTable vtable;
+  vtable.referring_table = table;
   vtable.fields = std::move(fields);
   vtable.table_size = table_size;
   vtable.vtable_size = vtable_size;
 
-  vtables_[vtable_offset] = vtable;
+  // Add this vtable to the collection of vtables at this offset.
+  vtables.push_back(std::move(vtable));
+
+  // Return the vtable we just added.
+  return &vtables.back();
 }
 
 void BinaryAnnotator::BuildTable(const uint64_t table_offset,
@@ -491,19 +510,17 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
 
   // Parse the vtable first so we know what the rest of the fields in the table
   // are.
-  BuildVTable(vtable_offset, table, table_offset);
+  const VTable *const vtable =
+      GetOrBuildVTable(vtable_offset, table, table_offset);
 
-  auto vtable_entry = vtables_.find(vtable_offset);
-  if (vtable_entry == vtables_.end()) {
+  if (vtable == nullptr) {
     // There is no valid vtable for this table, so we cannot process the rest of
     // the table entries.
     return;
   }
 
-  const VTable &vtable = vtable_entry->second;
-
   // This is the size and length of this table.
-  const uint16_t table_size = vtable.table_size;
+  const uint16_t table_size = vtable->table_size;
   uint64_t table_end_offset = table_offset + table_size;
 
   if (!IsValidOffset(table_end_offset - 1)) {
@@ -516,7 +533,7 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
   // not by their IDs. So copy them over to another vector that we can sort on
   // the offset_from_table property.
   std::vector<VTable::Entry> fields;
-  for (const auto &vtable_field : vtable.fields) {
+  for (const auto &vtable_field : vtable->fields) {
     fields.push_back(vtable_field.second);
   }
 
@@ -707,7 +724,8 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
         regions.push_back(MakeBinaryRegion(
             field_offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
             offset_of_next_item, offset_field_comment));
-        BuildVector(offset_of_next_item, table, field, table_offset, vtable);
+        BuildVector(offset_of_next_item, table, field, table_offset,
+                    vtable->fields);
       } break;
 
       case reflection::BaseType::Union: {
@@ -716,8 +734,8 @@ void BinaryAnnotator::BuildTable(const uint64_t table_offset,
         // The union type field is always one less than the union itself.
         const uint16_t union_type_id = field->id() - 1;
 
-        auto vtable_field = vtable.fields.find(union_type_id);
-        if (vtable_field == vtable.fields.end()) {
+        auto vtable_field = vtable->fields.find(union_type_id);
+        if (vtable_field == vtable->fields.end()) {
           // TODO(dbaileychess): need to capture this error condition.
           break;
         }
@@ -959,11 +977,10 @@ void BinaryAnnotator::BuildString(const uint64_t string_offset,
                                BinarySectionType::String, std::move(regions)));
 }
 
-void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
-                                  const reflection::Object *const table,
-                                  const reflection::Field *const field,
-                                  const uint64_t parent_table_offset,
-                                  const VTable &vtable) {
+void BinaryAnnotator::BuildVector(
+    const uint64_t vector_offset, const reflection::Object *const table,
+    const reflection::Field *const field, const uint64_t parent_table_offset,
+    const std::map<uint16_t, VTable::Entry> vtable_fields) {
   if (ContainsSection(vector_offset)) { return; }
 
   BinaryRegionComment vector_length_comment;
@@ -1011,7 +1028,7 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
   regions.push_back(MakeBinaryRegion(vector_offset, sizeof(uint32_t),
                                      BinaryRegionType::Uint32, 0, 0,
                                      vector_length_comment));
-
+  // Consume the vector length offset.
   uint64_t offset = vector_offset + sizeof(uint32_t);
 
   switch (field->type()->element()) {
@@ -1079,6 +1096,7 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
               offset, sizeof(uint32_t), BinaryRegionType::UOffset, 0,
               table_offset, vector_object_comment));
 
+          // Consume the offset to the table.
           offset += sizeof(uint32_t);
 
           BuildTable(table_offset, BinarySectionType::Table, object);
@@ -1135,8 +1153,8 @@ void BinaryAnnotator::BuildVector(const uint64_t vector_offset,
       // location.
       const uint16_t union_type_vector_id = field->id() - 1;
 
-      auto vtable_entry = vtable.fields.find(union_type_vector_id);
-      if (vtable_entry == vtable.fields.end()) {
+      auto vtable_entry = vtable_fields.find(union_type_vector_id);
+      if (vtable_entry == vtable_fields.end()) {
         // TODO(dbaileychess): need to capture this error condition.
         break;
       }

--- a/src/binary_annotator.h
+++ b/src/binary_annotator.h
@@ -17,6 +17,7 @@
 #ifndef FLATBUFFERS_BINARY_ANNOTATOR_H_
 #define FLATBUFFERS_BINARY_ANNOTATOR_H_
 
+#include <list>
 #include <map>
 #include <string>
 #include <vector>
@@ -52,8 +53,8 @@ enum class BinaryRegionType {
 template<typename T>
 static inline std::string ToHex(T i, size_t width = sizeof(T)) {
   std::stringstream stream;
-  stream << std::hex << std::uppercase << std::setfill('0') << std::setw(static_cast<int>(width))
-         << i;
+  stream << std::hex << std::uppercase << std::setfill('0')
+         << std::setw(static_cast<int>(width)) << i;
   return stream.str();
 }
 
@@ -257,6 +258,8 @@ class BinaryAnnotator {
       uint16_t offset_from_table = 0;
     };
 
+    const reflection::Object *referring_table;
+
     // Field ID -> {field def, offset from table}
     std::map<uint16_t, Entry> fields;
 
@@ -266,8 +269,12 @@ class BinaryAnnotator {
 
   uint64_t BuildHeader(uint64_t offset);
 
-  void BuildVTable(uint64_t offset, const reflection::Object *table,
-                   uint64_t offset_of_referring_table);
+  // VTables can be shared across instances or even across objects. This
+  // attempts to get an existing vtable given the offset and table type,
+  // otherwise it will built the vtable, memorize it, and return the built
+  // VTable. Returns nullptr if building the VTable fails.
+  VTable *GetOrBuildVTable(uint64_t offset, const reflection::Object *table,
+                           uint64_t offset_of_referring_table);
 
   void BuildTable(uint64_t offset, const BinarySectionType type,
                   const reflection::Object *table);
@@ -281,7 +288,7 @@ class BinaryAnnotator {
 
   void BuildVector(uint64_t offset, const reflection::Object *table,
                    const reflection::Field *field, uint64_t parent_table_offset,
-                   const VTable &vtable);
+                   const std::map<uint16_t, VTable::Entry> vtable_fields);
 
   std::string BuildUnion(uint64_t offset, uint8_t realized_type,
                          const reflection::Field *field);
@@ -382,7 +389,7 @@ class BinaryAnnotator {
   const uint64_t binary_length_;
 
   // Map of binary offset to vtables, to dedupe vtables.
-  std::map<uint64_t, VTable> vtables_;
+  std::map<uint64_t, std::list<VTable>> vtables_;
 
   // The annotated binary sections, index by their absolute offset.
   std::map<uint64_t, BinarySection> sections_;

--- a/tests/annotated_binary/annotated_binary.afb
+++ b/tests/annotated_binary/annotated_binary.afb
@@ -4,294 +4,294 @@
 // Binary file: annotated_binary.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]    | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]    | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2] | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t   | 0x003A (58)                    | size of this vtable
-  +0x000C | 68 00                   | uint16_t   | 0x0068 (104)                   | size of referring table
-  +0x000E | 0C 00                   | VOffset16  | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16  | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16  | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16  | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16  | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16  | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16  | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16  | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16  | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16  | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16  | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16  | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16  | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16  | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16  | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16  | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16  | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16  | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16  | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16  | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16  | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16  | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16  | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16  | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16  | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16  | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16  | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t   | 0x003A (58)                   | size of this vtable
+  +0x000C | 68 00                   | uint16_t   | 0x0068 (104)                  | size of referring table
+  +0x000E | 0C 00                   | VOffset16  | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16  | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16  | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16  | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16  | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16  | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16  | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16  | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16  | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16  | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16  | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16  | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16  | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16  | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16  | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16  | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16  | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16  | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16  | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16  | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16  | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16  | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16  | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16  | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16  | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16  | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16  | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32  | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x004B | 01                      | uint8_t    | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t    | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8     | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8     | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8     | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t   | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32  | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t    | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t    | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t    | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1] | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32  | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
-  +0x0078 | 5C 01 00 00             | UOffset32  | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
-  +0x007C | 50 01 00 00             | UOffset32  | 0x00000150 (336) Loc: +0x01CC  | offset to field `bar_baz` (union of type `Baz`)
-  +0x0080 | 34 01 00 00             | UOffset32  | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
-  +0x0084 | 24 01 00 00             | UOffset32  | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
-  +0x0088 | 14 01 00 00             | UOffset32  | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
-  +0x008C | 0D 00 00 00             | uint32_t   | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32  | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
-  +0x0094 | A0 00 00 00             | UOffset32  | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32  | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32  | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32  | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x004B | 01                      | uint8_t    | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t    | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8     | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8     | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8     | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t   | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32  | 0x00000228 (552) Loc: 0x027C  | offset to field `bar` (table)
+  +0x0058 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t    | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t    | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t    | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1] | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32  | 0x000001C8 (456) Loc: 0x023C  | offset to field `name` (string)
+  +0x0078 | 5C 01 00 00             | UOffset32  | 0x0000015C (348) Loc: 0x01D4  | offset to field `bars` (vector)
+  +0x007C | 50 01 00 00             | UOffset32  | 0x00000150 (336) Loc: 0x01CC  | offset to field `bar_baz` (union of type `Baz`)
+  +0x0080 | 34 01 00 00             | UOffset32  | 0x00000134 (308) Loc: 0x01B4  | offset to field `accounts` (vector)
+  +0x0084 | 24 01 00 00             | UOffset32  | 0x00000124 (292) Loc: 0x01A8  | offset to field `bob` (string)
+  +0x0088 | 14 01 00 00             | UOffset32  | 0x00000114 (276) Loc: 0x019C  | offset to field `alice` (string)
+  +0x008C | 0D 00 00 00             | uint32_t   | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32  | 0x000000DC (220) Loc: 0x016C  | offset to field `names` (vector)
+  +0x0094 | A0 00 00 00             | UOffset32  | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32  | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32  | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t   | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]    | alice                          | string literal
-  +0x00B5 | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t   | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]    | alice                         | string literal
+  +0x00B5 | 00                      | char       | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2] | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t   | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t   | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16  | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16  | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t   | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t   | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16  | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16  | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32  | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float      | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double     | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3] | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32  | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float      | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double     | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3] | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t    | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t    | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32  | 0xFFFFFED2 (-302) Loc: +0x0212 | offset to vtable
-  +0x00E8 | 00 80 23 44             | float      | 0x44238000 (654)               | table field `b` (Float)
-  +0x00EC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: +0x00FC   | offset to field `c` (table)
-  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double     | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x00F8 | 00 00 00 00             | uint8_t[4] | ....                           | padding
+  +0x00E4 | D2 FE FF FF             | SOffset32  | 0xFFFFFED2 (-302) Loc: 0x0212 | offset to vtable
+  +0x00E8 | 00 80 23 44             | float      | 0x44238000 (654)              | table field `b` (Float)
+  +0x00EC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x00FC   | offset to field `c` (table)
+  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double     | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x00F8 | 00 00 00 00             | uint8_t[4] | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x00FC | 6A FE FF FF             | SOffset32  | 0xFFFFFE6A (-406) Loc: +0x0292 | offset to vtable
-  +0x0100 | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x0103 | 03                      | uint8_t    | 0x03 (3)                       | table field `meal` (Byte)
+  +0x00FC | 6A FE FF FF             | SOffset32  | 0xFFFFFE6A (-406) Loc: 0x0292 | offset to vtable
+  +0x0100 | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x0103 | 03                      | uint8_t    | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t   | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t   | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t   | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t   | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32  | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32  | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32  | 0xFFFFFEFA (-262) Loc: +0x0212 | offset to vtable
-  +0x0110 | 00 00 E4 43             | float      | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0114 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: +0x0124   | offset to field `c` (table)
-  +0x0118 | 00 00 00 00 00 C0 5E 40 | double     | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0120 | 00 00 00 00             | uint8_t[4] | ....                           | padding
+  +0x010C | FA FE FF FF             | SOffset32  | 0xFFFFFEFA (-262) Loc: 0x0212 | offset to vtable
+  +0x0110 | 00 00 E4 43             | float      | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0114 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0124   | offset to field `c` (table)
+  +0x0118 | 00 00 00 00 00 C0 5E 40 | double     | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0120 | 00 00 00 00             | uint8_t[4] | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0124 | 92 FE FF FF             | SOffset32  | 0xFFFFFE92 (-366) Loc: +0x0292 | offset to vtable
-  +0x0128 | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x012B | 01                      | uint8_t    | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0124 | 92 FE FF FF             | SOffset32  | 0xFFFFFE92 (-366) Loc: 0x0292 | offset to vtable
+  +0x0128 | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x012B | 01                      | uint8_t    | 0x01 (1)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8     | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8     | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8     | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8     | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8     | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8     | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double     | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double     | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double     | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double     | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double     | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double     | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0134 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                | length of vector (# items)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double     | 0x4045A33333333333 (43.275)   | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double     | 0xC053875BFF04577E (-78.115)  | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double     | 0x4042B60420F6F08D (37.422)   | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double     | 0xC05E85614163779F (-122.084) | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double     | 0xC04B35DC8323358F (-54.4208) | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double     | 0x400AC58793DD97F6 (3.34645)  | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
-  +0x0168 | 00 00 00 00             | uint8_t[4] | ....                           | padding
+  +0x0168 | 00 00 00 00             | uint8_t[4] | ....                          | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
-  +0x0170 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: +0x0190   | offset to string[0]
-  +0x0174 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: +0x0188   | offset to string[1]
-  +0x0178 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x017C    | offset to string[2]
+  +0x016C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                | length of vector (# items)
+  +0x0170 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0190   | offset to string[0]
+  +0x0174 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0188   | offset to string[1]
+  +0x0178 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x017C    | offset to string[2]
 
 string (AnnotatedBinary.Foo.names):
-  +0x017C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
-  +0x0187 | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x017C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                | length of string
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]    | charlie                       | string literal
+  +0x0187 | 00                      | char       | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0188 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]    | bob                            | string literal
-  +0x018F | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x0188 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                | length of string
+  +0x018C | 62 6F 62                | char[3]    | bob                           | string literal
+  +0x018F | 00                      | char       | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0190 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]    | alice                          | string literal
-  +0x0199 | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x0190 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                | length of string
+  +0x0194 | 61 6C 69 63 65          | char[5]    | alice                         | string literal
+  +0x0199 | 00                      | char       | 0x00 (0)                      | string terminator
 
 padding:
-  +0x019A | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x019A | 00 00                   | uint8_t[2] | ..                            | padding
 
 string (AnnotatedBinary.Foo.alice):
-  +0x019C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
-  +0x01A7 | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x019C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                | length of string
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]    | charlie                       | string literal
+  +0x01A7 | 00                      | char       | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.bob):
-  +0x01A8 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
-  +0x01B3 | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x01A8 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                | length of string
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]    | charlie                       | string literal
+  +0x01B3 | 00                      | char       | 0x00 (0)                      | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
-  +0x01B4 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                 | length of vector (# items)
-  +0x01B8 | 09 00                   | uint16_t   | 0x0009 (9)                     | value[0]
-  +0x01BA | 08 00                   | uint16_t   | 0x0008 (8)                     | value[1]
-  +0x01BC | 07 00                   | uint16_t   | 0x0007 (7)                     | value[2]
-  +0x01BE | 01 00                   | uint16_t   | 0x0001 (1)                     | value[3]
-  +0x01C0 | 02 00                   | uint16_t   | 0x0002 (2)                     | value[4]
-  +0x01C2 | 03 00                   | uint16_t   | 0x0003 (3)                     | value[5]
-  +0x01C4 | 06 00                   | uint16_t   | 0x0006 (6)                     | value[6]
-  +0x01C6 | 05 00                   | uint16_t   | 0x0005 (5)                     | value[7]
-  +0x01C8 | 04 00                   | uint16_t   | 0x0004 (4)                     | value[8]
+  +0x01B4 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                | length of vector (# items)
+  +0x01B8 | 09 00                   | uint16_t   | 0x0009 (9)                    | value[0]
+  +0x01BA | 08 00                   | uint16_t   | 0x0008 (8)                    | value[1]
+  +0x01BC | 07 00                   | uint16_t   | 0x0007 (7)                    | value[2]
+  +0x01BE | 01 00                   | uint16_t   | 0x0001 (1)                    | value[3]
+  +0x01C0 | 02 00                   | uint16_t   | 0x0002 (2)                    | value[4]
+  +0x01C2 | 03 00                   | uint16_t   | 0x0003 (3)                    | value[5]
+  +0x01C4 | 06 00                   | uint16_t   | 0x0006 (6)                    | value[6]
+  +0x01C6 | 05 00                   | uint16_t   | 0x0005 (5)                    | value[7]
+  +0x01C8 | 04 00                   | uint16_t   | 0x0004 (4)                    | value[8]
 
 padding:
-  +0x01CA | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x01CA | 00 00                   | uint8_t[2] | ..                            | padding
 
 table (AnnotatedBinary.Baz):
-  +0x01CC | 3A FF FF FF             | SOffset32  | 0xFFFFFF3A (-198) Loc: +0x0292 | offset to vtable
-  +0x01D0 | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x01D3 | 03                      | uint8_t    | 0x03 (3)                       | table field `meal` (Byte)
+  +0x01CC | 3A FF FF FF             | SOffset32  | 0xFFFFFF3A (-198) Loc: 0x0292 | offset to vtable
+  +0x01D0 | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x01D3 | 03                      | uint8_t    | 0x03 (3)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.bars):
-  +0x01D4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                 | length of vector (# items)
-  +0x01D8 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: +0x021C   | offset to table[0]
-  +0x01DC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: +0x01EC   | offset to table[1]
+  +0x01D4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                | length of vector (# items)
+  +0x01D8 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x021C   | offset to table[0]
+  +0x01DC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x01EC   | offset to table[1]
 
 padding:
-  +0x01E0 | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x01E0 | 00 00                   | uint8_t[2] | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x01E2 | 0A 00                   | uint16_t   | 0x000A (10)                    | size of this vtable
-  +0x01E4 | 1A 00                   | uint16_t   | 0x001A (26)                    | size of referring table
-  +0x01E6 | 0C 00                   | VOffset16  | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x01E8 | 04 00                   | VOffset16  | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x01EA | 08 00                   | VOffset16  | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x01E2 | 0A 00                   | uint16_t   | 0x000A (10)                   | size of this vtable
+  +0x01E4 | 1A 00                   | uint16_t   | 0x001A (26)                   | size of referring table
+  +0x01E6 | 0C 00                   | VOffset16  | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x01E8 | 04 00                   | VOffset16  | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x01EA | 08 00                   | VOffset16  | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x01EC | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: +0x01E2   | offset to vtable
-  +0x01F0 | 00 80 23 44             | float      | 0x44238000 (654)               | table field `b` (Float)
-  +0x01F4 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: +0x020C   | offset to field `c` (table)
-  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double     | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x0200 | 00 00 00 00 00 00       | uint8_t[6] | ......                         | padding
+  +0x01EC | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: 0x01E2   | offset to vtable
+  +0x01F0 | 00 80 23 44             | float      | 0x44238000 (654)              | table field `b` (Float)
+  +0x01F4 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x020C   | offset to field `c` (table)
+  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double     | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x0200 | 00 00 00 00 00 00       | uint8_t[6] | ......                        | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0206 | 06 00                   | uint16_t   | 0x0006 (6)                     | size of this vtable
-  +0x0208 | 06 00                   | uint16_t   | 0x0006 (6)                     | size of referring table
-  +0x020A | 05 00                   | VOffset16  | 0x0005 (5)                     | offset to field `meal` (id: 0)
+  +0x0206 | 06 00                   | uint16_t   | 0x0006 (6)                    | size of this vtable
+  +0x0208 | 06 00                   | uint16_t   | 0x0006 (6)                    | size of referring table
+  +0x020A | 05 00                   | VOffset16  | 0x0005 (5)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x020C | 06 00 00 00             | SOffset32  | 0x00000006 (6) Loc: +0x0206    | offset to vtable
-  +0x0210 | 00                      | uint8_t[1] | .                              | padding
-  +0x0211 | 03                      | uint8_t    | 0x03 (3)                       | table field `meal` (Byte)
+  +0x020C | 06 00 00 00             | SOffset32  | 0x00000006 (6) Loc: 0x0206    | offset to vtable
+  +0x0210 | 00                      | uint8_t[1] | .                             | padding
+  +0x0211 | 03                      | uint8_t    | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Bar):
-  +0x0212 | 0A 00                   | uint16_t   | 0x000A (10)                    | size of this vtable
-  +0x0214 | 18 00                   | uint16_t   | 0x0018 (24)                    | size of referring table
-  +0x0216 | 0C 00                   | VOffset16  | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0218 | 04 00                   | VOffset16  | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x021A | 08 00                   | VOffset16  | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0212 | 0A 00                   | uint16_t   | 0x000A (10)                   | size of this vtable
+  +0x0214 | 18 00                   | uint16_t   | 0x0018 (24)                   | size of referring table
+  +0x0216 | 0C 00                   | VOffset16  | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0218 | 04 00                   | VOffset16  | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x021A | 08 00                   | VOffset16  | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x021C | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: +0x0212   | offset to vtable
-  +0x0220 | 00 00 E4 43             | float      | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0224 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: +0x0234   | offset to field `c` (table)
-  +0x0228 | 00 00 00 00 00 C0 5E 40 | double     | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0230 | 00 00 00 00             | uint8_t[4] | ....                           | padding
+  +0x021C | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: 0x0212   | offset to vtable
+  +0x0220 | 00 00 E4 43             | float      | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0224 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0234   | offset to field `c` (table)
+  +0x0228 | 00 00 00 00 00 C0 5E 40 | double     | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0230 | 00 00 00 00             | uint8_t[4] | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0234 | A2 FF FF FF             | SOffset32  | 0xFFFFFFA2 (-94) Loc: +0x0292  | offset to vtable
-  +0x0238 | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x023B | 01                      | uint8_t    | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0234 | A2 FF FF FF             | SOffset32  | 0xFFFFFFA2 (-94) Loc: 0x0292  | offset to vtable
+  +0x0238 | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x023B | 01                      | uint8_t    | 0x01 (1)                      | table field `meal` (Byte)
 
 string (AnnotatedBinary.Foo.name):
-  +0x023C | 2F 00 00 00             | uint32_t   | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]   | This is                        | string literal
+  +0x023C | 2F 00 00 00             | uint32_t   | 0x0000002F (47)               | length of string
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]   | This is                       | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |            | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |            | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |            |  show ho
   +0x0260 | 77 20 69 74 20 62 72 65 |            | w it bre
   +0x0268 | 61 6B 73 20 75 70 2E    |            | aks up.
-  +0x026F | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x026F | 00                      | char       | 0x00 (0)                      | string terminator
 
 padding:
-  +0x0270 | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x0270 | 00 00                   | uint8_t[2] | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x0272 | 0A 00                   | uint16_t   | 0x000A (10)                    | size of this vtable
-  +0x0274 | 16 00                   | uint16_t   | 0x0016 (22)                    | size of referring table
-  +0x0276 | 0C 00                   | VOffset16  | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0278 | 04 00                   | VOffset16  | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x027A | 08 00                   | VOffset16  | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0272 | 0A 00                   | uint16_t   | 0x000A (10)                   | size of this vtable
+  +0x0274 | 16 00                   | uint16_t   | 0x0016 (22)                   | size of referring table
+  +0x0276 | 0C 00                   | VOffset16  | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0278 | 04 00                   | VOffset16  | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x027A | 08 00                   | VOffset16  | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x027C | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: +0x0272   | offset to vtable
-  +0x0280 | 65 20 71 49             | float      | 0x49712065 (987654)            | table field `b` (Float)
-  +0x0284 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: +0x0298   | offset to field `c` (table)
-  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double     | 0x40FE240C9FBE76C9 (123457)    | table field `a` (Double)
-  +0x0290 | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x027C | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: 0x0272   | offset to vtable
+  +0x0280 | 65 20 71 49             | float      | 0x49712065 (987654)           | table field `b` (Float)
+  +0x0284 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0298   | offset to field `c` (table)
+  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double     | 0x40FE240C9FBE76C9 (123457)   | table field `a` (Double)
+  +0x0290 | 00 00                   | uint8_t[2] | ..                            | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0292 | 06 00                   | uint16_t   | 0x0006 (6)                     | size of this vtable
-  +0x0294 | 08 00                   | uint16_t   | 0x0008 (8)                     | size of referring table
-  +0x0296 | 07 00                   | VOffset16  | 0x0007 (7)                     | offset to field `meal` (id: 0)
+  +0x0292 | 06 00                   | uint16_t   | 0x0006 (6)                    | size of this vtable
+  +0x0294 | 08 00                   | uint16_t   | 0x0008 (8)                    | size of referring table
+  +0x0296 | 07 00                   | VOffset16  | 0x0007 (7)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x0298 | 06 00 00 00             | SOffset32  | 0x00000006 (6) Loc: +0x0292    | offset to vtable
-  +0x029C | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x029F | 01                      | uint8_t    | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0298 | 06 00 00 00             | SOffset32  | 0x00000006 (6) Loc: 0x0292    | offset to vtable
+  +0x029C | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x029F | 01                      | uint8_t    | 0x01 (1)                      | table field `meal` (Byte)

--- a/tests/annotated_binary/tests/invalid_root_offset.afb
+++ b/tests/annotated_binary/tests/invalid_root_offset.afb
@@ -4,11 +4,11 @@
 // Binary file: tests/invalid_root_offset.bin
 
 header:
-  +0x0000 | FF FF 00 00             | UOffset32     | 0x0000FFFF (65535) Loc: +0xFFFF | ERROR: offset to root table `AnnotatedBinary.Foo`. Invalid offset, points outside the binary.
-  +0x0004 | 41 4E 4E 4F             | char[4]       | ANNO                            | File Identifier
+  +0x0000 | FF FF 00 00             | UOffset32     | 0x0000FFFF (65535) Loc: 0xFFFF | ERROR: offset to root table `AnnotatedBinary.Foo`. Invalid offset, points outside the binary.
+  +0x0004 | 41 4E 4E 4F             | char[4]       | ANNO                           | File Identifier
 
 unknown (no known references):
-  +0x0008 | 00 00 3A 00 68 00 0C 00 | ?uint8_t[664] | ..:.h...                        | WARN: nothing refers to this section.
+  +0x0008 | 00 00 3A 00 68 00 0C 00 | ?uint8_t[664] | ..:.h...                       | WARN: nothing refers to this section.
   +0x0010 | 07 00 00 00 08 00 10 00 |               | ........
   +0x0018 | 14 00 30 00 34 00 09 00 |               | ..0.4...
   +0x0020 | 38 00 3C 00 40 00 44 00 |               | 8.<.@.D.

--- a/tests/annotated_binary/tests/invalid_root_table_too_short.afb
+++ b/tests/annotated_binary/tests/invalid_root_table_too_short.afb
@@ -4,11 +4,11 @@
 // Binary file: tests/invalid_root_table_too_short.bin
 
 header:
-  +0x00 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x44 | offset to root table `AnnotatedBinary.Foo`
-  +0x04 | 41 4E 4E 4F             | char[4]      | ANNO                       | File Identifier
+  +0x00 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x44 | offset to root table `AnnotatedBinary.Foo`
+  +0x04 | 41 4E 4E 4F             | char[4]      | ANNO                      | File Identifier
 
 unknown (no known references):
-  +0x08 | 00 00 3A 00 68 00 0C 00 | ?uint8_t[60] | ..:.h...                   | WARN: nothing refers to this section.
+  +0x08 | 00 00 3A 00 68 00 0C 00 | ?uint8_t[60] | ..:.h...                  | WARN: nothing refers to this section.
   +0x10 | 07 00 00 00 08 00 10 00 |              | ........
   +0x18 | 14 00 30 00 34 00 09 00 |              | ..0.4...
   +0x20 | 38 00 3C 00 40 00 44 00 |              | 8.<.@.D.
@@ -18,4 +18,4 @@ unknown (no known references):
   +0x40 | 00 00 64 00             |              | ..d.
 
 root_table (AnnotatedBinary.Foo):
-  +0x44 | 3A 00                   | ?uint8_t[2]  | :.                         | ERROR: offset to vtable. Incomplete binary, expected to read 4 bytes.
+  +0x44 | 3A 00                   | ?uint8_t[2]  | :.                        | ERROR: offset to vtable. Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_root_table_vtable_offset.afb
+++ b/tests/annotated_binary/tests/invalid_root_table_vtable_offset.afb
@@ -4,11 +4,11 @@
 // Binary file: tests/invalid_root_table_vtable_offset.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32     | 0x00000044 (68) Loc: +0x0044                | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]       | ANNO                                        | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32     | 0x00000044 (68) Loc: 0x0044                | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]       | ANNO                                       | File Identifier
 
 unknown (no known references):
-  +0x0008 | 00 00 3A 00 68 00 0C 00 | ?uint8_t[60]  | ..:.h...                                    | WARN: nothing refers to this section.
+  +0x0008 | 00 00 3A 00 68 00 0C 00 | ?uint8_t[60]  | ..:.h...                                   | WARN: nothing refers to this section.
   +0x0010 | 07 00 00 00 08 00 10 00 |               | ........
   +0x0018 | 14 00 30 00 34 00 09 00 |               | ..0.4...
   +0x0020 | 38 00 3C 00 40 00 44 00 |               | 8.<.@.D.
@@ -18,10 +18,10 @@ unknown (no known references):
   +0x0040 | 00 00 64 00             |               | ..d.
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | FF FF 00 00             | SOffset32     | 0x0000FFFF (65535) Loc: +0xFFFFFFFFFFFF0045 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x0044 | FF FF 00 00             | SOffset32     | 0x0000FFFF (65535) Loc: 0xFFFFFFFFFFFF0045 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x0048 | 00 00 00 01 02 02 01 01 | ?uint8_t[600] | ........                                    | WARN: nothing refers to this section.
+  +0x0048 | 00 00 00 01 02 02 01 01 | ?uint8_t[600] | ........                                   | WARN: nothing refers to this section.
   +0x0050 | D2 04 00 00 28 02 00 00 |               | ....(...
   +0x0058 | 01 00 00 00 02 00 00 00 |               | ........
   +0x0060 | 0C 00 00 00 0A 00 00 00 |               | ........

--- a/tests/annotated_binary/tests/invalid_string_length.afb
+++ b/tests/annotated_binary/tests/invalid_string_length.afb
@@ -4,292 +4,292 @@
 // Binary file: tests/invalid_string_length.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]     | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]     | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2]  | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t    | 0x003A (58)                    | size of this vtable
-  +0x000C | 68 00                   | uint16_t    | 0x0068 (104)                   | size of referring table
-  +0x000E | 0C 00                   | VOffset16   | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16   | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16   | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16   | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16   | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16   | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16   | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16   | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16   | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16   | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16   | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16   | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16   | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16   | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16   | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16   | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16   | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16   | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16   | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16   | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16   | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16   | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16   | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16   | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16   | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16   | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16   | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t    | 0x003A (58)                   | size of this vtable
+  +0x000C | 68 00                   | uint16_t    | 0x0068 (104)                  | size of referring table
+  +0x000E | 0C 00                   | VOffset16   | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16   | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16   | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16   | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16   | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16   | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16   | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16   | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16   | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16   | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16   | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16   | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16   | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16   | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16   | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16   | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16   | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16   | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16   | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16   | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16   | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16   | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16   | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16   | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16   | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16   | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16   | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x004B | 01                      | uint8_t     | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t     | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8      | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8      | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8      | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t     | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t     | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t     | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1]  | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
-  +0x0078 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
-  +0x007C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: +0x01CC  | offset to field `bar_baz` (union of type `Baz`)
-  +0x0080 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
-  +0x0084 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
-  +0x0088 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
-  +0x008C | 0D 00 00 00             | uint32_t    | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
-  +0x0094 | A0 00 00 00             | UOffset32   | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32   | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32   | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x004B | 01                      | uint8_t     | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t     | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8      | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8      | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8      | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: 0x027C  | offset to field `bar` (table)
+  +0x0058 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t     | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t     | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t     | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1]  | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: 0x023C  | offset to field `name` (string)
+  +0x0078 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: 0x01D4  | offset to field `bars` (vector)
+  +0x007C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: 0x01CC  | offset to field `bar_baz` (union of type `Baz`)
+  +0x0080 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: 0x01B4  | offset to field `accounts` (vector)
+  +0x0084 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: 0x01A8  | offset to field `bob` (string)
+  +0x0088 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: 0x019C  | offset to field `alice` (string)
+  +0x008C | 0D 00 00 00             | uint32_t    | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: 0x016C  | offset to field `names` (vector)
+  +0x0094 | A0 00 00 00             | UOffset32   | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32   | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32   | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | FF FF 00 00             | uint32_t    | 0x0000FFFF (65535)             | ERROR: length of string. Longer than the binary.
+  +0x00AC | FF FF 00 00             | uint32_t    | 0x0000FFFF (65535)            | ERROR: length of string. Longer than the binary.
 
 unknown (no known references):
-  +0x00B0 | 61 6C 69 63 65 00 00 00 | ?uint8_t[8] | alice...                       | WARN: nothing refers to this section.
+  +0x00B0 | 61 6C 69 63 65 00 00 00 | ?uint8_t[8] | alice...                      | WARN: nothing refers to this section.
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t    | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t    | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16   | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16   | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t    | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t    | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16   | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16   | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32   | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float       | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double      | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3]  | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32   | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float       | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double      | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3]  | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t     | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t     | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32   | 0xFFFFFED2 (-302) Loc: +0x0212 | offset to vtable
-  +0x00E8 | 00 80 23 44             | float       | 0x44238000 (654)               | table field `b` (Float)
-  +0x00EC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x00FC   | offset to field `c` (table)
-  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double      | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x00F8 | 00 00 00 00             | uint8_t[4]  | ....                           | padding
+  +0x00E4 | D2 FE FF FF             | SOffset32   | 0xFFFFFED2 (-302) Loc: 0x0212 | offset to vtable
+  +0x00E8 | 00 80 23 44             | float       | 0x44238000 (654)              | table field `b` (Float)
+  +0x00EC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: 0x00FC   | offset to field `c` (table)
+  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double      | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x00F8 | 00 00 00 00             | uint8_t[4]  | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x00FC | 6A FE FF FF             | SOffset32   | 0xFFFFFE6A (-406) Loc: +0x0292 | offset to vtable
-  +0x0100 | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x0103 | 03                      | uint8_t     | 0x03 (3)                       | table field `meal` (Byte)
+  +0x00FC | 6A FE FF FF             | SOffset32   | 0xFFFFFE6A (-406) Loc: 0x0292 | offset to vtable
+  +0x0100 | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x0103 | 03                      | uint8_t     | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t    | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t    | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t    | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t    | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32   | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32   | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32   | 0xFFFFFEFA (-262) Loc: +0x0212 | offset to vtable
-  +0x0110 | 00 00 E4 43             | float       | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0114 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0124   | offset to field `c` (table)
-  +0x0118 | 00 00 00 00 00 C0 5E 40 | double      | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0120 | 00 00 00 00             | uint8_t[4]  | ....                           | padding
+  +0x010C | FA FE FF FF             | SOffset32   | 0xFFFFFEFA (-262) Loc: 0x0212 | offset to vtable
+  +0x0110 | 00 00 E4 43             | float       | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0114 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: 0x0124   | offset to field `c` (table)
+  +0x0118 | 00 00 00 00 00 C0 5E 40 | double      | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0120 | 00 00 00 00             | uint8_t[4]  | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0124 | 92 FE FF FF             | SOffset32   | 0xFFFFFE92 (-366) Loc: +0x0292 | offset to vtable
-  +0x0128 | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x012B | 01                      | uint8_t     | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0124 | 92 FE FF FF             | SOffset32   | 0xFFFFFE92 (-366) Loc: 0x0292 | offset to vtable
+  +0x0128 | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x012B | 01                      | uint8_t     | 0x01 (1)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8      | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8      | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8      | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8      | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8      | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8      | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double      | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double      | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double      | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double      | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double      | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double      | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0134 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                | length of vector (# items)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double      | 0x4045A33333333333 (43.275)   | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double      | 0xC053875BFF04577E (-78.115)  | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double      | 0x4042B60420F6F08D (37.422)   | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double      | 0xC05E85614163779F (-122.084) | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double      | 0xC04B35DC8323358F (-54.4208) | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double      | 0x400AC58793DD97F6 (3.34645)  | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
-  +0x0168 | 00 00 00 00             | uint8_t[4]  | ....                           | padding
+  +0x0168 | 00 00 00 00             | uint8_t[4]  | ....                          | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
-  +0x0170 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0190   | offset to string[0]
-  +0x0174 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0188   | offset to string[1]
-  +0x0178 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x017C    | offset to string[2]
+  +0x016C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                | length of vector (# items)
+  +0x0170 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: 0x0190   | offset to string[0]
+  +0x0174 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: 0x0188   | offset to string[1]
+  +0x0178 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: 0x017C    | offset to string[2]
 
 string (AnnotatedBinary.Foo.names):
-  +0x017C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
-  +0x0187 | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x017C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                | length of string
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]     | charlie                       | string literal
+  +0x0187 | 00                      | char        | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0188 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]     | bob                            | string literal
-  +0x018F | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x0188 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                | length of string
+  +0x018C | 62 6F 62                | char[3]     | bob                           | string literal
+  +0x018F | 00                      | char        | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0190 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]     | alice                          | string literal
-  +0x0199 | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x0190 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                | length of string
+  +0x0194 | 61 6C 69 63 65          | char[5]     | alice                         | string literal
+  +0x0199 | 00                      | char        | 0x00 (0)                      | string terminator
 
 padding:
-  +0x019A | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x019A | 00 00                   | uint8_t[2]  | ..                            | padding
 
 string (AnnotatedBinary.Foo.alice):
-  +0x019C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
-  +0x01A7 | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x019C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                | length of string
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]     | charlie                       | string literal
+  +0x01A7 | 00                      | char        | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.bob):
-  +0x01A8 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
-  +0x01B3 | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x01A8 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                | length of string
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]     | charlie                       | string literal
+  +0x01B3 | 00                      | char        | 0x00 (0)                      | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
-  +0x01B4 | 09 00 00 00             | uint32_t    | 0x00000009 (9)                 | length of vector (# items)
-  +0x01B8 | 09 00                   | uint16_t    | 0x0009 (9)                     | value[0]
-  +0x01BA | 08 00                   | uint16_t    | 0x0008 (8)                     | value[1]
-  +0x01BC | 07 00                   | uint16_t    | 0x0007 (7)                     | value[2]
-  +0x01BE | 01 00                   | uint16_t    | 0x0001 (1)                     | value[3]
-  +0x01C0 | 02 00                   | uint16_t    | 0x0002 (2)                     | value[4]
-  +0x01C2 | 03 00                   | uint16_t    | 0x0003 (3)                     | value[5]
-  +0x01C4 | 06 00                   | uint16_t    | 0x0006 (6)                     | value[6]
-  +0x01C6 | 05 00                   | uint16_t    | 0x0005 (5)                     | value[7]
-  +0x01C8 | 04 00                   | uint16_t    | 0x0004 (4)                     | value[8]
+  +0x01B4 | 09 00 00 00             | uint32_t    | 0x00000009 (9)                | length of vector (# items)
+  +0x01B8 | 09 00                   | uint16_t    | 0x0009 (9)                    | value[0]
+  +0x01BA | 08 00                   | uint16_t    | 0x0008 (8)                    | value[1]
+  +0x01BC | 07 00                   | uint16_t    | 0x0007 (7)                    | value[2]
+  +0x01BE | 01 00                   | uint16_t    | 0x0001 (1)                    | value[3]
+  +0x01C0 | 02 00                   | uint16_t    | 0x0002 (2)                    | value[4]
+  +0x01C2 | 03 00                   | uint16_t    | 0x0003 (3)                    | value[5]
+  +0x01C4 | 06 00                   | uint16_t    | 0x0006 (6)                    | value[6]
+  +0x01C6 | 05 00                   | uint16_t    | 0x0005 (5)                    | value[7]
+  +0x01C8 | 04 00                   | uint16_t    | 0x0004 (4)                    | value[8]
 
 padding:
-  +0x01CA | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x01CA | 00 00                   | uint8_t[2]  | ..                            | padding
 
 table (AnnotatedBinary.Baz):
-  +0x01CC | 3A FF FF FF             | SOffset32   | 0xFFFFFF3A (-198) Loc: +0x0292 | offset to vtable
-  +0x01D0 | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x01D3 | 03                      | uint8_t     | 0x03 (3)                       | table field `meal` (Byte)
+  +0x01CC | 3A FF FF FF             | SOffset32   | 0xFFFFFF3A (-198) Loc: 0x0292 | offset to vtable
+  +0x01D0 | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x01D3 | 03                      | uint8_t     | 0x03 (3)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.bars):
-  +0x01D4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                 | length of vector (# items)
-  +0x01D8 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x021C   | offset to table[0]
-  +0x01DC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x01EC   | offset to table[1]
+  +0x01D4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                | length of vector (# items)
+  +0x01D8 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: 0x021C   | offset to table[0]
+  +0x01DC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: 0x01EC   | offset to table[1]
 
 padding:
-  +0x01E0 | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x01E0 | 00 00                   | uint8_t[2]  | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x01E2 | 0A 00                   | uint16_t    | 0x000A (10)                    | size of this vtable
-  +0x01E4 | 1A 00                   | uint16_t    | 0x001A (26)                    | size of referring table
-  +0x01E6 | 0C 00                   | VOffset16   | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x01E8 | 04 00                   | VOffset16   | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x01EA | 08 00                   | VOffset16   | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x01E2 | 0A 00                   | uint16_t    | 0x000A (10)                   | size of this vtable
+  +0x01E4 | 1A 00                   | uint16_t    | 0x001A (26)                   | size of referring table
+  +0x01E6 | 0C 00                   | VOffset16   | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x01E8 | 04 00                   | VOffset16   | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x01EA | 08 00                   | VOffset16   | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x01EC | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: +0x01E2   | offset to vtable
-  +0x01F0 | 00 80 23 44             | float       | 0x44238000 (654)               | table field `b` (Float)
-  +0x01F4 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x020C   | offset to field `c` (table)
-  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double      | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x0200 | 00 00 00 00 00 00       | uint8_t[6]  | ......                         | padding
+  +0x01EC | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: 0x01E2   | offset to vtable
+  +0x01F0 | 00 80 23 44             | float       | 0x44238000 (654)              | table field `b` (Float)
+  +0x01F4 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: 0x020C   | offset to field `c` (table)
+  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double      | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x0200 | 00 00 00 00 00 00       | uint8_t[6]  | ......                        | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0206 | 06 00                   | uint16_t    | 0x0006 (6)                     | size of this vtable
-  +0x0208 | 06 00                   | uint16_t    | 0x0006 (6)                     | size of referring table
-  +0x020A | 05 00                   | VOffset16   | 0x0005 (5)                     | offset to field `meal` (id: 0)
+  +0x0206 | 06 00                   | uint16_t    | 0x0006 (6)                    | size of this vtable
+  +0x0208 | 06 00                   | uint16_t    | 0x0006 (6)                    | size of referring table
+  +0x020A | 05 00                   | VOffset16   | 0x0005 (5)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x020C | 06 00 00 00             | SOffset32   | 0x00000006 (6) Loc: +0x0206    | offset to vtable
-  +0x0210 | 00                      | uint8_t[1]  | .                              | padding
-  +0x0211 | 03                      | uint8_t     | 0x03 (3)                       | table field `meal` (Byte)
+  +0x020C | 06 00 00 00             | SOffset32   | 0x00000006 (6) Loc: 0x0206    | offset to vtable
+  +0x0210 | 00                      | uint8_t[1]  | .                             | padding
+  +0x0211 | 03                      | uint8_t     | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Bar):
-  +0x0212 | 0A 00                   | uint16_t    | 0x000A (10)                    | size of this vtable
-  +0x0214 | 18 00                   | uint16_t    | 0x0018 (24)                    | size of referring table
-  +0x0216 | 0C 00                   | VOffset16   | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0218 | 04 00                   | VOffset16   | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x021A | 08 00                   | VOffset16   | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0212 | 0A 00                   | uint16_t    | 0x000A (10)                   | size of this vtable
+  +0x0214 | 18 00                   | uint16_t    | 0x0018 (24)                   | size of referring table
+  +0x0216 | 0C 00                   | VOffset16   | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0218 | 04 00                   | VOffset16   | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x021A | 08 00                   | VOffset16   | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x021C | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: +0x0212   | offset to vtable
-  +0x0220 | 00 00 E4 43             | float       | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0224 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0234   | offset to field `c` (table)
-  +0x0228 | 00 00 00 00 00 C0 5E 40 | double      | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0230 | 00 00 00 00             | uint8_t[4]  | ....                           | padding
+  +0x021C | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: 0x0212   | offset to vtable
+  +0x0220 | 00 00 E4 43             | float       | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0224 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: 0x0234   | offset to field `c` (table)
+  +0x0228 | 00 00 00 00 00 C0 5E 40 | double      | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0230 | 00 00 00 00             | uint8_t[4]  | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0234 | A2 FF FF FF             | SOffset32   | 0xFFFFFFA2 (-94) Loc: +0x0292  | offset to vtable
-  +0x0238 | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x023B | 01                      | uint8_t     | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0234 | A2 FF FF FF             | SOffset32   | 0xFFFFFFA2 (-94) Loc: 0x0292  | offset to vtable
+  +0x0238 | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x023B | 01                      | uint8_t     | 0x01 (1)                      | table field `meal` (Byte)
 
 string (AnnotatedBinary.Foo.name):
-  +0x023C | 2F 00 00 00             | uint32_t    | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]    | This is                        | string literal
+  +0x023C | 2F 00 00 00             | uint32_t    | 0x0000002F (47)               | length of string
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]    | This is                       | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |             | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |             | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |             |  show ho
   +0x0260 | 77 20 69 74 20 62 72 65 |             | w it bre
   +0x0268 | 61 6B 73 20 75 70 2E    |             | aks up.
-  +0x026F | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x026F | 00                      | char        | 0x00 (0)                      | string terminator
 
 padding:
-  +0x0270 | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x0270 | 00 00                   | uint8_t[2]  | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x0272 | 0A 00                   | uint16_t    | 0x000A (10)                    | size of this vtable
-  +0x0274 | 16 00                   | uint16_t    | 0x0016 (22)                    | size of referring table
-  +0x0276 | 0C 00                   | VOffset16   | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0278 | 04 00                   | VOffset16   | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x027A | 08 00                   | VOffset16   | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0272 | 0A 00                   | uint16_t    | 0x000A (10)                   | size of this vtable
+  +0x0274 | 16 00                   | uint16_t    | 0x0016 (22)                   | size of referring table
+  +0x0276 | 0C 00                   | VOffset16   | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0278 | 04 00                   | VOffset16   | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x027A | 08 00                   | VOffset16   | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x027C | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: +0x0272   | offset to vtable
-  +0x0280 | 65 20 71 49             | float       | 0x49712065 (987654)            | table field `b` (Float)
-  +0x0284 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0298   | offset to field `c` (table)
-  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double      | 0x40FE240C9FBE76C9 (123457)    | table field `a` (Double)
-  +0x0290 | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x027C | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: 0x0272   | offset to vtable
+  +0x0280 | 65 20 71 49             | float       | 0x49712065 (987654)           | table field `b` (Float)
+  +0x0284 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: 0x0298   | offset to field `c` (table)
+  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double      | 0x40FE240C9FBE76C9 (123457)   | table field `a` (Double)
+  +0x0290 | 00 00                   | uint8_t[2]  | ..                            | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0292 | 06 00                   | uint16_t    | 0x0006 (6)                     | size of this vtable
-  +0x0294 | 08 00                   | uint16_t    | 0x0008 (8)                     | size of referring table
-  +0x0296 | 07 00                   | VOffset16   | 0x0007 (7)                     | offset to field `meal` (id: 0)
+  +0x0292 | 06 00                   | uint16_t    | 0x0006 (6)                    | size of this vtable
+  +0x0294 | 08 00                   | uint16_t    | 0x0008 (8)                    | size of referring table
+  +0x0296 | 07 00                   | VOffset16   | 0x0007 (7)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x0298 | 06 00 00 00             | SOffset32   | 0x00000006 (6) Loc: +0x0292    | offset to vtable
-  +0x029C | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x029F | 01                      | uint8_t     | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0298 | 06 00 00 00             | SOffset32   | 0x00000006 (6) Loc: 0x0292    | offset to vtable
+  +0x029C | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x029F | 01                      | uint8_t     | 0x01 (1)                      | table field `meal` (Byte)

--- a/tests/annotated_binary/tests/invalid_string_length_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_string_length_cut_short.afb
@@ -4,77 +4,77 @@
 // Binary file: tests/invalid_string_length_cut_short.bin
 
 header:
-  +0x00 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x44   | offset to root table `AnnotatedBinary.Foo`
-  +0x04 | 41 4E 4E 4F             | char[4]     | ANNO                         | File Identifier
+  +0x00 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: 0x44   | offset to root table `AnnotatedBinary.Foo`
+  +0x04 | 41 4E 4E 4F             | char[4]     | ANNO                        | File Identifier
 
 padding:
-  +0x08 | 00 00                   | uint8_t[2]  | ..                           | padding
+  +0x08 | 00 00                   | uint8_t[2]  | ..                          | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                  | size of this vtable
-  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                 | size of referring table
-  +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                  | offset to field `counter` (id: 0)
-  +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                   | offset to field `healthy` (id: 1)
-  +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                   | offset to field `meal` (id: 3)
-  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                  | offset to field `bar` (id: 4)
-  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                  | offset to field `home` (id: 5)
-  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                  | offset to field `name` (id: 6)
-  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                  | offset to field `bars` (id: 7)
-  +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                   | offset to field `bar_baz_type` (id: 8)
-  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                  | offset to field `bar_baz` (id: 9)
-  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                  | offset to field `accounts` (id: 10)
-  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                  | offset to field `bob` (id: 11)
-  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                  | offset to field `alice` (id: 12)
-  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | offset to field `just_i32` (id: 15)
-  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                  | offset to field `names` (id: 16)
-  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                  | offset to field `points_of_interest` (id: 17)
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | offset to field `foobars_type` (id: 18)
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | offset to field `foobars` (id: 19)
-  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                  | offset to field `measurement_type` (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | offset to field `measurement` (id: 21)
-  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                  | offset to field `anything_type` (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | offset to field `anything` (id: 23)
-  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | offset to field `charlie` (id: 26)
+  +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                 | size of this vtable
+  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                | size of referring table
+  +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                 | offset to field `counter` (id: 0)
+  +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                  | offset to field `healthy` (id: 1)
+  +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                  | offset to field `meal` (id: 3)
+  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                 | offset to field `bar` (id: 4)
+  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                 | offset to field `home` (id: 5)
+  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                 | offset to field `name` (id: 6)
+  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                 | offset to field `bars` (id: 7)
+  +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                  | offset to field `bar_baz_type` (id: 8)
+  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                 | offset to field `bar_baz` (id: 9)
+  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                 | offset to field `accounts` (id: 10)
+  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                 | offset to field `bob` (id: 11)
+  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                 | offset to field `alice` (id: 12)
+  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                 | offset to field `just_i32` (id: 15)
+  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                 | offset to field `names` (id: 16)
+  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                 | offset to field `points_of_interest` (id: 17)
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                 | offset to field `foobars_type` (id: 18)
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                 | offset to field `foobars` (id: 19)
+  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                 | offset to field `measurement_type` (id: 20)
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                 | offset to field `measurement` (id: 21)
+  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                 | offset to field `anything_type` (id: 22)
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                 | offset to field `anything` (id: 23)
+  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x44 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: +0x0A   | offset to vtable
-  +0x48 | 00 00 00                | uint8_t[3]  | ...                          | padding
-  +0x4B | 01                      | uint8_t     | 0x01 (1)                     | table field `healthy` (Bool)
-  +0x4C | 02                      | uint8_t     | 0x02 (2)                     | table field `meal` (Byte)
-  +0x4D | 02                      | UType8      | 0x02 (2)                     | table field `bar_baz_type` (UType)
-  +0x4E | 01                      | UType8      | 0x01 (1)                     | table field `measurement_type` (UType)
-  +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
-  +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
-  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)              | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x70 | 01                      | uint8_t     | 0x01 (1)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x71 | 02                      | uint8_t     | 0x02 (2)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x72 | 03                      | uint8_t     | 0x03 (3)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x73 | 00                      | uint8_t[1]  | .                            | padding
-  +0x74 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x23C | ERROR: offset to field `name`. Invalid offset, points outside the binary.
-  +0x78 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x1D4 | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
-  +0x7C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: +0x1CC | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
-  +0x80 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: +0x1B4 | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
-  +0x84 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: +0x1A8 | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
-  +0x88 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: +0x19C | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
-  +0x8C | 0D 00 00 00             | uint32_t    | 0x0000000D (13)              | table field `just_i32` (Int)
-  +0x90 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: +0x16C | ERROR: offset to field `names`. Invalid offset, points outside the binary.
-  +0x94 | A0 00 00 00             | UOffset32   | 0x000000A0 (160) Loc: +0x134 | ERROR: offset to field `points_of_interest`. Invalid offset, points outside the binary.
-  +0x98 | 94 00 00 00             | UOffset32   | 0x00000094 (148) Loc: +0x12C | ERROR: offset to field `foobars_type`. Invalid offset, points outside the binary.
-  +0x9C | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0xD4   | ERROR: offset to field `foobars`. Invalid offset, points outside the binary.
-  +0xA0 | 33 00 00 00             | UOffset32   | 0x00000033 (51) Loc: +0xD3   | ERROR: offset to field `measurement`. Invalid offset, points outside the binary.
-  +0xA4 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0xC0   | ERROR: offset to field `anything`. Invalid offset, points outside the binary.
-  +0xA8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0xAC    | offset to field `charlie` (string)
+  +0x44 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: 0x0A   | offset to vtable
+  +0x48 | 00 00 00                | uint8_t[3]  | ...                         | padding
+  +0x4B | 01                      | uint8_t     | 0x01 (1)                    | table field `healthy` (Bool)
+  +0x4C | 02                      | uint8_t     | 0x02 (2)                    | table field `meal` (Byte)
+  +0x4D | 02                      | UType8      | 0x02 (2)                    | table field `bar_baz_type` (UType)
+  +0x4E | 01                      | UType8      | 0x01 (1)                    | table field `measurement_type` (UType)
+  +0x4F | 01                      | UType8      | 0x01 (1)                    | table field `anything_type` (UType)
+  +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)           | table field `counter` (Int)
+  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: 0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
+  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)              | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)              | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)             | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)             | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)             | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)             | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x70 | 01                      | uint8_t     | 0x01 (1)                    | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x71 | 02                      | uint8_t     | 0x02 (2)                    | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x72 | 03                      | uint8_t     | 0x03 (3)                    | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x73 | 00                      | uint8_t[1]  | .                           | padding
+  +0x74 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: 0x23C | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x78 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: 0x1D4 | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x7C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: 0x1CC | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
+  +0x80 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: 0x1B4 | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
+  +0x84 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: 0x1A8 | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
+  +0x88 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: 0x19C | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
+  +0x8C | 0D 00 00 00             | uint32_t    | 0x0000000D (13)             | table field `just_i32` (Int)
+  +0x90 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: 0x16C | ERROR: offset to field `names`. Invalid offset, points outside the binary.
+  +0x94 | A0 00 00 00             | UOffset32   | 0x000000A0 (160) Loc: 0x134 | ERROR: offset to field `points_of_interest`. Invalid offset, points outside the binary.
+  +0x98 | 94 00 00 00             | UOffset32   | 0x00000094 (148) Loc: 0x12C | ERROR: offset to field `foobars_type`. Invalid offset, points outside the binary.
+  +0x9C | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: 0xD4   | ERROR: offset to field `foobars`. Invalid offset, points outside the binary.
+  +0xA0 | 33 00 00 00             | UOffset32   | 0x00000033 (51) Loc: 0xD3   | ERROR: offset to field `measurement`. Invalid offset, points outside the binary.
+  +0xA4 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: 0xC0   | ERROR: offset to field `anything`. Invalid offset, points outside the binary.
+  +0xA8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: 0xAC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0xAC | 05 00                   | ?uint8_t[2] | ..                           | ERROR: length of string. Incomplete binary, expected to read 4 bytes.
+  +0xAC | 05 00                   | ?uint8_t[2] | ..                          | ERROR: length of string. Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_struct_array_field_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_struct_array_field_cut_short.afb
@@ -4,69 +4,69 @@
 // Binary file: tests/invalid_struct_array_field_cut_short.bin
 
 header:
-  +0x00 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x44   | offset to root table `AnnotatedBinary.Foo`
-  +0x04 | 41 4E 4E 4F             | char[4]     | ANNO                         | File Identifier
+  +0x00 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: 0x44   | offset to root table `AnnotatedBinary.Foo`
+  +0x04 | 41 4E 4E 4F             | char[4]     | ANNO                        | File Identifier
 
 padding:
-  +0x08 | 00 00                   | uint8_t[2]  | ..                           | padding
+  +0x08 | 00 00                   | uint8_t[2]  | ..                          | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                  | size of this vtable
-  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                 | ERROR: size of referring table. Longer than the binary.
-  +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                  | offset to field `counter` (id: 0)
-  +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                   | offset to field `healthy` (id: 1)
-  +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                   | offset to field `meal` (id: 3)
-  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                  | offset to field `bar` (id: 4)
-  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                  | offset to field `home` (id: 5)
-  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                  | ERROR: offset to field `name` (id: 6). Invalid offset, points outside the binary.
-  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                  | ERROR: offset to field `bars` (id: 7). Invalid offset, points outside the binary.
-  +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                   | offset to field `bar_baz_type` (id: 8)
-  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                  | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points outside the binary.
-  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                  | ERROR: offset to field `accounts` (id: 10). Invalid offset, points outside the binary.
-  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                  | ERROR: offset to field `bob` (id: 11). Invalid offset, points outside the binary.
-  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                  | ERROR: offset to field `alice` (id: 12). Invalid offset, points outside the binary.
-  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points outside the binary.
-  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                  | ERROR: offset to field `names` (id: 16). Invalid offset, points outside the binary.
-  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                  | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points outside the binary.
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
-  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                  | offset to field `measurement_type` (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
-  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                  | offset to field `anything_type` (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
-  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
-  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 13)
-  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 14)
-  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | offset to unknown field (id: 15)
-  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                  | offset to unknown field (id: 16)
-  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                  | offset to unknown field (id: 17)
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | offset to unknown field (id: 18)
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | offset to unknown field (id: 19)
-  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                  | offset to unknown field (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | offset to unknown field (id: 21)
-  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                  | offset to unknown field (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | offset to unknown field (id: 23)
-  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 24)
-  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 25)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | offset to unknown field (id: 26)
+  +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                 | size of this vtable
+  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                | ERROR: size of referring table. Longer than the binary.
+  +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                 | offset to field `counter` (id: 0)
+  +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                  | offset to field `healthy` (id: 1)
+  +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                  | offset to field `meal` (id: 3)
+  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                 | offset to field `bar` (id: 4)
+  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                 | offset to field `home` (id: 5)
+  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                 | ERROR: offset to field `name` (id: 6). Invalid offset, points outside the binary.
+  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                 | ERROR: offset to field `bars` (id: 7). Invalid offset, points outside the binary.
+  +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                  | offset to field `bar_baz_type` (id: 8)
+  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                 | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points outside the binary.
+  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                 | ERROR: offset to field `accounts` (id: 10). Invalid offset, points outside the binary.
+  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                 | ERROR: offset to field `bob` (id: 11). Invalid offset, points outside the binary.
+  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                 | ERROR: offset to field `alice` (id: 12). Invalid offset, points outside the binary.
+  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                 | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points outside the binary.
+  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                 | ERROR: offset to field `names` (id: 16). Invalid offset, points outside the binary.
+  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                 | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points outside the binary.
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                 | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                 | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
+  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                 | offset to field `measurement_type` (id: 20)
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                 | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
+  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                 | offset to field `anything_type` (id: 22)
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                 | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
+  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
+  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to unknown field (id: 13)
+  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to unknown field (id: 14)
+  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                 | offset to unknown field (id: 15)
+  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                 | offset to unknown field (id: 16)
+  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                 | offset to unknown field (id: 17)
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                 | offset to unknown field (id: 18)
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                 | offset to unknown field (id: 19)
+  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                 | offset to unknown field (id: 20)
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                 | offset to unknown field (id: 21)
+  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                 | offset to unknown field (id: 22)
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                 | offset to unknown field (id: 23)
+  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to unknown field (id: 24)
+  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to unknown field (id: 25)
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                | offset to unknown field (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x44 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: +0x0A   | offset to vtable
-  +0x48 | 00 00 00                | uint8_t[3]  | ...                          | padding
-  +0x4B | 01                      | uint8_t     | 0x01 (1)                     | table field `healthy` (Bool)
-  +0x4C | 02                      | uint8_t     | 0x02 (2)                     | table field `meal` (Byte)
-  +0x4D | 02                      | UType8      | 0x02 (2)                     | table field `bar_baz_type` (UType)
-  +0x4E | 01                      | UType8      | 0x01 (1)                     | table field `measurement_type` (UType)
-  +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
-  +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
-  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x68 | 0C 00                   | ?uint8_t[2] | ..                           | ERROR: array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int). Incomplete binary, expected to read 4 bytes.
+  +0x44 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: 0x0A   | offset to vtable
+  +0x48 | 00 00 00                | uint8_t[3]  | ...                         | padding
+  +0x4B | 01                      | uint8_t     | 0x01 (1)                    | table field `healthy` (Bool)
+  +0x4C | 02                      | uint8_t     | 0x02 (2)                    | table field `meal` (Byte)
+  +0x4D | 02                      | UType8      | 0x02 (2)                    | table field `bar_baz_type` (UType)
+  +0x4E | 01                      | UType8      | 0x01 (1)                    | table field `measurement_type` (UType)
+  +0x4F | 01                      | UType8      | 0x01 (1)                    | table field `anything_type` (UType)
+  +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)           | table field `counter` (Int)
+  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: 0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
+  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)              | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)              | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)             | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)             | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x68 | 0C 00                   | ?uint8_t[2] | ..                          | ERROR: array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int). Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_struct_field_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_struct_field_cut_short.afb
@@ -4,66 +4,66 @@
 // Binary file: tests/invalid_struct_field_cut_short.bin
 
 header:
-  +0x00 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x44   | offset to root table `AnnotatedBinary.Foo`
-  +0x04 | 41 4E 4E 4F             | char[4]     | ANNO                         | File Identifier
+  +0x00 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: 0x44   | offset to root table `AnnotatedBinary.Foo`
+  +0x04 | 41 4E 4E 4F             | char[4]     | ANNO                        | File Identifier
 
 padding:
-  +0x08 | 00 00                   | uint8_t[2]  | ..                           | padding
+  +0x08 | 00 00                   | uint8_t[2]  | ..                          | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                  | size of this vtable
-  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                 | ERROR: size of referring table. Longer than the binary.
-  +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                  | offset to field `counter` (id: 0)
-  +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                   | offset to field `healthy` (id: 1)
-  +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                   | offset to field `meal` (id: 3)
-  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                  | offset to field `bar` (id: 4)
-  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                  | offset to field `home` (id: 5)
-  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                  | ERROR: offset to field `name` (id: 6). Invalid offset, points outside the binary.
-  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                  | ERROR: offset to field `bars` (id: 7). Invalid offset, points outside the binary.
-  +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                   | offset to field `bar_baz_type` (id: 8)
-  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                  | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points outside the binary.
-  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                  | ERROR: offset to field `accounts` (id: 10). Invalid offset, points outside the binary.
-  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                  | ERROR: offset to field `bob` (id: 11). Invalid offset, points outside the binary.
-  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                  | ERROR: offset to field `alice` (id: 12). Invalid offset, points outside the binary.
-  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points outside the binary.
-  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                  | ERROR: offset to field `names` (id: 16). Invalid offset, points outside the binary.
-  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                  | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points outside the binary.
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
-  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                  | offset to field `measurement_type` (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
-  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                  | offset to field `anything_type` (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
-  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
-  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 13)
-  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 14)
-  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | offset to unknown field (id: 15)
-  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                  | offset to unknown field (id: 16)
-  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                  | offset to unknown field (id: 17)
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | offset to unknown field (id: 18)
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | offset to unknown field (id: 19)
-  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                  | offset to unknown field (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | offset to unknown field (id: 21)
-  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                  | offset to unknown field (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | offset to unknown field (id: 23)
-  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 24)
-  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 25)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | offset to unknown field (id: 26)
+  +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                 | size of this vtable
+  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                | ERROR: size of referring table. Longer than the binary.
+  +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                 | offset to field `counter` (id: 0)
+  +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                  | offset to field `healthy` (id: 1)
+  +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                  | offset to field `meal` (id: 3)
+  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                 | offset to field `bar` (id: 4)
+  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                 | offset to field `home` (id: 5)
+  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                 | ERROR: offset to field `name` (id: 6). Invalid offset, points outside the binary.
+  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                 | ERROR: offset to field `bars` (id: 7). Invalid offset, points outside the binary.
+  +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                  | offset to field `bar_baz_type` (id: 8)
+  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                 | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points outside the binary.
+  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                 | ERROR: offset to field `accounts` (id: 10). Invalid offset, points outside the binary.
+  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                 | ERROR: offset to field `bob` (id: 11). Invalid offset, points outside the binary.
+  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                 | ERROR: offset to field `alice` (id: 12). Invalid offset, points outside the binary.
+  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                 | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points outside the binary.
+  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                 | ERROR: offset to field `names` (id: 16). Invalid offset, points outside the binary.
+  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                 | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points outside the binary.
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                 | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                 | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
+  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                 | offset to field `measurement_type` (id: 20)
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                 | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
+  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                 | offset to field `anything_type` (id: 22)
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                 | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
+  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
+  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to unknown field (id: 13)
+  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to unknown field (id: 14)
+  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                 | offset to unknown field (id: 15)
+  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                 | offset to unknown field (id: 16)
+  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                 | offset to unknown field (id: 17)
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                 | offset to unknown field (id: 18)
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                 | offset to unknown field (id: 19)
+  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                 | offset to unknown field (id: 20)
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                 | offset to unknown field (id: 21)
+  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                 | offset to unknown field (id: 22)
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                 | offset to unknown field (id: 23)
+  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to unknown field (id: 24)
+  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to unknown field (id: 25)
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                | offset to unknown field (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x44 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: +0x0A   | offset to vtable
-  +0x48 | 00 00 00                | uint8_t[3]  | ...                          | padding
-  +0x4B | 01                      | uint8_t     | 0x01 (1)                     | table field `healthy` (Bool)
-  +0x4C | 02                      | uint8_t     | 0x02 (2)                     | table field `meal` (Byte)
-  +0x4D | 02                      | UType8      | 0x02 (2)                     | table field `bar_baz_type` (UType)
-  +0x4E | 01                      | UType8      | 0x01 (1)                     | table field `measurement_type` (UType)
-  +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
-  +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
-  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x5C | 02 00                   | ?uint8_t[2] | ..                           | ERROR: struct field `home.doors` of 'AnnotatedBinary.Building' (Int). Incomplete binary, expected to read 4 bytes.
+  +0x44 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: 0x0A   | offset to vtable
+  +0x48 | 00 00 00                | uint8_t[3]  | ...                         | padding
+  +0x4B | 01                      | uint8_t     | 0x01 (1)                    | table field `healthy` (Bool)
+  +0x4C | 02                      | uint8_t     | 0x02 (2)                    | table field `meal` (Byte)
+  +0x4D | 02                      | UType8      | 0x02 (2)                    | table field `bar_baz_type` (UType)
+  +0x4E | 01                      | UType8      | 0x01 (1)                    | table field `measurement_type` (UType)
+  +0x4F | 01                      | UType8      | 0x01 (1)                    | table field `anything_type` (UType)
+  +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)           | table field `counter` (Int)
+  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: 0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
+  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)              | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x5C | 02 00                   | ?uint8_t[2] | ..                          | ERROR: struct field `home.doors` of 'AnnotatedBinary.Building' (Int). Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_table_field_offset.afb
+++ b/tests/annotated_binary/tests/invalid_table_field_offset.afb
@@ -4,74 +4,74 @@
 // Binary file: tests/invalid_table_field_offset.bin
 
 header:
-  +0x00 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x44   | offset to root table `AnnotatedBinary.Foo`
-  +0x04 | 41 4E 4E 4F             | char[4]     | ANNO                         | File Identifier
+  +0x00 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: 0x44   | offset to root table `AnnotatedBinary.Foo`
+  +0x04 | 41 4E 4E 4F             | char[4]     | ANNO                        | File Identifier
 
 padding:
-  +0x08 | 00 00                   | uint8_t[2]  | ..                           | padding
+  +0x08 | 00 00                   | uint8_t[2]  | ..                          | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                  | size of this vtable
-  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                 | ERROR: size of referring table. Longer than the binary.
-  +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                  | offset to field `counter` (id: 0)
-  +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                   | offset to field `healthy` (id: 1)
-  +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                   | offset to field `meal` (id: 3)
-  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                  | offset to field `bar` (id: 4)
-  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                  | offset to field `home` (id: 5)
-  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                  | offset to field `name` (id: 6)
-  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                  | offset to field `bars` (id: 7)
-  +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                   | offset to field `bar_baz_type` (id: 8)
-  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                  | offset to field `bar_baz` (id: 9)
-  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                  | offset to field `accounts` (id: 10)
-  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                  | offset to field `bob` (id: 11)
-  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                  | offset to field `alice` (id: 12)
-  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                  | offset to field `just_i32` (id: 15)
-  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                  | offset to field `names` (id: 16)
-  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                  | offset to field `points_of_interest` (id: 17)
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                  | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                  | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
-  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                  | offset to field `measurement_type` (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                  | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
-  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                  | offset to field `anything_type` (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
-  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
-  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                  | offset to unknown field (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                  | offset to unknown field (id: 23)
-  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 24)
-  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                   | offset to unknown field (id: 25)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                 | offset to unknown field (id: 26)
+  +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                 | size of this vtable
+  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)                | ERROR: size of referring table. Longer than the binary.
+  +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                 | offset to field `counter` (id: 0)
+  +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                  | offset to field `healthy` (id: 1)
+  +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                  | offset to field `meal` (id: 3)
+  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                 | offset to field `bar` (id: 4)
+  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                 | offset to field `home` (id: 5)
+  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                 | offset to field `name` (id: 6)
+  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                 | offset to field `bars` (id: 7)
+  +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                  | offset to field `bar_baz_type` (id: 8)
+  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                 | offset to field `bar_baz` (id: 9)
+  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                 | offset to field `accounts` (id: 10)
+  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                 | offset to field `bob` (id: 11)
+  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                 | offset to field `alice` (id: 12)
+  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                 | offset to field `just_i32` (id: 15)
+  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                 | offset to field `names` (id: 16)
+  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                 | offset to field `points_of_interest` (id: 17)
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                 | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                 | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
+  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                 | offset to field `measurement_type` (id: 20)
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                 | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
+  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                 | offset to field `anything_type` (id: 22)
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                 | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
+  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
+  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                 | offset to unknown field (id: 22)
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                 | offset to unknown field (id: 23)
+  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to unknown field (id: 24)
+  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                  | offset to unknown field (id: 25)
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)                | offset to unknown field (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x44 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: +0x0A   | offset to vtable
-  +0x48 | 00 00 00                | uint8_t[3]  | ...                          | padding
-  +0x4B | 01                      | uint8_t     | 0x01 (1)                     | table field `healthy` (Bool)
-  +0x4C | 02                      | uint8_t     | 0x02 (2)                     | table field `meal` (Byte)
-  +0x4D | 02                      | UType8      | 0x02 (2)                     | table field `bar_baz_type` (UType)
-  +0x4E | 01                      | UType8      | 0x01 (1)                     | table field `measurement_type` (UType)
-  +0x4F | 01                      | UType8      | 0x01 (1)                     | table field `anything_type` (UType)
-  +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)            | table field `counter` (Int)
-  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)               | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)               | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)              | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)              | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)              | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x70 | 01                      | uint8_t     | 0x01 (1)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x71 | 02                      | uint8_t     | 0x02 (2)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x72 | 03                      | uint8_t     | 0x03 (3)                     | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x73 | 00                      | uint8_t[1]  | .                            | padding
-  +0x74 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x23C | ERROR: offset to field `name`. Invalid offset, points outside the binary.
-  +0x78 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x1D4 | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
-  +0x7C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: +0x1CC | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
-  +0x80 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: +0x1B4 | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
-  +0x84 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: +0x1A8 | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
-  +0x88 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: +0x19C | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
-  +0x8C | 0D 00 00 00             | uint32_t    | 0x0000000D (13)              | table field `just_i32` (Int)
-  +0x90 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: +0x16C | ERROR: offset to field `names`. Invalid offset, points outside the binary.
-  +0x94 | A0 00                   | ?uint8_t[2] | ..                           | ERROR: offset to field `points_of_interest`. Incomplete binary, expected to read 4 bytes.
+  +0x44 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: 0x0A   | offset to vtable
+  +0x48 | 00 00 00                | uint8_t[3]  | ...                         | padding
+  +0x4B | 01                      | uint8_t     | 0x01 (1)                    | table field `healthy` (Bool)
+  +0x4C | 02                      | uint8_t     | 0x02 (2)                    | table field `meal` (Byte)
+  +0x4D | 02                      | UType8      | 0x02 (2)                    | table field `bar_baz_type` (UType)
+  +0x4E | 01                      | UType8      | 0x01 (1)                    | table field `measurement_type` (UType)
+  +0x4F | 01                      | UType8      | 0x01 (1)                    | table field `anything_type` (UType)
+  +0x50 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)           | table field `counter` (Int)
+  +0x54 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: 0x27C | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
+  +0x58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)              | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)              | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x60 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)             | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x64 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)             | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x68 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)             | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x6C | 14 00 00 00             | uint32_t    | 0x00000014 (20)             | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x70 | 01                      | uint8_t     | 0x01 (1)                    | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x71 | 02                      | uint8_t     | 0x02 (2)                    | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x72 | 03                      | uint8_t     | 0x03 (3)                    | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x73 | 00                      | uint8_t[1]  | .                           | padding
+  +0x74 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: 0x23C | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x78 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: 0x1D4 | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x7C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: 0x1CC | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
+  +0x80 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: 0x1B4 | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
+  +0x84 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: 0x1A8 | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
+  +0x88 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: 0x19C | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
+  +0x8C | 0D 00 00 00             | uint32_t    | 0x0000000D (13)             | table field `just_i32` (Int)
+  +0x90 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: 0x16C | ERROR: offset to field `names`. Invalid offset, points outside the binary.
+  +0x94 | A0 00                   | ?uint8_t[2] | ..                          | ERROR: offset to field `points_of_interest`. Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_table_field_size.afb
+++ b/tests/annotated_binary/tests/invalid_table_field_size.afb
@@ -4,65 +4,65 @@
 // Binary file: tests/invalid_table_field_size.bin
 
 header:
-  +0x00 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x44 | offset to root table `AnnotatedBinary.Foo`
-  +0x04 | 41 4E 4E 4F             | char[4]     | ANNO                       | File Identifier
+  +0x00 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: 0x44 | offset to root table `AnnotatedBinary.Foo`
+  +0x04 | 41 4E 4E 4F             | char[4]     | ANNO                      | File Identifier
 
 padding:
-  +0x08 | 00 00                   | uint8_t[2]  | ..                         | padding
+  +0x08 | 00 00                   | uint8_t[2]  | ..                        | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x0A | 3A 00                   | uint16_t    | 0x003A (58)                | size of this vtable
-  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)               | ERROR: size of referring table. Longer than the binary.
-  +0x0E | 0C 00                   | VOffset16   | 0x000C (12)                | offset to field `counter` (id: 0)
-  +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                 | offset to field `healthy` (id: 1)
-  +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                 | offset to field `meal` (id: 3)
-  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)                | ERROR: offset to field `bar` (id: 4). Invalid offset, points outside the binary.
-  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)                | ERROR: offset to field `home` (id: 5). Invalid offset, points outside the binary.
-  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)                | ERROR: offset to field `name` (id: 6). Invalid offset, points outside the binary.
-  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)                | ERROR: offset to field `bars` (id: 7). Invalid offset, points outside the binary.
-  +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                 | offset to field `bar_baz_type` (id: 8)
-  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)                | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points outside the binary.
-  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)                | ERROR: offset to field `accounts` (id: 10). Invalid offset, points outside the binary.
-  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                | ERROR: offset to field `bob` (id: 11). Invalid offset, points outside the binary.
-  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                | ERROR: offset to field `alice` (id: 12). Invalid offset, points outside the binary.
-  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points outside the binary.
-  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                | ERROR: offset to field `names` (id: 16). Invalid offset, points outside the binary.
-  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points outside the binary.
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
-  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                | offset to field `measurement_type` (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
-  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                | offset to field `anything_type` (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
-  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)               | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
-  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)                | offset to unknown field (id: 11)
-  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)                | offset to unknown field (id: 12)
-  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to unknown field (id: 13)
-  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to unknown field (id: 14)
-  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)                | offset to unknown field (id: 15)
-  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)                | offset to unknown field (id: 16)
-  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)                | offset to unknown field (id: 17)
-  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)                | offset to unknown field (id: 18)
-  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)                | offset to unknown field (id: 19)
-  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)                | offset to unknown field (id: 20)
-  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)                | offset to unknown field (id: 21)
-  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)                | offset to unknown field (id: 22)
-  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)                | offset to unknown field (id: 23)
-  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to unknown field (id: 24)
-  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                 | offset to unknown field (id: 25)
-  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)               | offset to unknown field (id: 26)
+  +0x0A | 3A 00                   | uint16_t    | 0x003A (58)               | size of this vtable
+  +0x0C | 68 00                   | uint16_t    | 0x0068 (104)              | ERROR: size of referring table. Longer than the binary.
+  +0x0E | 0C 00                   | VOffset16   | 0x000C (12)               | offset to field `counter` (id: 0)
+  +0x10 | 07 00                   | VOffset16   | 0x0007 (7)                | offset to field `healthy` (id: 1)
+  +0x12 | 00 00                   | VOffset16   | 0x0000 (0)                | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x14 | 08 00                   | VOffset16   | 0x0008 (8)                | offset to field `meal` (id: 3)
+  +0x16 | 10 00                   | VOffset16   | 0x0010 (16)               | ERROR: offset to field `bar` (id: 4). Invalid offset, points outside the binary.
+  +0x18 | 14 00                   | VOffset16   | 0x0014 (20)               | ERROR: offset to field `home` (id: 5). Invalid offset, points outside the binary.
+  +0x1A | 30 00                   | VOffset16   | 0x0030 (48)               | ERROR: offset to field `name` (id: 6). Invalid offset, points outside the binary.
+  +0x1C | 34 00                   | VOffset16   | 0x0034 (52)               | ERROR: offset to field `bars` (id: 7). Invalid offset, points outside the binary.
+  +0x1E | 09 00                   | VOffset16   | 0x0009 (9)                | offset to field `bar_baz_type` (id: 8)
+  +0x20 | 38 00                   | VOffset16   | 0x0038 (56)               | ERROR: offset to field `bar_baz` (id: 9). Invalid offset, points outside the binary.
+  +0x22 | 3C 00                   | VOffset16   | 0x003C (60)               | ERROR: offset to field `accounts` (id: 10). Invalid offset, points outside the binary.
+  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)               | ERROR: offset to field `bob` (id: 11). Invalid offset, points outside the binary.
+  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)               | ERROR: offset to field `alice` (id: 12). Invalid offset, points outside the binary.
+  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)               | ERROR: offset to field `just_i32` (id: 15). Invalid offset, points outside the binary.
+  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)               | ERROR: offset to field `names` (id: 16). Invalid offset, points outside the binary.
+  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)               | ERROR: offset to field `points_of_interest` (id: 17). Invalid offset, points outside the binary.
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)               | ERROR: offset to field `foobars_type` (id: 18). Invalid offset, points outside the binary.
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)               | ERROR: offset to field `foobars` (id: 19). Invalid offset, points outside the binary.
+  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)               | offset to field `measurement_type` (id: 20)
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)               | ERROR: offset to field `measurement` (id: 21). Invalid offset, points outside the binary.
+  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)               | offset to field `anything_type` (id: 22)
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)               | ERROR: offset to field `anything` (id: 23). Invalid offset, points outside the binary.
+  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)              | ERROR: offset to field `charlie` (id: 26). Invalid offset, points outside the binary.
+  +0x24 | 40 00                   | VOffset16   | 0x0040 (64)               | offset to unknown field (id: 11)
+  +0x26 | 44 00                   | VOffset16   | 0x0044 (68)               | offset to unknown field (id: 12)
+  +0x28 | 00 00                   | VOffset16   | 0x0000 (0)                | offset to unknown field (id: 13)
+  +0x2A | 00 00                   | VOffset16   | 0x0000 (0)                | offset to unknown field (id: 14)
+  +0x2C | 48 00                   | VOffset16   | 0x0048 (72)               | offset to unknown field (id: 15)
+  +0x2E | 4C 00                   | VOffset16   | 0x004C (76)               | offset to unknown field (id: 16)
+  +0x30 | 50 00                   | VOffset16   | 0x0050 (80)               | offset to unknown field (id: 17)
+  +0x32 | 54 00                   | VOffset16   | 0x0054 (84)               | offset to unknown field (id: 18)
+  +0x34 | 58 00                   | VOffset16   | 0x0058 (88)               | offset to unknown field (id: 19)
+  +0x36 | 0A 00                   | VOffset16   | 0x000A (10)               | offset to unknown field (id: 20)
+  +0x38 | 5C 00                   | VOffset16   | 0x005C (92)               | offset to unknown field (id: 21)
+  +0x3A | 0B 00                   | VOffset16   | 0x000B (11)               | offset to unknown field (id: 22)
+  +0x3C | 60 00                   | VOffset16   | 0x0060 (96)               | offset to unknown field (id: 23)
+  +0x3E | 00 00                   | VOffset16   | 0x0000 (0)                | offset to unknown field (id: 24)
+  +0x40 | 00 00                   | VOffset16   | 0x0000 (0)                | offset to unknown field (id: 25)
+  +0x42 | 64 00                   | VOffset16   | 0x0064 (100)              | offset to unknown field (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x44 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: +0x0A | offset to vtable
-  +0x48 | 00 00 00                | uint8_t[3]  | ...                        | padding
-  +0x4B | 01                      | uint8_t     | 0x01 (1)                   | table field `healthy` (Bool)
-  +0x4C | 02                      | uint8_t     | 0x02 (2)                   | table field `meal` (Byte)
-  +0x4D | 02                      | UType8      | 0x02 (2)                   | table field `bar_baz_type` (UType)
-  +0x4E | 01                      | UType8      | 0x01 (1)                   | table field `measurement_type` (UType)
-  +0x4F | 01                      | UType8      | 0x01 (1)                   | table field `anything_type` (UType)
-  +0x50 | D2 04                   | ?uint8_t[2] | ..                         | ERROR: table field `counter` (Int). Incomplete binary, expected to read 4 bytes.
+  +0x44 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: 0x0A | offset to vtable
+  +0x48 | 00 00 00                | uint8_t[3]  | ...                       | padding
+  +0x4B | 01                      | uint8_t     | 0x01 (1)                  | table field `healthy` (Bool)
+  +0x4C | 02                      | uint8_t     | 0x02 (2)                  | table field `meal` (Byte)
+  +0x4D | 02                      | UType8      | 0x02 (2)                  | table field `bar_baz_type` (UType)
+  +0x4E | 01                      | UType8      | 0x01 (1)                  | table field `measurement_type` (UType)
+  +0x4F | 01                      | UType8      | 0x01 (1)                  | table field `anything_type` (UType)
+  +0x50 | D2 04                   | ?uint8_t[2] | ..                        | ERROR: table field `counter` (Int). Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_union_type_value.afb
+++ b/tests/annotated_binary/tests/invalid_union_type_value.afb
@@ -4,290 +4,290 @@
 // Binary file: tests/invalid_union_type_value.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                    | size of this vtable
-  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                   | size of referring table
-  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                   | size of this vtable
+  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                  | size of referring table
+  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x004B | 01                      | uint8_t      | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t      | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | FF                      | UType8       | 0xFF (255)                     | ERROR: table field `bar_baz_type` (UType). Invalid union type value.
-  +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
-  +0x007C | 50 01 00 00             | ?uint8_t[4]  | P...                           | WARN: nothing refers to this section.
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
-  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
-  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x004B | 01                      | uint8_t      | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t      | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | FF                      | UType8       | 0xFF (255)                    | ERROR: table field `bar_baz_type` (UType). Invalid union type value.
+  +0x004E | 01                      | UType8       | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8       | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: 0x027C  | offset to field `bar` (table)
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: 0x023C  | offset to field `name` (string)
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: 0x01D4  | offset to field `bars` (vector)
+  +0x007C | 50 01 00 00             | ?uint8_t[4]  | P...                          | WARN: nothing refers to this section.
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: 0x01B4  | offset to field `accounts` (vector)
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: 0x01A8  | offset to field `bob` (string)
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: 0x019C  | offset to field `alice` (string)
+  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: 0x016C  | offset to field `names` (vector)
+  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x00B5 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | offset to vtable
-  +0x00E8 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00EC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x00FC   | offset to field `c` (table)
-  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x00F8 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: 0x0212 | offset to vtable
+  +0x00E8 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00EC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x00FC   | offset to field `c` (table)
+  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x00F8 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x00FC | 6A FE FF FF             | SOffset32    | 0xFFFFFE6A (-406) Loc: +0x0292 | offset to vtable
-  +0x0100 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x0103 | 03                      | uint8_t      | 0x03 (3)                       | table field `meal` (Byte)
+  +0x00FC | 6A FE FF FF             | SOffset32    | 0xFFFFFE6A (-406) Loc: 0x0292 | offset to vtable
+  +0x0100 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x0103 | 03                      | uint8_t      | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | offset to vtable
-  +0x0110 | 00 00 E4 43             | float        | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0114 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x0124   | offset to field `c` (table)
-  +0x0118 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0120 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: 0x0212 | offset to vtable
+  +0x0110 | 00 00 E4 43             | float        | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0114 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x0124   | offset to field `c` (table)
+  +0x0118 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0120 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0124 | 92 FE FF FF             | SOffset32    | 0xFFFFFE92 (-366) Loc: +0x0292 | offset to vtable
-  +0x0128 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x012B | 01                      | uint8_t      | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0124 | 92 FE FF FF             | SOffset32    | 0xFFFFFE92 (-366) Loc: 0x0292 | offset to vtable
+  +0x0128 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x012B | 01                      | uint8_t      | 0x01 (1)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8       | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8       | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8       | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8       | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8       | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8       | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)   | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)  | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)   | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084) | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208) | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)  | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
-  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: +0x0190   | offset to string[0]
-  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: +0x0188   | offset to string[1]
-  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x017C    | offset to string[2]
+  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: 0x0190   | offset to string[0]
+  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: 0x0188   | offset to string[1]
+  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x017C    | offset to string[2]
 
 string (AnnotatedBinary.Foo.names):
-  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x0187 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
-  +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of string
+  +0x018C | 62 6F 62                | char[3]      | bob                           | string literal
+  +0x018F | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x0199 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x019A | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x019A | 00 00                   | uint8_t[2]   | ..                            | padding
 
 string (AnnotatedBinary.Foo.alice):
-  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01A7 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.bob):
-  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01B3 | 00                      | char         | 0x00 (0)                      | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
-  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                 | length of vector (# items)
-  +0x01B8 | 09 00                   | uint16_t     | 0x0009 (9)                     | value[0]
-  +0x01BA | 08 00                   | uint16_t     | 0x0008 (8)                     | value[1]
-  +0x01BC | 07 00                   | uint16_t     | 0x0007 (7)                     | value[2]
-  +0x01BE | 01 00                   | uint16_t     | 0x0001 (1)                     | value[3]
-  +0x01C0 | 02 00                   | uint16_t     | 0x0002 (2)                     | value[4]
-  +0x01C2 | 03 00                   | uint16_t     | 0x0003 (3)                     | value[5]
-  +0x01C4 | 06 00                   | uint16_t     | 0x0006 (6)                     | value[6]
-  +0x01C6 | 05 00                   | uint16_t     | 0x0005 (5)                     | value[7]
-  +0x01C8 | 04 00                   | uint16_t     | 0x0004 (4)                     | value[8]
+  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                | length of vector (# items)
+  +0x01B8 | 09 00                   | uint16_t     | 0x0009 (9)                    | value[0]
+  +0x01BA | 08 00                   | uint16_t     | 0x0008 (8)                    | value[1]
+  +0x01BC | 07 00                   | uint16_t     | 0x0007 (7)                    | value[2]
+  +0x01BE | 01 00                   | uint16_t     | 0x0001 (1)                    | value[3]
+  +0x01C0 | 02 00                   | uint16_t     | 0x0002 (2)                    | value[4]
+  +0x01C2 | 03 00                   | uint16_t     | 0x0003 (3)                    | value[5]
+  +0x01C4 | 06 00                   | uint16_t     | 0x0006 (6)                    | value[6]
+  +0x01C6 | 05 00                   | uint16_t     | 0x0005 (5)                    | value[7]
+  +0x01C8 | 04 00                   | uint16_t     | 0x0004 (4)                    | value[8]
 
 unknown (no known references):
-  +0x01CA | 00 00 3A FF FF FF 00 00 | ?uint8_t[10] | ..:.....                       | WARN: nothing refers to this section.
+  +0x01CA | 00 00 3A FF FF FF 00 00 | ?uint8_t[10] | ..:.....                      | WARN: nothing refers to this section.
   +0x01D2 | 00 03                   |              | ..
 
 vector (AnnotatedBinary.Foo.bars):
-  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | length of vector (# items)
-  +0x01D8 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x021C   | offset to table[0]
-  +0x01DC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x01EC   | offset to table[1]
+  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | length of vector (# items)
+  +0x01D8 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x021C   | offset to table[0]
+  +0x01DC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x01EC   | offset to table[1]
 
 padding:
-  +0x01E0 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x01E0 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x01E2 | 0A 00                   | uint16_t     | 0x000A (10)                    | size of this vtable
-  +0x01E4 | 1A 00                   | uint16_t     | 0x001A (26)                    | size of referring table
-  +0x01E6 | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x01E8 | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x01EA | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x01E2 | 0A 00                   | uint16_t     | 0x000A (10)                   | size of this vtable
+  +0x01E4 | 1A 00                   | uint16_t     | 0x001A (26)                   | size of referring table
+  +0x01E6 | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x01E8 | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x01EA | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x01EC | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: +0x01E2   | offset to vtable
-  +0x01F0 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x01F4 | 18 00 00 00             | UOffset32    | 0x00000018 (24) Loc: +0x020C   | offset to field `c` (table)
-  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x0200 | 00 00 00 00 00 00       | uint8_t[6]   | ......                         | padding
+  +0x01EC | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: 0x01E2   | offset to vtable
+  +0x01F0 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x01F4 | 18 00 00 00             | UOffset32    | 0x00000018 (24) Loc: 0x020C   | offset to field `c` (table)
+  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x0200 | 00 00 00 00 00 00       | uint8_t[6]   | ......                        | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0206 | 06 00                   | uint16_t     | 0x0006 (6)                     | size of this vtable
-  +0x0208 | 06 00                   | uint16_t     | 0x0006 (6)                     | size of referring table
-  +0x020A | 05 00                   | VOffset16    | 0x0005 (5)                     | offset to field `meal` (id: 0)
+  +0x0206 | 06 00                   | uint16_t     | 0x0006 (6)                    | size of this vtable
+  +0x0208 | 06 00                   | uint16_t     | 0x0006 (6)                    | size of referring table
+  +0x020A | 05 00                   | VOffset16    | 0x0005 (5)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x020C | 06 00 00 00             | SOffset32    | 0x00000006 (6) Loc: +0x0206    | offset to vtable
-  +0x0210 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0211 | 03                      | uint8_t      | 0x03 (3)                       | table field `meal` (Byte)
+  +0x020C | 06 00 00 00             | SOffset32    | 0x00000006 (6) Loc: 0x0206    | offset to vtable
+  +0x0210 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0211 | 03                      | uint8_t      | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Bar):
-  +0x0212 | 0A 00                   | uint16_t     | 0x000A (10)                    | size of this vtable
-  +0x0214 | 18 00                   | uint16_t     | 0x0018 (24)                    | size of referring table
-  +0x0216 | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0218 | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x021A | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0212 | 0A 00                   | uint16_t     | 0x000A (10)                   | size of this vtable
+  +0x0214 | 18 00                   | uint16_t     | 0x0018 (24)                   | size of referring table
+  +0x0216 | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0218 | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x021A | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x021C | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: +0x0212   | offset to vtable
-  +0x0220 | 00 00 E4 43             | float        | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0224 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x0234   | offset to field `c` (table)
-  +0x0228 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0230 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x021C | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: 0x0212   | offset to vtable
+  +0x0220 | 00 00 E4 43             | float        | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0224 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x0234   | offset to field `c` (table)
+  +0x0228 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0230 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0234 | A2 FF FF FF             | SOffset32    | 0xFFFFFFA2 (-94) Loc: +0x0292  | offset to vtable
-  +0x0238 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x023B | 01                      | uint8_t      | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0234 | A2 FF FF FF             | SOffset32    | 0xFFFFFFA2 (-94) Loc: 0x0292  | offset to vtable
+  +0x0238 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x023B | 01                      | uint8_t      | 0x01 (1)                      | table field `meal` (Byte)
 
 string (AnnotatedBinary.Foo.name):
-  +0x023C | 2F 00 00 00             | uint32_t     | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                        | string literal
+  +0x023C | 2F 00 00 00             | uint32_t     | 0x0000002F (47)               | length of string
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                       | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |              | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |              | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |              |  show ho
   +0x0260 | 77 20 69 74 20 62 72 65 |              | w it bre
   +0x0268 | 61 6B 73 20 75 70 2E    |              | aks up.
-  +0x026F | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x026F | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x0270 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x0270 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x0272 | 0A 00                   | uint16_t     | 0x000A (10)                    | size of this vtable
-  +0x0274 | 16 00                   | uint16_t     | 0x0016 (22)                    | size of referring table
-  +0x0276 | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0278 | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x027A | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0272 | 0A 00                   | uint16_t     | 0x000A (10)                   | size of this vtable
+  +0x0274 | 16 00                   | uint16_t     | 0x0016 (22)                   | size of referring table
+  +0x0276 | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0278 | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x027A | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x027C | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: +0x0272   | offset to vtable
-  +0x0280 | 65 20 71 49             | float        | 0x49712065 (987654)            | table field `b` (Float)
-  +0x0284 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: +0x0298   | offset to field `c` (table)
-  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double       | 0x40FE240C9FBE76C9 (123457)    | table field `a` (Double)
-  +0x0290 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x027C | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: 0x0272   | offset to vtable
+  +0x0280 | 65 20 71 49             | float        | 0x49712065 (987654)           | table field `b` (Float)
+  +0x0284 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: 0x0298   | offset to field `c` (table)
+  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double       | 0x40FE240C9FBE76C9 (123457)   | table field `a` (Double)
+  +0x0290 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0292 | 06 00                   | uint16_t     | 0x0006 (6)                     | size of this vtable
-  +0x0294 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of referring table
-  +0x0296 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `meal` (id: 0)
+  +0x0292 | 06 00                   | uint16_t     | 0x0006 (6)                    | size of this vtable
+  +0x0294 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of referring table
+  +0x0296 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x0298 | 06 00 00 00             | SOffset32    | 0x00000006 (6) Loc: +0x0292    | offset to vtable
-  +0x029C | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x029F | 01                      | uint8_t      | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0298 | 06 00 00 00             | SOffset32    | 0x00000006 (6) Loc: 0x0292    | offset to vtable
+  +0x029C | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x029F | 01                      | uint8_t      | 0x01 (1)                      | table field `meal` (Byte)

--- a/tests/annotated_binary/tests/invalid_vector_length_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_length_cut_short.afb
@@ -4,137 +4,137 @@
 // Binary file: tests/invalid_vector_length_cut_short.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                    | size of this vtable
-  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                   | size of referring table
-  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                   | size of this vtable
+  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                  | size of referring table
+  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x004B | 01                      | uint8_t      | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t      | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8       | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
-  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | ERROR: offset to field `names`. Invalid offset, points outside the binary.
-  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x004B | 01                      | uint8_t      | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t      | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8       | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8       | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8       | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: 0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: 0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: 0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: 0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: 0x01B4  | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: 0x01A8  | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: 0x019C  | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
+  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: 0x016C  | ERROR: offset to field `names`. Invalid offset, points outside the binary.
+  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x00B5 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
+  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                      | WARN: nothing refers to this section.
   +0x00F0 | 00 00 00 00 00 D8 8E 40 |              | .......@
   +0x00F8 | 00 00 00 00 6A FE FF FF |              | ....j...
   +0x0100 | 00 00 00 03             |              | ....
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
+  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                      | WARN: nothing refers to this section.
   +0x0118 | 00 00 00 00 00 C0 5E 40 |              | ......^@
   +0x0120 | 00 00 00 00 92 FE FF FF |              | ........
   +0x0128 | 00 00 00 01             |              | ....
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8       | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8       | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8       | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8       | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8       | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8       | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00                   | ?uint8_t[2]  | ..                             | ERROR: length of vector (# items). Incomplete binary, expected to read 4 bytes.
+  +0x0134 | 03 00                   | ?uint8_t[2]  | ..                            | ERROR: length of vector (# items). Incomplete binary, expected to read 4 bytes.

--- a/tests/annotated_binary/tests/invalid_vector_scalars_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_scalars_cut_short.afb
@@ -4,187 +4,187 @@
 // Binary file: tests/invalid_vector_scalars_cut_short.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                    | size of this vtable
-  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                   | size of referring table
-  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                   | size of this vtable
+  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                  | size of referring table
+  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x004B | 01                      | uint8_t      | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t      | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8       | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
-  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
-  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x004B | 01                      | uint8_t      | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t      | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8       | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8       | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8       | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: 0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: 0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: 0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: 0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: 0x01B4  | offset to field `accounts` (vector)
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: 0x01A8  | offset to field `bob` (string)
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: 0x019C  | offset to field `alice` (string)
+  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: 0x016C  | offset to field `names` (vector)
+  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x00B5 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
+  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                      | WARN: nothing refers to this section.
   +0x00F0 | 00 00 00 00 00 D8 8E 40 |              | .......@
   +0x00F8 | 00 00 00 00 6A FE FF FF |              | ....j...
   +0x0100 | 00 00 00 03             |              | ....
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
+  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                      | WARN: nothing refers to this section.
   +0x0118 | 00 00 00 00 00 C0 5E 40 |              | ......^@
   +0x0120 | 00 00 00 00 92 FE FF FF |              | ........
   +0x0128 | 00 00 00 01             |              | ....
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8       | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8       | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8       | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8       | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8       | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8       | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)   | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)  | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)   | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084) | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208) | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)  | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
-  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: +0x0190   | offset to string[0]
-  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: +0x0188   | offset to string[1]
-  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x017C    | offset to string[2]
+  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: 0x0190   | offset to string[0]
+  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: 0x0188   | offset to string[1]
+  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x017C    | offset to string[2]
 
 string (AnnotatedBinary.Foo.names):
-  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x0187 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
-  +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of string
+  +0x018C | 62 6F 62                | char[3]      | bob                           | string literal
+  +0x018F | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x0199 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x019A | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x019A | 00 00                   | uint8_t[2]   | ..                            | padding
 
 string (AnnotatedBinary.Foo.alice):
-  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01A7 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.bob):
-  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01B3 | 00                      | char         | 0x00 (0)                      | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
-  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                 | ERROR: length of vector (# items). Longer than the binary.
+  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                | ERROR: length of vector (# items). Longer than the binary.
 
 unknown (no known references):
-  +0x01B8 | 09 00 08 00 07 00 01 00 | ?uint8_t[9]  | ........                       | WARN: nothing refers to this section.
+  +0x01B8 | 09 00 08 00 07 00 01 00 | ?uint8_t[9]  | ........                      | WARN: nothing refers to this section.
   +0x01C0 | 02                      |              | .

--- a/tests/annotated_binary/tests/invalid_vector_strings_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_strings_cut_short.afb
@@ -4,152 +4,152 @@
 // Binary file: tests/invalid_vector_strings_cut_short.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                    | size of this vtable
-  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                   | size of referring table
-  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                   | size of this vtable
+  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                  | size of referring table
+  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x004B | 01                      | uint8_t      | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t      | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8       | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
-  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
-  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x004B | 01                      | uint8_t      | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t      | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8       | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8       | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8       | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: 0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: 0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: 0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: 0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: 0x01B4  | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: 0x01A8  | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: 0x019C  | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
+  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: 0x016C  | offset to field `names` (vector)
+  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x00B5 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
+  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                      | WARN: nothing refers to this section.
   +0x00F0 | 00 00 00 00 00 D8 8E 40 |              | .......@
   +0x00F8 | 00 00 00 00 6A FE FF FF |              | ....j...
   +0x0100 | 00 00 00 03             |              | ....
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
+  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                      | WARN: nothing refers to this section.
   +0x0118 | 00 00 00 00 00 C0 5E 40 |              | ......^@
   +0x0120 | 00 00 00 00 92 FE FF FF |              | ........
   +0x0128 | 00 00 00 01             |              | ....
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8       | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8       | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8       | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8       | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8       | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8       | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)   | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)  | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)   | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084) | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208) | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)  | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
-  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | ERROR: length of vector (# items). Longer than the binary.
+  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | ERROR: length of vector (# items). Longer than the binary.
 
 unknown (no known references):
-  +0x0170 | 20 00 00 00 14 00       | ?uint8_t[6]  |  .....                         | WARN: could be corrupted padding region.
+  +0x0170 | 20 00 00 00 14 00       | ?uint8_t[6]  |  .....                        | WARN: could be corrupted padding region.

--- a/tests/annotated_binary/tests/invalid_vector_structs_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_structs_cut_short.afb
@@ -4,143 +4,143 @@
 // Binary file: tests/invalid_vector_structs_cut_short.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                    | size of this vtable
-  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                   | size of referring table
-  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                   | size of this vtable
+  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                  | size of referring table
+  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x004B | 01                      | uint8_t      | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t      | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8       | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
-  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | ERROR: offset to field `names`. Invalid offset, points outside the binary.
-  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x004B | 01                      | uint8_t      | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t      | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8       | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8       | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8       | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: 0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: 0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: 0x01D4  | ERROR: offset to field `bars`. Invalid offset, points outside the binary.
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: 0x01CC  | ERROR: offset to field `bar_baz`. Invalid offset, points outside the binary.
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: 0x01B4  | ERROR: offset to field `accounts`. Invalid offset, points outside the binary.
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: 0x01A8  | ERROR: offset to field `bob`. Invalid offset, points outside the binary.
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: 0x019C  | ERROR: offset to field `alice`. Invalid offset, points outside the binary.
+  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: 0x016C  | ERROR: offset to field `names`. Invalid offset, points outside the binary.
+  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x00B5 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
+  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                      | WARN: nothing refers to this section.
   +0x00F0 | 00 00 00 00 00 D8 8E 40 |              | .......@
   +0x00F8 | 00 00 00 00 6A FE FF FF |              | ....j...
   +0x0100 | 00 00 00 03             |              | ....
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
+  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                      | WARN: nothing refers to this section.
   +0x0118 | 00 00 00 00 00 C0 5E 40 |              | ......^@
   +0x0120 | 00 00 00 00 92 FE FF FF |              | ........
   +0x0128 | 00 00 00 01             |              | ....
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8       | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8       | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8       | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8       | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8       | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8       | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | ERROR: length of vector (# items). Longer than the binary.
+  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | ERROR: length of vector (# items). Longer than the binary.
 
 unknown (no known references):
-  +0x0138 | 33 33 33 33 33 A3 45 40 | ?uint8_t[28] | 33333.E@                       | WARN: nothing refers to this section.
+  +0x0138 | 33 33 33 33 33 A3 45 40 | ?uint8_t[28] | 33333.E@                      | WARN: nothing refers to this section.
   +0x0140 | 7E 57 04 FF 5B 87 53 C0 |              | ~W..[.S.
   +0x0148 | 8D F0 F6 20 04 B6 42 40 |              | ... ..B@
   +0x0150 | 9F 77 63 41             |              | .wcA

--- a/tests/annotated_binary/tests/invalid_vector_tables_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_tables_cut_short.afb
@@ -4,207 +4,207 @@
 // Binary file: tests/invalid_vector_tables_cut_short.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                    | size of this vtable
-  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                   | size of referring table
-  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                   | size of this vtable
+  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                  | size of referring table
+  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x004B | 01                      | uint8_t      | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t      | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8       | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | offset to field `bar_baz` (union of type `Baz`)
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
-  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
-  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x004B | 01                      | uint8_t      | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t      | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8       | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8       | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8       | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: 0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: 0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: 0x01D4  | offset to field `bars` (vector)
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: 0x01CC  | offset to field `bar_baz` (union of type `Baz`)
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: 0x01B4  | offset to field `accounts` (vector)
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: 0x01A8  | offset to field `bob` (string)
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: 0x019C  | offset to field `alice` (string)
+  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: 0x016C  | offset to field `names` (vector)
+  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x00B5 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
+  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                      | WARN: nothing refers to this section.
   +0x00F0 | 00 00 00 00 00 D8 8E 40 |              | .......@
   +0x00F8 | 00 00 00 00 6A FE FF FF |              | ....j...
   +0x0100 | 00 00 00 03             |              | ....
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
+  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                      | WARN: nothing refers to this section.
   +0x0118 | 00 00 00 00 00 C0 5E 40 |              | ......^@
   +0x0120 | 00 00 00 00 92 FE FF FF |              | ........
   +0x0128 | 00 00 00 01             |              | ....
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8       | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8       | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8       | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8       | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8       | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8       | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)   | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)  | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)   | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084) | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208) | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)  | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
-  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: +0x0190   | offset to string[0]
-  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: +0x0188   | offset to string[1]
-  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x017C    | offset to string[2]
+  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: 0x0190   | offset to string[0]
+  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: 0x0188   | offset to string[1]
+  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x017C    | offset to string[2]
 
 string (AnnotatedBinary.Foo.names):
-  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x0187 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
-  +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of string
+  +0x018C | 62 6F 62                | char[3]      | bob                           | string literal
+  +0x018F | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x0199 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x019A | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x019A | 00 00                   | uint8_t[2]   | ..                            | padding
 
 string (AnnotatedBinary.Foo.alice):
-  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01A7 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.bob):
-  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01B3 | 00                      | char         | 0x00 (0)                      | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
-  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                 | length of vector (# items)
-  +0x01B8 | 09 00                   | uint16_t     | 0x0009 (9)                     | value[0]
-  +0x01BA | 08 00                   | uint16_t     | 0x0008 (8)                     | value[1]
-  +0x01BC | 07 00                   | uint16_t     | 0x0007 (7)                     | value[2]
-  +0x01BE | 01 00                   | uint16_t     | 0x0001 (1)                     | value[3]
-  +0x01C0 | 02 00                   | uint16_t     | 0x0002 (2)                     | value[4]
-  +0x01C2 | 03 00                   | uint16_t     | 0x0003 (3)                     | value[5]
-  +0x01C4 | 06 00                   | uint16_t     | 0x0006 (6)                     | value[6]
-  +0x01C6 | 05 00                   | uint16_t     | 0x0005 (5)                     | value[7]
-  +0x01C8 | 04 00                   | uint16_t     | 0x0004 (4)                     | value[8]
+  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                | length of vector (# items)
+  +0x01B8 | 09 00                   | uint16_t     | 0x0009 (9)                    | value[0]
+  +0x01BA | 08 00                   | uint16_t     | 0x0008 (8)                    | value[1]
+  +0x01BC | 07 00                   | uint16_t     | 0x0007 (7)                    | value[2]
+  +0x01BE | 01 00                   | uint16_t     | 0x0001 (1)                    | value[3]
+  +0x01C0 | 02 00                   | uint16_t     | 0x0002 (2)                    | value[4]
+  +0x01C2 | 03 00                   | uint16_t     | 0x0003 (3)                    | value[5]
+  +0x01C4 | 06 00                   | uint16_t     | 0x0006 (6)                    | value[6]
+  +0x01C6 | 05 00                   | uint16_t     | 0x0005 (5)                    | value[7]
+  +0x01C8 | 04 00                   | uint16_t     | 0x0004 (4)                    | value[8]
 
 padding:
-  +0x01CA | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x01CA | 00 00                   | uint8_t[2]   | ..                            | padding
 
 table (AnnotatedBinary.Baz):
-  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: +0x0292 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: 0x0292 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x01D0 | 00 00 00 03             | ?uint8_t[4]  | ....                           | WARN: could be corrupted padding region.
+  +0x01D0 | 00 00 00 03             | ?uint8_t[4]  | ....                          | WARN: could be corrupted padding region.
 
 vector (AnnotatedBinary.Foo.bars):
-  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | ERROR: length of vector (# items). Longer than the binary.
+  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | ERROR: length of vector (# items). Longer than the binary.
 
 unknown (no known references):
-  +0x01D8 | 44 00 00 00 10 00       | ?uint8_t[6]  | D.....                         | WARN: could be corrupted padding region.
+  +0x01D8 | 44 00 00 00 10 00       | ?uint8_t[6]  | D.....                        | WARN: could be corrupted padding region.

--- a/tests/annotated_binary/tests/invalid_vector_union_type_value.afb
+++ b/tests/annotated_binary/tests/invalid_vector_union_type_value.afb
@@ -4,290 +4,290 @@
 // Binary file: tests/invalid_vector_union_type_value.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]     | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]     | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2]  | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t    | 0x003A (58)                    | size of this vtable
-  +0x000C | 68 00                   | uint16_t    | 0x0068 (104)                   | size of referring table
-  +0x000E | 0C 00                   | VOffset16   | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16   | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16   | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16   | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16   | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16   | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16   | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16   | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16   | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16   | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16   | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16   | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16   | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16   | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16   | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16   | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16   | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16   | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16   | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16   | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16   | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16   | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16   | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16   | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16   | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16   | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16   | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t    | 0x003A (58)                   | size of this vtable
+  +0x000C | 68 00                   | uint16_t    | 0x0068 (104)                  | size of referring table
+  +0x000E | 0C 00                   | VOffset16   | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16   | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16   | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16   | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16   | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16   | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16   | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16   | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16   | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16   | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16   | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16   | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16   | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16   | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16   | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16   | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16   | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16   | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16   | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16   | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16   | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16   | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16   | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16   | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16   | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16   | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16   | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x004B | 01                      | uint8_t     | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t     | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8      | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8      | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8      | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t     | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t     | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t     | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1]  | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
-  +0x0078 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
-  +0x007C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: +0x01CC  | offset to field `bar_baz` (union of type `Baz`)
-  +0x0080 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
-  +0x0084 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
-  +0x0088 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
-  +0x008C | 0D 00 00 00             | uint32_t    | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
-  +0x0094 | A0 00 00 00             | UOffset32   | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32   | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32   | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32   | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x004B | 01                      | uint8_t     | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t     | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8      | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8      | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8      | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t    | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32   | 0x00000228 (552) Loc: 0x027C  | offset to field `bar` (table)
+  +0x0058 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t    | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t     | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t     | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t     | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1]  | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32   | 0x000001C8 (456) Loc: 0x023C  | offset to field `name` (string)
+  +0x0078 | 5C 01 00 00             | UOffset32   | 0x0000015C (348) Loc: 0x01D4  | offset to field `bars` (vector)
+  +0x007C | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: 0x01CC  | offset to field `bar_baz` (union of type `Baz`)
+  +0x0080 | 34 01 00 00             | UOffset32   | 0x00000134 (308) Loc: 0x01B4  | offset to field `accounts` (vector)
+  +0x0084 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: 0x01A8  | offset to field `bob` (string)
+  +0x0088 | 14 01 00 00             | UOffset32   | 0x00000114 (276) Loc: 0x019C  | offset to field `alice` (string)
+  +0x008C | 0D 00 00 00             | uint32_t    | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: 0x016C  | offset to field `names` (vector)
+  +0x0094 | A0 00 00 00             | UOffset32   | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32   | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32   | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t    | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]     | alice                          | string literal
-  +0x00B5 | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t    | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]     | alice                         | string literal
+  +0x00B5 | 00                      | char        | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2]  | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t    | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t    | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16   | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16   | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t    | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t    | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16   | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16   | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32   | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float       | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double      | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3]  | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32   | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float       | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double      | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3]  | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t     | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t     | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | ?uint8_t[4] | ,...                           | WARN: nothing refers to this section.
-  +0x00E0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | ?uint8_t[4] | ,...                          | WARN: nothing refers to this section.
+  +0x00E0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32   | 0xFFFFFED2 (-302) Loc: +0x0212 | offset to vtable
-  +0x00E8 | 00 80 23 44             | float       | 0x44238000 (654)               | table field `b` (Float)
-  +0x00EC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x00FC   | offset to field `c` (table)
-  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double      | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x00F8 | 00 00 00 00             | uint8_t[4]  | ....                           | padding
+  +0x00E4 | D2 FE FF FF             | SOffset32   | 0xFFFFFED2 (-302) Loc: 0x0212 | offset to vtable
+  +0x00E8 | 00 80 23 44             | float       | 0x44238000 (654)              | table field `b` (Float)
+  +0x00EC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: 0x00FC   | offset to field `c` (table)
+  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double      | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x00F8 | 00 00 00 00             | uint8_t[4]  | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x00FC | 6A FE FF FF             | SOffset32   | 0xFFFFFE6A (-406) Loc: +0x0292 | offset to vtable
-  +0x0100 | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x0103 | 03                      | uint8_t     | 0x03 (3)                       | table field `meal` (Byte)
+  +0x00FC | 6A FE FF FF             | SOffset32   | 0xFFFFFE6A (-406) Loc: 0x0292 | offset to vtable
+  +0x0100 | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x0103 | 03                      | uint8_t     | 0x03 (3)                      | table field `meal` (Byte)
 
 unknown (no known references):
-  +0x0104 | 04 00 04 00 04 00 00 00 | ?uint8_t[8] | ........                       | WARN: nothing refers to this section.
+  +0x0104 | 04 00 04 00 04 00 00 00 | ?uint8_t[8] | ........                      | WARN: nothing refers to this section.
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32   | 0xFFFFFEFA (-262) Loc: +0x0212 | offset to vtable
-  +0x0110 | 00 00 E4 43             | float       | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0114 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0124   | offset to field `c` (table)
-  +0x0118 | 00 00 00 00 00 C0 5E 40 | double      | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0120 | 00 00 00 00             | uint8_t[4]  | ....                           | padding
+  +0x010C | FA FE FF FF             | SOffset32   | 0xFFFFFEFA (-262) Loc: 0x0212 | offset to vtable
+  +0x0110 | 00 00 E4 43             | float       | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0114 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: 0x0124   | offset to field `c` (table)
+  +0x0118 | 00 00 00 00 00 C0 5E 40 | double      | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0120 | 00 00 00 00             | uint8_t[4]  | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0124 | 92 FE FF FF             | SOffset32   | 0xFFFFFE92 (-366) Loc: +0x0292 | offset to vtable
-  +0x0128 | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x012B | 01                      | uint8_t     | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0124 | 92 FE FF FF             | SOffset32   | 0xFFFFFE92 (-366) Loc: 0x0292 | offset to vtable
+  +0x0128 | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x012B | 01                      | uint8_t     | 0x01 (1)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8      | 0x01 (1)                       | value[0]
-  +0x0131 | FF                      | UType8      | 0xFF (255)                     | ERROR: value[1]. Invalid union type value.
-  +0x0132 | 01                      | UType8      | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8      | 0x01 (1)                      | value[0]
+  +0x0131 | FF                      | UType8      | 0xFF (255)                    | ERROR: value[1]. Invalid union type value.
+  +0x0132 | 01                      | UType8      | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double      | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double      | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double      | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double      | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double      | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double      | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0134 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                | length of vector (# items)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double      | 0x4045A33333333333 (43.275)   | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double      | 0xC053875BFF04577E (-78.115)  | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double      | 0x4042B60420F6F08D (37.422)   | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double      | 0xC05E85614163779F (-122.084) | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double      | 0xC04B35DC8323358F (-54.4208) | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double      | 0x400AC58793DD97F6 (3.34645)  | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
-  +0x0168 | 00 00 00 00             | uint8_t[4]  | ....                           | padding
+  +0x0168 | 00 00 00 00             | uint8_t[4]  | ....                          | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of vector (# items)
-  +0x0170 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0190   | offset to string[0]
-  +0x0174 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0188   | offset to string[1]
-  +0x0178 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x017C    | offset to string[2]
+  +0x016C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                | length of vector (# items)
+  +0x0170 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: 0x0190   | offset to string[0]
+  +0x0174 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: 0x0188   | offset to string[1]
+  +0x0178 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: 0x017C    | offset to string[2]
 
 string (AnnotatedBinary.Foo.names):
-  +0x017C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
-  +0x0187 | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x017C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                | length of string
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]     | charlie                       | string literal
+  +0x0187 | 00                      | char        | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0188 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]     | bob                            | string literal
-  +0x018F | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x0188 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                | length of string
+  +0x018C | 62 6F 62                | char[3]     | bob                           | string literal
+  +0x018F | 00                      | char        | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0190 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]     | alice                          | string literal
-  +0x0199 | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x0190 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                | length of string
+  +0x0194 | 61 6C 69 63 65          | char[5]     | alice                         | string literal
+  +0x0199 | 00                      | char        | 0x00 (0)                      | string terminator
 
 padding:
-  +0x019A | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x019A | 00 00                   | uint8_t[2]  | ..                            | padding
 
 string (AnnotatedBinary.Foo.alice):
-  +0x019C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
-  +0x01A7 | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x019C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                | length of string
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]     | charlie                       | string literal
+  +0x01A7 | 00                      | char        | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.bob):
-  +0x01A8 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]     | charlie                        | string literal
-  +0x01B3 | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x01A8 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                | length of string
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]     | charlie                       | string literal
+  +0x01B3 | 00                      | char        | 0x00 (0)                      | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
-  +0x01B4 | 09 00 00 00             | uint32_t    | 0x00000009 (9)                 | length of vector (# items)
-  +0x01B8 | 09 00                   | uint16_t    | 0x0009 (9)                     | value[0]
-  +0x01BA | 08 00                   | uint16_t    | 0x0008 (8)                     | value[1]
-  +0x01BC | 07 00                   | uint16_t    | 0x0007 (7)                     | value[2]
-  +0x01BE | 01 00                   | uint16_t    | 0x0001 (1)                     | value[3]
-  +0x01C0 | 02 00                   | uint16_t    | 0x0002 (2)                     | value[4]
-  +0x01C2 | 03 00                   | uint16_t    | 0x0003 (3)                     | value[5]
-  +0x01C4 | 06 00                   | uint16_t    | 0x0006 (6)                     | value[6]
-  +0x01C6 | 05 00                   | uint16_t    | 0x0005 (5)                     | value[7]
-  +0x01C8 | 04 00                   | uint16_t    | 0x0004 (4)                     | value[8]
+  +0x01B4 | 09 00 00 00             | uint32_t    | 0x00000009 (9)                | length of vector (# items)
+  +0x01B8 | 09 00                   | uint16_t    | 0x0009 (9)                    | value[0]
+  +0x01BA | 08 00                   | uint16_t    | 0x0008 (8)                    | value[1]
+  +0x01BC | 07 00                   | uint16_t    | 0x0007 (7)                    | value[2]
+  +0x01BE | 01 00                   | uint16_t    | 0x0001 (1)                    | value[3]
+  +0x01C0 | 02 00                   | uint16_t    | 0x0002 (2)                    | value[4]
+  +0x01C2 | 03 00                   | uint16_t    | 0x0003 (3)                    | value[5]
+  +0x01C4 | 06 00                   | uint16_t    | 0x0006 (6)                    | value[6]
+  +0x01C6 | 05 00                   | uint16_t    | 0x0005 (5)                    | value[7]
+  +0x01C8 | 04 00                   | uint16_t    | 0x0004 (4)                    | value[8]
 
 padding:
-  +0x01CA | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x01CA | 00 00                   | uint8_t[2]  | ..                            | padding
 
 table (AnnotatedBinary.Baz):
-  +0x01CC | 3A FF FF FF             | SOffset32   | 0xFFFFFF3A (-198) Loc: +0x0292 | offset to vtable
-  +0x01D0 | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x01D3 | 03                      | uint8_t     | 0x03 (3)                       | table field `meal` (Byte)
+  +0x01CC | 3A FF FF FF             | SOffset32   | 0xFFFFFF3A (-198) Loc: 0x0292 | offset to vtable
+  +0x01D0 | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x01D3 | 03                      | uint8_t     | 0x03 (3)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.bars):
-  +0x01D4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                 | length of vector (# items)
-  +0x01D8 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x021C   | offset to table[0]
-  +0x01DC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x01EC   | offset to table[1]
+  +0x01D4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                | length of vector (# items)
+  +0x01D8 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: 0x021C   | offset to table[0]
+  +0x01DC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: 0x01EC   | offset to table[1]
 
 padding:
-  +0x01E0 | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x01E0 | 00 00                   | uint8_t[2]  | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x01E2 | 0A 00                   | uint16_t    | 0x000A (10)                    | size of this vtable
-  +0x01E4 | 1A 00                   | uint16_t    | 0x001A (26)                    | size of referring table
-  +0x01E6 | 0C 00                   | VOffset16   | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x01E8 | 04 00                   | VOffset16   | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x01EA | 08 00                   | VOffset16   | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x01E2 | 0A 00                   | uint16_t    | 0x000A (10)                   | size of this vtable
+  +0x01E4 | 1A 00                   | uint16_t    | 0x001A (26)                   | size of referring table
+  +0x01E6 | 0C 00                   | VOffset16   | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x01E8 | 04 00                   | VOffset16   | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x01EA | 08 00                   | VOffset16   | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x01EC | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: +0x01E2   | offset to vtable
-  +0x01F0 | 00 80 23 44             | float       | 0x44238000 (654)               | table field `b` (Float)
-  +0x01F4 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x020C   | offset to field `c` (table)
-  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double      | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x0200 | 00 00 00 00 00 00       | uint8_t[6]  | ......                         | padding
+  +0x01EC | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: 0x01E2   | offset to vtable
+  +0x01F0 | 00 80 23 44             | float       | 0x44238000 (654)              | table field `b` (Float)
+  +0x01F4 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: 0x020C   | offset to field `c` (table)
+  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double      | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x0200 | 00 00 00 00 00 00       | uint8_t[6]  | ......                        | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0206 | 06 00                   | uint16_t    | 0x0006 (6)                     | size of this vtable
-  +0x0208 | 06 00                   | uint16_t    | 0x0006 (6)                     | size of referring table
-  +0x020A | 05 00                   | VOffset16   | 0x0005 (5)                     | offset to field `meal` (id: 0)
+  +0x0206 | 06 00                   | uint16_t    | 0x0006 (6)                    | size of this vtable
+  +0x0208 | 06 00                   | uint16_t    | 0x0006 (6)                    | size of referring table
+  +0x020A | 05 00                   | VOffset16   | 0x0005 (5)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x020C | 06 00 00 00             | SOffset32   | 0x00000006 (6) Loc: +0x0206    | offset to vtable
-  +0x0210 | 00                      | uint8_t[1]  | .                              | padding
-  +0x0211 | 03                      | uint8_t     | 0x03 (3)                       | table field `meal` (Byte)
+  +0x020C | 06 00 00 00             | SOffset32   | 0x00000006 (6) Loc: 0x0206    | offset to vtable
+  +0x0210 | 00                      | uint8_t[1]  | .                             | padding
+  +0x0211 | 03                      | uint8_t     | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Bar):
-  +0x0212 | 0A 00                   | uint16_t    | 0x000A (10)                    | size of this vtable
-  +0x0214 | 18 00                   | uint16_t    | 0x0018 (24)                    | size of referring table
-  +0x0216 | 0C 00                   | VOffset16   | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0218 | 04 00                   | VOffset16   | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x021A | 08 00                   | VOffset16   | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0212 | 0A 00                   | uint16_t    | 0x000A (10)                   | size of this vtable
+  +0x0214 | 18 00                   | uint16_t    | 0x0018 (24)                   | size of referring table
+  +0x0216 | 0C 00                   | VOffset16   | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0218 | 04 00                   | VOffset16   | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x021A | 08 00                   | VOffset16   | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x021C | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: +0x0212   | offset to vtable
-  +0x0220 | 00 00 E4 43             | float       | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0224 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0234   | offset to field `c` (table)
-  +0x0228 | 00 00 00 00 00 C0 5E 40 | double      | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0230 | 00 00 00 00             | uint8_t[4]  | ....                           | padding
+  +0x021C | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: 0x0212   | offset to vtable
+  +0x0220 | 00 00 E4 43             | float       | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0224 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: 0x0234   | offset to field `c` (table)
+  +0x0228 | 00 00 00 00 00 C0 5E 40 | double      | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0230 | 00 00 00 00             | uint8_t[4]  | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0234 | A2 FF FF FF             | SOffset32   | 0xFFFFFFA2 (-94) Loc: +0x0292  | offset to vtable
-  +0x0238 | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x023B | 01                      | uint8_t     | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0234 | A2 FF FF FF             | SOffset32   | 0xFFFFFFA2 (-94) Loc: 0x0292  | offset to vtable
+  +0x0238 | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x023B | 01                      | uint8_t     | 0x01 (1)                      | table field `meal` (Byte)
 
 string (AnnotatedBinary.Foo.name):
-  +0x023C | 2F 00 00 00             | uint32_t    | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]    | This is                        | string literal
+  +0x023C | 2F 00 00 00             | uint32_t    | 0x0000002F (47)               | length of string
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]    | This is                       | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |             | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |             | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |             |  show ho
   +0x0260 | 77 20 69 74 20 62 72 65 |             | w it bre
   +0x0268 | 61 6B 73 20 75 70 2E    |             | aks up.
-  +0x026F | 00                      | char        | 0x00 (0)                       | string terminator
+  +0x026F | 00                      | char        | 0x00 (0)                      | string terminator
 
 padding:
-  +0x0270 | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x0270 | 00 00                   | uint8_t[2]  | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x0272 | 0A 00                   | uint16_t    | 0x000A (10)                    | size of this vtable
-  +0x0274 | 16 00                   | uint16_t    | 0x0016 (22)                    | size of referring table
-  +0x0276 | 0C 00                   | VOffset16   | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0278 | 04 00                   | VOffset16   | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x027A | 08 00                   | VOffset16   | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0272 | 0A 00                   | uint16_t    | 0x000A (10)                   | size of this vtable
+  +0x0274 | 16 00                   | uint16_t    | 0x0016 (22)                   | size of referring table
+  +0x0276 | 0C 00                   | VOffset16   | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0278 | 04 00                   | VOffset16   | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x027A | 08 00                   | VOffset16   | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x027C | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: +0x0272   | offset to vtable
-  +0x0280 | 65 20 71 49             | float       | 0x49712065 (987654)            | table field `b` (Float)
-  +0x0284 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0298   | offset to field `c` (table)
-  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double      | 0x40FE240C9FBE76C9 (123457)    | table field `a` (Double)
-  +0x0290 | 00 00                   | uint8_t[2]  | ..                             | padding
+  +0x027C | 0A 00 00 00             | SOffset32   | 0x0000000A (10) Loc: 0x0272   | offset to vtable
+  +0x0280 | 65 20 71 49             | float       | 0x49712065 (987654)           | table field `b` (Float)
+  +0x0284 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: 0x0298   | offset to field `c` (table)
+  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double      | 0x40FE240C9FBE76C9 (123457)   | table field `a` (Double)
+  +0x0290 | 00 00                   | uint8_t[2]  | ..                            | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0292 | 06 00                   | uint16_t    | 0x0006 (6)                     | size of this vtable
-  +0x0294 | 08 00                   | uint16_t    | 0x0008 (8)                     | size of referring table
-  +0x0296 | 07 00                   | VOffset16   | 0x0007 (7)                     | offset to field `meal` (id: 0)
+  +0x0292 | 06 00                   | uint16_t    | 0x0006 (6)                    | size of this vtable
+  +0x0294 | 08 00                   | uint16_t    | 0x0008 (8)                    | size of referring table
+  +0x0296 | 07 00                   | VOffset16   | 0x0007 (7)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x0298 | 06 00 00 00             | SOffset32   | 0x00000006 (6) Loc: +0x0292    | offset to vtable
-  +0x029C | 00 00 00                | uint8_t[3]  | ...                            | padding
-  +0x029F | 01                      | uint8_t     | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0298 | 06 00 00 00             | SOffset32   | 0x00000006 (6) Loc: 0x0292    | offset to vtable
+  +0x029C | 00 00 00                | uint8_t[3]  | ...                           | padding
+  +0x029F | 01                      | uint8_t     | 0x01 (1)                      | table field `meal` (Byte)

--- a/tests/annotated_binary/tests/invalid_vector_unions_cut_short.afb
+++ b/tests/annotated_binary/tests/invalid_vector_unions_cut_short.afb
@@ -4,207 +4,207 @@
 // Binary file: tests/invalid_vector_unions_cut_short.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                    | size of this vtable
-  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                   | size of referring table
-  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                   | size of this vtable
+  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                  | size of referring table
+  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x004B | 01                      | uint8_t      | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t      | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8       | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | offset to field `bar_baz` (union of type `Baz`)
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
-  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
-  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x004B | 01                      | uint8_t      | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t      | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8       | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8       | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8       | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: 0x027C  | ERROR: offset to field `bar`. Invalid offset, points outside the binary.
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: 0x023C  | ERROR: offset to field `name`. Invalid offset, points outside the binary.
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: 0x01D4  | offset to field `bars` (vector)
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: 0x01CC  | offset to field `bar_baz` (union of type `Baz`)
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: 0x01B4  | offset to field `accounts` (vector)
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: 0x01A8  | offset to field `bob` (string)
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: 0x019C  | offset to field `alice` (string)
+  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: 0x016C  | offset to field `names` (vector)
+  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x00B5 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                       | WARN: nothing refers to this section.
+  +0x00E8 | 00 80 23 44 10 00 00 00 | ?uint8_t[28] | ..#D....                      | WARN: nothing refers to this section.
   +0x00F0 | 00 00 00 00 00 D8 8E 40 |              | .......@
   +0x00F8 | 00 00 00 00 6A FE FF FF |              | ....j...
   +0x0100 | 00 00 00 03             |              | ....
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: 0x0212 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                       | WARN: nothing refers to this section.
+  +0x0110 | 00 00 E4 43 10 00 00 00 | ?uint8_t[28] | ...C....                      | WARN: nothing refers to this section.
   +0x0118 | 00 00 00 00 00 C0 5E 40 |              | ......^@
   +0x0120 | 00 00 00 00 92 FE FF FF |              | ........
   +0x0128 | 00 00 00 01             |              | ....
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8       | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8       | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8       | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8       | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8       | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8       | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)   | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)  | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)   | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084) | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208) | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)  | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
-  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: +0x0190   | offset to string[0]
-  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: +0x0188   | offset to string[1]
-  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x017C    | offset to string[2]
+  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: 0x0190   | offset to string[0]
+  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: 0x0188   | offset to string[1]
+  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x017C    | offset to string[2]
 
 string (AnnotatedBinary.Foo.names):
-  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x0187 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
-  +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of string
+  +0x018C | 62 6F 62                | char[3]      | bob                           | string literal
+  +0x018F | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x0199 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x019A | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x019A | 00 00                   | uint8_t[2]   | ..                            | padding
 
 string (AnnotatedBinary.Foo.alice):
-  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01A7 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.bob):
-  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01B3 | 00                      | char         | 0x00 (0)                      | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
-  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                 | length of vector (# items)
-  +0x01B8 | 09 00                   | uint16_t     | 0x0009 (9)                     | value[0]
-  +0x01BA | 08 00                   | uint16_t     | 0x0008 (8)                     | value[1]
-  +0x01BC | 07 00                   | uint16_t     | 0x0007 (7)                     | value[2]
-  +0x01BE | 01 00                   | uint16_t     | 0x0001 (1)                     | value[3]
-  +0x01C0 | 02 00                   | uint16_t     | 0x0002 (2)                     | value[4]
-  +0x01C2 | 03 00                   | uint16_t     | 0x0003 (3)                     | value[5]
-  +0x01C4 | 06 00                   | uint16_t     | 0x0006 (6)                     | value[6]
-  +0x01C6 | 05 00                   | uint16_t     | 0x0005 (5)                     | value[7]
-  +0x01C8 | 04 00                   | uint16_t     | 0x0004 (4)                     | value[8]
+  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                | length of vector (# items)
+  +0x01B8 | 09 00                   | uint16_t     | 0x0009 (9)                    | value[0]
+  +0x01BA | 08 00                   | uint16_t     | 0x0008 (8)                    | value[1]
+  +0x01BC | 07 00                   | uint16_t     | 0x0007 (7)                    | value[2]
+  +0x01BE | 01 00                   | uint16_t     | 0x0001 (1)                    | value[3]
+  +0x01C0 | 02 00                   | uint16_t     | 0x0002 (2)                    | value[4]
+  +0x01C2 | 03 00                   | uint16_t     | 0x0003 (3)                    | value[5]
+  +0x01C4 | 06 00                   | uint16_t     | 0x0006 (6)                    | value[6]
+  +0x01C6 | 05 00                   | uint16_t     | 0x0005 (5)                    | value[7]
+  +0x01C8 | 04 00                   | uint16_t     | 0x0004 (4)                    | value[8]
 
 padding:
-  +0x01CA | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x01CA | 00 00                   | uint8_t[2]   | ..                            | padding
 
 table (AnnotatedBinary.Baz):
-  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: +0x0292 | ERROR: offset to vtable. Invalid offset, points outside the binary.
+  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: 0x0292 | ERROR: offset to vtable. Invalid offset, points outside the binary.
 
 unknown (no known references):
-  +0x01D0 | 00 00 00 03             | ?uint8_t[4]  | ....                           | WARN: could be corrupted padding region.
+  +0x01D0 | 00 00 00 03             | ?uint8_t[4]  | ....                          | WARN: could be corrupted padding region.
 
 vector (AnnotatedBinary.Foo.bars):
-  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | ERROR: length of vector (# items). Longer than the binary.
+  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | ERROR: length of vector (# items). Longer than the binary.
 
 unknown (no known references):
-  +0x01D8 | 44 00 00 00 10 00       | ?uint8_t[6]  | D.....                         | WARN: could be corrupted padding region.
+  +0x01D8 | 44 00 00 00 10 00       | ?uint8_t[6]  | D.....                        | WARN: could be corrupted padding region.

--- a/tests/annotated_binary/tests/invalid_vtable_field_offset.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_field_offset.afb
@@ -4,283 +4,283 @@
 // Binary file: tests/invalid_vtable_field_offset.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                    | size of this vtable
-  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                   | size of referring table
-  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | FF FF                   | VOffset16    | 0xFFFF (65535)                 | ERROR: offset to field `bar` (id: 4). Invalid offset, points outside the binary.
-  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                   | offset to field `charlie` (id: 26)
-  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                   | offset to unknown field (id: 26)
+  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                   | size of this vtable
+  +0x000C | 68 00                   | uint16_t     | 0x0068 (104)                  | size of referring table
+  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | FF FF                   | VOffset16    | 0xFFFF (65535)                | ERROR: offset to field `bar` (id: 4). Invalid offset, points outside the binary.
+  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                  | offset to field `charlie` (id: 26)
+  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                  | offset to unknown field (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x004B | 01                      | uint8_t      | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t      | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8       | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | ?uint8_t[4]  | (...                           | WARN: nothing refers to this section.
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | offset to field `bar_baz` (union of type `Baz`)
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
-  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
-  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x004B | 01                      | uint8_t      | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t      | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8       | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8       | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8       | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | ?uint8_t[4]  | (...                          | WARN: nothing refers to this section.
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: 0x023C  | offset to field `name` (string)
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: 0x01D4  | offset to field `bars` (vector)
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: 0x01CC  | offset to field `bar_baz` (union of type `Baz`)
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: 0x01B4  | offset to field `accounts` (vector)
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: 0x01A8  | offset to field `bob` (string)
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: 0x019C  | offset to field `alice` (string)
+  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: 0x016C  | offset to field `names` (vector)
+  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x00B5 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | offset to vtable
-  +0x00E8 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00EC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x00FC   | offset to field `c` (table)
-  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x00F8 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: 0x0212 | offset to vtable
+  +0x00E8 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00EC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x00FC   | offset to field `c` (table)
+  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x00F8 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x00FC | 6A FE FF FF             | SOffset32    | 0xFFFFFE6A (-406) Loc: +0x0292 | offset to vtable
-  +0x0100 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x0103 | 03                      | uint8_t      | 0x03 (3)                       | table field `meal` (Byte)
+  +0x00FC | 6A FE FF FF             | SOffset32    | 0xFFFFFE6A (-406) Loc: 0x0292 | offset to vtable
+  +0x0100 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x0103 | 03                      | uint8_t      | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | offset to vtable
-  +0x0110 | 00 00 E4 43             | float        | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0114 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x0124   | offset to field `c` (table)
-  +0x0118 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0120 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: 0x0212 | offset to vtable
+  +0x0110 | 00 00 E4 43             | float        | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0114 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x0124   | offset to field `c` (table)
+  +0x0118 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0120 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0124 | 92 FE FF FF             | SOffset32    | 0xFFFFFE92 (-366) Loc: +0x0292 | offset to vtable
-  +0x0128 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x012B | 01                      | uint8_t      | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0124 | 92 FE FF FF             | SOffset32    | 0xFFFFFE92 (-366) Loc: 0x0292 | offset to vtable
+  +0x0128 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x012B | 01                      | uint8_t      | 0x01 (1)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8       | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8       | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8       | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8       | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8       | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8       | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)   | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)  | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)   | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084) | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208) | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)  | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
-  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: +0x0190   | offset to string[0]
-  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: +0x0188   | offset to string[1]
-  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x017C    | offset to string[2]
+  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: 0x0190   | offset to string[0]
+  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: 0x0188   | offset to string[1]
+  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x017C    | offset to string[2]
 
 string (AnnotatedBinary.Foo.names):
-  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x0187 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
-  +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of string
+  +0x018C | 62 6F 62                | char[3]      | bob                           | string literal
+  +0x018F | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x0199 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x019A | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x019A | 00 00                   | uint8_t[2]   | ..                            | padding
 
 string (AnnotatedBinary.Foo.alice):
-  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01A7 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.bob):
-  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01B3 | 00                      | char         | 0x00 (0)                      | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
-  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                 | length of vector (# items)
-  +0x01B8 | 09 00                   | uint16_t     | 0x0009 (9)                     | value[0]
-  +0x01BA | 08 00                   | uint16_t     | 0x0008 (8)                     | value[1]
-  +0x01BC | 07 00                   | uint16_t     | 0x0007 (7)                     | value[2]
-  +0x01BE | 01 00                   | uint16_t     | 0x0001 (1)                     | value[3]
-  +0x01C0 | 02 00                   | uint16_t     | 0x0002 (2)                     | value[4]
-  +0x01C2 | 03 00                   | uint16_t     | 0x0003 (3)                     | value[5]
-  +0x01C4 | 06 00                   | uint16_t     | 0x0006 (6)                     | value[6]
-  +0x01C6 | 05 00                   | uint16_t     | 0x0005 (5)                     | value[7]
-  +0x01C8 | 04 00                   | uint16_t     | 0x0004 (4)                     | value[8]
+  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                | length of vector (# items)
+  +0x01B8 | 09 00                   | uint16_t     | 0x0009 (9)                    | value[0]
+  +0x01BA | 08 00                   | uint16_t     | 0x0008 (8)                    | value[1]
+  +0x01BC | 07 00                   | uint16_t     | 0x0007 (7)                    | value[2]
+  +0x01BE | 01 00                   | uint16_t     | 0x0001 (1)                    | value[3]
+  +0x01C0 | 02 00                   | uint16_t     | 0x0002 (2)                    | value[4]
+  +0x01C2 | 03 00                   | uint16_t     | 0x0003 (3)                    | value[5]
+  +0x01C4 | 06 00                   | uint16_t     | 0x0006 (6)                    | value[6]
+  +0x01C6 | 05 00                   | uint16_t     | 0x0005 (5)                    | value[7]
+  +0x01C8 | 04 00                   | uint16_t     | 0x0004 (4)                    | value[8]
 
 padding:
-  +0x01CA | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x01CA | 00 00                   | uint8_t[2]   | ..                            | padding
 
 table (AnnotatedBinary.Baz):
-  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: +0x0292 | offset to vtable
-  +0x01D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x01D3 | 03                      | uint8_t      | 0x03 (3)                       | table field `meal` (Byte)
+  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: 0x0292 | offset to vtable
+  +0x01D0 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x01D3 | 03                      | uint8_t      | 0x03 (3)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.bars):
-  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | length of vector (# items)
-  +0x01D8 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x021C   | offset to table[0]
-  +0x01DC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x01EC   | offset to table[1]
+  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | length of vector (# items)
+  +0x01D8 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x021C   | offset to table[0]
+  +0x01DC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x01EC   | offset to table[1]
 
 padding:
-  +0x01E0 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x01E0 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x01E2 | 0A 00                   | uint16_t     | 0x000A (10)                    | size of this vtable
-  +0x01E4 | 1A 00                   | uint16_t     | 0x001A (26)                    | size of referring table
-  +0x01E6 | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x01E8 | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x01EA | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x01E2 | 0A 00                   | uint16_t     | 0x000A (10)                   | size of this vtable
+  +0x01E4 | 1A 00                   | uint16_t     | 0x001A (26)                   | size of referring table
+  +0x01E6 | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x01E8 | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x01EA | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x01EC | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: +0x01E2   | offset to vtable
-  +0x01F0 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x01F4 | 18 00 00 00             | UOffset32    | 0x00000018 (24) Loc: +0x020C   | offset to field `c` (table)
-  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x0200 | 00 00 00 00 00 00       | uint8_t[6]   | ......                         | padding
+  +0x01EC | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: 0x01E2   | offset to vtable
+  +0x01F0 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x01F4 | 18 00 00 00             | UOffset32    | 0x00000018 (24) Loc: 0x020C   | offset to field `c` (table)
+  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x0200 | 00 00 00 00 00 00       | uint8_t[6]   | ......                        | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0206 | 06 00                   | uint16_t     | 0x0006 (6)                     | size of this vtable
-  +0x0208 | 06 00                   | uint16_t     | 0x0006 (6)                     | size of referring table
-  +0x020A | 05 00                   | VOffset16    | 0x0005 (5)                     | offset to field `meal` (id: 0)
+  +0x0206 | 06 00                   | uint16_t     | 0x0006 (6)                    | size of this vtable
+  +0x0208 | 06 00                   | uint16_t     | 0x0006 (6)                    | size of referring table
+  +0x020A | 05 00                   | VOffset16    | 0x0005 (5)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x020C | 06 00 00 00             | SOffset32    | 0x00000006 (6) Loc: +0x0206    | offset to vtable
-  +0x0210 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0211 | 03                      | uint8_t      | 0x03 (3)                       | table field `meal` (Byte)
+  +0x020C | 06 00 00 00             | SOffset32    | 0x00000006 (6) Loc: 0x0206    | offset to vtable
+  +0x0210 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0211 | 03                      | uint8_t      | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Bar):
-  +0x0212 | 0A 00                   | uint16_t     | 0x000A (10)                    | size of this vtable
-  +0x0214 | 18 00                   | uint16_t     | 0x0018 (24)                    | size of referring table
-  +0x0216 | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0218 | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x021A | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0212 | 0A 00                   | uint16_t     | 0x000A (10)                   | size of this vtable
+  +0x0214 | 18 00                   | uint16_t     | 0x0018 (24)                   | size of referring table
+  +0x0216 | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0218 | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x021A | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x021C | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: +0x0212   | offset to vtable
-  +0x0220 | 00 00 E4 43             | float        | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0224 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x0234   | offset to field `c` (table)
-  +0x0228 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0230 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x021C | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: 0x0212   | offset to vtable
+  +0x0220 | 00 00 E4 43             | float        | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0224 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x0234   | offset to field `c` (table)
+  +0x0228 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0230 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0234 | A2 FF FF FF             | SOffset32    | 0xFFFFFFA2 (-94) Loc: +0x0292  | offset to vtable
-  +0x0238 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x023B | 01                      | uint8_t      | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0234 | A2 FF FF FF             | SOffset32    | 0xFFFFFFA2 (-94) Loc: 0x0292  | offset to vtable
+  +0x0238 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x023B | 01                      | uint8_t      | 0x01 (1)                      | table field `meal` (Byte)
 
 string (AnnotatedBinary.Foo.name):
-  +0x023C | 2F 00 00 00             | uint32_t     | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                        | string literal
+  +0x023C | 2F 00 00 00             | uint32_t     | 0x0000002F (47)               | length of string
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                       | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |              | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |              | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |              |  show ho
   +0x0260 | 77 20 69 74 20 62 72 65 |              | w it bre
   +0x0268 | 61 6B 73 20 75 70 2E    |              | aks up.
-  +0x026F | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x026F | 00                      | char         | 0x00 (0)                      | string terminator
 
 unknown (no known references):
-  +0x0270 | 00 00 0A 00 16 00 0C 00 | ?uint8_t[34] | ........                       | WARN: nothing refers to this section.
+  +0x0270 | 00 00 0A 00 16 00 0C 00 | ?uint8_t[34] | ........                      | WARN: nothing refers to this section.
   +0x0278 | 04 00 08 00 0A 00 00 00 |              | ........
   +0x0280 | 65 20 71 49 14 00 00 00 |              | e qI....
   +0x0288 | C9 76 BE 9F 0C 24 FE 40 |              | .v...$.@
   +0x0290 | 00 00                   |              | ..
 
 vtable (AnnotatedBinary.Baz):
-  +0x0292 | 06 00                   | uint16_t     | 0x0006 (6)                     | size of this vtable
-  +0x0294 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of referring table
-  +0x0296 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `meal` (id: 0)
+  +0x0292 | 06 00                   | uint16_t     | 0x0006 (6)                    | size of this vtable
+  +0x0294 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of referring table
+  +0x0296 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `meal` (id: 0)
 
 unknown (no known references):
-  +0x0298 | 06 00 00 00 00 00 00 01 | ?uint8_t[8]  | ........                       | WARN: nothing refers to this section.
+  +0x0298 | 06 00 00 00 00 00 00 01 | ?uint8_t[8]  | ........                      | WARN: nothing refers to this section.

--- a/tests/annotated_binary/tests/invalid_vtable_ref_table_size.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_ref_table_size.afb
@@ -4,78 +4,78 @@
 // Binary file: tests/invalid_vtable_ref_table_size.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]      | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                    | size of this vtable
-  +0x000C | FF FF                   | uint16_t     | 0xFFFF (65535)                 | ERROR: size of referring table. Longer than the binary.
-  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t     | 0x003A (58)                   | size of this vtable
+  +0x000C | FF FF                   | uint16_t     | 0xFFFF (65535)                | ERROR: size of referring table. Longer than the binary.
+  +0x000E | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16    | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16    | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16    | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16    | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16    | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16    | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16    | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16    | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16    | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16    | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16    | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16    | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16    | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16    | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16    | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16    | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16    | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16    | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16    | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16    | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x004B | 01                      | uint8_t      | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t      | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8       | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8       | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8       | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t      | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t      | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t      | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
-  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
-  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: +0x01CC  | offset to field `bar_baz` (union of type `Baz`)
-  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
-  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
-  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
-  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
-  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
-  +0x00AC | 05 00 00 00 61 6C 69 63 | uint8_t[500] | ....alic                       | padding
+  +0x0044 | 3A 00 00 00             | SOffset32    | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x004B | 01                      | uint8_t      | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t      | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8       | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8       | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8       | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t     | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32    | 0x00000228 (552) Loc: 0x027C  | offset to field `bar` (table)
+  +0x0058 | 01 00 00 00             | uint32_t     | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t     | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t     | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t     | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t      | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t      | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t      | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32    | 0x000001C8 (456) Loc: 0x023C  | offset to field `name` (string)
+  +0x0078 | 5C 01 00 00             | UOffset32    | 0x0000015C (348) Loc: 0x01D4  | offset to field `bars` (vector)
+  +0x007C | 50 01 00 00             | UOffset32    | 0x00000150 (336) Loc: 0x01CC  | offset to field `bar_baz` (union of type `Baz`)
+  +0x0080 | 34 01 00 00             | UOffset32    | 0x00000134 (308) Loc: 0x01B4  | offset to field `accounts` (vector)
+  +0x0084 | 24 01 00 00             | UOffset32    | 0x00000124 (292) Loc: 0x01A8  | offset to field `bob` (string)
+  +0x0088 | 14 01 00 00             | UOffset32    | 0x00000114 (276) Loc: 0x019C  | offset to field `alice` (string)
+  +0x008C | 0D 00 00 00             | uint32_t     | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32    | 0x000000DC (220) Loc: 0x016C  | offset to field `names` (vector)
+  +0x0094 | A0 00 00 00             | UOffset32    | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32    | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32    | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32    | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32    | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
+  +0x00AC | 05 00 00 00 61 6C 69 63 | uint8_t[500] | ....alic                      | padding
   +0x00B4 | 65 00 00 00 08 00 13 00 |              | e.......
   +0x00BC | 08 00 04 00 08 00 00 00 |              | ........
   +0x00C4 | 00 80 23 44 00 00 00 00 |              | ..#D....
@@ -140,221 +140,221 @@ root_table (AnnotatedBinary.Foo):
   +0x029C | 00 00 00 01             |              | ....
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x00B5 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x00B5 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t     | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32    | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double       | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3]   | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t      | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32    | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32    | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: +0x0212 | offset to vtable
-  +0x00E8 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x00EC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x00FC   | offset to field `c` (table)
-  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x00F8 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x00E4 | D2 FE FF FF             | SOffset32    | 0xFFFFFED2 (-302) Loc: 0x0212 | offset to vtable
+  +0x00E8 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x00EC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x00FC   | offset to field `c` (table)
+  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x00F8 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x00FC | 6A FE FF FF             | SOffset32    | 0xFFFFFE6A (-406) Loc: +0x0292 | offset to vtable
-  +0x0100 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x0103 | 03                      | uint8_t      | 0x03 (3)                       | table field `meal` (Byte)
+  +0x00FC | 6A FE FF FF             | SOffset32    | 0xFFFFFE6A (-406) Loc: 0x0292 | offset to vtable
+  +0x0100 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x0103 | 03                      | uint8_t      | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t     | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32    | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: +0x0212 | offset to vtable
-  +0x0110 | 00 00 E4 43             | float        | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0114 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x0124   | offset to field `c` (table)
-  +0x0118 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0120 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x010C | FA FE FF FF             | SOffset32    | 0xFFFFFEFA (-262) Loc: 0x0212 | offset to vtable
+  +0x0110 | 00 00 E4 43             | float        | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0114 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x0124   | offset to field `c` (table)
+  +0x0118 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0120 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0124 | 92 FE FF FF             | SOffset32    | 0xFFFFFE92 (-366) Loc: +0x0292 | offset to vtable
-  +0x0128 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x012B | 01                      | uint8_t      | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0124 | 92 FE FF FF             | SOffset32    | 0xFFFFFE92 (-366) Loc: 0x0292 | offset to vtable
+  +0x0128 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x012B | 01                      | uint8_t      | 0x01 (1)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8       | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8       | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8       | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8       | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8       | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8       | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0134 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double       | 0x4045A33333333333 (43.275)   | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double       | 0xC053875BFF04577E (-78.115)  | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double       | 0x4042B60420F6F08D (37.422)   | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double       | 0xC05E85614163779F (-122.084) | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double       | 0xC04B35DC8323358F (-54.4208) | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double       | 0x400AC58793DD97F6 (3.34645)  | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
-  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x0168 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of vector (# items)
-  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: +0x0190   | offset to string[0]
-  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: +0x0188   | offset to string[1]
-  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: +0x017C    | offset to string[2]
+  +0x016C | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of vector (# items)
+  +0x0170 | 20 00 00 00             | UOffset32    | 0x00000020 (32) Loc: 0x0190   | offset to string[0]
+  +0x0174 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: 0x0188   | offset to string[1]
+  +0x0178 | 04 00 00 00             | UOffset32    | 0x00000004 (4) Loc: 0x017C    | offset to string[2]
 
 string (AnnotatedBinary.Foo.names):
-  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x0187 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x017C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x0187 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]      | bob                            | string literal
-  +0x018F | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0188 | 03 00 00 00             | uint32_t     | 0x00000003 (3)                | length of string
+  +0x018C | 62 6F 62                | char[3]      | bob                           | string literal
+  +0x018F | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                          | string literal
-  +0x0199 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x0190 | 05 00 00 00             | uint32_t     | 0x00000005 (5)                | length of string
+  +0x0194 | 61 6C 69 63 65          | char[5]      | alice                         | string literal
+  +0x0199 | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x019A | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x019A | 00 00                   | uint8_t[2]   | ..                            | padding
 
 string (AnnotatedBinary.Foo.alice):
-  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01A7 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x019C | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01A7 | 00                      | char         | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.bob):
-  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                        | string literal
-  +0x01B3 | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x01A8 | 07 00 00 00             | uint32_t     | 0x00000007 (7)                | length of string
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]      | charlie                       | string literal
+  +0x01B3 | 00                      | char         | 0x00 (0)                      | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
-  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                 | length of vector (# items)
-  +0x01B8 | 09 00                   | uint16_t     | 0x0009 (9)                     | value[0]
-  +0x01BA | 08 00                   | uint16_t     | 0x0008 (8)                     | value[1]
-  +0x01BC | 07 00                   | uint16_t     | 0x0007 (7)                     | value[2]
-  +0x01BE | 01 00                   | uint16_t     | 0x0001 (1)                     | value[3]
-  +0x01C0 | 02 00                   | uint16_t     | 0x0002 (2)                     | value[4]
-  +0x01C2 | 03 00                   | uint16_t     | 0x0003 (3)                     | value[5]
-  +0x01C4 | 06 00                   | uint16_t     | 0x0006 (6)                     | value[6]
-  +0x01C6 | 05 00                   | uint16_t     | 0x0005 (5)                     | value[7]
-  +0x01C8 | 04 00                   | uint16_t     | 0x0004 (4)                     | value[8]
+  +0x01B4 | 09 00 00 00             | uint32_t     | 0x00000009 (9)                | length of vector (# items)
+  +0x01B8 | 09 00                   | uint16_t     | 0x0009 (9)                    | value[0]
+  +0x01BA | 08 00                   | uint16_t     | 0x0008 (8)                    | value[1]
+  +0x01BC | 07 00                   | uint16_t     | 0x0007 (7)                    | value[2]
+  +0x01BE | 01 00                   | uint16_t     | 0x0001 (1)                    | value[3]
+  +0x01C0 | 02 00                   | uint16_t     | 0x0002 (2)                    | value[4]
+  +0x01C2 | 03 00                   | uint16_t     | 0x0003 (3)                    | value[5]
+  +0x01C4 | 06 00                   | uint16_t     | 0x0006 (6)                    | value[6]
+  +0x01C6 | 05 00                   | uint16_t     | 0x0005 (5)                    | value[7]
+  +0x01C8 | 04 00                   | uint16_t     | 0x0004 (4)                    | value[8]
 
 padding:
-  +0x01CA | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x01CA | 00 00                   | uint8_t[2]   | ..                            | padding
 
 table (AnnotatedBinary.Baz):
-  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: +0x0292 | offset to vtable
-  +0x01D0 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x01D3 | 03                      | uint8_t      | 0x03 (3)                       | table field `meal` (Byte)
+  +0x01CC | 3A FF FF FF             | SOffset32    | 0xFFFFFF3A (-198) Loc: 0x0292 | offset to vtable
+  +0x01D0 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x01D3 | 03                      | uint8_t      | 0x03 (3)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.bars):
-  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                 | length of vector (# items)
-  +0x01D8 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: +0x021C   | offset to table[0]
-  +0x01DC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x01EC   | offset to table[1]
+  +0x01D4 | 02 00 00 00             | uint32_t     | 0x00000002 (2)                | length of vector (# items)
+  +0x01D8 | 44 00 00 00             | UOffset32    | 0x00000044 (68) Loc: 0x021C   | offset to table[0]
+  +0x01DC | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x01EC   | offset to table[1]
 
 padding:
-  +0x01E0 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x01E0 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x01E2 | 0A 00                   | uint16_t     | 0x000A (10)                    | size of this vtable
-  +0x01E4 | 1A 00                   | uint16_t     | 0x001A (26)                    | size of referring table
-  +0x01E6 | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x01E8 | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x01EA | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x01E2 | 0A 00                   | uint16_t     | 0x000A (10)                   | size of this vtable
+  +0x01E4 | 1A 00                   | uint16_t     | 0x001A (26)                   | size of referring table
+  +0x01E6 | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x01E8 | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x01EA | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x01EC | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: +0x01E2   | offset to vtable
-  +0x01F0 | 00 80 23 44             | float        | 0x44238000 (654)               | table field `b` (Float)
-  +0x01F4 | 18 00 00 00             | UOffset32    | 0x00000018 (24) Loc: +0x020C   | offset to field `c` (table)
-  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x0200 | 00 00 00 00 00 00       | uint8_t[6]   | ......                         | padding
+  +0x01EC | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: 0x01E2   | offset to vtable
+  +0x01F0 | 00 80 23 44             | float        | 0x44238000 (654)              | table field `b` (Float)
+  +0x01F4 | 18 00 00 00             | UOffset32    | 0x00000018 (24) Loc: 0x020C   | offset to field `c` (table)
+  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double       | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x0200 | 00 00 00 00 00 00       | uint8_t[6]   | ......                        | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0206 | 06 00                   | uint16_t     | 0x0006 (6)                     | size of this vtable
-  +0x0208 | 06 00                   | uint16_t     | 0x0006 (6)                     | size of referring table
-  +0x020A | 05 00                   | VOffset16    | 0x0005 (5)                     | offset to field `meal` (id: 0)
+  +0x0206 | 06 00                   | uint16_t     | 0x0006 (6)                    | size of this vtable
+  +0x0208 | 06 00                   | uint16_t     | 0x0006 (6)                    | size of referring table
+  +0x020A | 05 00                   | VOffset16    | 0x0005 (5)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x020C | 06 00 00 00             | SOffset32    | 0x00000006 (6) Loc: +0x0206    | offset to vtable
-  +0x0210 | 00                      | uint8_t[1]   | .                              | padding
-  +0x0211 | 03                      | uint8_t      | 0x03 (3)                       | table field `meal` (Byte)
+  +0x020C | 06 00 00 00             | SOffset32    | 0x00000006 (6) Loc: 0x0206    | offset to vtable
+  +0x0210 | 00                      | uint8_t[1]   | .                             | padding
+  +0x0211 | 03                      | uint8_t      | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Bar):
-  +0x0212 | 0A 00                   | uint16_t     | 0x000A (10)                    | size of this vtable
-  +0x0214 | 18 00                   | uint16_t     | 0x0018 (24)                    | size of referring table
-  +0x0216 | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0218 | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x021A | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0212 | 0A 00                   | uint16_t     | 0x000A (10)                   | size of this vtable
+  +0x0214 | 18 00                   | uint16_t     | 0x0018 (24)                   | size of referring table
+  +0x0216 | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0218 | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x021A | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x021C | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: +0x0212   | offset to vtable
-  +0x0220 | 00 00 E4 43             | float        | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0224 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: +0x0234   | offset to field `c` (table)
-  +0x0228 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0230 | 00 00 00 00             | uint8_t[4]   | ....                           | padding
+  +0x021C | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: 0x0212   | offset to vtable
+  +0x0220 | 00 00 E4 43             | float        | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0224 | 10 00 00 00             | UOffset32    | 0x00000010 (16) Loc: 0x0234   | offset to field `c` (table)
+  +0x0228 | 00 00 00 00 00 C0 5E 40 | double       | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0230 | 00 00 00 00             | uint8_t[4]   | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0234 | A2 FF FF FF             | SOffset32    | 0xFFFFFFA2 (-94) Loc: +0x0292  | offset to vtable
-  +0x0238 | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x023B | 01                      | uint8_t      | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0234 | A2 FF FF FF             | SOffset32    | 0xFFFFFFA2 (-94) Loc: 0x0292  | offset to vtable
+  +0x0238 | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x023B | 01                      | uint8_t      | 0x01 (1)                      | table field `meal` (Byte)
 
 string (AnnotatedBinary.Foo.name):
-  +0x023C | 2F 00 00 00             | uint32_t     | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                        | string literal
+  +0x023C | 2F 00 00 00             | uint32_t     | 0x0000002F (47)               | length of string
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]     | This is                       | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |              | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |              | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |              |  show ho
   +0x0260 | 77 20 69 74 20 62 72 65 |              | w it bre
   +0x0268 | 61 6B 73 20 75 70 2E    |              | aks up.
-  +0x026F | 00                      | char         | 0x00 (0)                       | string terminator
+  +0x026F | 00                      | char         | 0x00 (0)                      | string terminator
 
 padding:
-  +0x0270 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x0270 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x0272 | 0A 00                   | uint16_t     | 0x000A (10)                    | size of this vtable
-  +0x0274 | 16 00                   | uint16_t     | 0x0016 (22)                    | size of referring table
-  +0x0276 | 0C 00                   | VOffset16    | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0278 | 04 00                   | VOffset16    | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x027A | 08 00                   | VOffset16    | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0272 | 0A 00                   | uint16_t     | 0x000A (10)                   | size of this vtable
+  +0x0274 | 16 00                   | uint16_t     | 0x0016 (22)                   | size of referring table
+  +0x0276 | 0C 00                   | VOffset16    | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0278 | 04 00                   | VOffset16    | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x027A | 08 00                   | VOffset16    | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x027C | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: +0x0272   | offset to vtable
-  +0x0280 | 65 20 71 49             | float        | 0x49712065 (987654)            | table field `b` (Float)
-  +0x0284 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: +0x0298   | offset to field `c` (table)
-  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double       | 0x40FE240C9FBE76C9 (123457)    | table field `a` (Double)
-  +0x0290 | 00 00                   | uint8_t[2]   | ..                             | padding
+  +0x027C | 0A 00 00 00             | SOffset32    | 0x0000000A (10) Loc: 0x0272   | offset to vtable
+  +0x0280 | 65 20 71 49             | float        | 0x49712065 (987654)           | table field `b` (Float)
+  +0x0284 | 14 00 00 00             | UOffset32    | 0x00000014 (20) Loc: 0x0298   | offset to field `c` (table)
+  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double       | 0x40FE240C9FBE76C9 (123457)   | table field `a` (Double)
+  +0x0290 | 00 00                   | uint8_t[2]   | ..                            | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0292 | 06 00                   | uint16_t     | 0x0006 (6)                     | size of this vtable
-  +0x0294 | 08 00                   | uint16_t     | 0x0008 (8)                     | size of referring table
-  +0x0296 | 07 00                   | VOffset16    | 0x0007 (7)                     | offset to field `meal` (id: 0)
+  +0x0292 | 06 00                   | uint16_t     | 0x0006 (6)                    | size of this vtable
+  +0x0294 | 08 00                   | uint16_t     | 0x0008 (8)                    | size of referring table
+  +0x0296 | 07 00                   | VOffset16    | 0x0007 (7)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x0298 | 06 00 00 00             | SOffset32    | 0x00000006 (6) Loc: +0x0292    | offset to vtable
-  +0x029C | 00 00 00                | uint8_t[3]   | ...                            | padding
-  +0x029F | 01                      | uint8_t      | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0298 | 06 00 00 00             | SOffset32    | 0x00000006 (6) Loc: 0x0292    | offset to vtable
+  +0x029C | 00 00 00                | uint8_t[3]   | ...                           | padding
+  +0x029F | 01                      | uint8_t      | 0x01 (1)                      | table field `meal` (Byte)

--- a/tests/annotated_binary/tests/invalid_vtable_ref_table_size_short.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_ref_table_size_short.afb
@@ -4,294 +4,294 @@
 // Binary file: tests/invalid_vtable_ref_table_size_short.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: +0x0044   | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]    | ANNO                           | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x0044   | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]    | ANNO                          | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x0008 | 00 00                   | uint8_t[2] | ..                            | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 3A 00                   | uint16_t   | 0x003A (58)                    | size of this vtable
-  +0x000C | 01 00                   | uint16_t   | 0x0001 (1)                     | ERROR: size of referring table. Shorter than the minimum length: 
-  +0x000E | 0C 00                   | VOffset16  | 0x000C (12)                    | offset to field `counter` (id: 0)
-  +0x0010 | 07 00                   | VOffset16  | 0x0007 (7)                     | offset to field `healthy` (id: 1)
-  +0x0012 | 00 00                   | VOffset16  | 0x0000 (0)                     | offset to field `level` (id: 2) <defaults to 99> (Long)
-  +0x0014 | 08 00                   | VOffset16  | 0x0008 (8)                     | offset to field `meal` (id: 3)
-  +0x0016 | 10 00                   | VOffset16  | 0x0010 (16)                    | offset to field `bar` (id: 4)
-  +0x0018 | 14 00                   | VOffset16  | 0x0014 (20)                    | offset to field `home` (id: 5)
-  +0x001A | 30 00                   | VOffset16  | 0x0030 (48)                    | offset to field `name` (id: 6)
-  +0x001C | 34 00                   | VOffset16  | 0x0034 (52)                    | offset to field `bars` (id: 7)
-  +0x001E | 09 00                   | VOffset16  | 0x0009 (9)                     | offset to field `bar_baz_type` (id: 8)
-  +0x0020 | 38 00                   | VOffset16  | 0x0038 (56)                    | offset to field `bar_baz` (id: 9)
-  +0x0022 | 3C 00                   | VOffset16  | 0x003C (60)                    | offset to field `accounts` (id: 10)
-  +0x0024 | 40 00                   | VOffset16  | 0x0040 (64)                    | offset to field `bob` (id: 11)
-  +0x0026 | 44 00                   | VOffset16  | 0x0044 (68)                    | offset to field `alice` (id: 12)
-  +0x0028 | 00 00                   | VOffset16  | 0x0000 (0)                     | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
-  +0x002A | 00 00                   | VOffset16  | 0x0000 (0)                     | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
-  +0x002C | 48 00                   | VOffset16  | 0x0048 (72)                    | offset to field `just_i32` (id: 15)
-  +0x002E | 4C 00                   | VOffset16  | 0x004C (76)                    | offset to field `names` (id: 16)
-  +0x0030 | 50 00                   | VOffset16  | 0x0050 (80)                    | offset to field `points_of_interest` (id: 17)
-  +0x0032 | 54 00                   | VOffset16  | 0x0054 (84)                    | offset to field `foobars_type` (id: 18)
-  +0x0034 | 58 00                   | VOffset16  | 0x0058 (88)                    | offset to field `foobars` (id: 19)
-  +0x0036 | 0A 00                   | VOffset16  | 0x000A (10)                    | offset to field `measurement_type` (id: 20)
-  +0x0038 | 5C 00                   | VOffset16  | 0x005C (92)                    | offset to field `measurement` (id: 21)
-  +0x003A | 0B 00                   | VOffset16  | 0x000B (11)                    | offset to field `anything_type` (id: 22)
-  +0x003C | 60 00                   | VOffset16  | 0x0060 (96)                    | offset to field `anything` (id: 23)
-  +0x003E | 00 00                   | VOffset16  | 0x0000 (0)                     | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
-  +0x0040 | 00 00                   | VOffset16  | 0x0000 (0)                     | offset to field `teetotaler` (id: 25) <null> (Obj)
-  +0x0042 | 64 00                   | VOffset16  | 0x0064 (100)                   | offset to field `charlie` (id: 26)
+  +0x000A | 3A 00                   | uint16_t   | 0x003A (58)                   | size of this vtable
+  +0x000C | 01 00                   | uint16_t   | 0x0001 (1)                    | ERROR: size of referring table. Shorter than the minimum length: 
+  +0x000E | 0C 00                   | VOffset16  | 0x000C (12)                   | offset to field `counter` (id: 0)
+  +0x0010 | 07 00                   | VOffset16  | 0x0007 (7)                    | offset to field `healthy` (id: 1)
+  +0x0012 | 00 00                   | VOffset16  | 0x0000 (0)                    | offset to field `level` (id: 2) <defaults to 99> (Long)
+  +0x0014 | 08 00                   | VOffset16  | 0x0008 (8)                    | offset to field `meal` (id: 3)
+  +0x0016 | 10 00                   | VOffset16  | 0x0010 (16)                   | offset to field `bar` (id: 4)
+  +0x0018 | 14 00                   | VOffset16  | 0x0014 (20)                   | offset to field `home` (id: 5)
+  +0x001A | 30 00                   | VOffset16  | 0x0030 (48)                   | offset to field `name` (id: 6)
+  +0x001C | 34 00                   | VOffset16  | 0x0034 (52)                   | offset to field `bars` (id: 7)
+  +0x001E | 09 00                   | VOffset16  | 0x0009 (9)                    | offset to field `bar_baz_type` (id: 8)
+  +0x0020 | 38 00                   | VOffset16  | 0x0038 (56)                   | offset to field `bar_baz` (id: 9)
+  +0x0022 | 3C 00                   | VOffset16  | 0x003C (60)                   | offset to field `accounts` (id: 10)
+  +0x0024 | 40 00                   | VOffset16  | 0x0040 (64)                   | offset to field `bob` (id: 11)
+  +0x0026 | 44 00                   | VOffset16  | 0x0044 (68)                   | offset to field `alice` (id: 12)
+  +0x0028 | 00 00                   | VOffset16  | 0x0000 (0)                    | offset to field `maybe_i32` (id: 13) <defaults to 0> (Int)
+  +0x002A | 00 00                   | VOffset16  | 0x0000 (0)                    | offset to field `default_i32` (id: 14) <defaults to 42> (Int)
+  +0x002C | 48 00                   | VOffset16  | 0x0048 (72)                   | offset to field `just_i32` (id: 15)
+  +0x002E | 4C 00                   | VOffset16  | 0x004C (76)                   | offset to field `names` (id: 16)
+  +0x0030 | 50 00                   | VOffset16  | 0x0050 (80)                   | offset to field `points_of_interest` (id: 17)
+  +0x0032 | 54 00                   | VOffset16  | 0x0054 (84)                   | offset to field `foobars_type` (id: 18)
+  +0x0034 | 58 00                   | VOffset16  | 0x0058 (88)                   | offset to field `foobars` (id: 19)
+  +0x0036 | 0A 00                   | VOffset16  | 0x000A (10)                   | offset to field `measurement_type` (id: 20)
+  +0x0038 | 5C 00                   | VOffset16  | 0x005C (92)                   | offset to field `measurement` (id: 21)
+  +0x003A | 0B 00                   | VOffset16  | 0x000B (11)                   | offset to field `anything_type` (id: 22)
+  +0x003C | 60 00                   | VOffset16  | 0x0060 (96)                   | offset to field `anything` (id: 23)
+  +0x003E | 00 00                   | VOffset16  | 0x0000 (0)                    | offset to field `temperature` (id: 24) <defaults to 98.600000> (Float)
+  +0x0040 | 00 00                   | VOffset16  | 0x0000 (0)                    | offset to field `teetotaler` (id: 25) <null> (Obj)
+  +0x0042 | 64 00                   | VOffset16  | 0x0064 (100)                  | offset to field `charlie` (id: 26)
 
 root_table (AnnotatedBinary.Foo):
-  +0x0044 | 3A 00 00 00             | SOffset32  | 0x0000003A (58) Loc: +0x000A   | offset to vtable
-  +0x0048 | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x004B | 01                      | uint8_t    | 0x01 (1)                       | table field `healthy` (Bool)
-  +0x004C | 02                      | uint8_t    | 0x02 (2)                       | table field `meal` (Byte)
-  +0x004D | 02                      | UType8     | 0x02 (2)                       | table field `bar_baz_type` (UType)
-  +0x004E | 01                      | UType8     | 0x01 (1)                       | table field `measurement_type` (UType)
-  +0x004F | 01                      | UType8     | 0x01 (1)                       | table field `anything_type` (UType)
-  +0x0050 | D2 04 00 00             | uint32_t   | 0x000004D2 (1234)              | table field `counter` (Int)
-  +0x0054 | 28 02 00 00             | UOffset32  | 0x00000228 (552) Loc: +0x027C  | offset to field `bar` (table)
-  +0x0058 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                 | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
-  +0x005C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                 | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
-  +0x0060 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
-  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
-  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)                | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
-  +0x0070 | 01                      | uint8_t    | 0x01 (1)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0071 | 02                      | uint8_t    | 0x02 (2)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0072 | 03                      | uint8_t    | 0x03 (3)                       | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
-  +0x0073 | 00                      | uint8_t[1] | .                              | padding
-  +0x0074 | C8 01 00 00             | UOffset32  | 0x000001C8 (456) Loc: +0x023C  | offset to field `name` (string)
-  +0x0078 | 5C 01 00 00             | UOffset32  | 0x0000015C (348) Loc: +0x01D4  | offset to field `bars` (vector)
-  +0x007C | 50 01 00 00             | UOffset32  | 0x00000150 (336) Loc: +0x01CC  | offset to field `bar_baz` (union of type `Baz`)
-  +0x0080 | 34 01 00 00             | UOffset32  | 0x00000134 (308) Loc: +0x01B4  | offset to field `accounts` (vector)
-  +0x0084 | 24 01 00 00             | UOffset32  | 0x00000124 (292) Loc: +0x01A8  | offset to field `bob` (string)
-  +0x0088 | 14 01 00 00             | UOffset32  | 0x00000114 (276) Loc: +0x019C  | offset to field `alice` (string)
-  +0x008C | 0D 00 00 00             | uint32_t   | 0x0000000D (13)                | table field `just_i32` (Int)
-  +0x0090 | DC 00 00 00             | UOffset32  | 0x000000DC (220) Loc: +0x016C  | offset to field `names` (vector)
-  +0x0094 | A0 00 00 00             | UOffset32  | 0x000000A0 (160) Loc: +0x0134  | offset to field `points_of_interest` (vector)
-  +0x0098 | 94 00 00 00             | UOffset32  | 0x00000094 (148) Loc: +0x012C  | offset to field `foobars_type` (vector)
-  +0x009C | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: +0x00D4   | offset to field `foobars` (vector)
-  +0x00A0 | 33 00 00 00             | UOffset32  | 0x00000033 (51) Loc: +0x00D3   | offset to field `measurement` (union of type `Tolerance`)
-  +0x00A4 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: +0x00C0   | offset to field `anything` (union of type `Bar`)
-  +0x00A8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x00AC    | offset to field `charlie` (string)
+  +0x0044 | 3A 00 00 00             | SOffset32  | 0x0000003A (58) Loc: 0x000A   | offset to vtable
+  +0x0048 | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x004B | 01                      | uint8_t    | 0x01 (1)                      | table field `healthy` (Bool)
+  +0x004C | 02                      | uint8_t    | 0x02 (2)                      | table field `meal` (Byte)
+  +0x004D | 02                      | UType8     | 0x02 (2)                      | table field `bar_baz_type` (UType)
+  +0x004E | 01                      | UType8     | 0x01 (1)                      | table field `measurement_type` (UType)
+  +0x004F | 01                      | UType8     | 0x01 (1)                      | table field `anything_type` (UType)
+  +0x0050 | D2 04 00 00             | uint32_t   | 0x000004D2 (1234)             | table field `counter` (Int)
+  +0x0054 | 28 02 00 00             | UOffset32  | 0x00000228 (552) Loc: 0x027C  | offset to field `bar` (table)
+  +0x0058 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                | struct field `home.floors` of 'AnnotatedBinary.Building' (Int)
+  +0x005C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                | struct field `home.doors` of 'AnnotatedBinary.Building' (Int)
+  +0x0060 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)               | struct field `home.windows` of 'AnnotatedBinary.Building' (Int)
+  +0x0064 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)               | array field `home.dimensions.values`[0] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0068 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)               | array field `home.dimensions.values`[1] of 'AnnotatedBinary.Dimension' (Int)
+  +0x006C | 14 00 00 00             | uint32_t   | 0x00000014 (20)               | array field `home.dimensions.values`[2] of 'AnnotatedBinary.Dimension' (Int)
+  +0x0070 | 01                      | uint8_t    | 0x01 (1)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0071 | 02                      | uint8_t    | 0x02 (2)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0072 | 03                      | uint8_t    | 0x03 (3)                      | struct field `home.dimensions.tolerances.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x0073 | 00                      | uint8_t[1] | .                             | padding
+  +0x0074 | C8 01 00 00             | UOffset32  | 0x000001C8 (456) Loc: 0x023C  | offset to field `name` (string)
+  +0x0078 | 5C 01 00 00             | UOffset32  | 0x0000015C (348) Loc: 0x01D4  | offset to field `bars` (vector)
+  +0x007C | 50 01 00 00             | UOffset32  | 0x00000150 (336) Loc: 0x01CC  | offset to field `bar_baz` (union of type `Baz`)
+  +0x0080 | 34 01 00 00             | UOffset32  | 0x00000134 (308) Loc: 0x01B4  | offset to field `accounts` (vector)
+  +0x0084 | 24 01 00 00             | UOffset32  | 0x00000124 (292) Loc: 0x01A8  | offset to field `bob` (string)
+  +0x0088 | 14 01 00 00             | UOffset32  | 0x00000114 (276) Loc: 0x019C  | offset to field `alice` (string)
+  +0x008C | 0D 00 00 00             | uint32_t   | 0x0000000D (13)               | table field `just_i32` (Int)
+  +0x0090 | DC 00 00 00             | UOffset32  | 0x000000DC (220) Loc: 0x016C  | offset to field `names` (vector)
+  +0x0094 | A0 00 00 00             | UOffset32  | 0x000000A0 (160) Loc: 0x0134  | offset to field `points_of_interest` (vector)
+  +0x0098 | 94 00 00 00             | UOffset32  | 0x00000094 (148) Loc: 0x012C  | offset to field `foobars_type` (vector)
+  +0x009C | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x00D4   | offset to field `foobars` (vector)
+  +0x00A0 | 33 00 00 00             | UOffset32  | 0x00000033 (51) Loc: 0x00D3   | offset to field `measurement` (union of type `Tolerance`)
+  +0x00A4 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: 0x00C0   | offset to field `anything` (union of type `Bar`)
+  +0x00A8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x00AC    | offset to field `charlie` (string)
 
 string (AnnotatedBinary.Foo.charlie):
-  +0x00AC | 05 00 00 00             | uint32_t   | 0x00000005 (5)                 | length of string
-  +0x00B0 | 61 6C 69 63 65          | char[5]    | alice                          | string literal
-  +0x00B5 | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x00AC | 05 00 00 00             | uint32_t   | 0x00000005 (5)                | length of string
+  +0x00B0 | 61 6C 69 63 65          | char[5]    | alice                         | string literal
+  +0x00B5 | 00                      | char       | 0x00 (0)                      | string terminator
 
 padding:
-  +0x00B6 | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x00B6 | 00 00                   | uint8_t[2] | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x00B8 | 08 00                   | uint16_t   | 0x0008 (8)                     | size of this vtable
-  +0x00BA | 13 00                   | uint16_t   | 0x0013 (19)                    | size of referring table
-  +0x00BC | 08 00                   | VOffset16  | 0x0008 (8)                     | offset to field `a` (id: 0)
-  +0x00BE | 04 00                   | VOffset16  | 0x0004 (4)                     | offset to field `b` (id: 1)
+  +0x00B8 | 08 00                   | uint16_t   | 0x0008 (8)                    | size of this vtable
+  +0x00BA | 13 00                   | uint16_t   | 0x0013 (19)                   | size of referring table
+  +0x00BC | 08 00                   | VOffset16  | 0x0008 (8)                    | offset to field `a` (id: 0)
+  +0x00BE | 04 00                   | VOffset16  | 0x0004 (4)                    | offset to field `b` (id: 1)
 
 table (AnnotatedBinary.Bar):
-  +0x00C0 | 08 00 00 00             | SOffset32  | 0x00000008 (8) Loc: +0x00B8    | offset to vtable
-  +0x00C4 | 00 80 23 44             | float      | 0x44238000 (654)               | table field `b` (Float)
-  +0x00C8 | 00 00 00 00 00 10 74 40 | double     | 0x4074100000000000 (321)       | table field `a` (Double)
-  +0x00D0 | 00 00 00                | uint8_t[3] | ...                            | padding
+  +0x00C0 | 08 00 00 00             | SOffset32  | 0x00000008 (8) Loc: 0x00B8    | offset to vtable
+  +0x00C4 | 00 80 23 44             | float      | 0x44238000 (654)              | table field `b` (Float)
+  +0x00C8 | 00 00 00 00 00 10 74 40 | double     | 0x4074100000000000 (321)      | table field `a` (Double)
+  +0x00D0 | 00 00 00                | uint8_t[3] | ...                           | padding
 
 union (AnnotatedBinary.Tolerance.measurement):
-  +0x00D3 | 05                      | uint8_t    | 0x05 (5)                       | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
+  +0x00D3 | 05                      | uint8_t    | 0x05 (5)                      | struct field `measurement.width` of 'AnnotatedBinary.Tolerance' (UByte)
 
 vector (AnnotatedBinary.Foo.foobars):
-  +0x00D4 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
-  +0x00D8 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: +0x010C   | offset to union[0] (`Bar`)
-  +0x00DC | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: +0x0108   | offset to union[1] (`Baz`)
-  +0x00E0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x00E4    | offset to union[2] (`Bar`)
+  +0x00D4 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                | length of vector (# items)
+  +0x00D8 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
+  +0x00DC | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x0108   | offset to union[1] (`Baz`)
+  +0x00E0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
 
 table (AnnotatedBinary.Bar):
-  +0x00E4 | D2 FE FF FF             | SOffset32  | 0xFFFFFED2 (-302) Loc: +0x0212 | offset to vtable
-  +0x00E8 | 00 80 23 44             | float      | 0x44238000 (654)               | table field `b` (Float)
-  +0x00EC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: +0x00FC   | offset to field `c` (table)
-  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double     | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x00F8 | 00 00 00 00             | uint8_t[4] | ....                           | padding
+  +0x00E4 | D2 FE FF FF             | SOffset32  | 0xFFFFFED2 (-302) Loc: 0x0212 | offset to vtable
+  +0x00E8 | 00 80 23 44             | float      | 0x44238000 (654)              | table field `b` (Float)
+  +0x00EC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x00FC   | offset to field `c` (table)
+  +0x00F0 | 00 00 00 00 00 D8 8E 40 | double     | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x00F8 | 00 00 00 00             | uint8_t[4] | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x00FC | 6A FE FF FF             | SOffset32  | 0xFFFFFE6A (-406) Loc: +0x0292 | offset to vtable
-  +0x0100 | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x0103 | 03                      | uint8_t    | 0x03 (3)                       | table field `meal` (Byte)
+  +0x00FC | 6A FE FF FF             | SOffset32  | 0xFFFFFE6A (-406) Loc: 0x0292 | offset to vtable
+  +0x0100 | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x0103 | 03                      | uint8_t    | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Baz):
-  +0x0104 | 04 00                   | uint16_t   | 0x0004 (4)                     | size of this vtable
-  +0x0106 | 04 00                   | uint16_t   | 0x0004 (4)                     | size of referring table
+  +0x0104 | 04 00                   | uint16_t   | 0x0004 (4)                    | size of this vtable
+  +0x0106 | 04 00                   | uint16_t   | 0x0004 (4)                    | size of referring table
 
 table (AnnotatedBinary.Baz):
-  +0x0108 | 04 00 00 00             | SOffset32  | 0x00000004 (4) Loc: +0x0104    | offset to vtable
+  +0x0108 | 04 00 00 00             | SOffset32  | 0x00000004 (4) Loc: 0x0104    | offset to vtable
 
 table (AnnotatedBinary.Bar):
-  +0x010C | FA FE FF FF             | SOffset32  | 0xFFFFFEFA (-262) Loc: +0x0212 | offset to vtable
-  +0x0110 | 00 00 E4 43             | float      | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0114 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: +0x0124   | offset to field `c` (table)
-  +0x0118 | 00 00 00 00 00 C0 5E 40 | double     | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0120 | 00 00 00 00             | uint8_t[4] | ....                           | padding
+  +0x010C | FA FE FF FF             | SOffset32  | 0xFFFFFEFA (-262) Loc: 0x0212 | offset to vtable
+  +0x0110 | 00 00 E4 43             | float      | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0114 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0124   | offset to field `c` (table)
+  +0x0118 | 00 00 00 00 00 C0 5E 40 | double     | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0120 | 00 00 00 00             | uint8_t[4] | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0124 | 92 FE FF FF             | SOffset32  | 0xFFFFFE92 (-366) Loc: +0x0292 | offset to vtable
-  +0x0128 | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x012B | 01                      | uint8_t    | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0124 | 92 FE FF FF             | SOffset32  | 0xFFFFFE92 (-366) Loc: 0x0292 | offset to vtable
+  +0x0128 | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x012B | 01                      | uint8_t    | 0x01 (1)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.foobars_type):
-  +0x012C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
-  +0x0130 | 01                      | UType8     | 0x01 (1)                       | value[0]
-  +0x0131 | 02                      | UType8     | 0x02 (2)                       | value[1]
-  +0x0132 | 01                      | UType8     | 0x01 (1)                       | value[2]
+  +0x012C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                | length of vector (# items)
+  +0x0130 | 01                      | UType8     | 0x01 (1)                      | value[0]
+  +0x0131 | 02                      | UType8     | 0x02 (2)                      | value[1]
+  +0x0132 | 01                      | UType8     | 0x01 (1)                      | value[2]
 
 vector (AnnotatedBinary.Foo.points_of_interest):
-  +0x0134 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
-  +0x0138 | 33 33 33 33 33 A3 45 40 | double     | 0x4045A33333333333 (43.275)    | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double     | 0xC053875BFF04577E (-78.115)   | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double     | 0x4042B60420F6F08D (37.422)    | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0150 | 9F 77 63 41 61 85 5E C0 | double     | 0xC05E85614163779F (-122.084)  | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double     | 0xC04B35DC8323358F (-54.4208)  | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
-  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double     | 0x400AC58793DD97F6 (3.34645)   | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0134 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                | length of vector (# items)
+  +0x0138 | 33 33 33 33 33 A3 45 40 | double     | 0x4045A33333333333 (43.275)   | struct field `[0].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0140 | 7E 57 04 FF 5B 87 53 C0 | double     | 0xC053875BFF04577E (-78.115)  | struct field `[0].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0148 | 8D F0 F6 20 04 B6 42 40 | double     | 0x4042B60420F6F08D (37.422)   | struct field `[1].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0150 | 9F 77 63 41 61 85 5E C0 | double     | 0xC05E85614163779F (-122.084) | struct field `[1].longitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0158 | 8F 35 23 83 DC 35 4B C0 | double     | 0xC04B35DC8323358F (-54.4208) | struct field `[2].latitude` of 'AnnotatedBinary.Location' (Double)
+  +0x0160 | F6 97 DD 93 87 C5 0A 40 | double     | 0x400AC58793DD97F6 (3.34645)  | struct field `[2].longitude` of 'AnnotatedBinary.Location' (Double)
 
 padding:
-  +0x0168 | 00 00 00 00             | uint8_t[4] | ....                           | padding
+  +0x0168 | 00 00 00 00             | uint8_t[4] | ....                          | padding
 
 vector (AnnotatedBinary.Foo.names):
-  +0x016C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of vector (# items)
-  +0x0170 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: +0x0190   | offset to string[0]
-  +0x0174 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: +0x0188   | offset to string[1]
-  +0x0178 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x017C    | offset to string[2]
+  +0x016C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                | length of vector (# items)
+  +0x0170 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0190   | offset to string[0]
+  +0x0174 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0188   | offset to string[1]
+  +0x0178 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x017C    | offset to string[2]
 
 string (AnnotatedBinary.Foo.names):
-  +0x017C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x0180 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
-  +0x0187 | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x017C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                | length of string
+  +0x0180 | 63 68 61 72 6C 69 65    | char[7]    | charlie                       | string literal
+  +0x0187 | 00                      | char       | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0188 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                 | length of string
-  +0x018C | 62 6F 62                | char[3]    | bob                            | string literal
-  +0x018F | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x0188 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                | length of string
+  +0x018C | 62 6F 62                | char[3]    | bob                           | string literal
+  +0x018F | 00                      | char       | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.names):
-  +0x0190 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                 | length of string
-  +0x0194 | 61 6C 69 63 65          | char[5]    | alice                          | string literal
-  +0x0199 | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x0190 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                | length of string
+  +0x0194 | 61 6C 69 63 65          | char[5]    | alice                         | string literal
+  +0x0199 | 00                      | char       | 0x00 (0)                      | string terminator
 
 padding:
-  +0x019A | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x019A | 00 00                   | uint8_t[2] | ..                            | padding
 
 string (AnnotatedBinary.Foo.alice):
-  +0x019C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
-  +0x01A7 | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x019C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                | length of string
+  +0x01A0 | 63 68 61 72 6C 69 65    | char[7]    | charlie                       | string literal
+  +0x01A7 | 00                      | char       | 0x00 (0)                      | string terminator
 
 string (AnnotatedBinary.Foo.bob):
-  +0x01A8 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                 | length of string
-  +0x01AC | 63 68 61 72 6C 69 65    | char[7]    | charlie                        | string literal
-  +0x01B3 | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x01A8 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                | length of string
+  +0x01AC | 63 68 61 72 6C 69 65    | char[7]    | charlie                       | string literal
+  +0x01B3 | 00                      | char       | 0x00 (0)                      | string terminator
 
 vector (AnnotatedBinary.Foo.accounts):
-  +0x01B4 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                 | length of vector (# items)
-  +0x01B8 | 09 00                   | uint16_t   | 0x0009 (9)                     | value[0]
-  +0x01BA | 08 00                   | uint16_t   | 0x0008 (8)                     | value[1]
-  +0x01BC | 07 00                   | uint16_t   | 0x0007 (7)                     | value[2]
-  +0x01BE | 01 00                   | uint16_t   | 0x0001 (1)                     | value[3]
-  +0x01C0 | 02 00                   | uint16_t   | 0x0002 (2)                     | value[4]
-  +0x01C2 | 03 00                   | uint16_t   | 0x0003 (3)                     | value[5]
-  +0x01C4 | 06 00                   | uint16_t   | 0x0006 (6)                     | value[6]
-  +0x01C6 | 05 00                   | uint16_t   | 0x0005 (5)                     | value[7]
-  +0x01C8 | 04 00                   | uint16_t   | 0x0004 (4)                     | value[8]
+  +0x01B4 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                | length of vector (# items)
+  +0x01B8 | 09 00                   | uint16_t   | 0x0009 (9)                    | value[0]
+  +0x01BA | 08 00                   | uint16_t   | 0x0008 (8)                    | value[1]
+  +0x01BC | 07 00                   | uint16_t   | 0x0007 (7)                    | value[2]
+  +0x01BE | 01 00                   | uint16_t   | 0x0001 (1)                    | value[3]
+  +0x01C0 | 02 00                   | uint16_t   | 0x0002 (2)                    | value[4]
+  +0x01C2 | 03 00                   | uint16_t   | 0x0003 (3)                    | value[5]
+  +0x01C4 | 06 00                   | uint16_t   | 0x0006 (6)                    | value[6]
+  +0x01C6 | 05 00                   | uint16_t   | 0x0005 (5)                    | value[7]
+  +0x01C8 | 04 00                   | uint16_t   | 0x0004 (4)                    | value[8]
 
 padding:
-  +0x01CA | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x01CA | 00 00                   | uint8_t[2] | ..                            | padding
 
 table (AnnotatedBinary.Baz):
-  +0x01CC | 3A FF FF FF             | SOffset32  | 0xFFFFFF3A (-198) Loc: +0x0292 | offset to vtable
-  +0x01D0 | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x01D3 | 03                      | uint8_t    | 0x03 (3)                       | table field `meal` (Byte)
+  +0x01CC | 3A FF FF FF             | SOffset32  | 0xFFFFFF3A (-198) Loc: 0x0292 | offset to vtable
+  +0x01D0 | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x01D3 | 03                      | uint8_t    | 0x03 (3)                      | table field `meal` (Byte)
 
 vector (AnnotatedBinary.Foo.bars):
-  +0x01D4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                 | length of vector (# items)
-  +0x01D8 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: +0x021C   | offset to table[0]
-  +0x01DC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: +0x01EC   | offset to table[1]
+  +0x01D4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                | length of vector (# items)
+  +0x01D8 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x021C   | offset to table[0]
+  +0x01DC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x01EC   | offset to table[1]
 
 padding:
-  +0x01E0 | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x01E0 | 00 00                   | uint8_t[2] | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x01E2 | 0A 00                   | uint16_t   | 0x000A (10)                    | size of this vtable
-  +0x01E4 | 1A 00                   | uint16_t   | 0x001A (26)                    | size of referring table
-  +0x01E6 | 0C 00                   | VOffset16  | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x01E8 | 04 00                   | VOffset16  | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x01EA | 08 00                   | VOffset16  | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x01E2 | 0A 00                   | uint16_t   | 0x000A (10)                   | size of this vtable
+  +0x01E4 | 1A 00                   | uint16_t   | 0x001A (26)                   | size of referring table
+  +0x01E6 | 0C 00                   | VOffset16  | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x01E8 | 04 00                   | VOffset16  | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x01EA | 08 00                   | VOffset16  | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x01EC | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: +0x01E2   | offset to vtable
-  +0x01F0 | 00 80 23 44             | float      | 0x44238000 (654)               | table field `b` (Float)
-  +0x01F4 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: +0x020C   | offset to field `c` (table)
-  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double     | 0x408ED80000000000 (987)       | table field `a` (Double)
-  +0x0200 | 00 00 00 00 00 00       | uint8_t[6] | ......                         | padding
+  +0x01EC | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: 0x01E2   | offset to vtable
+  +0x01F0 | 00 80 23 44             | float      | 0x44238000 (654)              | table field `b` (Float)
+  +0x01F4 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x020C   | offset to field `c` (table)
+  +0x01F8 | 00 00 00 00 00 D8 8E 40 | double     | 0x408ED80000000000 (987)      | table field `a` (Double)
+  +0x0200 | 00 00 00 00 00 00       | uint8_t[6] | ......                        | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0206 | 06 00                   | uint16_t   | 0x0006 (6)                     | size of this vtable
-  +0x0208 | 06 00                   | uint16_t   | 0x0006 (6)                     | size of referring table
-  +0x020A | 05 00                   | VOffset16  | 0x0005 (5)                     | offset to field `meal` (id: 0)
+  +0x0206 | 06 00                   | uint16_t   | 0x0006 (6)                    | size of this vtable
+  +0x0208 | 06 00                   | uint16_t   | 0x0006 (6)                    | size of referring table
+  +0x020A | 05 00                   | VOffset16  | 0x0005 (5)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x020C | 06 00 00 00             | SOffset32  | 0x00000006 (6) Loc: +0x0206    | offset to vtable
-  +0x0210 | 00                      | uint8_t[1] | .                              | padding
-  +0x0211 | 03                      | uint8_t    | 0x03 (3)                       | table field `meal` (Byte)
+  +0x020C | 06 00 00 00             | SOffset32  | 0x00000006 (6) Loc: 0x0206    | offset to vtable
+  +0x0210 | 00                      | uint8_t[1] | .                             | padding
+  +0x0211 | 03                      | uint8_t    | 0x03 (3)                      | table field `meal` (Byte)
 
 vtable (AnnotatedBinary.Bar):
-  +0x0212 | 0A 00                   | uint16_t   | 0x000A (10)                    | size of this vtable
-  +0x0214 | 18 00                   | uint16_t   | 0x0018 (24)                    | size of referring table
-  +0x0216 | 0C 00                   | VOffset16  | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0218 | 04 00                   | VOffset16  | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x021A | 08 00                   | VOffset16  | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0212 | 0A 00                   | uint16_t   | 0x000A (10)                   | size of this vtable
+  +0x0214 | 18 00                   | uint16_t   | 0x0018 (24)                   | size of referring table
+  +0x0216 | 0C 00                   | VOffset16  | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0218 | 04 00                   | VOffset16  | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x021A | 08 00                   | VOffset16  | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x021C | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: +0x0212   | offset to vtable
-  +0x0220 | 00 00 E4 43             | float      | 0x43E40000 (456)               | table field `b` (Float)
-  +0x0224 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: +0x0234   | offset to field `c` (table)
-  +0x0228 | 00 00 00 00 00 C0 5E 40 | double     | 0x405EC00000000000 (123)       | table field `a` (Double)
-  +0x0230 | 00 00 00 00             | uint8_t[4] | ....                           | padding
+  +0x021C | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: 0x0212   | offset to vtable
+  +0x0220 | 00 00 E4 43             | float      | 0x43E40000 (456)              | table field `b` (Float)
+  +0x0224 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0234   | offset to field `c` (table)
+  +0x0228 | 00 00 00 00 00 C0 5E 40 | double     | 0x405EC00000000000 (123)      | table field `a` (Double)
+  +0x0230 | 00 00 00 00             | uint8_t[4] | ....                          | padding
 
 table (AnnotatedBinary.Baz):
-  +0x0234 | A2 FF FF FF             | SOffset32  | 0xFFFFFFA2 (-94) Loc: +0x0292  | offset to vtable
-  +0x0238 | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x023B | 01                      | uint8_t    | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0234 | A2 FF FF FF             | SOffset32  | 0xFFFFFFA2 (-94) Loc: 0x0292  | offset to vtable
+  +0x0238 | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x023B | 01                      | uint8_t    | 0x01 (1)                      | table field `meal` (Byte)
 
 string (AnnotatedBinary.Foo.name):
-  +0x023C | 2F 00 00 00             | uint32_t   | 0x0000002F (47)                | length of string
-  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]   | This is                        | string literal
+  +0x023C | 2F 00 00 00             | uint32_t   | 0x0000002F (47)               | length of string
+  +0x0240 | 54 68 69 73 20 69 73 20 | char[47]   | This is                       | string literal
   +0x0248 | 61 20 6C 6F 6E 67 20 73 |            | a long s
   +0x0250 | 74 72 69 6E 67 20 74 6F |            | tring to
   +0x0258 | 20 73 68 6F 77 20 68 6F |            |  show ho
   +0x0260 | 77 20 69 74 20 62 72 65 |            | w it bre
   +0x0268 | 61 6B 73 20 75 70 2E    |            | aks up.
-  +0x026F | 00                      | char       | 0x00 (0)                       | string terminator
+  +0x026F | 00                      | char       | 0x00 (0)                      | string terminator
 
 padding:
-  +0x0270 | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x0270 | 00 00                   | uint8_t[2] | ..                            | padding
 
 vtable (AnnotatedBinary.Bar):
-  +0x0272 | 0A 00                   | uint16_t   | 0x000A (10)                    | size of this vtable
-  +0x0274 | 16 00                   | uint16_t   | 0x0016 (22)                    | size of referring table
-  +0x0276 | 0C 00                   | VOffset16  | 0x000C (12)                    | offset to field `a` (id: 0)
-  +0x0278 | 04 00                   | VOffset16  | 0x0004 (4)                     | offset to field `b` (id: 1)
-  +0x027A | 08 00                   | VOffset16  | 0x0008 (8)                     | offset to field `c` (id: 2)
+  +0x0272 | 0A 00                   | uint16_t   | 0x000A (10)                   | size of this vtable
+  +0x0274 | 16 00                   | uint16_t   | 0x0016 (22)                   | size of referring table
+  +0x0276 | 0C 00                   | VOffset16  | 0x000C (12)                   | offset to field `a` (id: 0)
+  +0x0278 | 04 00                   | VOffset16  | 0x0004 (4)                    | offset to field `b` (id: 1)
+  +0x027A | 08 00                   | VOffset16  | 0x0008 (8)                    | offset to field `c` (id: 2)
 
 table (AnnotatedBinary.Bar):
-  +0x027C | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: +0x0272   | offset to vtable
-  +0x0280 | 65 20 71 49             | float      | 0x49712065 (987654)            | table field `b` (Float)
-  +0x0284 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: +0x0298   | offset to field `c` (table)
-  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double     | 0x40FE240C9FBE76C9 (123457)    | table field `a` (Double)
-  +0x0290 | 00 00                   | uint8_t[2] | ..                             | padding
+  +0x027C | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: 0x0272   | offset to vtable
+  +0x0280 | 65 20 71 49             | float      | 0x49712065 (987654)           | table field `b` (Float)
+  +0x0284 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0298   | offset to field `c` (table)
+  +0x0288 | C9 76 BE 9F 0C 24 FE 40 | double     | 0x40FE240C9FBE76C9 (123457)   | table field `a` (Double)
+  +0x0290 | 00 00                   | uint8_t[2] | ..                            | padding
 
 vtable (AnnotatedBinary.Baz):
-  +0x0292 | 06 00                   | uint16_t   | 0x0006 (6)                     | size of this vtable
-  +0x0294 | 08 00                   | uint16_t   | 0x0008 (8)                     | size of referring table
-  +0x0296 | 07 00                   | VOffset16  | 0x0007 (7)                     | offset to field `meal` (id: 0)
+  +0x0292 | 06 00                   | uint16_t   | 0x0006 (6)                    | size of this vtable
+  +0x0294 | 08 00                   | uint16_t   | 0x0008 (8)                    | size of referring table
+  +0x0296 | 07 00                   | VOffset16  | 0x0007 (7)                    | offset to field `meal` (id: 0)
 
 table (AnnotatedBinary.Baz):
-  +0x0298 | 06 00 00 00             | SOffset32  | 0x00000006 (6) Loc: +0x0292    | offset to vtable
-  +0x029C | 00 00 00                | uint8_t[3] | ...                            | padding
-  +0x029F | 01                      | uint8_t    | 0x01 (1)                       | table field `meal` (Byte)
+  +0x0298 | 06 00 00 00             | SOffset32  | 0x00000006 (6) Loc: 0x0292    | offset to vtable
+  +0x029C | 00 00 00                | uint8_t[3] | ...                           | padding
+  +0x029F | 01                      | uint8_t    | 0x01 (1)                      | table field `meal` (Byte)

--- a/tests/annotated_binary/tests/invalid_vtable_size.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_size.afb
@@ -4,17 +4,17 @@
 // Binary file: tests/invalid_vtable_size.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32     | 0x00000044 (68) Loc: +0x0044 | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]       | ANNO                         | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32     | 0x00000044 (68) Loc: 0x0044 | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]       | ANNO                        | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]    | ..                           | padding
+  +0x0008 | 00 00                   | uint8_t[2]    | ..                          | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | FF FF                   | uint16_t      | 0xFFFF (65535)               | ERROR: size of this vtable. Longer than the binary.
+  +0x000A | FF FF                   | uint16_t      | 0xFFFF (65535)              | ERROR: size of this vtable. Longer than the binary.
 
 unknown (no known references):
-  +0x000C | 68 00 0C 00 07 00 00 00 | ?uint8_t[660] | h.......                     | WARN: nothing refers to this section.
+  +0x000C | 68 00 0C 00 07 00 00 00 | ?uint8_t[660] | h.......                    | WARN: nothing refers to this section.
   +0x0014 | 08 00 10 00 14 00 30 00 |               | ......0.
   +0x001C | 34 00 09 00 38 00 3C 00 |               | 4...8.<.
   +0x0024 | 40 00 44 00 00 00 00 00 |               | @.D.....

--- a/tests/annotated_binary/tests/invalid_vtable_size_short.afb
+++ b/tests/annotated_binary/tests/invalid_vtable_size_short.afb
@@ -4,17 +4,17 @@
 // Binary file: tests/invalid_vtable_size_short.bin
 
 header:
-  +0x0000 | 44 00 00 00             | UOffset32     | 0x00000044 (68) Loc: +0x0044 | offset to root table `AnnotatedBinary.Foo`
-  +0x0004 | 41 4E 4E 4F             | char[4]       | ANNO                         | File Identifier
+  +0x0000 | 44 00 00 00             | UOffset32     | 0x00000044 (68) Loc: 0x0044 | offset to root table `AnnotatedBinary.Foo`
+  +0x0004 | 41 4E 4E 4F             | char[4]       | ANNO                        | File Identifier
 
 padding:
-  +0x0008 | 00 00                   | uint8_t[2]    | ..                           | padding
+  +0x0008 | 00 00                   | uint8_t[2]    | ..                          | padding
 
 vtable (AnnotatedBinary.Foo):
-  +0x000A | 01 00                   | uint16_t      | 0x0001 (1)                   | ERROR: size of this vtable. Shorter than the minimum length: 
+  +0x000A | 01 00                   | uint16_t      | 0x0001 (1)                  | ERROR: size of this vtable. Shorter than the minimum length: 
 
 unknown (no known references):
-  +0x000C | 68 00 0C 00 07 00 00 00 | ?uint8_t[660] | h.......                     | WARN: nothing refers to this section.
+  +0x000C | 68 00 0C 00 07 00 00 00 | ?uint8_t[660] | h.......                    | WARN: nothing refers to this section.
   +0x0014 | 08 00 10 00 14 00 30 00 |               | ......0.
   +0x001C | 34 00 09 00 38 00 3C 00 |               | 4...8.<.
   +0x0024 | 40 00 44 00 00 00 00 00 |               | @.D.....

--- a/tests/monster_test.afb
+++ b/tests/monster_test.afb
@@ -4,6497 +4,6491 @@
 // Binary file: monster_test.bfbs
 
 header:
-  +0x0000 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0020       | offset to root table `reflection.Schema`
-  +0x0004 | 42 46 42 53             | char[4]     | BFBS                               | File Identifier
+  +0x0000 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0020        | offset to root table `reflection.Schema`
+  +0x0004 | 42 46 42 53             | char[4]    | BFBS                               | File Identifier
 
 padding:
-  +0x0008 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x0008 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 vtable (reflection.Schema):
-  +0x000C | 14 00                   | uint16_t    | 0x0014 (20)                        | size of this vtable
-  +0x000E | 20 00                   | uint16_t    | 0x0020 (32)                        | size of referring table
-  +0x0010 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `objects` (id: 0)
-  +0x0012 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `enums` (id: 1)
-  +0x0014 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `file_ident` (id: 2)
-  +0x0016 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `file_ext` (id: 3)
-  +0x0018 | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `root_table` (id: 4)
-  +0x001A | 18 00                   | VOffset16   | 0x0018 (24)                        | offset to field `services` (id: 5)
-  +0x001C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `advanced_features` (id: 6) <defaults to 0> (ULong)
-  +0x001E | 1C 00                   | VOffset16   | 0x001C (28)                        | offset to field `fbs_files` (id: 7)
+  +0x000C | 14 00                   | uint16_t   | 0x0014 (20)                        | size of this vtable
+  +0x000E | 20 00                   | uint16_t   | 0x0020 (32)                        | size of referring table
+  +0x0010 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `objects` (id: 0)
+  +0x0012 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `enums` (id: 1)
+  +0x0014 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `file_ident` (id: 2)
+  +0x0016 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `file_ext` (id: 3)
+  +0x0018 | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `root_table` (id: 4)
+  +0x001A | 18 00                   | VOffset16  | 0x0018 (24)                        | offset to field `services` (id: 5)
+  +0x001C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `advanced_features` (id: 6) <defaults to 0> (ULong)
+  +0x001E | 1C 00                   | VOffset16  | 0x001C (28)                        | offset to field `fbs_files` (id: 7)
 
 root_table (reflection.Schema):
-  +0x0020 | 14 00 00 00             | SOffset32   | 0x00000014 (20) Loc: +0x000C       | offset to vtable
-  +0x0024 | 58 00 00 00             | UOffset32   | 0x00000058 (88) Loc: +0x007C       | offset to field `objects` (vector)
-  +0x0028 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x005C       | offset to field `enums` (vector)
-  +0x002C | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x0050       | offset to field `file_ident` (string)
-  +0x0030 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x0048       | offset to field `file_ext` (string)
-  +0x0034 | 50 0D 00 00             | UOffset32   | 0x00000D50 (3408) Loc: +0x0D84     | offset to field `root_table` (table)
-  +0x0038 | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x0040        | offset to field `services` (vector)
-  +0x003C | 80 00 00 00             | UOffset32   | 0x00000080 (128) Loc: +0x00BC      | offset to field `fbs_files` (vector)
+  +0x0020 | 14 00 00 00             | SOffset32  | 0x00000014 (20) Loc: 0x000C        | offset to vtable
+  +0x0024 | 58 00 00 00             | UOffset32  | 0x00000058 (88) Loc: 0x007C        | offset to field `objects` (vector)
+  +0x0028 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x005C        | offset to field `enums` (vector)
+  +0x002C | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x0050        | offset to field `file_ident` (string)
+  +0x0030 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x0048        | offset to field `file_ext` (string)
+  +0x0034 | 50 0D 00 00             | UOffset32  | 0x00000D50 (3408) Loc: 0x0D84      | offset to field `root_table` (table)
+  +0x0038 | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x0040         | offset to field `services` (vector)
+  +0x003C | 80 00 00 00             | UOffset32  | 0x00000080 (128) Loc: 0x00BC       | offset to field `fbs_files` (vector)
 
 vector (reflection.Schema.services):
-  +0x0040 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x0044 | DC 00 00 00             | UOffset32   | 0x000000DC (220) Loc: +0x0120      | offset to table[0]
+  +0x0040 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x0044 | DC 00 00 00             | UOffset32  | 0x000000DC (220) Loc: 0x0120       | offset to table[0]
 
 string (reflection.Schema.file_ext):
-  +0x0048 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x004C | 6D 6F 6E                | char[3]     | mon                                | string literal
-  +0x004F | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0048 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x004C | 6D 6F 6E                | char[3]    | mon                                | string literal
+  +0x004F | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.Schema.file_ident):
-  +0x0050 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x0054 | 4D 4F 4E 53             | char[4]     | MONS                               | string literal
-  +0x0058 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0050 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x0054 | 4D 4F 4E 53             | char[4]    | MONS                               | string literal
+  +0x0058 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0059 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x0059 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 vector (reflection.Schema.enums):
-  +0x005C | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of vector (# items)
-  +0x0060 | D4 04 00 00             | UOffset32   | 0x000004D4 (1236) Loc: +0x0534     | offset to table[0]
-  +0x0064 | 90 02 00 00             | UOffset32   | 0x00000290 (656) Loc: +0x02F4      | offset to table[1]
-  +0x0068 | A8 03 00 00             | UOffset32   | 0x000003A8 (936) Loc: +0x0410      | offset to table[2]
-  +0x006C | 30 08 00 00             | UOffset32   | 0x00000830 (2096) Loc: +0x089C     | offset to table[3]
-  +0x0070 | 00 06 00 00             | UOffset32   | 0x00000600 (1536) Loc: +0x0670     | offset to table[4]
-  +0x0074 | 0C 07 00 00             | UOffset32   | 0x0000070C (1804) Loc: +0x0780     | offset to table[5]
-  +0x0078 | 10 0A 00 00             | UOffset32   | 0x00000A10 (2576) Loc: +0x0A88     | offset to table[6]
+  +0x005C | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of vector (# items)
+  +0x0060 | D4 04 00 00             | UOffset32  | 0x000004D4 (1236) Loc: 0x0534      | offset to table[0]
+  +0x0064 | 90 02 00 00             | UOffset32  | 0x00000290 (656) Loc: 0x02F4       | offset to table[1]
+  +0x0068 | A8 03 00 00             | UOffset32  | 0x000003A8 (936) Loc: 0x0410       | offset to table[2]
+  +0x006C | 30 08 00 00             | UOffset32  | 0x00000830 (2096) Loc: 0x089C      | offset to table[3]
+  +0x0070 | 00 06 00 00             | UOffset32  | 0x00000600 (1536) Loc: 0x0670      | offset to table[4]
+  +0x0074 | 0C 07 00 00             | UOffset32  | 0x0000070C (1804) Loc: 0x0780      | offset to table[5]
+  +0x0078 | 10 0A 00 00             | UOffset32  | 0x00000A10 (2576) Loc: 0x0A88      | offset to table[6]
 
 vector (reflection.Schema.objects):
-  +0x007C | 0F 00 00 00             | uint32_t    | 0x0000000F (15)                    | length of vector (# items)
-  +0x0080 | BC 31 00 00             | UOffset32   | 0x000031BC (12732) Loc: +0x323C    | offset to table[0]
-  +0x0084 | 00 0D 00 00             | UOffset32   | 0x00000D00 (3328) Loc: +0x0D84     | offset to table[1]
-  +0x0088 | 6C 2E 00 00             | UOffset32   | 0x00002E6C (11884) Loc: +0x2EF4    | offset to table[2]
-  +0x008C | 38 2F 00 00             | UOffset32   | 0x00002F38 (12088) Loc: +0x2FC4    | offset to table[3]
-  +0x0090 | A4 30 00 00             | UOffset32   | 0x000030A4 (12452) Loc: +0x3134    | offset to table[4]
-  +0x0094 | 28 30 00 00             | UOffset32   | 0x00003028 (12328) Loc: +0x30BC    | offset to table[5]
-  +0x0098 | 44 35 00 00             | UOffset32   | 0x00003544 (13636) Loc: +0x35DC    | offset to table[6]
-  +0x009C | 44 34 00 00             | UOffset32   | 0x00003444 (13380) Loc: +0x34E0    | offset to table[7]
-  +0x00A0 | 84 0A 00 00             | UOffset32   | 0x00000A84 (2692) Loc: +0x0B24     | offset to table[8]
-  +0x00A4 | 80 32 00 00             | UOffset32   | 0x00003280 (12928) Loc: +0x3324    | offset to table[9]
-  +0x00A8 | F4 35 00 00             | UOffset32   | 0x000035F4 (13812) Loc: +0x369C    | offset to table[10]
-  +0x00AC | 24 36 00 00             | UOffset32   | 0x00003624 (13860) Loc: +0x36D0    | offset to table[11]
-  +0x00B0 | FC 36 00 00             | UOffset32   | 0x000036FC (14076) Loc: +0x37AC    | offset to table[12]
-  +0x00B4 | A0 37 00 00             | UOffset32   | 0x000037A0 (14240) Loc: +0x3854    | offset to table[13]
-  +0x00B8 | 68 36 00 00             | UOffset32   | 0x00003668 (13928) Loc: +0x3720    | offset to table[14]
+  +0x007C | 0F 00 00 00             | uint32_t   | 0x0000000F (15)                    | length of vector (# items)
+  +0x0080 | BC 31 00 00             | UOffset32  | 0x000031BC (12732) Loc: 0x323C     | offset to table[0]
+  +0x0084 | 00 0D 00 00             | UOffset32  | 0x00000D00 (3328) Loc: 0x0D84      | offset to table[1]
+  +0x0088 | 6C 2E 00 00             | UOffset32  | 0x00002E6C (11884) Loc: 0x2EF4     | offset to table[2]
+  +0x008C | 38 2F 00 00             | UOffset32  | 0x00002F38 (12088) Loc: 0x2FC4     | offset to table[3]
+  +0x0090 | A4 30 00 00             | UOffset32  | 0x000030A4 (12452) Loc: 0x3134     | offset to table[4]
+  +0x0094 | 28 30 00 00             | UOffset32  | 0x00003028 (12328) Loc: 0x30BC     | offset to table[5]
+  +0x0098 | 44 35 00 00             | UOffset32  | 0x00003544 (13636) Loc: 0x35DC     | offset to table[6]
+  +0x009C | 44 34 00 00             | UOffset32  | 0x00003444 (13380) Loc: 0x34E0     | offset to table[7]
+  +0x00A0 | 84 0A 00 00             | UOffset32  | 0x00000A84 (2692) Loc: 0x0B24      | offset to table[8]
+  +0x00A4 | 80 32 00 00             | UOffset32  | 0x00003280 (12928) Loc: 0x3324     | offset to table[9]
+  +0x00A8 | F4 35 00 00             | UOffset32  | 0x000035F4 (13812) Loc: 0x369C     | offset to table[10]
+  +0x00AC | 24 36 00 00             | UOffset32  | 0x00003624 (13860) Loc: 0x36D0     | offset to table[11]
+  +0x00B0 | FC 36 00 00             | UOffset32  | 0x000036FC (14076) Loc: 0x37AC     | offset to table[12]
+  +0x00B4 | A0 37 00 00             | UOffset32  | 0x000037A0 (14240) Loc: 0x3854     | offset to table[13]
+  +0x00B8 | 68 36 00 00             | UOffset32  | 0x00003668 (13928) Loc: 0x3720     | offset to table[14]
 
 vector (reflection.Schema.fbs_files):
-  +0x00BC | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of vector (# items)
-  +0x00C0 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x00F8       | offset to table[0]
-  +0x00C4 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0x00E0       | offset to table[1]
-  +0x00C8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x00CC        | offset to table[2]
+  +0x00BC | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of vector (# items)
+  +0x00C0 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x00F8        | offset to table[0]
+  +0x00C4 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: 0x00E0        | offset to table[1]
+  +0x00C8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x00CC         | offset to table[2]
 
 table (reflection.SchemaFile):
-  +0x00CC | 04 C8 FF FF             | SOffset32   | 0xFFFFC804 (-14332) Loc: +0x38C8   | offset to vtable
-  +0x00D0 | 14 36 00 00             | UOffset32   | 0x00003614 (13844) Loc: +0x36E4    | offset to field `key` (string)
-  +0x00D4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x00D8        | offset to field `value` (string)
+  +0x00CC | 04 C8 FF FF             | SOffset32  | 0xFFFFC804 (-14332) Loc: 0x38C8    | offset to vtable
+  +0x00D0 | 14 36 00 00             | UOffset32  | 0x00003614 (13844) Loc: 0x36E4     | offset to field `filename` (string)
+  +0x00D4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x00D8         | offset to field `included_filenames` (vector)
 
-string (reflection.SchemaFile.value):
-  +0x00D8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x00DC | 58                      | char[1]     | X                                  | string literal
-  +0x00DD | 36                      | char        | 0x36 (54)                          | string terminator
+vector (reflection.SchemaFile.included_filenames):
+  +0x00D8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x00DC | 58 36 00 00             | UOffset32  | 0x00003658 (13912) Loc: 0x3734     | offset to string[0]
+
+table (reflection.SchemaFile):
+  +0x00E0 | 18 C8 FF FF             | SOffset32  | 0xFFFFC818 (-14312) Loc: 0x38C8    | offset to vtable
+  +0x00E4 | 8C 37 00 00             | UOffset32  | 0x0000378C (14220) Loc: 0x3870     | offset to field `filename` (string)
+  +0x00E8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x00EC         | offset to field `included_filenames` (vector)
+
+vector (reflection.SchemaFile.included_filenames):
+  +0x00EC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x00F0 | 44 36 00 00             | UOffset32  | 0x00003644 (13892) Loc: 0x3734     | offset to string[0]
+  +0x00F4 | 7C 37 00 00             | UOffset32  | 0x0000377C (14204) Loc: 0x3870     | offset to string[1]
+
+table (reflection.SchemaFile):
+  +0x00F8 | 30 C8 FF FF             | SOffset32  | 0xFFFFC830 (-14288) Loc: 0x38C8    | offset to vtable
+  +0x00FC | 38 36 00 00             | UOffset32  | 0x00003638 (13880) Loc: 0x3734     | offset to field `filename` (string)
+  +0x0100 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0104         | offset to field `included_filenames` (vector)
+
+vector (reflection.SchemaFile.included_filenames):
+  +0x0104 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x0108 | 2C 36 00 00             | UOffset32  | 0x0000362C (13868) Loc: 0x3734     | offset to string[0]
+  +0x010C | 64 37 00 00             | UOffset32  | 0x00003764 (14180) Loc: 0x3870     | offset to string[1]
 
 padding:
-  +0x00DE | 00 00                   | uint8_t[2]  | ..                                 | padding
-
-table (reflection.SchemaFile):
-  +0x00E0 | 18 C8 FF FF             | SOffset32   | 0xFFFFC818 (-14312) Loc: +0x38C8   | offset to vtable
-  +0x00E4 | 8C 37 00 00             | UOffset32   | 0x0000378C (14220) Loc: +0x3870    | offset to field `key` (string)
-  +0x00E8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x00EC        | offset to field `value` (string)
-
-string (reflection.SchemaFile.value):
-  +0x00EC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x00F0 | 44 36                   | char[2]     | D6                                 | string literal
-  +0x00F2 | 00                      | char        | 0x00 (0)                           | string terminator
-
-unknown (no known references):
-  +0x00F3 | 00 7C 37 00 00          | ?uint8_t[5] | .|7..                              | WARN: could be corrupted padding region.
-
-table (reflection.SchemaFile):
-  +0x00F8 | 30 C8 FF FF             | SOffset32   | 0xFFFFC830 (-14288) Loc: +0x38C8   | offset to vtable
-  +0x00FC | 38 36 00 00             | UOffset32   | 0x00003638 (13880) Loc: +0x3734    | offset to field `key` (string)
-  +0x0100 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0104        | offset to field `value` (string)
-
-string (reflection.SchemaFile.value):
-  +0x0104 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x0108 | 2C 36                   | char[2]     | ,6                                 | string literal
-  +0x010A | 00                      | char        | 0x00 (0)                           | string terminator
-
-unknown (no known references):
-  +0x010B | 00 64 37 00 00 00 00    | ?uint8_t[7] | .d7....                            | WARN: could be corrupted padding region.
+  +0x0110 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Service):
-  +0x0112 | 0E 00                   | uint16_t    | 0x000E (14)                        | size of this vtable
-  +0x0114 | 10 00                   | uint16_t    | 0x0010 (16)                        | size of referring table
-  +0x0116 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x0118 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `calls` (id: 1)
-  +0x011A | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `attributes` (id: 2) <null> (Vector)
-  +0x011C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 3) <null> (Vector)
-  +0x011E | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `declaration_file` (id: 4)
+  +0x0112 | 0E 00                   | uint16_t   | 0x000E (14)                        | size of this vtable
+  +0x0114 | 10 00                   | uint16_t   | 0x0010 (16)                        | size of referring table
+  +0x0116 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x0118 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `calls` (id: 1)
+  +0x011A | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `attributes` (id: 2) <null> (Vector)
+  +0x011C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 3) <null> (Vector)
+  +0x011E | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `declaration_file` (id: 4)
 
 table (reflection.Service):
-  +0x0120 | 0E 00 00 00             | SOffset32   | 0x0000000E (14) Loc: +0x0112       | offset to vtable
-  +0x0124 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0144       | offset to field `name` (string)
-  +0x0128 | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x0130        | offset to field `calls` (vector)
-  +0x012C | B8 35 00 00             | UOffset32   | 0x000035B8 (13752) Loc: +0x36E4    | offset to field `declaration_file` (string)
+  +0x0120 | 0E 00 00 00             | SOffset32  | 0x0000000E (14) Loc: 0x0112        | offset to vtable
+  +0x0124 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0144        | offset to field `name` (string)
+  +0x0128 | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x0130         | offset to field `calls` (vector)
+  +0x012C | B8 35 00 00             | UOffset32  | 0x000035B8 (13752) Loc: 0x36E4     | offset to field `declaration_file` (string)
 
 vector (reflection.Service.calls):
-  +0x0130 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of vector (# items)
-  +0x0134 | 70 01 00 00             | UOffset32   | 0x00000170 (368) Loc: +0x02A4      | offset to table[0]
-  +0x0138 | E4 00 00 00             | UOffset32   | 0x000000E4 (228) Loc: +0x021C      | offset to table[1]
-  +0x013C | 88 00 00 00             | UOffset32   | 0x00000088 (136) Loc: +0x01C4      | offset to table[2]
-  +0x0140 | 28 00 00 00             | UOffset32   | 0x00000028 (40) Loc: +0x0168       | offset to table[3]
+  +0x0130 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of vector (# items)
+  +0x0134 | 70 01 00 00             | UOffset32  | 0x00000170 (368) Loc: 0x02A4       | offset to table[0]
+  +0x0138 | E4 00 00 00             | UOffset32  | 0x000000E4 (228) Loc: 0x021C       | offset to table[1]
+  +0x013C | 88 00 00 00             | UOffset32  | 0x00000088 (136) Loc: 0x01C4       | offset to table[2]
+  +0x0140 | 28 00 00 00             | UOffset32  | 0x00000028 (40) Loc: 0x0168        | offset to table[3]
 
 string (reflection.Service.name):
-  +0x0144 | 1D 00 00 00             | uint32_t    | 0x0000001D (29)                    | length of string
-  +0x0148 | 4D 79 47 61 6D 65 2E 45 | char[29]    | MyGame.E                           | string literal
-  +0x0150 | 78 61 6D 70 6C 65 2E 4D |             | xample.M
-  +0x0158 | 6F 6E 73 74 65 72 53 74 |             | onsterSt
-  +0x0160 | 6F 72 61 67 65          |             | orage
-  +0x0165 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0144 | 1D 00 00 00             | uint32_t   | 0x0000001D (29)                    | length of string
+  +0x0148 | 4D 79 47 61 6D 65 2E 45 | char[29]   | MyGame.E                           | string literal
+  +0x0150 | 78 61 6D 70 6C 65 2E 4D |            | xample.M
+  +0x0158 | 6F 6E 73 74 65 72 53 74 |            | onsterSt
+  +0x0160 | 6F 72 61 67 65          |            | orage
+  +0x0165 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0166 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x0166 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.RPCCall):
-  +0x0168 | D0 FE FF FF             | SOffset32   | 0xFFFFFED0 (-304) Loc: +0x0298     | offset to vtable
-  +0x016C | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x01AC       | offset to field `name` (string)
-  +0x0170 | 14 0C 00 00             | UOffset32   | 0x00000C14 (3092) Loc: +0x0D84     | offset to field `request` (table)
-  +0x0174 | 50 2E 00 00             | UOffset32   | 0x00002E50 (11856) Loc: +0x2FC4    | offset to field `response` (table)
-  +0x0178 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x017C        | offset to field `attributes` (vector)
+  +0x0168 | D0 FE FF FF             | SOffset32  | 0xFFFFFED0 (-304) Loc: 0x0298      | offset to vtable
+  +0x016C | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x01AC        | offset to field `name` (string)
+  +0x0170 | 14 0C 00 00             | UOffset32  | 0x00000C14 (3092) Loc: 0x0D84      | offset to field `request` (table)
+  +0x0174 | 50 2E 00 00             | UOffset32  | 0x00002E50 (11856) Loc: 0x2FC4     | offset to field `response` (table)
+  +0x0178 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x017C         | offset to field `attributes` (vector)
 
 vector (reflection.RPCCall.attributes):
-  +0x017C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x0180 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0184        | offset to table[0]
+  +0x017C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x0180 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0184         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x0184 | BC C8 FF FF             | SOffset32   | 0xFFFFC8BC (-14148) Loc: +0x38C8   | offset to vtable
-  +0x0188 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x019C       | offset to field `key` (string)
-  +0x018C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0190        | offset to field `value` (string)
+  +0x0184 | BC C8 FF FF             | SOffset32  | 0xFFFFC8BC (-14148) Loc: 0x38C8    | offset to vtable
+  +0x0188 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x019C        | offset to field `key` (string)
+  +0x018C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0190         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x0190 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x0194 | 62 69 64 69             | char[4]     | bidi                               | string literal
-  +0x0198 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0190 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x0194 | 62 69 64 69             | char[4]    | bidi                               | string literal
+  +0x0198 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0199 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x0199 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x019C | 09 00 00 00             | uint32_t    | 0x00000009 (9)                     | length of string
-  +0x01A0 | 73 74 72 65 61 6D 69 6E | char[9]     | streamin                           | string literal
-  +0x01A8 | 67                      |             | g
-  +0x01A9 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x019C | 09 00 00 00             | uint32_t   | 0x00000009 (9)                     | length of string
+  +0x01A0 | 73 74 72 65 61 6D 69 6E | char[9]    | streamin                           | string literal
+  +0x01A8 | 67                      |            | g
+  +0x01A9 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x01AA | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x01AA | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.RPCCall.name):
-  +0x01AC | 12 00 00 00             | uint32_t    | 0x00000012 (18)                    | length of string
-  +0x01B0 | 47 65 74 4D 69 6E 4D 61 | char[18]    | GetMinMa                           | string literal
-  +0x01B8 | 78 48 69 74 50 6F 69 6E |             | xHitPoin
-  +0x01C0 | 74 73                   |             | ts
-  +0x01C2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x01AC | 12 00 00 00             | uint32_t   | 0x00000012 (18)                    | length of string
+  +0x01B0 | 47 65 74 4D 69 6E 4D 61 | char[18]   | GetMinMa                           | string literal
+  +0x01B8 | 78 48 69 74 50 6F 69 6E |            | xHitPoin
+  +0x01C0 | 74 73                   |            | ts
+  +0x01C2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.RPCCall):
-  +0x01C4 | 2C FF FF FF             | SOffset32   | 0xFFFFFF2C (-212) Loc: +0x0298     | offset to vtable
-  +0x01C8 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x0208       | offset to field `name` (string)
-  +0x01CC | B8 0B 00 00             | UOffset32   | 0x00000BB8 (3000) Loc: +0x0D84     | offset to field `request` (table)
-  +0x01D0 | F4 2D 00 00             | UOffset32   | 0x00002DF4 (11764) Loc: +0x2FC4    | offset to field `response` (table)
-  +0x01D4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x01D8        | offset to field `attributes` (vector)
+  +0x01C4 | 2C FF FF FF             | SOffset32  | 0xFFFFFF2C (-212) Loc: 0x0298      | offset to vtable
+  +0x01C8 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x0208        | offset to field `name` (string)
+  +0x01CC | B8 0B 00 00             | UOffset32  | 0x00000BB8 (3000) Loc: 0x0D84      | offset to field `request` (table)
+  +0x01D0 | F4 2D 00 00             | UOffset32  | 0x00002DF4 (11764) Loc: 0x2FC4     | offset to field `response` (table)
+  +0x01D4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x01D8         | offset to field `attributes` (vector)
 
 vector (reflection.RPCCall.attributes):
-  +0x01D8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x01DC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x01E0        | offset to table[0]
+  +0x01D8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x01DC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x01E0         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x01E0 | 18 C9 FF FF             | SOffset32   | 0xFFFFC918 (-14056) Loc: +0x38C8   | offset to vtable
-  +0x01E4 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x01F8       | offset to field `key` (string)
-  +0x01E8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x01EC        | offset to field `value` (string)
+  +0x01E0 | 18 C9 FF FF             | SOffset32  | 0xFFFFC918 (-14056) Loc: 0x38C8    | offset to vtable
+  +0x01E4 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x01F8        | offset to field `key` (string)
+  +0x01E8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x01EC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x01EC | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | length of string
-  +0x01F0 | 63 6C 69 65 6E 74       | char[6]     | client                             | string literal
-  +0x01F6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x01EC | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | length of string
+  +0x01F0 | 63 6C 69 65 6E 74       | char[6]    | client                             | string literal
+  +0x01F6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x01F8 | 09 00 00 00             | uint32_t    | 0x00000009 (9)                     | length of string
-  +0x01FC | 73 74 72 65 61 6D 69 6E | char[9]     | streamin                           | string literal
-  +0x0204 | 67                      |             | g
-  +0x0205 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x01F8 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                     | length of string
+  +0x01FC | 73 74 72 65 61 6D 69 6E | char[9]    | streamin                           | string literal
+  +0x0204 | 67                      |            | g
+  +0x0205 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0206 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x0206 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.RPCCall.name):
-  +0x0208 | 0E 00 00 00             | uint32_t    | 0x0000000E (14)                    | length of string
-  +0x020C | 47 65 74 4D 61 78 48 69 | char[14]    | GetMaxHi                           | string literal
-  +0x0214 | 74 50 6F 69 6E 74       |             | tPoint
-  +0x021A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0208 | 0E 00 00 00             | uint32_t   | 0x0000000E (14)                    | length of string
+  +0x020C | 47 65 74 4D 61 78 48 69 | char[14]   | GetMaxHi                           | string literal
+  +0x0214 | 74 50 6F 69 6E 74       |            | tPoint
+  +0x021A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.RPCCall):
-  +0x021C | 84 FF FF FF             | SOffset32   | 0xFFFFFF84 (-124) Loc: +0x0298     | offset to vtable
-  +0x0220 | 68 00 00 00             | UOffset32   | 0x00000068 (104) Loc: +0x0288      | offset to field `name` (string)
-  +0x0224 | A0 2D 00 00             | UOffset32   | 0x00002DA0 (11680) Loc: +0x2FC4    | offset to field `request` (table)
-  +0x0228 | 5C 0B 00 00             | UOffset32   | 0x00000B5C (2908) Loc: +0x0D84     | offset to field `response` (table)
-  +0x022C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0230        | offset to field `attributes` (vector)
+  +0x021C | 84 FF FF FF             | SOffset32  | 0xFFFFFF84 (-124) Loc: 0x0298      | offset to vtable
+  +0x0220 | 68 00 00 00             | UOffset32  | 0x00000068 (104) Loc: 0x0288       | offset to field `name` (string)
+  +0x0224 | A0 2D 00 00             | UOffset32  | 0x00002DA0 (11680) Loc: 0x2FC4     | offset to field `request` (table)
+  +0x0228 | 5C 0B 00 00             | UOffset32  | 0x00000B5C (2908) Loc: 0x0D84      | offset to field `response` (table)
+  +0x022C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0230         | offset to field `attributes` (vector)
 
 vector (reflection.RPCCall.attributes):
-  +0x0230 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x0234 | 30 00 00 00             | UOffset32   | 0x00000030 (48) Loc: +0x0264       | offset to table[0]
-  +0x0238 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x023C        | offset to table[1]
+  +0x0230 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x0234 | 30 00 00 00             | UOffset32  | 0x00000030 (48) Loc: 0x0264        | offset to table[0]
+  +0x0238 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x023C         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x023C | 74 C9 FF FF             | SOffset32   | 0xFFFFC974 (-13964) Loc: +0x38C8   | offset to vtable
-  +0x0240 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0254       | offset to field `key` (string)
-  +0x0244 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0248        | offset to field `value` (string)
+  +0x023C | 74 C9 FF FF             | SOffset32  | 0xFFFFC974 (-13964) Loc: 0x38C8    | offset to vtable
+  +0x0240 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0254        | offset to field `key` (string)
+  +0x0244 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0248         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x0248 | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | length of string
-  +0x024C | 73 65 72 76 65 72       | char[6]     | server                             | string literal
-  +0x0252 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0248 | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | length of string
+  +0x024C | 73 65 72 76 65 72       | char[6]    | server                             | string literal
+  +0x0252 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x0254 | 09 00 00 00             | uint32_t    | 0x00000009 (9)                     | length of string
-  +0x0258 | 73 74 72 65 61 6D 69 6E | char[9]     | streamin                           | string literal
-  +0x0260 | 67                      |             | g
-  +0x0261 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0254 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                     | length of string
+  +0x0258 | 73 74 72 65 61 6D 69 6E | char[9]    | streamin                           | string literal
+  +0x0260 | 67                      |            | g
+  +0x0261 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0262 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x0262 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.KeyValue):
-  +0x0264 | 9C C9 FF FF             | SOffset32   | 0xFFFFC99C (-13924) Loc: +0x38C8   | offset to vtable
-  +0x0268 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0278       | offset to field `key` (string)
-  +0x026C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0270        | offset to field `value` (string)
+  +0x0264 | 9C C9 FF FF             | SOffset32  | 0xFFFFC99C (-13924) Loc: 0x38C8    | offset to vtable
+  +0x0268 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0278        | offset to field `key` (string)
+  +0x026C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0270         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x0270 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x0274 | 30                      | char[1]     | 0                                  | string literal
-  +0x0275 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0270 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x0274 | 30                      | char[1]    | 0                                  | string literal
+  +0x0275 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0276 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x0276 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x0278 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                    | length of string
-  +0x027C | 69 64 65 6D 70 6F 74 65 | char[10]    | idempote                           | string literal
-  +0x0284 | 6E 74                   |             | nt
-  +0x0286 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0278 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                    | length of string
+  +0x027C | 69 64 65 6D 70 6F 74 65 | char[10]   | idempote                           | string literal
+  +0x0284 | 6E 74                   |            | nt
+  +0x0286 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.RPCCall.name):
-  +0x0288 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x028C | 52 65 74 72 69 65 76 65 | char[8]     | Retrieve                           | string literal
-  +0x0294 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0288 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x028C | 52 65 74 72 69 65 76 65 | char[8]    | Retrieve                           | string literal
+  +0x0294 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0295 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x0295 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 vtable (reflection.RPCCall):
-  +0x0298 | 0C 00                   | uint16_t    | 0x000C (12)                        | size of this vtable
-  +0x029A | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x029C | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x029E | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `request` (id: 1)
-  +0x02A0 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `response` (id: 2)
-  +0x02A2 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 3)
+  +0x0298 | 0C 00                   | uint16_t   | 0x000C (12)                        | size of this vtable
+  +0x029A | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x029C | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x029E | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `request` (id: 1)
+  +0x02A0 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `response` (id: 2)
+  +0x02A2 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 3)
 
 table (reflection.RPCCall):
-  +0x02A4 | 0C 00 00 00             | SOffset32   | 0x0000000C (12) Loc: +0x0298       | offset to vtable
-  +0x02A8 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x02E8       | offset to field `name` (string)
-  +0x02AC | D8 0A 00 00             | UOffset32   | 0x00000AD8 (2776) Loc: +0x0D84     | offset to field `request` (table)
-  +0x02B0 | 14 2D 00 00             | UOffset32   | 0x00002D14 (11540) Loc: +0x2FC4    | offset to field `response` (table)
-  +0x02B4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x02B8        | offset to field `attributes` (vector)
+  +0x02A4 | 0C 00 00 00             | SOffset32  | 0x0000000C (12) Loc: 0x0298        | offset to vtable
+  +0x02A8 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x02E8        | offset to field `name` (string)
+  +0x02AC | D8 0A 00 00             | UOffset32  | 0x00000AD8 (2776) Loc: 0x0D84      | offset to field `request` (table)
+  +0x02B0 | 14 2D 00 00             | UOffset32  | 0x00002D14 (11540) Loc: 0x2FC4     | offset to field `response` (table)
+  +0x02B4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x02B8         | offset to field `attributes` (vector)
 
 vector (reflection.RPCCall.attributes):
-  +0x02B8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x02BC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x02C0        | offset to table[0]
+  +0x02B8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x02BC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x02C0         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x02C0 | F8 C9 FF FF             | SOffset32   | 0xFFFFC9F8 (-13832) Loc: +0x38C8   | offset to vtable
-  +0x02C4 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x02D8       | offset to field `key` (string)
-  +0x02C8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x02CC        | offset to field `value` (string)
+  +0x02C0 | F8 C9 FF FF             | SOffset32  | 0xFFFFC9F8 (-13832) Loc: 0x38C8    | offset to vtable
+  +0x02C4 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x02D8        | offset to field `key` (string)
+  +0x02C8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x02CC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x02CC | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x02D0 | 6E 6F 6E 65             | char[4]     | none                               | string literal
-  +0x02D4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x02CC | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x02D0 | 6E 6F 6E 65             | char[4]    | none                               | string literal
+  +0x02D4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x02D5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x02D5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x02D8 | 09 00 00 00             | uint32_t    | 0x00000009 (9)                     | length of string
-  +0x02DC | 73 74 72 65 61 6D 69 6E | char[9]     | streamin                           | string literal
-  +0x02E4 | 67                      |             | g
-  +0x02E5 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x02D8 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                     | length of string
+  +0x02DC | 73 74 72 65 61 6D 69 6E | char[9]    | streamin                           | string literal
+  +0x02E4 | 67                      |            | g
+  +0x02E5 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x02E6 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x02E6 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.RPCCall.name):
-  +0x02E8 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x02EC | 53 74 6F 72 65          | char[5]     | Store                              | string literal
-  +0x02F1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x02E8 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x02EC | 53 74 6F 72 65          | char[5]    | Store                              | string literal
+  +0x02F1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x02F2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x02F2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Enum):
-  +0x02F4 | D2 FD FF FF             | SOffset32   | 0xFFFFFDD2 (-558) Loc: +0x0522     | offset to vtable
-  +0x02F8 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x02FB | 01                      | uint8_t     | 0x01 (1)                           | table field `is_union` (Bool)
-  +0x02FC | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x0334       | offset to field `name` (string)
-  +0x0300 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0320       | offset to field `values` (vector)
-  +0x0304 | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x030C        | offset to field `underlying_type` (table)
-  +0x0308 | DC 33 00 00             | UOffset32   | 0x000033DC (13276) Loc: +0x36E4    | offset to field `declaration_file` (string)
+  +0x02F4 | D2 FD FF FF             | SOffset32  | 0xFFFFFDD2 (-558) Loc: 0x0522      | offset to vtable
+  +0x02F8 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x02FB | 01                      | uint8_t    | 0x01 (1)                           | table field `is_union` (Bool)
+  +0x02FC | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x0334        | offset to field `name` (string)
+  +0x0300 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0320        | offset to field `values` (vector)
+  +0x0304 | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x030C         | offset to field `underlying_type` (table)
+  +0x0308 | DC 33 00 00             | UOffset32  | 0x000033DC (13276) Loc: 0x36E4     | offset to field `declaration_file` (string)
 
 table (reflection.Type):
-  +0x030C | 60 CD FF FF             | SOffset32   | 0xFFFFCD60 (-12960) Loc: +0x35AC   | offset to vtable
-  +0x0310 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0313 | 01                      | uint8_t     | 0x01 (1)                           | table field `base_type` (Byte)
-  +0x0314 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `index` (Int)
-  +0x0318 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x031C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x030C | 60 CD FF FF             | SOffset32  | 0xFFFFCD60 (-12960) Loc: 0x35AC    | offset to vtable
+  +0x0310 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0313 | 01                      | uint8_t    | 0x01 (1)                           | table field `base_type` (Byte)
+  +0x0314 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `index` (Int)
+  +0x0318 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x031C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 vector (reflection.Enum.values):
-  +0x0320 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of vector (# items)
-  +0x0324 | C8 00 00 00             | UOffset32   | 0x000000C8 (200) Loc: +0x03EC      | offset to table[0]
-  +0x0328 | 94 00 00 00             | UOffset32   | 0x00000094 (148) Loc: +0x03BC      | offset to table[1]
-  +0x032C | 60 00 00 00             | UOffset32   | 0x00000060 (96) Loc: +0x038C       | offset to table[2]
-  +0x0330 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x035C       | offset to table[3]
+  +0x0320 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of vector (# items)
+  +0x0324 | C8 00 00 00             | UOffset32  | 0x000000C8 (200) Loc: 0x03EC       | offset to table[0]
+  +0x0328 | 94 00 00 00             | UOffset32  | 0x00000094 (148) Loc: 0x03BC       | offset to table[1]
+  +0x032C | 60 00 00 00             | UOffset32  | 0x00000060 (96) Loc: 0x038C        | offset to table[2]
+  +0x0330 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x035C        | offset to table[3]
 
 string (reflection.Enum.name):
-  +0x0334 | 22 00 00 00             | uint32_t    | 0x00000022 (34)                    | length of string
-  +0x0338 | 4D 79 47 61 6D 65 2E 45 | char[34]    | MyGame.E                           | string literal
-  +0x0340 | 78 61 6D 70 6C 65 2E 41 |             | xample.A
-  +0x0348 | 6E 79 41 6D 62 69 67 75 |             | nyAmbigu
-  +0x0350 | 6F 75 73 41 6C 69 61 73 |             | ousAlias
-  +0x0358 | 65 73                   |             | es
-  +0x035A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0334 | 22 00 00 00             | uint32_t   | 0x00000022 (34)                    | length of string
+  +0x0338 | 4D 79 47 61 6D 65 2E 45 | char[34]   | MyGame.E                           | string literal
+  +0x0340 | 78 61 6D 70 6C 65 2E 41 |            | xample.A
+  +0x0348 | 6E 79 41 6D 62 69 67 75 |            | nyAmbigu
+  +0x0350 | 6F 75 73 41 6C 69 61 73 |            | ousAlias
+  +0x0358 | 65 73                   |            | es
+  +0x035A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x035C | 0C FB FF FF             | SOffset32   | 0xFFFFFB0C (-1268) Loc: +0x0850    | offset to vtable
-  +0x0360 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x0384       | offset to field `name` (string)
-  +0x0364 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0374       | offset to field `union_type` (table)
-  +0x0368 | 03 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000003 (3)             | table field `value` (Long)
-  +0x0370 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x035C | 0C FB FF FF             | SOffset32  | 0xFFFFFB0C (-1268) Loc: 0x0850     | offset to vtable
+  +0x0360 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x0384        | offset to field `name` (string)
+  +0x0364 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0374        | offset to field `union_type` (table)
+  +0x0368 | 03 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000003 (3)             | table field `value` (Long)
+  +0x0370 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 table (reflection.Type):
-  +0x0374 | 5C CB FF FF             | SOffset32   | 0xFFFFCB5C (-13476) Loc: +0x3818   | offset to vtable
-  +0x0378 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x037B | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x037C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `index` (Int)
-  +0x0380 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0374 | 5C CB FF FF             | SOffset32  | 0xFFFFCB5C (-13476) Loc: 0x3818    | offset to vtable
+  +0x0378 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x037B | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x037C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `index` (Int)
+  +0x0380 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0384 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x0388 | 4D 33                   | char[2]     | M3                                 | string literal
-  +0x038A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0384 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x0388 | 4D 33                   | char[2]    | M3                                 | string literal
+  +0x038A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x038C | 3C FB FF FF             | SOffset32   | 0xFFFFFB3C (-1220) Loc: +0x0850    | offset to vtable
-  +0x0390 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x03B4       | offset to field `name` (string)
-  +0x0394 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x03A4       | offset to field `union_type` (table)
-  +0x0398 | 02 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000002 (2)             | table field `value` (Long)
-  +0x03A0 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x038C | 3C FB FF FF             | SOffset32  | 0xFFFFFB3C (-1220) Loc: 0x0850     | offset to vtable
+  +0x0390 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x03B4        | offset to field `name` (string)
+  +0x0394 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x03A4        | offset to field `union_type` (table)
+  +0x0398 | 02 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000002 (2)             | table field `value` (Long)
+  +0x03A0 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 table (reflection.Type):
-  +0x03A4 | 8C CB FF FF             | SOffset32   | 0xFFFFCB8C (-13428) Loc: +0x3818   | offset to vtable
-  +0x03A8 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x03AB | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x03AC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `index` (Int)
-  +0x03B0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x03A4 | 8C CB FF FF             | SOffset32  | 0xFFFFCB8C (-13428) Loc: 0x3818    | offset to vtable
+  +0x03A8 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x03AB | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x03AC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `index` (Int)
+  +0x03B0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x03B4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x03B8 | 4D 32                   | char[2]     | M2                                 | string literal
-  +0x03BA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x03B4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x03B8 | 4D 32                   | char[2]    | M2                                 | string literal
+  +0x03BA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x03BC | 6C FB FF FF             | SOffset32   | 0xFFFFFB6C (-1172) Loc: +0x0850    | offset to vtable
-  +0x03C0 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x03E4       | offset to field `name` (string)
-  +0x03C4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x03D4       | offset to field `union_type` (table)
-  +0x03C8 | 01 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000001 (1)             | table field `value` (Long)
-  +0x03D0 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x03BC | 6C FB FF FF             | SOffset32  | 0xFFFFFB6C (-1172) Loc: 0x0850     | offset to vtable
+  +0x03C0 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x03E4        | offset to field `name` (string)
+  +0x03C4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x03D4        | offset to field `union_type` (table)
+  +0x03C8 | 01 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000001 (1)             | table field `value` (Long)
+  +0x03D0 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 table (reflection.Type):
-  +0x03D4 | BC CB FF FF             | SOffset32   | 0xFFFFCBBC (-13380) Loc: +0x3818   | offset to vtable
-  +0x03D8 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x03DB | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x03DC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `index` (Int)
-  +0x03E0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x03D4 | BC CB FF FF             | SOffset32  | 0xFFFFCBBC (-13380) Loc: 0x3818    | offset to vtable
+  +0x03D8 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x03DB | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x03DC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `index` (Int)
+  +0x03E0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x03E4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x03E8 | 4D 31                   | char[2]     | M1                                 | string literal
-  +0x03EA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x03E4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x03E8 | 4D 31                   | char[2]    | M1                                 | string literal
+  +0x03EA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x03EC | 0C F9 FF FF             | SOffset32   | 0xFFFFF90C (-1780) Loc: +0x0AE0    | offset to vtable
-  +0x03F0 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0404       | offset to field `name` (string)
-  +0x03F4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x03F8        | offset to field `union_type` (table)
+  +0x03EC | 0C F9 FF FF             | SOffset32  | 0xFFFFF90C (-1780) Loc: 0x0AE0     | offset to vtable
+  +0x03F0 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0404        | offset to field `name` (string)
+  +0x03F4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x03F8         | offset to field `union_type` (table)
 
 table (reflection.Type):
-  +0x03F8 | 00 F9 FF FF             | SOffset32   | 0xFFFFF900 (-1792) Loc: +0x0AF8    | offset to vtable
-  +0x03FC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0400 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x03F8 | 00 F9 FF FF             | SOffset32  | 0xFFFFF900 (-1792) Loc: 0x0AF8     | offset to vtable
+  +0x03FC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0400 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0404 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x0408 | 4E 4F 4E 45             | char[4]     | NONE                               | string literal
-  +0x040C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0404 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x0408 | 4E 4F 4E 45             | char[4]    | NONE                               | string literal
+  +0x040C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x040D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x040D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Enum):
-  +0x0410 | EE FE FF FF             | SOffset32   | 0xFFFFFEEE (-274) Loc: +0x0522     | offset to vtable
-  +0x0414 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0417 | 01                      | uint8_t     | 0x01 (1)                           | table field `is_union` (Bool)
-  +0x0418 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x0450       | offset to field `name` (string)
-  +0x041C | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x043C       | offset to field `values` (vector)
-  +0x0420 | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x0428        | offset to field `underlying_type` (table)
-  +0x0424 | C0 32 00 00             | UOffset32   | 0x000032C0 (12992) Loc: +0x36E4    | offset to field `declaration_file` (string)
+  +0x0410 | EE FE FF FF             | SOffset32  | 0xFFFFFEEE (-274) Loc: 0x0522      | offset to vtable
+  +0x0414 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0417 | 01                      | uint8_t    | 0x01 (1)                           | table field `is_union` (Bool)
+  +0x0418 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x0450        | offset to field `name` (string)
+  +0x041C | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x043C        | offset to field `values` (vector)
+  +0x0420 | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x0428         | offset to field `underlying_type` (table)
+  +0x0424 | C0 32 00 00             | UOffset32  | 0x000032C0 (12992) Loc: 0x36E4     | offset to field `declaration_file` (string)
 
 table (reflection.Type):
-  +0x0428 | 7C CE FF FF             | SOffset32   | 0xFFFFCE7C (-12676) Loc: +0x35AC   | offset to vtable
-  +0x042C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x042F | 01                      | uint8_t     | 0x01 (1)                           | table field `base_type` (Byte)
-  +0x0430 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | table field `index` (Int)
-  +0x0434 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0438 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0428 | 7C CE FF FF             | SOffset32  | 0xFFFFCE7C (-12676) Loc: 0x35AC    | offset to vtable
+  +0x042C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x042F | 01                      | uint8_t    | 0x01 (1)                           | table field `base_type` (Byte)
+  +0x0430 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `index` (Int)
+  +0x0434 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0438 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 vector (reflection.Enum.values):
-  +0x043C | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of vector (# items)
-  +0x0440 | C0 00 00 00             | UOffset32   | 0x000000C0 (192) Loc: +0x0500      | offset to table[0]
-  +0x0444 | 90 00 00 00             | UOffset32   | 0x00000090 (144) Loc: +0x04D4      | offset to table[1]
-  +0x0448 | 5C 00 00 00             | UOffset32   | 0x0000005C (92) Loc: +0x04A4       | offset to table[2]
-  +0x044C | 28 00 00 00             | UOffset32   | 0x00000028 (40) Loc: +0x0474       | offset to table[3]
+  +0x043C | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of vector (# items)
+  +0x0440 | C0 00 00 00             | UOffset32  | 0x000000C0 (192) Loc: 0x0500       | offset to table[0]
+  +0x0444 | 90 00 00 00             | UOffset32  | 0x00000090 (144) Loc: 0x04D4       | offset to table[1]
+  +0x0448 | 5C 00 00 00             | UOffset32  | 0x0000005C (92) Loc: 0x04A4        | offset to table[2]
+  +0x044C | 28 00 00 00             | UOffset32  | 0x00000028 (40) Loc: 0x0474        | offset to table[3]
 
 string (reflection.Enum.name):
-  +0x0450 | 1F 00 00 00             | uint32_t    | 0x0000001F (31)                    | length of string
-  +0x0454 | 4D 79 47 61 6D 65 2E 45 | char[31]    | MyGame.E                           | string literal
-  +0x045C | 78 61 6D 70 6C 65 2E 41 |             | xample.A
-  +0x0464 | 6E 79 55 6E 69 71 75 65 |             | nyUnique
-  +0x046C | 41 6C 69 61 73 65 73    |             | Aliases
-  +0x0473 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0450 | 1F 00 00 00             | uint32_t   | 0x0000001F (31)                    | length of string
+  +0x0454 | 4D 79 47 61 6D 65 2E 45 | char[31]   | MyGame.E                           | string literal
+  +0x045C | 78 61 6D 70 6C 65 2E 41 |            | xample.A
+  +0x0464 | 6E 79 55 6E 69 71 75 65 |            | nyUnique
+  +0x046C | 41 6C 69 61 73 65 73    |            | Aliases
+  +0x0473 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x0474 | 24 FC FF FF             | SOffset32   | 0xFFFFFC24 (-988) Loc: +0x0850     | offset to vtable
-  +0x0478 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x049C       | offset to field `name` (string)
-  +0x047C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x048C       | offset to field `union_type` (table)
-  +0x0480 | 03 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000003 (3)             | table field `value` (Long)
-  +0x0488 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x0474 | 24 FC FF FF             | SOffset32  | 0xFFFFFC24 (-988) Loc: 0x0850      | offset to vtable
+  +0x0478 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x049C        | offset to field `name` (string)
+  +0x047C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x048C        | offset to field `union_type` (table)
+  +0x0480 | 03 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000003 (3)             | table field `value` (Long)
+  +0x0488 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 table (reflection.Type):
-  +0x048C | 74 CC FF FF             | SOffset32   | 0xFFFFCC74 (-13196) Loc: +0x3818   | offset to vtable
-  +0x0490 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0493 | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x0494 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                    | table field `index` (Int)
-  +0x0498 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x048C | 74 CC FF FF             | SOffset32  | 0xFFFFCC74 (-13196) Loc: 0x3818    | offset to vtable
+  +0x0490 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0493 | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x0494 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                    | table field `index` (Int)
+  +0x0498 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x049C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x04A0 | 4D 32                   | char[2]     | M2                                 | string literal
-  +0x04A2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x049C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x04A0 | 4D 32                   | char[2]    | M2                                 | string literal
+  +0x04A2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x04A4 | 54 FC FF FF             | SOffset32   | 0xFFFFFC54 (-940) Loc: +0x0850     | offset to vtable
-  +0x04A8 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x04CC       | offset to field `name` (string)
-  +0x04AC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x04BC       | offset to field `union_type` (table)
-  +0x04B0 | 02 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000002 (2)             | table field `value` (Long)
-  +0x04B8 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x04A4 | 54 FC FF FF             | SOffset32  | 0xFFFFFC54 (-940) Loc: 0x0850      | offset to vtable
+  +0x04A8 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x04CC        | offset to field `name` (string)
+  +0x04AC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x04BC        | offset to field `union_type` (table)
+  +0x04B0 | 02 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000002 (2)             | table field `value` (Long)
+  +0x04B8 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 table (reflection.Type):
-  +0x04BC | A4 CC FF FF             | SOffset32   | 0xFFFFCCA4 (-13148) Loc: +0x3818   | offset to vtable
-  +0x04C0 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x04C3 | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x04C4 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | table field `index` (Int)
-  +0x04C8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x04BC | A4 CC FF FF             | SOffset32  | 0xFFFFCCA4 (-13148) Loc: 0x3818    | offset to vtable
+  +0x04C0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x04C3 | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x04C4 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | table field `index` (Int)
+  +0x04C8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x04CC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x04D0 | 54 53                   | char[2]     | TS                                 | string literal
-  +0x04D2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x04CC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x04D0 | 54 53                   | char[2]    | TS                                 | string literal
+  +0x04D2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x04D4 | 94 FA FF FF             | SOffset32   | 0xFFFFFA94 (-1388) Loc: +0x0A40    | offset to vtable
-  +0x04D8 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x04F8       | offset to field `name` (string)
-  +0x04DC | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x04E8       | offset to field `union_type` (table)
-  +0x04E0 | 01 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000001 (1)             | table field `value` (Long)
+  +0x04D4 | 94 FA FF FF             | SOffset32  | 0xFFFFFA94 (-1388) Loc: 0x0A40     | offset to vtable
+  +0x04D8 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x04F8        | offset to field `name` (string)
+  +0x04DC | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x04E8        | offset to field `union_type` (table)
+  +0x04E0 | 01 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000001 (1)             | table field `value` (Long)
 
 table (reflection.Type):
-  +0x04E8 | D0 CC FF FF             | SOffset32   | 0xFFFFCCD0 (-13104) Loc: +0x3818   | offset to vtable
-  +0x04EC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x04EF | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x04F0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `index` (Int)
-  +0x04F4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x04E8 | D0 CC FF FF             | SOffset32  | 0xFFFFCCD0 (-13104) Loc: 0x3818    | offset to vtable
+  +0x04EC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x04EF | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x04F0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `index` (Int)
+  +0x04F4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x04F8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x04FC | 4D                      | char[1]     | M                                  | string literal
-  +0x04FD | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x04F8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x04FC | 4D                      | char[1]    | M                                  | string literal
+  +0x04FD | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x04FE | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x04FE | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.EnumVal):
-  +0x0500 | 20 FA FF FF             | SOffset32   | 0xFFFFFA20 (-1504) Loc: +0x0AE0    | offset to vtable
-  +0x0504 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0518       | offset to field `name` (string)
-  +0x0508 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x050C        | offset to field `union_type` (table)
+  +0x0500 | 20 FA FF FF             | SOffset32  | 0xFFFFFA20 (-1504) Loc: 0x0AE0     | offset to vtable
+  +0x0504 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0518        | offset to field `name` (string)
+  +0x0508 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x050C         | offset to field `union_type` (table)
 
 table (reflection.Type):
-  +0x050C | 14 FA FF FF             | SOffset32   | 0xFFFFFA14 (-1516) Loc: +0x0AF8    | offset to vtable
-  +0x0510 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0514 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x050C | 14 FA FF FF             | SOffset32  | 0xFFFFFA14 (-1516) Loc: 0x0AF8     | offset to vtable
+  +0x0510 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0514 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0518 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x051C | 4E 4F 4E 45             | char[4]     | NONE                               | string literal
-  +0x0520 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0518 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x051C | 4E 4F 4E 45             | char[4]    | NONE                               | string literal
+  +0x0520 | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Enum):
-  +0x0522 | 12 00                   | uint16_t    | 0x0012 (18)                        | size of this vtable
-  +0x0524 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of referring table
-  +0x0526 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x0528 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `values` (id: 1)
-  +0x052A | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `is_union` (id: 2)
-  +0x052C | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `underlying_type` (id: 3)
-  +0x052E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `attributes` (id: 4) <null> (Vector)
-  +0x0530 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 5) <null> (Vector)
-  +0x0532 | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `declaration_file` (id: 6)
+  +0x0522 | 12 00                   | uint16_t   | 0x0012 (18)                        | size of this vtable
+  +0x0524 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of referring table
+  +0x0526 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x0528 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `values` (id: 1)
+  +0x052A | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `is_union` (id: 2)
+  +0x052C | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `underlying_type` (id: 3)
+  +0x052E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `attributes` (id: 4) <null> (Vector)
+  +0x0530 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 5) <null> (Vector)
+  +0x0532 | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `declaration_file` (id: 6)
 
 table (reflection.Enum):
-  +0x0534 | 12 00 00 00             | SOffset32   | 0x00000012 (18) Loc: +0x0522       | offset to vtable
-  +0x0538 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x053B | 01                      | uint8_t     | 0x01 (1)                           | table field `is_union` (Bool)
-  +0x053C | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x0574       | offset to field `name` (string)
-  +0x0540 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0560       | offset to field `values` (vector)
-  +0x0544 | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x054C        | offset to field `underlying_type` (table)
-  +0x0548 | 9C 31 00 00             | UOffset32   | 0x0000319C (12700) Loc: +0x36E4    | offset to field `declaration_file` (string)
+  +0x0534 | 12 00 00 00             | SOffset32  | 0x00000012 (18) Loc: 0x0522        | offset to vtable
+  +0x0538 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x053B | 01                      | uint8_t    | 0x01 (1)                           | table field `is_union` (Bool)
+  +0x053C | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x0574        | offset to field `name` (string)
+  +0x0540 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0560        | offset to field `values` (vector)
+  +0x0544 | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x054C         | offset to field `underlying_type` (table)
+  +0x0548 | 9C 31 00 00             | UOffset32  | 0x0000319C (12700) Loc: 0x36E4     | offset to field `declaration_file` (string)
 
 table (reflection.Type):
-  +0x054C | A0 CF FF FF             | SOffset32   | 0xFFFFCFA0 (-12384) Loc: +0x35AC   | offset to vtable
-  +0x0550 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0553 | 01                      | uint8_t     | 0x01 (1)                           | table field `base_type` (Byte)
-  +0x0554 | 00 00 00 00             | uint32_t    | 0x00000000 (0)                     | table field `index` (Int)
-  +0x0558 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x055C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x054C | A0 CF FF FF             | SOffset32  | 0xFFFFCFA0 (-12384) Loc: 0x35AC    | offset to vtable
+  +0x0550 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0553 | 01                      | uint8_t    | 0x01 (1)                           | table field `base_type` (Byte)
+  +0x0554 | 00 00 00 00             | uint32_t   | 0x00000000 (0)                     | table field `index` (Int)
+  +0x0558 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x055C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 vector (reflection.Enum.values):
-  +0x0560 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of vector (# items)
-  +0x0564 | D8 00 00 00             | UOffset32   | 0x000000D8 (216) Loc: +0x063C      | offset to table[0]
-  +0x0568 | A4 00 00 00             | UOffset32   | 0x000000A4 (164) Loc: +0x060C      | offset to table[1]
-  +0x056C | 60 00 00 00             | UOffset32   | 0x00000060 (96) Loc: +0x05CC       | offset to table[2]
-  +0x0570 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0x058C       | offset to table[3]
+  +0x0560 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of vector (# items)
+  +0x0564 | D8 00 00 00             | UOffset32  | 0x000000D8 (216) Loc: 0x063C       | offset to table[0]
+  +0x0568 | A4 00 00 00             | UOffset32  | 0x000000A4 (164) Loc: 0x060C       | offset to table[1]
+  +0x056C | 60 00 00 00             | UOffset32  | 0x00000060 (96) Loc: 0x05CC        | offset to table[2]
+  +0x0570 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: 0x058C        | offset to table[3]
 
 string (reflection.Enum.name):
-  +0x0574 | 12 00 00 00             | uint32_t    | 0x00000012 (18)                    | length of string
-  +0x0578 | 4D 79 47 61 6D 65 2E 45 | char[18]    | MyGame.E                           | string literal
-  +0x0580 | 78 61 6D 70 6C 65 2E 41 |             | xample.A
-  +0x0588 | 6E 79                   |             | ny
-  +0x058A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0574 | 12 00 00 00             | uint32_t   | 0x00000012 (18)                    | length of string
+  +0x0578 | 4D 79 47 61 6D 65 2E 45 | char[18]   | MyGame.E                           | string literal
+  +0x0580 | 78 61 6D 70 6C 65 2E 41 |            | xample.A
+  +0x0588 | 6E 79                   |            | ny
+  +0x058A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x058C | 4C FB FF FF             | SOffset32   | 0xFFFFFB4C (-1204) Loc: +0x0A40    | offset to vtable
-  +0x0590 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x05B0       | offset to field `name` (string)
-  +0x0594 | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x05A0       | offset to field `union_type` (table)
-  +0x0598 | 03 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000003 (3)             | table field `value` (Long)
+  +0x058C | 4C FB FF FF             | SOffset32  | 0xFFFFFB4C (-1204) Loc: 0x0A40     | offset to vtable
+  +0x0590 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x05B0        | offset to field `name` (string)
+  +0x0594 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x05A0        | offset to field `union_type` (table)
+  +0x0598 | 03 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000003 (3)             | table field `value` (Long)
 
 table (reflection.Type):
-  +0x05A0 | 88 CD FF FF             | SOffset32   | 0xFFFFCD88 (-12920) Loc: +0x3818   | offset to vtable
-  +0x05A4 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x05A7 | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x05A8 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                    | table field `index` (Int)
-  +0x05AC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x05A0 | 88 CD FF FF             | SOffset32  | 0xFFFFCD88 (-12920) Loc: 0x3818    | offset to vtable
+  +0x05A4 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x05A7 | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x05A8 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                    | table field `index` (Int)
+  +0x05AC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x05B0 | 17 00 00 00             | uint32_t    | 0x00000017 (23)                    | length of string
-  +0x05B4 | 4D 79 47 61 6D 65 5F 45 | char[23]    | MyGame_E                           | string literal
-  +0x05BC | 78 61 6D 70 6C 65 32 5F |             | xample2_
-  +0x05C4 | 4D 6F 6E 73 74 65 72    |             | Monster
-  +0x05CB | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x05B0 | 17 00 00 00             | uint32_t   | 0x00000017 (23)                    | length of string
+  +0x05B4 | 4D 79 47 61 6D 65 5F 45 | char[23]   | MyGame_E                           | string literal
+  +0x05BC | 78 61 6D 70 6C 65 32 5F |            | xample2_
+  +0x05C4 | 4D 6F 6E 73 74 65 72    |            | Monster
+  +0x05CB | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x05CC | 8C FB FF FF             | SOffset32   | 0xFFFFFB8C (-1140) Loc: +0x0A40    | offset to vtable
-  +0x05D0 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x05F0       | offset to field `name` (string)
-  +0x05D4 | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x05E0       | offset to field `union_type` (table)
-  +0x05D8 | 02 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000002 (2)             | table field `value` (Long)
+  +0x05CC | 8C FB FF FF             | SOffset32  | 0xFFFFFB8C (-1140) Loc: 0x0A40     | offset to vtable
+  +0x05D0 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x05F0        | offset to field `name` (string)
+  +0x05D4 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x05E0        | offset to field `union_type` (table)
+  +0x05D8 | 02 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000002 (2)             | table field `value` (Long)
 
 table (reflection.Type):
-  +0x05E0 | C8 CD FF FF             | SOffset32   | 0xFFFFCDC8 (-12856) Loc: +0x3818   | offset to vtable
-  +0x05E4 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x05E7 | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x05E8 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | table field `index` (Int)
-  +0x05EC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x05E0 | C8 CD FF FF             | SOffset32  | 0xFFFFCDC8 (-12856) Loc: 0x3818    | offset to vtable
+  +0x05E4 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x05E7 | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x05E8 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | table field `index` (Int)
+  +0x05EC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x05F0 | 17 00 00 00             | uint32_t    | 0x00000017 (23)                    | length of string
-  +0x05F4 | 54 65 73 74 53 69 6D 70 | char[23]    | TestSimp                           | string literal
-  +0x05FC | 6C 65 54 61 62 6C 65 57 |             | leTableW
-  +0x0604 | 69 74 68 45 6E 75 6D    |             | ithEnum
-  +0x060B | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x05F0 | 17 00 00 00             | uint32_t   | 0x00000017 (23)                    | length of string
+  +0x05F4 | 54 65 73 74 53 69 6D 70 | char[23]   | TestSimp                           | string literal
+  +0x05FC | 6C 65 54 61 62 6C 65 57 |            | leTableW
+  +0x0604 | 69 74 68 45 6E 75 6D    |            | ithEnum
+  +0x060B | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x060C | CC FB FF FF             | SOffset32   | 0xFFFFFBCC (-1076) Loc: +0x0A40    | offset to vtable
-  +0x0610 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0630       | offset to field `name` (string)
-  +0x0614 | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x0620       | offset to field `union_type` (table)
-  +0x0618 | 01 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000001 (1)             | table field `value` (Long)
+  +0x060C | CC FB FF FF             | SOffset32  | 0xFFFFFBCC (-1076) Loc: 0x0A40     | offset to vtable
+  +0x0610 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0630        | offset to field `name` (string)
+  +0x0614 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x0620        | offset to field `union_type` (table)
+  +0x0618 | 01 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000001 (1)             | table field `value` (Long)
 
 table (reflection.Type):
-  +0x0620 | 08 CE FF FF             | SOffset32   | 0xFFFFCE08 (-12792) Loc: +0x3818   | offset to vtable
-  +0x0624 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0627 | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x0628 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `index` (Int)
-  +0x062C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0620 | 08 CE FF FF             | SOffset32  | 0xFFFFCE08 (-12792) Loc: 0x3818    | offset to vtable
+  +0x0624 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0627 | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x0628 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `index` (Int)
+  +0x062C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0630 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of string
-  +0x0634 | 4D 6F 6E 73 74 65 72    | char[7]     | Monster                            | string literal
-  +0x063B | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0630 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of string
+  +0x0634 | 4D 6F 6E 73 74 65 72    | char[7]    | Monster                            | string literal
+  +0x063B | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x063C | 5C FB FF FF             | SOffset32   | 0xFFFFFB5C (-1188) Loc: +0x0AE0    | offset to vtable
-  +0x0640 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0654       | offset to field `name` (string)
-  +0x0644 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0648        | offset to field `union_type` (table)
+  +0x063C | 5C FB FF FF             | SOffset32  | 0xFFFFFB5C (-1188) Loc: 0x0AE0     | offset to vtable
+  +0x0640 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0654        | offset to field `name` (string)
+  +0x0644 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0648         | offset to field `union_type` (table)
 
 table (reflection.Type):
-  +0x0648 | 50 FB FF FF             | SOffset32   | 0xFFFFFB50 (-1200) Loc: +0x0AF8    | offset to vtable
-  +0x064C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0650 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0648 | 50 FB FF FF             | SOffset32  | 0xFFFFFB50 (-1200) Loc: 0x0AF8     | offset to vtable
+  +0x064C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0650 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0654 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x0658 | 4E 4F 4E 45             | char[4]     | NONE                               | string literal
-  +0x065C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0654 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x0658 | 4E 4F 4E 45             | char[4]    | NONE                               | string literal
+  +0x065C | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Enum):
-  +0x065E | 12 00                   | uint16_t    | 0x0012 (18)                        | size of this vtable
-  +0x0660 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of referring table
-  +0x0662 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x0664 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `values` (id: 1)
-  +0x0666 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `is_union` (id: 2) <defaults to 0> (Bool)
-  +0x0668 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `underlying_type` (id: 3)
-  +0x066A | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 4)
-  +0x066C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 5) <null> (Vector)
-  +0x066E | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `declaration_file` (id: 6)
+  +0x065E | 12 00                   | uint16_t   | 0x0012 (18)                        | size of this vtable
+  +0x0660 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of referring table
+  +0x0662 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x0664 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `values` (id: 1)
+  +0x0666 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `is_union` (id: 2) <defaults to 0> (Bool)
+  +0x0668 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `underlying_type` (id: 3)
+  +0x066A | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 4)
+  +0x066C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 5) <null> (Vector)
+  +0x066E | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `declaration_file` (id: 6)
 
 table (reflection.Enum):
-  +0x0670 | 12 00 00 00             | SOffset32   | 0x00000012 (18) Loc: +0x065E       | offset to vtable
-  +0x0674 | 64 00 00 00             | UOffset32   | 0x00000064 (100) Loc: +0x06D8      | offset to field `name` (string)
-  +0x0678 | 50 00 00 00             | UOffset32   | 0x00000050 (80) Loc: +0x06C8       | offset to field `values` (vector)
-  +0x067C | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x06B4       | offset to field `underlying_type` (table)
-  +0x0680 | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x0688        | offset to field `attributes` (vector)
-  +0x0684 | 60 30 00 00             | UOffset32   | 0x00003060 (12384) Loc: +0x36E4    | offset to field `declaration_file` (string)
+  +0x0670 | 12 00 00 00             | SOffset32  | 0x00000012 (18) Loc: 0x065E        | offset to vtable
+  +0x0674 | 64 00 00 00             | UOffset32  | 0x00000064 (100) Loc: 0x06D8       | offset to field `name` (string)
+  +0x0678 | 50 00 00 00             | UOffset32  | 0x00000050 (80) Loc: 0x06C8        | offset to field `values` (vector)
+  +0x067C | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x06B4        | offset to field `underlying_type` (table)
+  +0x0680 | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x0688         | offset to field `attributes` (vector)
+  +0x0684 | 60 30 00 00             | UOffset32  | 0x00003060 (12384) Loc: 0x36E4     | offset to field `declaration_file` (string)
 
 vector (reflection.Enum.attributes):
-  +0x0688 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x068C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0690        | offset to table[0]
+  +0x0688 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x068C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0690         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x0690 | C8 CD FF FF             | SOffset32   | 0xFFFFCDC8 (-12856) Loc: +0x38C8   | offset to vtable
-  +0x0694 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x06A4       | offset to field `key` (string)
-  +0x0698 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x069C        | offset to field `value` (string)
+  +0x0690 | C8 CD FF FF             | SOffset32  | 0xFFFFCDC8 (-12856) Loc: 0x38C8    | offset to vtable
+  +0x0694 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x06A4        | offset to field `key` (string)
+  +0x0698 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x069C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x069C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x06A0 | 30                      | char[1]     | 0                                  | string literal
-  +0x06A1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x069C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x06A0 | 30                      | char[1]    | 0                                  | string literal
+  +0x06A1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x06A2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x06A2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x06A4 | 09 00 00 00             | uint32_t    | 0x00000009 (9)                     | length of string
-  +0x06A8 | 62 69 74 5F 66 6C 61 67 | char[9]     | bit_flag                           | string literal
-  +0x06B0 | 73                      |             | s
-  +0x06B1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x06A4 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                     | length of string
+  +0x06A8 | 62 69 74 5F 66 6C 61 67 | char[9]    | bit_flag                           | string literal
+  +0x06B0 | 73                      |            | s
+  +0x06B1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x06B2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x06B2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Type):
-  +0x06B4 | 08 D1 FF FF             | SOffset32   | 0xFFFFD108 (-12024) Loc: +0x35AC   | offset to vtable
-  +0x06B8 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x06BB | 0A                      | uint8_t     | 0x0A (10)                          | table field `base_type` (Byte)
-  +0x06BC | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `index` (Int)
-  +0x06C0 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x06C4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x06B4 | 08 D1 FF FF             | SOffset32  | 0xFFFFD108 (-12024) Loc: 0x35AC    | offset to vtable
+  +0x06B8 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x06BB | 0A                      | uint8_t    | 0x0A (10)                          | table field `base_type` (Byte)
+  +0x06BC | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `index` (Int)
+  +0x06C0 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x06C4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 vector (reflection.Enum.values):
-  +0x06C8 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of vector (# items)
-  +0x06CC | 88 00 00 00             | UOffset32   | 0x00000088 (136) Loc: +0x0754      | offset to table[0]
-  +0x06D0 | 54 00 00 00             | UOffset32   | 0x00000054 (84) Loc: +0x0724       | offset to table[1]
-  +0x06D4 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x06F4       | offset to table[2]
+  +0x06C8 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of vector (# items)
+  +0x06CC | 88 00 00 00             | UOffset32  | 0x00000088 (136) Loc: 0x0754       | offset to table[0]
+  +0x06D0 | 54 00 00 00             | UOffset32  | 0x00000054 (84) Loc: 0x0724        | offset to table[1]
+  +0x06D4 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x06F4        | offset to table[2]
 
 string (reflection.Enum.name):
-  +0x06D8 | 17 00 00 00             | uint32_t    | 0x00000017 (23)                    | length of string
-  +0x06DC | 4D 79 47 61 6D 65 2E 45 | char[23]    | MyGame.E                           | string literal
-  +0x06E4 | 78 61 6D 70 6C 65 2E 4C |             | xample.L
-  +0x06EC | 6F 6E 67 45 6E 75 6D    |             | ongEnum
-  +0x06F3 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x06D8 | 17 00 00 00             | uint32_t   | 0x00000017 (23)                    | length of string
+  +0x06DC | 4D 79 47 61 6D 65 2E 45 | char[23]   | MyGame.E                           | string literal
+  +0x06E4 | 78 61 6D 70 6C 65 2E 4C |            | xample.L
+  +0x06EC | 6F 6E 67 45 6E 75 6D    |            | ongEnum
+  +0x06F3 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x06F4 | A4 FE FF FF             | SOffset32   | 0xFFFFFEA4 (-348) Loc: +0x0850     | offset to vtable
-  +0x06F8 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0718       | offset to field `name` (string)
-  +0x06FC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x070C       | offset to field `union_type` (table)
-  +0x0700 | 00 00 00 00 00 01 00 00 | int64_t     | 0x0000010000000000 (1099511627776) | table field `value` (Long)
-  +0x0708 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x06F4 | A4 FE FF FF             | SOffset32  | 0xFFFFFEA4 (-348) Loc: 0x0850      | offset to vtable
+  +0x06F8 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0718        | offset to field `name` (string)
+  +0x06FC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x070C        | offset to field `union_type` (table)
+  +0x0700 | 00 00 00 00 00 01 00 00 | int64_t    | 0x0000010000000000 (1099511627776) | table field `value` (Long)
+  +0x0708 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 table (reflection.Type):
-  +0x070C | 14 FC FF FF             | SOffset32   | 0xFFFFFC14 (-1004) Loc: +0x0AF8    | offset to vtable
-  +0x0710 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0714 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x070C | 14 FC FF FF             | SOffset32  | 0xFFFFFC14 (-1004) Loc: 0x0AF8     | offset to vtable
+  +0x0710 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0714 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0718 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of string
-  +0x071C | 4C 6F 6E 67 42 69 67    | char[7]     | LongBig                            | string literal
-  +0x0723 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0718 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of string
+  +0x071C | 4C 6F 6E 67 42 69 67    | char[7]    | LongBig                            | string literal
+  +0x0723 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x0724 | D4 FE FF FF             | SOffset32   | 0xFFFFFED4 (-300) Loc: +0x0850     | offset to vtable
-  +0x0728 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0748       | offset to field `name` (string)
-  +0x072C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x073C       | offset to field `union_type` (table)
-  +0x0730 | 04 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000004 (4)             | table field `value` (Long)
-  +0x0738 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x0724 | D4 FE FF FF             | SOffset32  | 0xFFFFFED4 (-300) Loc: 0x0850      | offset to vtable
+  +0x0728 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0748        | offset to field `name` (string)
+  +0x072C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x073C        | offset to field `union_type` (table)
+  +0x0730 | 04 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000004 (4)             | table field `value` (Long)
+  +0x0738 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 table (reflection.Type):
-  +0x073C | 44 FC FF FF             | SOffset32   | 0xFFFFFC44 (-956) Loc: +0x0AF8     | offset to vtable
-  +0x0740 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0744 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x073C | 44 FC FF FF             | SOffset32  | 0xFFFFFC44 (-956) Loc: 0x0AF8      | offset to vtable
+  +0x0740 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0744 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0748 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of string
-  +0x074C | 4C 6F 6E 67 54 77 6F    | char[7]     | LongTwo                            | string literal
-  +0x0753 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0748 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of string
+  +0x074C | 4C 6F 6E 67 54 77 6F    | char[7]    | LongTwo                            | string literal
+  +0x0753 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x0754 | 14 FD FF FF             | SOffset32   | 0xFFFFFD14 (-748) Loc: +0x0A40     | offset to vtable
-  +0x0758 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0x0774       | offset to field `name` (string)
-  +0x075C | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x0768       | offset to field `union_type` (table)
-  +0x0760 | 02 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000002 (2)             | table field `value` (Long)
+  +0x0754 | 14 FD FF FF             | SOffset32  | 0xFFFFFD14 (-748) Loc: 0x0A40      | offset to vtable
+  +0x0758 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: 0x0774        | offset to field `name` (string)
+  +0x075C | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x0768        | offset to field `union_type` (table)
+  +0x0760 | 02 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000002 (2)             | table field `value` (Long)
 
 table (reflection.Type):
-  +0x0768 | 70 FC FF FF             | SOffset32   | 0xFFFFFC70 (-912) Loc: +0x0AF8     | offset to vtable
-  +0x076C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0770 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0768 | 70 FC FF FF             | SOffset32  | 0xFFFFFC70 (-912) Loc: 0x0AF8      | offset to vtable
+  +0x076C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0770 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0774 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of string
-  +0x0778 | 4C 6F 6E 67 4F 6E 65    | char[7]     | LongOne                            | string literal
-  +0x077F | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0774 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of string
+  +0x0778 | 4C 6F 6E 67 4F 6E 65    | char[7]    | LongOne                            | string literal
+  +0x077F | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Enum):
-  +0x0780 | 0A FD FF FF             | SOffset32   | 0xFFFFFD0A (-758) Loc: +0x0A76     | offset to vtable
-  +0x0784 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x07BC       | offset to field `name` (string)
-  +0x0788 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x07A8       | offset to field `values` (vector)
-  +0x078C | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x0794        | offset to field `underlying_type` (table)
-  +0x0790 | 54 2F 00 00             | UOffset32   | 0x00002F54 (12116) Loc: +0x36E4    | offset to field `declaration_file` (string)
+  +0x0780 | 0A FD FF FF             | SOffset32  | 0xFFFFFD0A (-758) Loc: 0x0A76      | offset to vtable
+  +0x0784 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x07BC        | offset to field `name` (string)
+  +0x0788 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x07A8        | offset to field `values` (vector)
+  +0x078C | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x0794         | offset to field `underlying_type` (table)
+  +0x0790 | 54 2F 00 00             | UOffset32  | 0x00002F54 (12116) Loc: 0x36E4     | offset to field `declaration_file` (string)
 
 table (reflection.Type):
-  +0x0794 | E8 D1 FF FF             | SOffset32   | 0xFFFFD1E8 (-11800) Loc: +0x35AC   | offset to vtable
-  +0x0798 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x079B | 03                      | uint8_t     | 0x03 (3)                           | table field `base_type` (Byte)
-  +0x079C | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | table field `index` (Int)
-  +0x07A0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x07A4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0794 | E8 D1 FF FF             | SOffset32  | 0xFFFFD1E8 (-11800) Loc: 0x35AC    | offset to vtable
+  +0x0798 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x079B | 03                      | uint8_t    | 0x03 (3)                           | table field `base_type` (Byte)
+  +0x079C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | table field `index` (Int)
+  +0x07A0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x07A4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 vector (reflection.Enum.values):
-  +0x07A8 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of vector (# items)
-  +0x07AC | B0 00 00 00             | UOffset32   | 0x000000B0 (176) Loc: +0x085C      | offset to table[0]
-  +0x07B0 | 7C 00 00 00             | UOffset32   | 0x0000007C (124) Loc: +0x082C      | offset to table[1]
-  +0x07B4 | 48 00 00 00             | UOffset32   | 0x00000048 (72) Loc: +0x07FC       | offset to table[2]
-  +0x07B8 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0x07D4       | offset to table[3]
+  +0x07A8 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of vector (# items)
+  +0x07AC | B0 00 00 00             | UOffset32  | 0x000000B0 (176) Loc: 0x085C       | offset to table[0]
+  +0x07B0 | 7C 00 00 00             | UOffset32  | 0x0000007C (124) Loc: 0x082C       | offset to table[1]
+  +0x07B4 | 48 00 00 00             | UOffset32  | 0x00000048 (72) Loc: 0x07FC        | offset to table[2]
+  +0x07B8 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: 0x07D4        | offset to table[3]
 
 string (reflection.Enum.name):
-  +0x07BC | 13 00 00 00             | uint32_t    | 0x00000013 (19)                    | length of string
-  +0x07C0 | 4D 79 47 61 6D 65 2E 45 | char[19]    | MyGame.E                           | string literal
-  +0x07C8 | 78 61 6D 70 6C 65 2E 52 |             | xample.R
-  +0x07D0 | 61 63 65                |             | ace
-  +0x07D3 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x07BC | 13 00 00 00             | uint32_t   | 0x00000013 (19)                    | length of string
+  +0x07C0 | 4D 79 47 61 6D 65 2E 45 | char[19]   | MyGame.E                           | string literal
+  +0x07C8 | 78 61 6D 70 6C 65 2E 52 |            | xample.R
+  +0x07D0 | 61 63 65                |            | ace
+  +0x07D3 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x07D4 | 94 FD FF FF             | SOffset32   | 0xFFFFFD94 (-620) Loc: +0x0A40     | offset to vtable
-  +0x07D8 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0x07F4       | offset to field `name` (string)
-  +0x07DC | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x07E8       | offset to field `union_type` (table)
-  +0x07E0 | 02 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000002 (2)             | table field `value` (Long)
+  +0x07D4 | 94 FD FF FF             | SOffset32  | 0xFFFFFD94 (-620) Loc: 0x0A40      | offset to vtable
+  +0x07D8 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: 0x07F4        | offset to field `name` (string)
+  +0x07DC | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x07E8        | offset to field `union_type` (table)
+  +0x07E0 | 02 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000002 (2)             | table field `value` (Long)
 
 table (reflection.Type):
-  +0x07E8 | F0 FC FF FF             | SOffset32   | 0xFFFFFCF0 (-784) Loc: +0x0AF8     | offset to vtable
-  +0x07EC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x07F0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x07E8 | F0 FC FF FF             | SOffset32  | 0xFFFFFCF0 (-784) Loc: 0x0AF8      | offset to vtable
+  +0x07EC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x07F0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x07F4 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x07F8 | 45 6C 66                | char[3]     | Elf                                | string literal
-  +0x07FB | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x07F4 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x07F8 | 45 6C 66                | char[3]    | Elf                                | string literal
+  +0x07FB | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.EnumVal):
-  +0x07FC | AC FF FF FF             | SOffset32   | 0xFFFFFFAC (-84) Loc: +0x0850      | offset to vtable
-  +0x0800 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0820       | offset to field `name` (string)
-  +0x0804 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0814       | offset to field `union_type` (table)
-  +0x0808 | 01 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000001 (1)             | table field `value` (Long)
-  +0x0810 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x07FC | AC FF FF FF             | SOffset32  | 0xFFFFFFAC (-84) Loc: 0x0850       | offset to vtable
+  +0x0800 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0820        | offset to field `name` (string)
+  +0x0804 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0814        | offset to field `union_type` (table)
+  +0x0808 | 01 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000001 (1)             | table field `value` (Long)
+  +0x0810 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 table (reflection.Type):
-  +0x0814 | 1C FD FF FF             | SOffset32   | 0xFFFFFD1C (-740) Loc: +0x0AF8     | offset to vtable
-  +0x0818 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x081C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0814 | 1C FD FF FF             | SOffset32  | 0xFFFFFD1C (-740) Loc: 0x0AF8      | offset to vtable
+  +0x0818 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x081C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0820 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x0824 | 44 77 61 72 66          | char[5]     | Dwarf                              | string literal
-  +0x0829 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0820 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x0824 | 44 77 61 72 66          | char[5]    | Dwarf                              | string literal
+  +0x0829 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x082A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x082A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.EnumVal):
-  +0x082C | 4C FD FF FF             | SOffset32   | 0xFFFFFD4C (-692) Loc: +0x0AE0     | offset to vtable
-  +0x0830 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0844       | offset to field `name` (string)
-  +0x0834 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0838        | offset to field `union_type` (table)
+  +0x082C | 4C FD FF FF             | SOffset32  | 0xFFFFFD4C (-692) Loc: 0x0AE0      | offset to vtable
+  +0x0830 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0844        | offset to field `name` (string)
+  +0x0834 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0838         | offset to field `union_type` (table)
 
 table (reflection.Type):
-  +0x0838 | 40 FD FF FF             | SOffset32   | 0xFFFFFD40 (-704) Loc: +0x0AF8     | offset to vtable
-  +0x083C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0840 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0838 | 40 FD FF FF             | SOffset32  | 0xFFFFFD40 (-704) Loc: 0x0AF8      | offset to vtable
+  +0x083C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0840 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0844 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x0848 | 48 75 6D 61 6E          | char[5]     | Human                              | string literal
-  +0x084D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0844 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x0848 | 48 75 6D 61 6E          | char[5]    | Human                              | string literal
+  +0x084D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x084E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x084E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.EnumVal):
-  +0x0850 | 0C 00                   | uint16_t    | 0x000C (12)                        | size of this vtable
-  +0x0852 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of referring table
-  +0x0854 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x0856 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `value` (id: 1)
-  +0x0858 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `object` (id: 2) <null> (Obj)
-  +0x085A | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `union_type` (id: 3)
+  +0x0850 | 0C 00                   | uint16_t   | 0x000C (12)                        | size of this vtable
+  +0x0852 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of referring table
+  +0x0854 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x0856 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `value` (id: 1)
+  +0x0858 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `object` (id: 2) <null> (Obj)
+  +0x085A | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `union_type` (id: 3)
 
 table (reflection.EnumVal):
-  +0x085C | 0C 00 00 00             | SOffset32   | 0x0000000C (12) Loc: +0x0850       | offset to vtable
-  +0x0860 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0880       | offset to field `name` (string)
-  +0x0864 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0874       | offset to field `union_type` (table)
-  +0x0868 | FF FF FF FF FF FF FF FF | int64_t     | 0xFFFFFFFFFFFFFFFF (-1)            | table field `value` (Long)
-  +0x0870 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x085C | 0C 00 00 00             | SOffset32  | 0x0000000C (12) Loc: 0x0850        | offset to vtable
+  +0x0860 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0880        | offset to field `name` (string)
+  +0x0864 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0874        | offset to field `union_type` (table)
+  +0x0868 | FF FF FF FF FF FF FF FF | int64_t    | 0xFFFFFFFFFFFFFFFF (-1)            | table field `value` (Long)
+  +0x0870 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 table (reflection.Type):
-  +0x0874 | 7C FD FF FF             | SOffset32   | 0xFFFFFD7C (-644) Loc: +0x0AF8     | offset to vtable
-  +0x0878 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x087C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0874 | 7C FD FF FF             | SOffset32  | 0xFFFFFD7C (-644) Loc: 0x0AF8      | offset to vtable
+  +0x0878 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x087C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0880 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x0884 | 4E 6F 6E 65             | char[4]     | None                               | string literal
-  +0x0888 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0880 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x0884 | 4E 6F 6E 65             | char[4]    | None                               | string literal
+  +0x0888 | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Enum):
-  +0x088A | 12 00                   | uint16_t    | 0x0012 (18)                        | size of this vtable
-  +0x088C | 1C 00                   | uint16_t    | 0x001C (28)                        | size of referring table
-  +0x088E | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x0890 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `values` (id: 1)
-  +0x0892 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `is_union` (id: 2) <defaults to 0> (Bool)
-  +0x0894 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `underlying_type` (id: 3)
-  +0x0896 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 4)
-  +0x0898 | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `documentation` (id: 5)
-  +0x089A | 18 00                   | VOffset16   | 0x0018 (24)                        | offset to field `declaration_file` (id: 6)
+  +0x088A | 12 00                   | uint16_t   | 0x0012 (18)                        | size of this vtable
+  +0x088C | 1C 00                   | uint16_t   | 0x001C (28)                        | size of referring table
+  +0x088E | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x0890 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `values` (id: 1)
+  +0x0892 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `is_union` (id: 2) <defaults to 0> (Bool)
+  +0x0894 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `underlying_type` (id: 3)
+  +0x0896 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 4)
+  +0x0898 | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `documentation` (id: 5)
+  +0x089A | 18 00                   | VOffset16  | 0x0018 (24)                        | offset to field `declaration_file` (id: 6)
 
 table (reflection.Enum):
-  +0x089C | 12 00 00 00             | SOffset32   | 0x00000012 (18) Loc: +0x088A       | offset to vtable
-  +0x08A0 | 9C 00 00 00             | UOffset32   | 0x0000009C (156) Loc: +0x093C      | offset to field `name` (string)
-  +0x08A4 | 88 00 00 00             | UOffset32   | 0x00000088 (136) Loc: +0x092C      | offset to field `values` (vector)
-  +0x08A8 | 70 00 00 00             | UOffset32   | 0x00000070 (112) Loc: +0x0918      | offset to field `underlying_type` (table)
-  +0x08AC | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x08EC       | offset to field `attributes` (vector)
-  +0x08B0 | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x08B8        | offset to field `documentation` (vector)
-  +0x08B4 | 30 2E 00 00             | UOffset32   | 0x00002E30 (11824) Loc: +0x36E4    | offset to field `declaration_file` (string)
+  +0x089C | 12 00 00 00             | SOffset32  | 0x00000012 (18) Loc: 0x088A        | offset to vtable
+  +0x08A0 | 9C 00 00 00             | UOffset32  | 0x0000009C (156) Loc: 0x093C       | offset to field `name` (string)
+  +0x08A4 | 88 00 00 00             | UOffset32  | 0x00000088 (136) Loc: 0x092C       | offset to field `values` (vector)
+  +0x08A8 | 70 00 00 00             | UOffset32  | 0x00000070 (112) Loc: 0x0918       | offset to field `underlying_type` (table)
+  +0x08AC | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x08EC        | offset to field `attributes` (vector)
+  +0x08B0 | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x08B8         | offset to field `documentation` (vector)
+  +0x08B4 | 30 2E 00 00             | UOffset32  | 0x00002E30 (11824) Loc: 0x36E4     | offset to field `declaration_file` (string)
 
 vector (reflection.Enum.documentation):
-  +0x08B8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x08BC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x08C0        | offset to string[0]
+  +0x08B8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x08BC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x08C0         | offset to string[0]
 
 string (reflection.Enum.documentation):
-  +0x08C0 | 27 00 00 00             | uint32_t    | 0x00000027 (39)                    | length of string
-  +0x08C4 | 20 43 6F 6D 70 6F 73 69 | char[39]    |  Composi                           | string literal
-  +0x08CC | 74 65 20 63 6F 6D 70 6F |             | te compo
-  +0x08D4 | 6E 65 6E 74 73 20 6F 66 |             | nents of
-  +0x08DC | 20 4D 6F 6E 73 74 65 72 |             |  Monster
-  +0x08E4 | 20 63 6F 6C 6F 72 2E    |             |  color.
-  +0x08EB | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x08C0 | 27 00 00 00             | uint32_t   | 0x00000027 (39)                    | length of string
+  +0x08C4 | 20 43 6F 6D 70 6F 73 69 | char[39]   |  Composi                           | string literal
+  +0x08CC | 74 65 20 63 6F 6D 70 6F |            | te compo
+  +0x08D4 | 6E 65 6E 74 73 20 6F 66 |            | nents of
+  +0x08DC | 20 4D 6F 6E 73 74 65 72 |            |  Monster
+  +0x08E4 | 20 63 6F 6C 6F 72 2E    |            |  color.
+  +0x08EB | 00                      | char       | 0x00 (0)                           | string terminator
 
 vector (reflection.Enum.attributes):
-  +0x08EC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x08F0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x08F4        | offset to table[0]
+  +0x08EC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x08F0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x08F4         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x08F4 | 2C D0 FF FF             | SOffset32   | 0xFFFFD02C (-12244) Loc: +0x38C8   | offset to vtable
-  +0x08F8 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0908       | offset to field `key` (string)
-  +0x08FC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0900        | offset to field `value` (string)
+  +0x08F4 | 2C D0 FF FF             | SOffset32  | 0xFFFFD02C (-12244) Loc: 0x38C8    | offset to vtable
+  +0x08F8 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0908        | offset to field `key` (string)
+  +0x08FC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0900         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x0900 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x0904 | 30                      | char[1]     | 0                                  | string literal
-  +0x0905 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0900 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x0904 | 30                      | char[1]    | 0                                  | string literal
+  +0x0905 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0906 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x0906 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x0908 | 09 00 00 00             | uint32_t    | 0x00000009 (9)                     | length of string
-  +0x090C | 62 69 74 5F 66 6C 61 67 | char[9]     | bit_flag                           | string literal
-  +0x0914 | 73                      |             | s
-  +0x0915 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0908 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                     | length of string
+  +0x090C | 62 69 74 5F 66 6C 61 67 | char[9]    | bit_flag                           | string literal
+  +0x0914 | 73                      |            | s
+  +0x0915 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0916 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x0916 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Type):
-  +0x0918 | 6C D3 FF FF             | SOffset32   | 0xFFFFD36C (-11412) Loc: +0x35AC   | offset to vtable
-  +0x091C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x091F | 04                      | uint8_t     | 0x04 (4)                           | table field `base_type` (Byte)
-  +0x0920 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | table field `index` (Int)
-  +0x0924 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0928 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0918 | 6C D3 FF FF             | SOffset32  | 0xFFFFD36C (-11412) Loc: 0x35AC    | offset to vtable
+  +0x091C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x091F | 04                      | uint8_t    | 0x04 (4)                           | table field `base_type` (Byte)
+  +0x0920 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | table field `index` (Int)
+  +0x0924 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0928 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 vector (reflection.Enum.values):
-  +0x092C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of vector (# items)
-  +0x0930 | 1C 01 00 00             | UOffset32   | 0x0000011C (284) Loc: +0x0A4C      | offset to table[0]
-  +0x0934 | 8C 00 00 00             | UOffset32   | 0x0000008C (140) Loc: +0x09C0      | offset to table[1]
-  +0x0938 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0958       | offset to table[2]
+  +0x092C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of vector (# items)
+  +0x0930 | 1C 01 00 00             | UOffset32  | 0x0000011C (284) Loc: 0x0A4C       | offset to table[0]
+  +0x0934 | 8C 00 00 00             | UOffset32  | 0x0000008C (140) Loc: 0x09C0       | offset to table[1]
+  +0x0938 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0958        | offset to table[2]
 
 string (reflection.Enum.name):
-  +0x093C | 14 00 00 00             | uint32_t    | 0x00000014 (20)                    | length of string
-  +0x0940 | 4D 79 47 61 6D 65 2E 45 | char[20]    | MyGame.E                           | string literal
-  +0x0948 | 78 61 6D 70 6C 65 2E 43 |             | xample.C
-  +0x0950 | 6F 6C 6F 72             |             | olor
-  +0x0954 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x093C | 14 00 00 00             | uint32_t   | 0x00000014 (20)                    | length of string
+  +0x0940 | 4D 79 47 61 6D 65 2E 45 | char[20]   | MyGame.E                           | string literal
+  +0x0948 | 78 61 6D 70 6C 65 2E 43 |            | xample.C
+  +0x0950 | 6F 6C 6F 72             |            | olor
+  +0x0954 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0955 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x0955 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.EnumVal):
-  +0x0958 | A6 FF FF FF             | SOffset32   | 0xFFFFFFA6 (-90) Loc: +0x09B2      | offset to vtable
-  +0x095C | 4C 00 00 00             | UOffset32   | 0x0000004C (76) Loc: +0x09A8       | offset to field `name` (string)
-  +0x0960 | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x099C       | offset to field `union_type` (table)
-  +0x0964 | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x0970       | offset to field `documentation` (vector)
-  +0x0968 | 08 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000008 (8)             | table field `value` (Long)
+  +0x0958 | A6 FF FF FF             | SOffset32  | 0xFFFFFFA6 (-90) Loc: 0x09B2       | offset to vtable
+  +0x095C | 4C 00 00 00             | UOffset32  | 0x0000004C (76) Loc: 0x09A8        | offset to field `name` (string)
+  +0x0960 | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x099C        | offset to field `union_type` (table)
+  +0x0964 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x0970        | offset to field `documentation` (vector)
+  +0x0968 | 08 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000008 (8)             | table field `value` (Long)
 
 vector (reflection.EnumVal.documentation):
-  +0x0970 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x0974 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0978        | offset to string[0]
+  +0x0970 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x0974 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0978         | offset to string[0]
 
 string (reflection.EnumVal.documentation):
-  +0x0978 | 1C 00 00 00             | uint32_t    | 0x0000001C (28)                    | length of string
-  +0x097C | 20 5C 62 72 69 65 66 20 | char[28]    |  \brief                            | string literal
-  +0x0984 | 63 6F 6C 6F 72 20 42 6C |             | color Bl
-  +0x098C | 75 65 20 28 31 75 20 3C |             | ue (1u <
-  +0x0994 | 3C 20 33 29             |             | < 3)
-  +0x0998 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0978 | 1C 00 00 00             | uint32_t   | 0x0000001C (28)                    | length of string
+  +0x097C | 20 5C 62 72 69 65 66 20 | char[28]   |  \brief                            | string literal
+  +0x0984 | 63 6F 6C 6F 72 20 42 6C |            | color Bl
+  +0x098C | 75 65 20 28 31 75 20 3C |            | ue (1u <
+  +0x0994 | 3C 20 33 29             |            | < 3)
+  +0x0998 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0999 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x0999 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x099C | A4 FE FF FF             | SOffset32   | 0xFFFFFEA4 (-348) Loc: +0x0AF8     | offset to vtable
-  +0x09A0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x09A4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x099C | A4 FE FF FF             | SOffset32  | 0xFFFFFEA4 (-348) Loc: 0x0AF8      | offset to vtable
+  +0x09A0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x09A4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x09A8 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x09AC | 42 6C 75 65             | char[4]     | Blue                               | string literal
-  +0x09B0 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x09A8 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x09AC | 42 6C 75 65             | char[4]    | Blue                               | string literal
+  +0x09B0 | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.EnumVal):
-  +0x09B2 | 0E 00                   | uint16_t    | 0x000E (14)                        | size of this vtable
-  +0x09B4 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of referring table
-  +0x09B6 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x09B8 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `value` (id: 1)
-  +0x09BA | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `object` (id: 2) <null> (Obj)
-  +0x09BC | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `union_type` (id: 3)
-  +0x09BE | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `documentation` (id: 4)
+  +0x09B2 | 0E 00                   | uint16_t   | 0x000E (14)                        | size of this vtable
+  +0x09B4 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of referring table
+  +0x09B6 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x09B8 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `value` (id: 1)
+  +0x09BA | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `object` (id: 2) <null> (Obj)
+  +0x09BC | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `union_type` (id: 3)
+  +0x09BE | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `documentation` (id: 4)
 
 table (reflection.EnumVal):
-  +0x09C0 | 0E 00 00 00             | SOffset32   | 0x0000000E (14) Loc: +0x09B2       | offset to vtable
-  +0x09C4 | 70 00 00 00             | UOffset32   | 0x00000070 (112) Loc: +0x0A34      | offset to field `name` (string)
-  +0x09C8 | 60 00 00 00             | UOffset32   | 0x00000060 (96) Loc: +0x0A28       | offset to field `union_type` (table)
-  +0x09CC | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x09D8       | offset to field `documentation` (vector)
-  +0x09D0 | 02 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000002 (2)             | table field `value` (Long)
+  +0x09C0 | 0E 00 00 00             | SOffset32  | 0x0000000E (14) Loc: 0x09B2        | offset to vtable
+  +0x09C4 | 70 00 00 00             | UOffset32  | 0x00000070 (112) Loc: 0x0A34       | offset to field `name` (string)
+  +0x09C8 | 60 00 00 00             | UOffset32  | 0x00000060 (96) Loc: 0x0A28        | offset to field `union_type` (table)
+  +0x09CC | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x09D8        | offset to field `documentation` (vector)
+  +0x09D0 | 02 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000002 (2)             | table field `value` (Long)
 
 vector (reflection.EnumVal.documentation):
-  +0x09D8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x09DC | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x0A10       | offset to string[0]
-  +0x09E0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x09E4        | offset to string[1]
+  +0x09D8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x09DC | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x0A10        | offset to string[0]
+  +0x09E0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x09E4         | offset to string[1]
 
 string (reflection.EnumVal.documentation):
-  +0x09E4 | 27 00 00 00             | uint32_t    | 0x00000027 (39)                    | length of string
-  +0x09E8 | 20 47 72 65 65 6E 20 69 | char[39]    |  Green i                           | string literal
-  +0x09F0 | 73 20 62 69 74 5F 66 6C |             | s bit_fl
-  +0x09F8 | 61 67 20 77 69 74 68 20 |             | ag with 
-  +0x0A00 | 76 61 6C 75 65 20 28 31 |             | value (1
-  +0x0A08 | 75 20 3C 3C 20 31 29    |             | u << 1)
-  +0x0A0F | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x09E4 | 27 00 00 00             | uint32_t   | 0x00000027 (39)                    | length of string
+  +0x09E8 | 20 47 72 65 65 6E 20 69 | char[39]   |  Green i                           | string literal
+  +0x09F0 | 73 20 62 69 74 5F 66 6C |            | s bit_fl
+  +0x09F8 | 61 67 20 77 69 74 68 20 |            | ag with 
+  +0x0A00 | 76 61 6C 75 65 20 28 31 |            | value (1
+  +0x0A08 | 75 20 3C 3C 20 31 29    |            | u << 1)
+  +0x0A0F | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.EnumVal.documentation):
-  +0x0A10 | 13 00 00 00             | uint32_t    | 0x00000013 (19)                    | length of string
-  +0x0A14 | 20 5C 62 72 69 65 66 20 | char[19]    |  \brief                            | string literal
-  +0x0A1C | 63 6F 6C 6F 72 20 47 72 |             | color Gr
-  +0x0A24 | 65 65 6E                |             | een
-  +0x0A27 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0A10 | 13 00 00 00             | uint32_t   | 0x00000013 (19)                    | length of string
+  +0x0A14 | 20 5C 62 72 69 65 66 20 | char[19]   |  \brief                            | string literal
+  +0x0A1C | 63 6F 6C 6F 72 20 47 72 |            | color Gr
+  +0x0A24 | 65 65 6E                |            | een
+  +0x0A27 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x0A28 | 30 FF FF FF             | SOffset32   | 0xFFFFFF30 (-208) Loc: +0x0AF8     | offset to vtable
-  +0x0A2C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0A30 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0A28 | 30 FF FF FF             | SOffset32  | 0xFFFFFF30 (-208) Loc: 0x0AF8      | offset to vtable
+  +0x0A2C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0A30 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0A34 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x0A38 | 47 72 65 65 6E          | char[5]     | Green                              | string literal
-  +0x0A3D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0A34 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x0A38 | 47 72 65 65 6E          | char[5]    | Green                              | string literal
+  +0x0A3D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0A3E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x0A3E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.EnumVal):
-  +0x0A40 | 0C 00                   | uint16_t    | 0x000C (12)                        | size of this vtable
-  +0x0A42 | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x0A44 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x0A46 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `value` (id: 1)
-  +0x0A48 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `object` (id: 2) <null> (Obj)
-  +0x0A4A | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `union_type` (id: 3)
+  +0x0A40 | 0C 00                   | uint16_t   | 0x000C (12)                        | size of this vtable
+  +0x0A42 | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x0A44 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x0A46 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `value` (id: 1)
+  +0x0A48 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `object` (id: 2) <null> (Obj)
+  +0x0A4A | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `union_type` (id: 3)
 
 table (reflection.EnumVal):
-  +0x0A4C | 0C 00 00 00             | SOffset32   | 0x0000000C (12) Loc: +0x0A40       | offset to vtable
-  +0x0A50 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0x0A6C       | offset to field `name` (string)
-  +0x0A54 | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x0A60       | offset to field `union_type` (table)
-  +0x0A58 | 01 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000001 (1)             | table field `value` (Long)
+  +0x0A4C | 0C 00 00 00             | SOffset32  | 0x0000000C (12) Loc: 0x0A40        | offset to vtable
+  +0x0A50 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: 0x0A6C        | offset to field `name` (string)
+  +0x0A54 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x0A60        | offset to field `union_type` (table)
+  +0x0A58 | 01 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000001 (1)             | table field `value` (Long)
 
 table (reflection.Type):
-  +0x0A60 | 68 FF FF FF             | SOffset32   | 0xFFFFFF68 (-152) Loc: +0x0AF8     | offset to vtable
-  +0x0A64 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0A68 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0A60 | 68 FF FF FF             | SOffset32  | 0xFFFFFF68 (-152) Loc: 0x0AF8      | offset to vtable
+  +0x0A64 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0A68 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0A6C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x0A70 | 52 65 64                | char[3]     | Red                                | string literal
-  +0x0A73 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0A6C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x0A70 | 52 65 64                | char[3]    | Red                                | string literal
+  +0x0A73 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0A74 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x0A74 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Enum):
-  +0x0A76 | 12 00                   | uint16_t    | 0x0012 (18)                        | size of this vtable
-  +0x0A78 | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x0A7A | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x0A7C | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `values` (id: 1)
-  +0x0A7E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `is_union` (id: 2) <defaults to 0> (Bool)
-  +0x0A80 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `underlying_type` (id: 3)
-  +0x0A82 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `attributes` (id: 4) <null> (Vector)
-  +0x0A84 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 5) <null> (Vector)
-  +0x0A86 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `declaration_file` (id: 6)
+  +0x0A76 | 12 00                   | uint16_t   | 0x0012 (18)                        | size of this vtable
+  +0x0A78 | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x0A7A | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x0A7C | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `values` (id: 1)
+  +0x0A7E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `is_union` (id: 2) <defaults to 0> (Bool)
+  +0x0A80 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `underlying_type` (id: 3)
+  +0x0A82 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `attributes` (id: 4) <null> (Vector)
+  +0x0A84 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 5) <null> (Vector)
+  +0x0A86 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `declaration_file` (id: 6)
 
 table (reflection.Enum):
-  +0x0A88 | 12 00 00 00             | SOffset32   | 0x00000012 (18) Loc: +0x0A76       | offset to vtable
-  +0x0A8C | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x0AB8       | offset to field `name` (string)
-  +0x0A90 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x0AB0       | offset to field `values` (vector)
-  +0x0A94 | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x0A9C        | offset to field `underlying_type` (table)
-  +0x0A98 | D8 2D 00 00             | UOffset32   | 0x00002DD8 (11736) Loc: +0x3870    | offset to field `declaration_file` (string)
+  +0x0A88 | 12 00 00 00             | SOffset32  | 0x00000012 (18) Loc: 0x0A76        | offset to vtable
+  +0x0A8C | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x0AB8        | offset to field `name` (string)
+  +0x0A90 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x0AB0        | offset to field `values` (vector)
+  +0x0A94 | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x0A9C         | offset to field `underlying_type` (table)
+  +0x0A98 | D8 2D 00 00             | UOffset32  | 0x00002DD8 (11736) Loc: 0x3870     | offset to field `declaration_file` (string)
 
 table (reflection.Type):
-  +0x0A9C | F0 D4 FF FF             | SOffset32   | 0xFFFFD4F0 (-11024) Loc: +0x35AC   | offset to vtable
-  +0x0AA0 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0AA3 | 09                      | uint8_t     | 0x09 (9)                           | table field `base_type` (Byte)
-  +0x0AA4 | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | table field `index` (Int)
-  +0x0AA8 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x0AAC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0A9C | F0 D4 FF FF             | SOffset32  | 0xFFFFD4F0 (-11024) Loc: 0x35AC    | offset to vtable
+  +0x0AA0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0AA3 | 09                      | uint8_t    | 0x09 (9)                           | table field `base_type` (Byte)
+  +0x0AA4 | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | table field `index` (Int)
+  +0x0AA8 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x0AAC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 vector (reflection.Enum.values):
-  +0x0AB0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x0AB4 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x0AEC       | offset to table[0]
+  +0x0AB0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x0AB4 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x0AEC        | offset to table[0]
 
 string (reflection.Enum.name):
-  +0x0AB8 | 21 00 00 00             | uint32_t    | 0x00000021 (33)                    | length of string
-  +0x0ABC | 4D 79 47 61 6D 65 2E 4F | char[33]    | MyGame.O                           | string literal
-  +0x0AC4 | 74 68 65 72 4E 61 6D 65 |             | therName
-  +0x0ACC | 53 70 61 63 65 2E 46 72 |             | Space.Fr
-  +0x0AD4 | 6F 6D 49 6E 63 6C 75 64 |             | omInclud
-  +0x0ADC | 65                      |             | e
-  +0x0ADD | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0AB8 | 21 00 00 00             | uint32_t   | 0x00000021 (33)                    | length of string
+  +0x0ABC | 4D 79 47 61 6D 65 2E 4F | char[33]   | MyGame.O                           | string literal
+  +0x0AC4 | 74 68 65 72 4E 61 6D 65 |            | therName
+  +0x0ACC | 53 70 61 63 65 2E 46 72 |            | Space.Fr
+  +0x0AD4 | 6F 6D 49 6E 63 6C 75 64 |            | omInclud
+  +0x0ADC | 65                      |            | e
+  +0x0ADD | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0ADE | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x0ADE | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.EnumVal):
-  +0x0AE0 | 0C 00                   | uint16_t    | 0x000C (12)                        | size of this vtable
-  +0x0AE2 | 0C 00                   | uint16_t    | 0x000C (12)                        | size of referring table
-  +0x0AE4 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x0AE6 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `value` (id: 1) <defaults to 0> (Long)
-  +0x0AE8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `object` (id: 2) <null> (Obj)
-  +0x0AEA | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `union_type` (id: 3)
+  +0x0AE0 | 0C 00                   | uint16_t   | 0x000C (12)                        | size of this vtable
+  +0x0AE2 | 0C 00                   | uint16_t   | 0x000C (12)                        | size of referring table
+  +0x0AE4 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x0AE6 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `value` (id: 1) <defaults to 0> (Long)
+  +0x0AE8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `object` (id: 2) <null> (Obj)
+  +0x0AEA | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `union_type` (id: 3)
 
 table (reflection.EnumVal):
-  +0x0AEC | 0C 00 00 00             | SOffset32   | 0x0000000C (12) Loc: +0x0AE0       | offset to vtable
-  +0x0AF0 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x0B14       | offset to field `name` (string)
-  +0x0AF4 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0B08       | offset to field `union_type` (table)
+  +0x0AEC | 0C 00 00 00             | SOffset32  | 0x0000000C (12) Loc: 0x0AE0        | offset to vtable
+  +0x0AF0 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x0B14        | offset to field `name` (string)
+  +0x0AF4 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0B08        | offset to field `union_type` (table)
 
 vtable (reflection.Type):
-  +0x0AF8 | 10 00                   | uint16_t    | 0x0010 (16)                        | size of this vtable
-  +0x0AFA | 0C 00                   | uint16_t    | 0x000C (12)                        | size of referring table
-  +0x0AFC | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `base_type` (id: 0) <defaults to 0> (Byte)
-  +0x0AFE | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `element` (id: 1) <defaults to 0> (Byte)
-  +0x0B00 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `index` (id: 2) <defaults to -1> (Int)
-  +0x0B02 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
-  +0x0B04 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `base_size` (id: 4)
-  +0x0B06 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `element_size` (id: 5)
+  +0x0AF8 | 10 00                   | uint16_t   | 0x0010 (16)                        | size of this vtable
+  +0x0AFA | 0C 00                   | uint16_t   | 0x000C (12)                        | size of referring table
+  +0x0AFC | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `base_type` (id: 0) <defaults to 0> (Byte)
+  +0x0AFE | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `element` (id: 1) <defaults to 0> (Byte)
+  +0x0B00 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `index` (id: 2) <defaults to -1> (Int)
+  +0x0B02 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
+  +0x0B04 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `base_size` (id: 4)
+  +0x0B06 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `element_size` (id: 5)
 
 table (reflection.Type):
-  +0x0B08 | 10 00 00 00             | SOffset32   | 0x00000010 (16) Loc: +0x0AF8       | offset to vtable
-  +0x0B0C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0B10 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0B08 | 10 00 00 00             | SOffset32  | 0x00000010 (16) Loc: 0x0AF8        | offset to vtable
+  +0x0B0C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0B10 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.EnumVal.name):
-  +0x0B14 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                    | length of string
-  +0x0B18 | 49 6E 63 6C 75 64 65 56 | char[10]    | IncludeV                           | string literal
-  +0x0B20 | 61 6C                   |             | al
-  +0x0B22 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0B14 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                    | length of string
+  +0x0B18 | 49 6E 63 6C 75 64 65 56 | char[10]   | IncludeV                           | string literal
+  +0x0B20 | 61 6C                   |            | al
+  +0x0B22 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Object):
-  +0x0B24 | 8C D3 FF FF             | SOffset32   | 0xFFFFD38C (-11380) Loc: +0x3798   | offset to vtable
-  +0x0B28 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x0B6C       | offset to field `name` (string)
-  +0x0B2C | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x0B38       | offset to field `fields` (vector)
-  +0x0B30 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `minalign` (Int)
-  +0x0B34 | B0 2B 00 00             | UOffset32   | 0x00002BB0 (11184) Loc: +0x36E4    | offset to field `declaration_file` (string)
+  +0x0B24 | 8C D3 FF FF             | SOffset32  | 0xFFFFD38C (-11380) Loc: 0x3798    | offset to vtable
+  +0x0B28 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x0B6C        | offset to field `name` (string)
+  +0x0B2C | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x0B38        | offset to field `fields` (vector)
+  +0x0B30 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `minalign` (Int)
+  +0x0B34 | B0 2B 00 00             | UOffset32  | 0x00002BB0 (11184) Loc: 0x36E4     | offset to field `declaration_file` (string)
 
 vector (reflection.Object.fields):
-  +0x0B38 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                    | length of vector (# items)
-  +0x0B3C | CC 00 00 00             | UOffset32   | 0x000000CC (204) Loc: +0x0C08      | offset to table[0]
-  +0x0B40 | A0 00 00 00             | UOffset32   | 0x000000A0 (160) Loc: +0x0BE0      | offset to table[1]
-  +0x0B44 | A8 01 00 00             | UOffset32   | 0x000001A8 (424) Loc: +0x0CEC      | offset to table[2]
-  +0x0B48 | 58 01 00 00             | UOffset32   | 0x00000158 (344) Loc: +0x0CA0      | offset to table[3]
-  +0x0B4C | 08 01 00 00             | UOffset32   | 0x00000108 (264) Loc: +0x0C54      | offset to table[4]
-  +0x0B50 | F8 01 00 00             | UOffset32   | 0x000001F8 (504) Loc: +0x0D48      | offset to table[5]
-  +0x0B54 | 70 01 00 00             | UOffset32   | 0x00000170 (368) Loc: +0x0CC4      | offset to table[6]
-  +0x0B58 | 24 01 00 00             | UOffset32   | 0x00000124 (292) Loc: +0x0C7C      | offset to table[7]
-  +0x0B5C | D0 00 00 00             | UOffset32   | 0x000000D0 (208) Loc: +0x0C2C      | offset to table[8]
-  +0x0B60 | B4 01 00 00             | UOffset32   | 0x000001B4 (436) Loc: +0x0D14      | offset to table[9]
-  +0x0B64 | 54 00 00 00             | UOffset32   | 0x00000054 (84) Loc: +0x0BB8       | offset to table[10]
-  +0x0B68 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x0B8C       | offset to table[11]
+  +0x0B38 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                    | length of vector (# items)
+  +0x0B3C | CC 00 00 00             | UOffset32  | 0x000000CC (204) Loc: 0x0C08       | offset to table[0]
+  +0x0B40 | A0 00 00 00             | UOffset32  | 0x000000A0 (160) Loc: 0x0BE0       | offset to table[1]
+  +0x0B44 | A8 01 00 00             | UOffset32  | 0x000001A8 (424) Loc: 0x0CEC       | offset to table[2]
+  +0x0B48 | 58 01 00 00             | UOffset32  | 0x00000158 (344) Loc: 0x0CA0       | offset to table[3]
+  +0x0B4C | 08 01 00 00             | UOffset32  | 0x00000108 (264) Loc: 0x0C54       | offset to table[4]
+  +0x0B50 | F8 01 00 00             | UOffset32  | 0x000001F8 (504) Loc: 0x0D48       | offset to table[5]
+  +0x0B54 | 70 01 00 00             | UOffset32  | 0x00000170 (368) Loc: 0x0CC4       | offset to table[6]
+  +0x0B58 | 24 01 00 00             | UOffset32  | 0x00000124 (292) Loc: 0x0C7C       | offset to table[7]
+  +0x0B5C | D0 00 00 00             | UOffset32  | 0x000000D0 (208) Loc: 0x0C2C       | offset to table[8]
+  +0x0B60 | B4 01 00 00             | UOffset32  | 0x000001B4 (436) Loc: 0x0D14       | offset to table[9]
+  +0x0B64 | 54 00 00 00             | UOffset32  | 0x00000054 (84) Loc: 0x0BB8        | offset to table[10]
+  +0x0B68 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x0B8C        | offset to table[11]
 
 string (reflection.Object.name):
-  +0x0B6C | 1A 00 00 00             | uint32_t    | 0x0000001A (26)                    | length of string
-  +0x0B70 | 4D 79 47 61 6D 65 2E 45 | char[26]    | MyGame.E                           | string literal
-  +0x0B78 | 78 61 6D 70 6C 65 2E 54 |             | xample.T
-  +0x0B80 | 79 70 65 41 6C 69 61 73 |             | ypeAlias
-  +0x0B88 | 65 73                   |             | es
-  +0x0B8A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0B6C | 1A 00 00 00             | uint32_t   | 0x0000001A (26)                    | length of string
+  +0x0B70 | 4D 79 47 61 6D 65 2E 45 | char[26]   | MyGame.E                           | string literal
+  +0x0B78 | 78 61 6D 70 6C 65 2E 54 |            | xample.T
+  +0x0B80 | 79 70 65 41 6C 69 61 73 |            | ypeAlias
+  +0x0B88 | 65 73                   |            | es
+  +0x0B8A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0B8C | DC D9 FF FF             | SOffset32   | 0xFFFFD9DC (-9764) Loc: +0x31B0    | offset to vtable
-  +0x0B90 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0B93 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x0B94 | 0B 00                   | uint16_t    | 0x000B (11)                        | table field `id` (UShort)
-  +0x0B96 | 1A 00                   | uint16_t    | 0x001A (26)                        | table field `offset` (UShort)
-  +0x0B98 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0BAC       | offset to field `name` (string)
-  +0x0B9C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0BA0        | offset to field `type` (table)
+  +0x0B8C | DC D9 FF FF             | SOffset32  | 0xFFFFD9DC (-9764) Loc: 0x31B0     | offset to vtable
+  +0x0B90 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0B93 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x0B94 | 0B 00                   | uint16_t   | 0x000B (11)                        | table field `id` (UShort)
+  +0x0B96 | 1A 00                   | uint16_t   | 0x001A (26)                        | table field `offset` (UShort)
+  +0x0B98 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0BAC        | offset to field `name` (string)
+  +0x0B9C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0BA0         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0BA0 | 60 DF FF FF             | SOffset32   | 0xFFFFDF60 (-8352) Loc: +0x2C40    | offset to vtable
-  +0x0BA4 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x0BA6 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x0BA7 | 0C                      | uint8_t     | 0x0C (12)                          | table field `element` (Byte)
-  +0x0BA8 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `element_size` (UInt)
+  +0x0BA0 | 60 DF FF FF             | SOffset32  | 0xFFFFDF60 (-8352) Loc: 0x2C40     | offset to vtable
+  +0x0BA4 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x0BA6 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x0BA7 | 0C                      | uint8_t    | 0x0C (12)                          | table field `element` (Byte)
+  +0x0BA8 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0BAC | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x0BB0 | 76 66 36 34             | char[4]     | vf64                               | string literal
-  +0x0BB4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0BAC | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x0BB0 | 76 66 36 34             | char[4]    | vf64                               | string literal
+  +0x0BB4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0BB5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x0BB5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x0BB8 | 08 DA FF FF             | SOffset32   | 0xFFFFDA08 (-9720) Loc: +0x31B0    | offset to vtable
-  +0x0BBC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0BBF | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x0BC0 | 0A 00                   | uint16_t    | 0x000A (10)                        | table field `id` (UShort)
-  +0x0BC2 | 18 00                   | uint16_t    | 0x0018 (24)                        | table field `offset` (UShort)
-  +0x0BC4 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0BD8       | offset to field `name` (string)
-  +0x0BC8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0BCC        | offset to field `type` (table)
+  +0x0BB8 | 08 DA FF FF             | SOffset32  | 0xFFFFDA08 (-9720) Loc: 0x31B0     | offset to vtable
+  +0x0BBC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0BBF | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x0BC0 | 0A 00                   | uint16_t   | 0x000A (10)                        | table field `id` (UShort)
+  +0x0BC2 | 18 00                   | uint16_t   | 0x0018 (24)                        | table field `offset` (UShort)
+  +0x0BC4 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0BD8        | offset to field `name` (string)
+  +0x0BC8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0BCC         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0BCC | 8C DF FF FF             | SOffset32   | 0xFFFFDF8C (-8308) Loc: +0x2C40    | offset to vtable
-  +0x0BD0 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x0BD2 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x0BD3 | 03                      | uint8_t     | 0x03 (3)                           | table field `element` (Byte)
-  +0x0BD4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0BCC | 8C DF FF FF             | SOffset32  | 0xFFFFDF8C (-8308) Loc: 0x2C40     | offset to vtable
+  +0x0BD0 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x0BD2 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x0BD3 | 03                      | uint8_t    | 0x03 (3)                           | table field `element` (Byte)
+  +0x0BD4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0BD8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x0BDC | 76 38                   | char[2]     | v8                                 | string literal
-  +0x0BDE | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0BD8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x0BDC | 76 38                   | char[2]    | v8                                 | string literal
+  +0x0BDE | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0BE0 | 64 D7 FF FF             | SOffset32   | 0xFFFFD764 (-10396) Loc: +0x347C   | offset to vtable
-  +0x0BE4 | 09 00                   | uint16_t    | 0x0009 (9)                         | table field `id` (UShort)
-  +0x0BE6 | 16 00                   | uint16_t    | 0x0016 (22)                        | table field `offset` (UShort)
-  +0x0BE8 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x0C00       | offset to field `name` (string)
-  +0x0BEC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0BF0        | offset to field `type` (table)
+  +0x0BE0 | 64 D7 FF FF             | SOffset32  | 0xFFFFD764 (-10396) Loc: 0x347C    | offset to vtable
+  +0x0BE4 | 09 00                   | uint16_t   | 0x0009 (9)                         | table field `id` (UShort)
+  +0x0BE6 | 16 00                   | uint16_t   | 0x0016 (22)                        | table field `offset` (UShort)
+  +0x0BE8 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x0C00        | offset to field `name` (string)
+  +0x0BEC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0BF0         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0BF0 | 7C D5 FF FF             | SOffset32   | 0xFFFFD57C (-10884) Loc: +0x3674   | offset to vtable
-  +0x0BF4 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0BF7 | 0C                      | uint8_t     | 0x0C (12)                          | table field `base_type` (Byte)
-  +0x0BF8 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x0BFC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0BF0 | 7C D5 FF FF             | SOffset32  | 0xFFFFD57C (-10884) Loc: 0x3674    | offset to vtable
+  +0x0BF4 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0BF7 | 0C                      | uint8_t    | 0x0C (12)                          | table field `base_type` (Byte)
+  +0x0BF8 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x0BFC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0C00 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x0C04 | 66 36 34                | char[3]     | f64                                | string literal
-  +0x0C07 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0C00 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x0C04 | 66 36 34                | char[3]    | f64                                | string literal
+  +0x0C07 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0C08 | 8C D7 FF FF             | SOffset32   | 0xFFFFD78C (-10356) Loc: +0x347C   | offset to vtable
-  +0x0C0C | 08 00                   | uint16_t    | 0x0008 (8)                         | table field `id` (UShort)
-  +0x0C0E | 14 00                   | uint16_t    | 0x0014 (20)                        | table field `offset` (UShort)
-  +0x0C10 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0C24       | offset to field `name` (string)
-  +0x0C14 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0C18        | offset to field `type` (table)
+  +0x0C08 | 8C D7 FF FF             | SOffset32  | 0xFFFFD78C (-10356) Loc: 0x347C    | offset to vtable
+  +0x0C0C | 08 00                   | uint16_t   | 0x0008 (8)                         | table field `id` (UShort)
+  +0x0C0E | 14 00                   | uint16_t   | 0x0014 (20)                        | table field `offset` (UShort)
+  +0x0C10 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0C24        | offset to field `name` (string)
+  +0x0C14 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0C18         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0C18 | 3C D3 FF FF             | SOffset32   | 0xFFFFD33C (-11460) Loc: +0x38DC   | offset to vtable
-  +0x0C1C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0C1F | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x0C20 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0C18 | 3C D3 FF FF             | SOffset32  | 0xFFFFD33C (-11460) Loc: 0x38DC    | offset to vtable
+  +0x0C1C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0C1F | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x0C20 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0C24 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x0C28 | 66 33 32                | char[3]     | f32                                | string literal
-  +0x0C2B | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0C24 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x0C28 | 66 33 32                | char[3]    | f32                                | string literal
+  +0x0C2B | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0C2C | B0 D7 FF FF             | SOffset32   | 0xFFFFD7B0 (-10320) Loc: +0x347C   | offset to vtable
-  +0x0C30 | 07 00                   | uint16_t    | 0x0007 (7)                         | table field `id` (UShort)
-  +0x0C32 | 12 00                   | uint16_t    | 0x0012 (18)                        | table field `offset` (UShort)
-  +0x0C34 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x0C4C       | offset to field `name` (string)
-  +0x0C38 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0C3C        | offset to field `type` (table)
+  +0x0C2C | B0 D7 FF FF             | SOffset32  | 0xFFFFD7B0 (-10320) Loc: 0x347C    | offset to vtable
+  +0x0C30 | 07 00                   | uint16_t   | 0x0007 (7)                         | table field `id` (UShort)
+  +0x0C32 | 12 00                   | uint16_t   | 0x0012 (18)                        | table field `offset` (UShort)
+  +0x0C34 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x0C4C        | offset to field `name` (string)
+  +0x0C38 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0C3C         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0C3C | C8 D5 FF FF             | SOffset32   | 0xFFFFD5C8 (-10808) Loc: +0x3674   | offset to vtable
-  +0x0C40 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0C43 | 0A                      | uint8_t     | 0x0A (10)                          | table field `base_type` (Byte)
-  +0x0C44 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x0C48 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0C3C | C8 D5 FF FF             | SOffset32  | 0xFFFFD5C8 (-10808) Loc: 0x3674    | offset to vtable
+  +0x0C40 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0C43 | 0A                      | uint8_t    | 0x0A (10)                          | table field `base_type` (Byte)
+  +0x0C44 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x0C48 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0C4C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x0C50 | 75 36 34                | char[3]     | u64                                | string literal
-  +0x0C53 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0C4C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x0C50 | 75 36 34                | char[3]    | u64                                | string literal
+  +0x0C53 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0C54 | D8 D7 FF FF             | SOffset32   | 0xFFFFD7D8 (-10280) Loc: +0x347C   | offset to vtable
-  +0x0C58 | 06 00                   | uint16_t    | 0x0006 (6)                         | table field `id` (UShort)
-  +0x0C5A | 10 00                   | uint16_t    | 0x0010 (16)                        | table field `offset` (UShort)
-  +0x0C5C | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x0C74       | offset to field `name` (string)
-  +0x0C60 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0C64        | offset to field `type` (table)
+  +0x0C54 | D8 D7 FF FF             | SOffset32  | 0xFFFFD7D8 (-10280) Loc: 0x347C    | offset to vtable
+  +0x0C58 | 06 00                   | uint16_t   | 0x0006 (6)                         | table field `id` (UShort)
+  +0x0C5A | 10 00                   | uint16_t   | 0x0010 (16)                        | table field `offset` (UShort)
+  +0x0C5C | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x0C74        | offset to field `name` (string)
+  +0x0C60 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0C64         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0C64 | F0 D5 FF FF             | SOffset32   | 0xFFFFD5F0 (-10768) Loc: +0x3674   | offset to vtable
-  +0x0C68 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0C6B | 09                      | uint8_t     | 0x09 (9)                           | table field `base_type` (Byte)
-  +0x0C6C | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x0C70 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0C64 | F0 D5 FF FF             | SOffset32  | 0xFFFFD5F0 (-10768) Loc: 0x3674    | offset to vtable
+  +0x0C68 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0C6B | 09                      | uint8_t    | 0x09 (9)                           | table field `base_type` (Byte)
+  +0x0C6C | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x0C70 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0C74 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x0C78 | 69 36 34                | char[3]     | i64                                | string literal
-  +0x0C7B | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0C74 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x0C78 | 69 36 34                | char[3]    | i64                                | string literal
+  +0x0C7B | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0C7C | 00 D8 FF FF             | SOffset32   | 0xFFFFD800 (-10240) Loc: +0x347C   | offset to vtable
-  +0x0C80 | 05 00                   | uint16_t    | 0x0005 (5)                         | table field `id` (UShort)
-  +0x0C82 | 0E 00                   | uint16_t    | 0x000E (14)                        | table field `offset` (UShort)
-  +0x0C84 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0C98       | offset to field `name` (string)
-  +0x0C88 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0C8C        | offset to field `type` (table)
+  +0x0C7C | 00 D8 FF FF             | SOffset32  | 0xFFFFD800 (-10240) Loc: 0x347C    | offset to vtable
+  +0x0C80 | 05 00                   | uint16_t   | 0x0005 (5)                         | table field `id` (UShort)
+  +0x0C82 | 0E 00                   | uint16_t   | 0x000E (14)                        | table field `offset` (UShort)
+  +0x0C84 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0C98        | offset to field `name` (string)
+  +0x0C88 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0C8C         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0C8C | B0 D3 FF FF             | SOffset32   | 0xFFFFD3B0 (-11344) Loc: +0x38DC   | offset to vtable
-  +0x0C90 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0C93 | 08                      | uint8_t     | 0x08 (8)                           | table field `base_type` (Byte)
-  +0x0C94 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0C8C | B0 D3 FF FF             | SOffset32  | 0xFFFFD3B0 (-11344) Loc: 0x38DC    | offset to vtable
+  +0x0C90 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0C93 | 08                      | uint8_t    | 0x08 (8)                           | table field `base_type` (Byte)
+  +0x0C94 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0C98 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x0C9C | 75 33 32                | char[3]     | u32                                | string literal
-  +0x0C9F | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0C98 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x0C9C | 75 33 32                | char[3]    | u32                                | string literal
+  +0x0C9F | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0CA0 | 24 D8 FF FF             | SOffset32   | 0xFFFFD824 (-10204) Loc: +0x347C   | offset to vtable
-  +0x0CA4 | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `id` (UShort)
-  +0x0CA6 | 0C 00                   | uint16_t    | 0x000C (12)                        | table field `offset` (UShort)
-  +0x0CA8 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x0CBC       | offset to field `name` (string)
-  +0x0CAC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0CB0        | offset to field `type` (table)
+  +0x0CA0 | 24 D8 FF FF             | SOffset32  | 0xFFFFD824 (-10204) Loc: 0x347C    | offset to vtable
+  +0x0CA4 | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `id` (UShort)
+  +0x0CA6 | 0C 00                   | uint16_t   | 0x000C (12)                        | table field `offset` (UShort)
+  +0x0CA8 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x0CBC        | offset to field `name` (string)
+  +0x0CAC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0CB0         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0CB0 | D4 D3 FF FF             | SOffset32   | 0xFFFFD3D4 (-11308) Loc: +0x38DC   | offset to vtable
-  +0x0CB4 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0CB7 | 07                      | uint8_t     | 0x07 (7)                           | table field `base_type` (Byte)
-  +0x0CB8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0CB0 | D4 D3 FF FF             | SOffset32  | 0xFFFFD3D4 (-11308) Loc: 0x38DC    | offset to vtable
+  +0x0CB4 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0CB7 | 07                      | uint8_t    | 0x07 (7)                           | table field `base_type` (Byte)
+  +0x0CB8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0CBC | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x0CC0 | 69 33 32                | char[3]     | i32                                | string literal
-  +0x0CC3 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0CBC | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x0CC0 | 69 33 32                | char[3]    | i32                                | string literal
+  +0x0CC3 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0CC4 | 48 D8 FF FF             | SOffset32   | 0xFFFFD848 (-10168) Loc: +0x347C   | offset to vtable
-  +0x0CC8 | 03 00                   | uint16_t    | 0x0003 (3)                         | table field `id` (UShort)
-  +0x0CCA | 0A 00                   | uint16_t    | 0x000A (10)                        | table field `offset` (UShort)
-  +0x0CCC | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x0CE4       | offset to field `name` (string)
-  +0x0CD0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0CD4        | offset to field `type` (table)
+  +0x0CC4 | 48 D8 FF FF             | SOffset32  | 0xFFFFD848 (-10168) Loc: 0x347C    | offset to vtable
+  +0x0CC8 | 03 00                   | uint16_t   | 0x0003 (3)                         | table field `id` (UShort)
+  +0x0CCA | 0A 00                   | uint16_t   | 0x000A (10)                        | table field `offset` (UShort)
+  +0x0CCC | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x0CE4        | offset to field `name` (string)
+  +0x0CD0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0CD4         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0CD4 | 60 D6 FF FF             | SOffset32   | 0xFFFFD660 (-10656) Loc: +0x3674   | offset to vtable
-  +0x0CD8 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0CDB | 06                      | uint8_t     | 0x06 (6)                           | table field `base_type` (Byte)
-  +0x0CDC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | table field `base_size` (UInt)
-  +0x0CE0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0CD4 | 60 D6 FF FF             | SOffset32  | 0xFFFFD660 (-10656) Loc: 0x3674    | offset to vtable
+  +0x0CD8 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0CDB | 06                      | uint8_t    | 0x06 (6)                           | table field `base_type` (Byte)
+  +0x0CDC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `base_size` (UInt)
+  +0x0CE0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0CE4 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x0CE8 | 75 31 36                | char[3]     | u16                                | string literal
-  +0x0CEB | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0CE4 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x0CE8 | 75 31 36                | char[3]    | u16                                | string literal
+  +0x0CEB | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0CEC | 70 D8 FF FF             | SOffset32   | 0xFFFFD870 (-10128) Loc: +0x347C   | offset to vtable
-  +0x0CF0 | 02 00                   | uint16_t    | 0x0002 (2)                         | table field `id` (UShort)
-  +0x0CF2 | 08 00                   | uint16_t    | 0x0008 (8)                         | table field `offset` (UShort)
-  +0x0CF4 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x0D0C       | offset to field `name` (string)
-  +0x0CF8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0CFC        | offset to field `type` (table)
+  +0x0CEC | 70 D8 FF FF             | SOffset32  | 0xFFFFD870 (-10128) Loc: 0x347C    | offset to vtable
+  +0x0CF0 | 02 00                   | uint16_t   | 0x0002 (2)                         | table field `id` (UShort)
+  +0x0CF2 | 08 00                   | uint16_t   | 0x0008 (8)                         | table field `offset` (UShort)
+  +0x0CF4 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x0D0C        | offset to field `name` (string)
+  +0x0CF8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0CFC         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0CFC | 88 D6 FF FF             | SOffset32   | 0xFFFFD688 (-10616) Loc: +0x3674   | offset to vtable
-  +0x0D00 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0D03 | 05                      | uint8_t     | 0x05 (5)                           | table field `base_type` (Byte)
-  +0x0D04 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | table field `base_size` (UInt)
-  +0x0D08 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0CFC | 88 D6 FF FF             | SOffset32  | 0xFFFFD688 (-10616) Loc: 0x3674    | offset to vtable
+  +0x0D00 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0D03 | 05                      | uint8_t    | 0x05 (5)                           | table field `base_type` (Byte)
+  +0x0D04 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `base_size` (UInt)
+  +0x0D08 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0D0C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x0D10 | 69 31 36                | char[3]     | i16                                | string literal
-  +0x0D13 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0D0C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x0D10 | 69 31 36                | char[3]    | i16                                | string literal
+  +0x0D13 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0D14 | 98 D8 FF FF             | SOffset32   | 0xFFFFD898 (-10088) Loc: +0x347C   | offset to vtable
-  +0x0D18 | 01 00                   | uint16_t    | 0x0001 (1)                         | table field `id` (UShort)
-  +0x0D1A | 06 00                   | uint16_t    | 0x0006 (6)                         | table field `offset` (UShort)
-  +0x0D1C | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x0D34       | offset to field `name` (string)
-  +0x0D20 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0D24        | offset to field `type` (table)
+  +0x0D14 | 98 D8 FF FF             | SOffset32  | 0xFFFFD898 (-10088) Loc: 0x347C    | offset to vtable
+  +0x0D18 | 01 00                   | uint16_t   | 0x0001 (1)                         | table field `id` (UShort)
+  +0x0D1A | 06 00                   | uint16_t   | 0x0006 (6)                         | table field `offset` (UShort)
+  +0x0D1C | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x0D34        | offset to field `name` (string)
+  +0x0D20 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0D24         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0D24 | B0 D6 FF FF             | SOffset32   | 0xFFFFD6B0 (-10576) Loc: +0x3674   | offset to vtable
-  +0x0D28 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0D2B | 04                      | uint8_t     | 0x04 (4)                           | table field `base_type` (Byte)
-  +0x0D2C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0D30 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0D24 | B0 D6 FF FF             | SOffset32  | 0xFFFFD6B0 (-10576) Loc: 0x3674    | offset to vtable
+  +0x0D28 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0D2B | 04                      | uint8_t    | 0x04 (4)                           | table field `base_type` (Byte)
+  +0x0D2C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0D30 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0D34 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x0D38 | 75 38                   | char[2]     | u8                                 | string literal
-  +0x0D3A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0D34 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x0D38 | 75 38                   | char[2]    | u8                                 | string literal
+  +0x0D3A | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Field):
-  +0x0D3C | 0C 00                   | uint16_t    | 0x000C (12)                        | size of this vtable
-  +0x0D3E | 10 00                   | uint16_t    | 0x0010 (16)                        | size of referring table
-  +0x0D40 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x0D42 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x0D44 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
-  +0x0D46 | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `offset` (id: 3)
+  +0x0D3C | 0C 00                   | uint16_t   | 0x000C (12)                        | size of this vtable
+  +0x0D3E | 10 00                   | uint16_t   | 0x0010 (16)                        | size of referring table
+  +0x0D40 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x0D42 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x0D44 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
+  +0x0D46 | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `offset` (id: 3)
 
 table (reflection.Field):
-  +0x0D48 | 0C 00 00 00             | SOffset32   | 0x0000000C (12) Loc: +0x0D3C       | offset to vtable
-  +0x0D4C | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x0D4E | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `offset` (UShort)
-  +0x0D50 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x0D68       | offset to field `name` (string)
-  +0x0D54 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0D58        | offset to field `type` (table)
+  +0x0D48 | 0C 00 00 00             | SOffset32  | 0x0000000C (12) Loc: 0x0D3C        | offset to vtable
+  +0x0D4C | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x0D4E | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `offset` (UShort)
+  +0x0D50 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x0D68        | offset to field `name` (string)
+  +0x0D54 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0D58         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x0D58 | E4 D6 FF FF             | SOffset32   | 0xFFFFD6E4 (-10524) Loc: +0x3674   | offset to vtable
-  +0x0D5C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0D5F | 03                      | uint8_t     | 0x03 (3)                           | table field `base_type` (Byte)
-  +0x0D60 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x0D64 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0D58 | E4 D6 FF FF             | SOffset32  | 0xFFFFD6E4 (-10524) Loc: 0x3674    | offset to vtable
+  +0x0D5C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0D5F | 03                      | uint8_t    | 0x03 (3)                           | table field `base_type` (Byte)
+  +0x0D60 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x0D64 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0D68 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x0D6C | 69 38                   | char[2]     | i8                                 | string literal
-  +0x0D6E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0D68 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x0D6C | 69 38                   | char[2]    | i8                                 | string literal
+  +0x0D6E | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Object):
-  +0x0D70 | 14 00                   | uint16_t    | 0x0014 (20)                        | size of this vtable
-  +0x0D72 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of referring table
-  +0x0D74 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x0D76 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `fields` (id: 1)
-  +0x0D78 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `is_struct` (id: 2) <defaults to 0> (Bool)
-  +0x0D7A | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `minalign` (id: 3)
-  +0x0D7C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `bytesize` (id: 4) <defaults to 0> (Int)
-  +0x0D7E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `attributes` (id: 5) <null> (Vector)
-  +0x0D80 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `documentation` (id: 6)
-  +0x0D82 | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `declaration_file` (id: 7)
+  +0x0D70 | 14 00                   | uint16_t   | 0x0014 (20)                        | size of this vtable
+  +0x0D72 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of referring table
+  +0x0D74 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x0D76 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `fields` (id: 1)
+  +0x0D78 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `is_struct` (id: 2) <defaults to 0> (Bool)
+  +0x0D7A | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `minalign` (id: 3)
+  +0x0D7C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `bytesize` (id: 4) <defaults to 0> (Int)
+  +0x0D7E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `attributes` (id: 5) <null> (Vector)
+  +0x0D80 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `documentation` (id: 6)
+  +0x0D82 | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `declaration_file` (id: 7)
 
 table (reflection.Object):
-  +0x0D84 | 14 00 00 00             | SOffset32   | 0x00000014 (20) Loc: +0x0D70       | offset to vtable
-  +0x0D88 | 50 01 00 00             | UOffset32   | 0x00000150 (336) Loc: +0x0ED8      | offset to field `name` (string)
-  +0x0D8C | 50 00 00 00             | UOffset32   | 0x00000050 (80) Loc: +0x0DDC       | offset to field `fields` (vector)
-  +0x0D90 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `minalign` (Int)
-  +0x0D94 | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x0D9C        | offset to field `documentation` (vector)
-  +0x0D98 | 4C 29 00 00             | UOffset32   | 0x0000294C (10572) Loc: +0x36E4    | offset to field `declaration_file` (string)
+  +0x0D84 | 14 00 00 00             | SOffset32  | 0x00000014 (20) Loc: 0x0D70        | offset to vtable
+  +0x0D88 | 50 01 00 00             | UOffset32  | 0x00000150 (336) Loc: 0x0ED8       | offset to field `name` (string)
+  +0x0D8C | 50 00 00 00             | UOffset32  | 0x00000050 (80) Loc: 0x0DDC        | offset to field `fields` (vector)
+  +0x0D90 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `minalign` (Int)
+  +0x0D94 | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x0D9C         | offset to field `documentation` (vector)
+  +0x0D98 | 4C 29 00 00             | UOffset32  | 0x0000294C (10572) Loc: 0x36E4     | offset to field `declaration_file` (string)
 
 vector (reflection.Object.documentation):
-  +0x0D9C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x0DA0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0DA4        | offset to string[0]
+  +0x0D9C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x0DA0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0DA4         | offset to string[0]
 
 string (reflection.Object.documentation):
-  +0x0DA4 | 33 00 00 00             | uint32_t    | 0x00000033 (51)                    | length of string
-  +0x0DA8 | 20 61 6E 20 65 78 61 6D | char[51]    |  an exam                           | string literal
-  +0x0DB0 | 70 6C 65 20 64 6F 63 75 |             | ple docu
-  +0x0DB8 | 6D 65 6E 74 61 74 69 6F |             | mentatio
-  +0x0DC0 | 6E 20 63 6F 6D 6D 65 6E |             | n commen
-  +0x0DC8 | 74 3A 20 22 6D 6F 6E 73 |             | t: "mons
-  +0x0DD0 | 74 65 72 20 6F 62 6A 65 |             | ter obje
-  +0x0DD8 | 63 74 22                |             | ct"
-  +0x0DDB | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0DA4 | 33 00 00 00             | uint32_t   | 0x00000033 (51)                    | length of string
+  +0x0DA8 | 20 61 6E 20 65 78 61 6D | char[51]   |  an exam                           | string literal
+  +0x0DB0 | 70 6C 65 20 64 6F 63 75 |            | ple docu
+  +0x0DB8 | 6D 65 6E 74 61 74 69 6F |            | mentatio
+  +0x0DC0 | 6E 20 63 6F 6D 6D 65 6E |            | n commen
+  +0x0DC8 | 74 3A 20 22 6D 6F 6E 73 |            | t: "mons
+  +0x0DD0 | 74 65 72 20 6F 62 6A 65 |            | ter obje
+  +0x0DD8 | 63 74 22                |            | ct"
+  +0x0DDB | 00                      | char       | 0x00 (0)                           | string terminator
 
 vector (reflection.Object.fields):
-  +0x0DDC | 3E 00 00 00             | uint32_t    | 0x0000003E (62)                    | length of vector (# items)
-  +0x0DE0 | A8 07 00 00             | UOffset32   | 0x000007A8 (1960) Loc: +0x1588     | offset to table[0]
-  +0x0DE4 | 04 08 00 00             | UOffset32   | 0x00000804 (2052) Loc: +0x15E8     | offset to table[1]
-  +0x0DE8 | 64 08 00 00             | UOffset32   | 0x00000864 (2148) Loc: +0x164C     | offset to table[2]
-  +0x0DEC | BC 08 00 00             | UOffset32   | 0x000008BC (2236) Loc: +0x16A8     | offset to table[3]
-  +0x0DF0 | 98 0C 00 00             | UOffset32   | 0x00000C98 (3224) Loc: +0x1A88     | offset to table[4]
-  +0x0DF4 | 90 1D 00 00             | UOffset32   | 0x00001D90 (7568) Loc: +0x2B84     | offset to table[5]
-  +0x0DF8 | FC 00 00 00             | UOffset32   | 0x000000FC (252) Loc: +0x0EF4      | offset to table[6]
-  +0x0DFC | 90 1A 00 00             | UOffset32   | 0x00001A90 (6800) Loc: +0x288C     | offset to table[7]
-  +0x0E00 | E8 11 00 00             | UOffset32   | 0x000011E8 (4584) Loc: +0x1FE8     | offset to table[8]
-  +0x0E04 | 80 1E 00 00             | UOffset32   | 0x00001E80 (7808) Loc: +0x2C84     | offset to table[9]
-  +0x0E08 | B4 1F 00 00             | UOffset32   | 0x00001FB4 (8116) Loc: +0x2DBC     | offset to table[10]
-  +0x0E0C | 68 03 00 00             | UOffset32   | 0x00000368 (872) Loc: +0x1174      | offset to table[11]
-  +0x0E10 | 94 02 00 00             | UOffset32   | 0x00000294 (660) Loc: +0x10A4      | offset to table[12]
-  +0x0E14 | F0 1D 00 00             | UOffset32   | 0x00001DF0 (7664) Loc: +0x2C04     | offset to table[13]
-  +0x0E18 | A8 04 00 00             | UOffset32   | 0x000004A8 (1192) Loc: +0x12C0     | offset to table[14]
-  +0x0E1C | 30 04 00 00             | UOffset32   | 0x00000430 (1072) Loc: +0x124C     | offset to table[15]
-  +0x0E20 | 0C 20 00 00             | UOffset32   | 0x0000200C (8204) Loc: +0x2E2C     | offset to table[16]
-  +0x0E24 | 24 1F 00 00             | UOffset32   | 0x00001F24 (7972) Loc: +0x2D48     | offset to table[17]
-  +0x0E28 | C4 03 00 00             | UOffset32   | 0x000003C4 (964) Loc: +0x11EC      | offset to table[18]
-  +0x0E2C | 00 05 00 00             | UOffset32   | 0x00000500 (1280) Loc: +0x132C     | offset to table[19]
-  +0x0E30 | 9C 01 00 00             | UOffset32   | 0x0000019C (412) Loc: +0x0FCC      | offset to table[20]
-  +0x0E34 | 28 01 00 00             | UOffset32   | 0x00000128 (296) Loc: +0x0F5C      | offset to table[21]
-  +0x0E38 | F8 09 00 00             | UOffset32   | 0x000009F8 (2552) Loc: +0x1830     | offset to table[22]
-  +0x0E3C | 30 10 00 00             | UOffset32   | 0x00001030 (4144) Loc: +0x1E6C     | offset to table[23]
-  +0x0E40 | 64 20 00 00             | UOffset32   | 0x00002064 (8292) Loc: +0x2EA4     | offset to table[24]
-  +0x0E44 | C8 02 00 00             | UOffset32   | 0x000002C8 (712) Loc: +0x110C      | offset to table[25]
-  +0x0E48 | EC 01 00 00             | UOffset32   | 0x000001EC (492) Loc: +0x1034      | offset to table[26]
-  +0x0E4C | 6C 05 00 00             | UOffset32   | 0x0000056C (1388) Loc: +0x13B8     | offset to table[27]
-  +0x0E50 | 74 06 00 00             | UOffset32   | 0x00000674 (1652) Loc: +0x14C4     | offset to table[28]
-  +0x0E54 | C0 0E 00 00             | UOffset32   | 0x00000EC0 (3776) Loc: +0x1D14     | offset to table[29]
-  +0x0E58 | 48 1C 00 00             | UOffset32   | 0x00001C48 (7240) Loc: +0x2AA0     | offset to table[30]
-  +0x0E5C | DC 1B 00 00             | UOffset32   | 0x00001BDC (7132) Loc: +0x2A38     | offset to table[31]
-  +0x0E60 | 30 11 00 00             | UOffset32   | 0x00001130 (4400) Loc: +0x1F90     | offset to table[32]
-  +0x0E64 | AC 1C 00 00             | UOffset32   | 0x00001CAC (7340) Loc: +0x2B10     | offset to table[33]
-  +0x0E68 | DC 13 00 00             | UOffset32   | 0x000013DC (5084) Loc: +0x2244     | offset to table[34]
-  +0x0E6C | F8 11 00 00             | UOffset32   | 0x000011F8 (4600) Loc: +0x2064     | offset to table[35]
-  +0x0E70 | 68 1B 00 00             | UOffset32   | 0x00001B68 (7016) Loc: +0x29D8     | offset to table[36]
-  +0x0E74 | 58 12 00 00             | UOffset32   | 0x00001258 (4696) Loc: +0x20CC     | offset to table[37]
-  +0x0E78 | 88 1A 00 00             | UOffset32   | 0x00001A88 (6792) Loc: +0x2900     | offset to table[38]
-  +0x0E7C | C4 18 00 00             | UOffset32   | 0x000018C4 (6340) Loc: +0x2740     | offset to table[39]
-  +0x0E80 | 18 19 00 00             | UOffset32   | 0x00001918 (6424) Loc: +0x2798     | offset to table[40]
-  +0x0E84 | 68 13 00 00             | UOffset32   | 0x00001368 (4968) Loc: +0x21EC     | offset to table[41]
-  +0x0E88 | F4 12 00 00             | UOffset32   | 0x000012F4 (4852) Loc: +0x217C     | offset to table[42]
-  +0x0E8C | A0 12 00 00             | UOffset32   | 0x000012A0 (4768) Loc: +0x212C     | offset to table[43]
-  +0x0E90 | 2C 18 00 00             | UOffset32   | 0x0000182C (6188) Loc: +0x26BC     | offset to table[44]
-  +0x0E94 | 0C 16 00 00             | UOffset32   | 0x0000160C (5644) Loc: +0x24A0     | offset to table[45]
-  +0x0E98 | 18 17 00 00             | UOffset32   | 0x00001718 (5912) Loc: +0x25B0     | offset to table[46]
-  +0x0E9C | 94 14 00 00             | UOffset32   | 0x00001494 (5268) Loc: +0x2330     | offset to table[47]
-  +0x0EA0 | 98 17 00 00             | UOffset32   | 0x00001798 (6040) Loc: +0x2638     | offset to table[48]
-  +0x0EA4 | 18 15 00 00             | UOffset32   | 0x00001518 (5400) Loc: +0x23BC     | offset to table[49]
-  +0x0EA8 | 80 16 00 00             | UOffset32   | 0x00001680 (5760) Loc: +0x2528     | offset to table[50]
-  +0x0EAC | F8 13 00 00             | UOffset32   | 0x000013F8 (5112) Loc: +0x22A4     | offset to table[51]
-  +0x0EB0 | 44 19 00 00             | UOffset32   | 0x00001944 (6468) Loc: +0x27F4     | offset to table[52]
-  +0x0EB4 | 70 05 00 00             | UOffset32   | 0x00000570 (1392) Loc: +0x1424     | offset to table[53]
-  +0x0EB8 | 98 0A 00 00             | UOffset32   | 0x00000A98 (2712) Loc: +0x1950     | offset to table[54]
-  +0x0EBC | 18 10 00 00             | UOffset32   | 0x00001018 (4120) Loc: +0x1ED4     | offset to table[55]
-  +0x0EC0 | 68 06 00 00             | UOffset32   | 0x00000668 (1640) Loc: +0x1528     | offset to table[56]
-  +0x0EC4 | 70 10 00 00             | UOffset32   | 0x00001070 (4208) Loc: +0x1F34     | offset to table[57]
-  +0x0EC8 | 40 08 00 00             | UOffset32   | 0x00000840 (2112) Loc: +0x1708     | offset to table[58]
-  +0x0ECC | 38 0F 00 00             | UOffset32   | 0x00000F38 (3896) Loc: +0x1E04     | offset to table[59]
-  +0x0ED0 | A4 0C 00 00             | UOffset32   | 0x00000CA4 (3236) Loc: +0x1B74     | offset to table[60]
-  +0x0ED4 | 4C 0D 00 00             | UOffset32   | 0x00000D4C (3404) Loc: +0x1C20     | offset to table[61]
+  +0x0DDC | 3E 00 00 00             | uint32_t   | 0x0000003E (62)                    | length of vector (# items)
+  +0x0DE0 | A8 07 00 00             | UOffset32  | 0x000007A8 (1960) Loc: 0x1588      | offset to table[0]
+  +0x0DE4 | 04 08 00 00             | UOffset32  | 0x00000804 (2052) Loc: 0x15E8      | offset to table[1]
+  +0x0DE8 | 64 08 00 00             | UOffset32  | 0x00000864 (2148) Loc: 0x164C      | offset to table[2]
+  +0x0DEC | BC 08 00 00             | UOffset32  | 0x000008BC (2236) Loc: 0x16A8      | offset to table[3]
+  +0x0DF0 | 98 0C 00 00             | UOffset32  | 0x00000C98 (3224) Loc: 0x1A88      | offset to table[4]
+  +0x0DF4 | 90 1D 00 00             | UOffset32  | 0x00001D90 (7568) Loc: 0x2B84      | offset to table[5]
+  +0x0DF8 | FC 00 00 00             | UOffset32  | 0x000000FC (252) Loc: 0x0EF4       | offset to table[6]
+  +0x0DFC | 90 1A 00 00             | UOffset32  | 0x00001A90 (6800) Loc: 0x288C      | offset to table[7]
+  +0x0E00 | E8 11 00 00             | UOffset32  | 0x000011E8 (4584) Loc: 0x1FE8      | offset to table[8]
+  +0x0E04 | 80 1E 00 00             | UOffset32  | 0x00001E80 (7808) Loc: 0x2C84      | offset to table[9]
+  +0x0E08 | B4 1F 00 00             | UOffset32  | 0x00001FB4 (8116) Loc: 0x2DBC      | offset to table[10]
+  +0x0E0C | 68 03 00 00             | UOffset32  | 0x00000368 (872) Loc: 0x1174       | offset to table[11]
+  +0x0E10 | 94 02 00 00             | UOffset32  | 0x00000294 (660) Loc: 0x10A4       | offset to table[12]
+  +0x0E14 | F0 1D 00 00             | UOffset32  | 0x00001DF0 (7664) Loc: 0x2C04      | offset to table[13]
+  +0x0E18 | A8 04 00 00             | UOffset32  | 0x000004A8 (1192) Loc: 0x12C0      | offset to table[14]
+  +0x0E1C | 30 04 00 00             | UOffset32  | 0x00000430 (1072) Loc: 0x124C      | offset to table[15]
+  +0x0E20 | 0C 20 00 00             | UOffset32  | 0x0000200C (8204) Loc: 0x2E2C      | offset to table[16]
+  +0x0E24 | 24 1F 00 00             | UOffset32  | 0x00001F24 (7972) Loc: 0x2D48      | offset to table[17]
+  +0x0E28 | C4 03 00 00             | UOffset32  | 0x000003C4 (964) Loc: 0x11EC       | offset to table[18]
+  +0x0E2C | 00 05 00 00             | UOffset32  | 0x00000500 (1280) Loc: 0x132C      | offset to table[19]
+  +0x0E30 | 9C 01 00 00             | UOffset32  | 0x0000019C (412) Loc: 0x0FCC       | offset to table[20]
+  +0x0E34 | 28 01 00 00             | UOffset32  | 0x00000128 (296) Loc: 0x0F5C       | offset to table[21]
+  +0x0E38 | F8 09 00 00             | UOffset32  | 0x000009F8 (2552) Loc: 0x1830      | offset to table[22]
+  +0x0E3C | 30 10 00 00             | UOffset32  | 0x00001030 (4144) Loc: 0x1E6C      | offset to table[23]
+  +0x0E40 | 64 20 00 00             | UOffset32  | 0x00002064 (8292) Loc: 0x2EA4      | offset to table[24]
+  +0x0E44 | C8 02 00 00             | UOffset32  | 0x000002C8 (712) Loc: 0x110C       | offset to table[25]
+  +0x0E48 | EC 01 00 00             | UOffset32  | 0x000001EC (492) Loc: 0x1034       | offset to table[26]
+  +0x0E4C | 6C 05 00 00             | UOffset32  | 0x0000056C (1388) Loc: 0x13B8      | offset to table[27]
+  +0x0E50 | 74 06 00 00             | UOffset32  | 0x00000674 (1652) Loc: 0x14C4      | offset to table[28]
+  +0x0E54 | C0 0E 00 00             | UOffset32  | 0x00000EC0 (3776) Loc: 0x1D14      | offset to table[29]
+  +0x0E58 | 48 1C 00 00             | UOffset32  | 0x00001C48 (7240) Loc: 0x2AA0      | offset to table[30]
+  +0x0E5C | DC 1B 00 00             | UOffset32  | 0x00001BDC (7132) Loc: 0x2A38      | offset to table[31]
+  +0x0E60 | 30 11 00 00             | UOffset32  | 0x00001130 (4400) Loc: 0x1F90      | offset to table[32]
+  +0x0E64 | AC 1C 00 00             | UOffset32  | 0x00001CAC (7340) Loc: 0x2B10      | offset to table[33]
+  +0x0E68 | DC 13 00 00             | UOffset32  | 0x000013DC (5084) Loc: 0x2244      | offset to table[34]
+  +0x0E6C | F8 11 00 00             | UOffset32  | 0x000011F8 (4600) Loc: 0x2064      | offset to table[35]
+  +0x0E70 | 68 1B 00 00             | UOffset32  | 0x00001B68 (7016) Loc: 0x29D8      | offset to table[36]
+  +0x0E74 | 58 12 00 00             | UOffset32  | 0x00001258 (4696) Loc: 0x20CC      | offset to table[37]
+  +0x0E78 | 88 1A 00 00             | UOffset32  | 0x00001A88 (6792) Loc: 0x2900      | offset to table[38]
+  +0x0E7C | C4 18 00 00             | UOffset32  | 0x000018C4 (6340) Loc: 0x2740      | offset to table[39]
+  +0x0E80 | 18 19 00 00             | UOffset32  | 0x00001918 (6424) Loc: 0x2798      | offset to table[40]
+  +0x0E84 | 68 13 00 00             | UOffset32  | 0x00001368 (4968) Loc: 0x21EC      | offset to table[41]
+  +0x0E88 | F4 12 00 00             | UOffset32  | 0x000012F4 (4852) Loc: 0x217C      | offset to table[42]
+  +0x0E8C | A0 12 00 00             | UOffset32  | 0x000012A0 (4768) Loc: 0x212C      | offset to table[43]
+  +0x0E90 | 2C 18 00 00             | UOffset32  | 0x0000182C (6188) Loc: 0x26BC      | offset to table[44]
+  +0x0E94 | 0C 16 00 00             | UOffset32  | 0x0000160C (5644) Loc: 0x24A0      | offset to table[45]
+  +0x0E98 | 18 17 00 00             | UOffset32  | 0x00001718 (5912) Loc: 0x25B0      | offset to table[46]
+  +0x0E9C | 94 14 00 00             | UOffset32  | 0x00001494 (5268) Loc: 0x2330      | offset to table[47]
+  +0x0EA0 | 98 17 00 00             | UOffset32  | 0x00001798 (6040) Loc: 0x2638      | offset to table[48]
+  +0x0EA4 | 18 15 00 00             | UOffset32  | 0x00001518 (5400) Loc: 0x23BC      | offset to table[49]
+  +0x0EA8 | 80 16 00 00             | UOffset32  | 0x00001680 (5760) Loc: 0x2528      | offset to table[50]
+  +0x0EAC | F8 13 00 00             | UOffset32  | 0x000013F8 (5112) Loc: 0x22A4      | offset to table[51]
+  +0x0EB0 | 44 19 00 00             | UOffset32  | 0x00001944 (6468) Loc: 0x27F4      | offset to table[52]
+  +0x0EB4 | 70 05 00 00             | UOffset32  | 0x00000570 (1392) Loc: 0x1424      | offset to table[53]
+  +0x0EB8 | 98 0A 00 00             | UOffset32  | 0x00000A98 (2712) Loc: 0x1950      | offset to table[54]
+  +0x0EBC | 18 10 00 00             | UOffset32  | 0x00001018 (4120) Loc: 0x1ED4      | offset to table[55]
+  +0x0EC0 | 68 06 00 00             | UOffset32  | 0x00000668 (1640) Loc: 0x1528      | offset to table[56]
+  +0x0EC4 | 70 10 00 00             | UOffset32  | 0x00001070 (4208) Loc: 0x1F34      | offset to table[57]
+  +0x0EC8 | 40 08 00 00             | UOffset32  | 0x00000840 (2112) Loc: 0x1708      | offset to table[58]
+  +0x0ECC | 38 0F 00 00             | UOffset32  | 0x00000F38 (3896) Loc: 0x1E04      | offset to table[59]
+  +0x0ED0 | A4 0C 00 00             | UOffset32  | 0x00000CA4 (3236) Loc: 0x1B74      | offset to table[60]
+  +0x0ED4 | 4C 0D 00 00             | UOffset32  | 0x00000D4C (3404) Loc: 0x1C20      | offset to table[61]
 
 string (reflection.Object.name):
-  +0x0ED8 | 16 00 00 00             | uint32_t    | 0x00000016 (22)                    | length of string
-  +0x0EDC | 4D 79 47 61 6D 65 2E 45 | char[22]    | MyGame.E                           | string literal
-  +0x0EE4 | 78 61 6D 70 6C 65 2E 4D |             | xample.M
-  +0x0EEC | 6F 6E 73 74 65 72       |             | onster
-  +0x0EF2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0ED8 | 16 00 00 00             | uint32_t   | 0x00000016 (22)                    | length of string
+  +0x0EDC | 4D 79 47 61 6D 65 2E 45 | char[22]   | MyGame.E                           | string literal
+  +0x0EE4 | 78 61 6D 70 6C 65 2E 4D |            | xample.M
+  +0x0EEC | 6F 6E 73 74 65 72       |            | onster
+  +0x0EF2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0EF4 | 20 ED FF FF             | SOffset32   | 0xFFFFED20 (-4832) Loc: +0x21D4    | offset to vtable
-  +0x0EF8 | 3D 00                   | uint16_t    | 0x003D (61)                        | table field `id` (UShort)
-  +0x0EFA | 7E 00                   | uint16_t    | 0x007E (126)                       | table field `offset` (UShort)
-  +0x0EFC | 48 00 00 00             | UOffset32   | 0x00000048 (72) Loc: +0x0F44       | offset to field `name` (string)
-  +0x0F00 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x0F34       | offset to field `type` (table)
-  +0x0F04 | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x0F10       | offset to field `attributes` (vector)
-  +0x0F08 | 00 00 00 00 00 00 F0 7F | double      | 0x7FF0000000000000 (inf)           | table field `default_real` (Double)
+  +0x0EF4 | 20 ED FF FF             | SOffset32  | 0xFFFFED20 (-4832) Loc: 0x21D4     | offset to vtable
+  +0x0EF8 | 3D 00                   | uint16_t   | 0x003D (61)                        | table field `id` (UShort)
+  +0x0EFA | 7E 00                   | uint16_t   | 0x007E (126)                       | table field `offset` (UShort)
+  +0x0EFC | 48 00 00 00             | UOffset32  | 0x00000048 (72) Loc: 0x0F44        | offset to field `name` (string)
+  +0x0F00 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x0F34        | offset to field `type` (table)
+  +0x0F04 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x0F10        | offset to field `attributes` (vector)
+  +0x0F08 | 00 00 00 00 00 00 F0 7F | double     | 0x7FF0000000000000 (inf)           | table field `default_real` (Double)
 
 vector (reflection.Field.attributes):
-  +0x0F10 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x0F14 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0F18        | offset to table[0]
+  +0x0F10 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x0F14 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0F18         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x0F18 | 50 D6 FF FF             | SOffset32   | 0xFFFFD650 (-10672) Loc: +0x38C8   | offset to vtable
-  +0x0F1C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0F2C       | offset to field `key` (string)
-  +0x0F20 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0F24        | offset to field `value` (string)
+  +0x0F18 | 50 D6 FF FF             | SOffset32  | 0xFFFFD650 (-10672) Loc: 0x38C8    | offset to vtable
+  +0x0F1C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0F2C        | offset to field `key` (string)
+  +0x0F20 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0F24         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x0F24 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x0F28 | 36 31                   | char[2]     | 61                                 | string literal
-  +0x0F2A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0F24 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x0F28 | 36 31                   | char[2]    | 61                                 | string literal
+  +0x0F2A | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x0F2C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x0F30 | 69 64                   | char[2]     | id                                 | string literal
-  +0x0F32 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0F2C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x0F30 | 69 64                   | char[2]    | id                                 | string literal
+  +0x0F32 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x0F34 | C0 D8 FF FF             | SOffset32   | 0xFFFFD8C0 (-10048) Loc: +0x3674   | offset to vtable
-  +0x0F38 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0F3B | 0C                      | uint8_t     | 0x0C (12)                          | table field `base_type` (Byte)
-  +0x0F3C | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x0F40 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0F34 | C0 D8 FF FF             | SOffset32  | 0xFFFFD8C0 (-10048) Loc: 0x3674    | offset to vtable
+  +0x0F38 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0F3B | 0C                      | uint8_t    | 0x0C (12)                          | table field `base_type` (Byte)
+  +0x0F3C | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x0F40 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0F44 | 12 00 00 00             | uint32_t    | 0x00000012 (18)                    | length of string
-  +0x0F48 | 64 6F 75 62 6C 65 5F 69 | char[18]    | double_i                           | string literal
-  +0x0F50 | 6E 66 5F 64 65 66 61 75 |             | nf_defau
-  +0x0F58 | 6C 74                   |             | lt
-  +0x0F5A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0F44 | 12 00 00 00             | uint32_t   | 0x00000012 (18)                    | length of string
+  +0x0F48 | 64 6F 75 62 6C 65 5F 69 | char[18]   | double_i                           | string literal
+  +0x0F50 | 6E 66 5F 64 65 66 61 75 |            | nf_defau
+  +0x0F58 | 6C 74                   |            | lt
+  +0x0F5A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x0F5C | 88 FD FF FF             | SOffset32   | 0xFFFFFD88 (-632) Loc: +0x11D4     | offset to vtable
-  +0x0F60 | 3C 00                   | uint16_t    | 0x003C (60)                        | table field `id` (UShort)
-  +0x0F62 | 7C 00                   | uint16_t    | 0x007C (124)                       | table field `offset` (UShort)
-  +0x0F64 | 48 00 00 00             | UOffset32   | 0x00000048 (72) Loc: +0x0FAC       | offset to field `name` (string)
-  +0x0F68 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x0FA0       | offset to field `type` (table)
-  +0x0F6C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0F7C       | offset to field `attributes` (vector)
-  +0x0F70 | 00 00 00 00 00 00 F0 FF | double      | 0xFFF0000000000000 (-inf)          | table field `default_real` (Double)
-  +0x0F78 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x0F5C | 88 FD FF FF             | SOffset32  | 0xFFFFFD88 (-632) Loc: 0x11D4      | offset to vtable
+  +0x0F60 | 3C 00                   | uint16_t   | 0x003C (60)                        | table field `id` (UShort)
+  +0x0F62 | 7C 00                   | uint16_t   | 0x007C (124)                       | table field `offset` (UShort)
+  +0x0F64 | 48 00 00 00             | UOffset32  | 0x00000048 (72) Loc: 0x0FAC        | offset to field `name` (string)
+  +0x0F68 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x0FA0        | offset to field `type` (table)
+  +0x0F6C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0F7C        | offset to field `attributes` (vector)
+  +0x0F70 | 00 00 00 00 00 00 F0 FF | double     | 0xFFF0000000000000 (-inf)          | table field `default_real` (Double)
+  +0x0F78 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 vector (reflection.Field.attributes):
-  +0x0F7C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x0F80 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0F84        | offset to table[0]
+  +0x0F7C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x0F80 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0F84         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x0F84 | BC D6 FF FF             | SOffset32   | 0xFFFFD6BC (-10564) Loc: +0x38C8   | offset to vtable
-  +0x0F88 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x0F98       | offset to field `key` (string)
-  +0x0F8C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0F90        | offset to field `value` (string)
+  +0x0F84 | BC D6 FF FF             | SOffset32  | 0xFFFFD6BC (-10564) Loc: 0x38C8    | offset to vtable
+  +0x0F88 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0F98        | offset to field `key` (string)
+  +0x0F8C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0F90         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x0F90 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x0F94 | 36 30                   | char[2]     | 60                                 | string literal
-  +0x0F96 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0F90 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x0F94 | 36 30                   | char[2]    | 60                                 | string literal
+  +0x0F96 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x0F98 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x0F9C | 69 64                   | char[2]     | id                                 | string literal
-  +0x0F9E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0F98 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x0F9C | 69 64                   | char[2]    | id                                 | string literal
+  +0x0F9E | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x0FA0 | C4 D6 FF FF             | SOffset32   | 0xFFFFD6C4 (-10556) Loc: +0x38DC   | offset to vtable
-  +0x0FA4 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x0FA7 | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x0FA8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x0FA0 | C4 D6 FF FF             | SOffset32  | 0xFFFFD6C4 (-10556) Loc: 0x38DC    | offset to vtable
+  +0x0FA4 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x0FA7 | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x0FA8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x0FAC | 19 00 00 00             | uint32_t    | 0x00000019 (25)                    | length of string
-  +0x0FB0 | 6E 65 67 61 74 69 76 65 | char[25]    | negative                           | string literal
-  +0x0FB8 | 5F 69 6E 66 69 6E 69 74 |             | _infinit
-  +0x0FC0 | 79 5F 64 65 66 61 75 6C |             | y_defaul
-  +0x0FC8 | 74                      |             | t
-  +0x0FC9 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0FAC | 19 00 00 00             | uint32_t   | 0x00000019 (25)                    | length of string
+  +0x0FB0 | 6E 65 67 61 74 69 76 65 | char[25]   | negative                           | string literal
+  +0x0FB8 | 5F 69 6E 66 69 6E 69 74 |            | _infinit
+  +0x0FC0 | 79 5F 64 65 66 61 75 6C |            | y_defaul
+  +0x0FC8 | 74                      |            | t
+  +0x0FC9 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x0FCA | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x0FCA | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x0FCC | F8 ED FF FF             | SOffset32   | 0xFFFFEDF8 (-4616) Loc: +0x21D4    | offset to vtable
-  +0x0FD0 | 3B 00                   | uint16_t    | 0x003B (59)                        | table field `id` (UShort)
-  +0x0FD2 | 7A 00                   | uint16_t    | 0x007A (122)                       | table field `offset` (UShort)
-  +0x0FD4 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x1018       | offset to field `name` (string)
-  +0x0FD8 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x100C       | offset to field `type` (table)
-  +0x0FDC | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x0FE8       | offset to field `attributes` (vector)
-  +0x0FE0 | 00 00 00 00 00 00 F0 FF | double      | 0xFFF0000000000000 (-inf)          | table field `default_real` (Double)
+  +0x0FCC | F8 ED FF FF             | SOffset32  | 0xFFFFEDF8 (-4616) Loc: 0x21D4     | offset to vtable
+  +0x0FD0 | 3B 00                   | uint16_t   | 0x003B (59)                        | table field `id` (UShort)
+  +0x0FD2 | 7A 00                   | uint16_t   | 0x007A (122)                       | table field `offset` (UShort)
+  +0x0FD4 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x1018        | offset to field `name` (string)
+  +0x0FD8 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x100C        | offset to field `type` (table)
+  +0x0FDC | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x0FE8        | offset to field `attributes` (vector)
+  +0x0FE0 | 00 00 00 00 00 00 F0 FF | double     | 0xFFF0000000000000 (-inf)          | table field `default_real` (Double)
 
 vector (reflection.Field.attributes):
-  +0x0FE8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x0FEC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0FF0        | offset to table[0]
+  +0x0FE8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x0FEC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0FF0         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x0FF0 | 28 D7 FF FF             | SOffset32   | 0xFFFFD728 (-10456) Loc: +0x38C8   | offset to vtable
-  +0x0FF4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1004       | offset to field `key` (string)
-  +0x0FF8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x0FFC        | offset to field `value` (string)
+  +0x0FF0 | 28 D7 FF FF             | SOffset32  | 0xFFFFD728 (-10456) Loc: 0x38C8    | offset to vtable
+  +0x0FF4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1004        | offset to field `key` (string)
+  +0x0FF8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0FFC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x0FFC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1000 | 35 39                   | char[2]     | 59                                 | string literal
-  +0x1002 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x0FFC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1000 | 35 39                   | char[2]    | 59                                 | string literal
+  +0x1002 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1004 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1008 | 69 64                   | char[2]     | id                                 | string literal
-  +0x100A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1004 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1008 | 69 64                   | char[2]    | id                                 | string literal
+  +0x100A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x100C | 30 D7 FF FF             | SOffset32   | 0xFFFFD730 (-10448) Loc: +0x38DC   | offset to vtable
-  +0x1010 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1013 | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x1014 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x100C | 30 D7 FF FF             | SOffset32  | 0xFFFFD730 (-10448) Loc: 0x38DC    | offset to vtable
+  +0x1010 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1013 | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x1014 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1018 | 14 00 00 00             | uint32_t    | 0x00000014 (20)                    | length of string
-  +0x101C | 6E 65 67 61 74 69 76 65 | char[20]    | negative                           | string literal
-  +0x1024 | 5F 69 6E 66 5F 64 65 66 |             | _inf_def
-  +0x102C | 61 75 6C 74             |             | ault
-  +0x1030 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1018 | 14 00 00 00             | uint32_t   | 0x00000014 (20)                    | length of string
+  +0x101C | 6E 65 67 61 74 69 76 65 | char[20]   | negative                           | string literal
+  +0x1024 | 5F 69 6E 66 5F 64 65 66 |            | _inf_def
+  +0x102C | 61 75 6C 74             |            | ault
+  +0x1030 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1031 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1031 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x1034 | 60 FE FF FF             | SOffset32   | 0xFFFFFE60 (-416) Loc: +0x11D4     | offset to vtable
-  +0x1038 | 3A 00                   | uint16_t    | 0x003A (58)                        | table field `id` (UShort)
-  +0x103A | 78 00                   | uint16_t    | 0x0078 (120)                       | table field `offset` (UShort)
-  +0x103C | 48 00 00 00             | UOffset32   | 0x00000048 (72) Loc: +0x1084       | offset to field `name` (string)
-  +0x1040 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x1078       | offset to field `type` (table)
-  +0x1044 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1054       | offset to field `attributes` (vector)
-  +0x1048 | 00 00 00 00 00 00 F0 7F | double      | 0x7FF0000000000000 (inf)           | table field `default_real` (Double)
-  +0x1050 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x1034 | 60 FE FF FF             | SOffset32  | 0xFFFFFE60 (-416) Loc: 0x11D4      | offset to vtable
+  +0x1038 | 3A 00                   | uint16_t   | 0x003A (58)                        | table field `id` (UShort)
+  +0x103A | 78 00                   | uint16_t   | 0x0078 (120)                       | table field `offset` (UShort)
+  +0x103C | 48 00 00 00             | UOffset32  | 0x00000048 (72) Loc: 0x1084        | offset to field `name` (string)
+  +0x1040 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x1078        | offset to field `type` (table)
+  +0x1044 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1054        | offset to field `attributes` (vector)
+  +0x1048 | 00 00 00 00 00 00 F0 7F | double     | 0x7FF0000000000000 (inf)           | table field `default_real` (Double)
+  +0x1050 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 vector (reflection.Field.attributes):
-  +0x1054 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x1058 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x105C        | offset to table[0]
+  +0x1054 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x1058 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x105C         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x105C | 94 D7 FF FF             | SOffset32   | 0xFFFFD794 (-10348) Loc: +0x38C8   | offset to vtable
-  +0x1060 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1070       | offset to field `key` (string)
-  +0x1064 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1068        | offset to field `value` (string)
+  +0x105C | 94 D7 FF FF             | SOffset32  | 0xFFFFD794 (-10348) Loc: 0x38C8    | offset to vtable
+  +0x1060 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1070        | offset to field `key` (string)
+  +0x1064 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1068         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1068 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x106C | 35 38                   | char[2]     | 58                                 | string literal
-  +0x106E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1068 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x106C | 35 38                   | char[2]    | 58                                 | string literal
+  +0x106E | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1070 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1074 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1076 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1070 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1074 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1076 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1078 | 9C D7 FF FF             | SOffset32   | 0xFFFFD79C (-10340) Loc: +0x38DC   | offset to vtable
-  +0x107C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x107F | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x1080 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1078 | 9C D7 FF FF             | SOffset32  | 0xFFFFD79C (-10340) Loc: 0x38DC    | offset to vtable
+  +0x107C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x107F | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x1080 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1084 | 19 00 00 00             | uint32_t    | 0x00000019 (25)                    | length of string
-  +0x1088 | 70 6F 73 69 74 69 76 65 | char[25]    | positive                           | string literal
-  +0x1090 | 5F 69 6E 66 69 6E 69 74 |             | _infinit
-  +0x1098 | 79 5F 64 65 66 61 75 6C |             | y_defaul
-  +0x10A0 | 74                      |             | t
-  +0x10A1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1084 | 19 00 00 00             | uint32_t   | 0x00000019 (25)                    | length of string
+  +0x1088 | 70 6F 73 69 74 69 76 65 | char[25]   | positive                           | string literal
+  +0x1090 | 5F 69 6E 66 69 6E 69 74 |            | _infinit
+  +0x1098 | 79 5F 64 65 66 61 75 6C |            | y_defaul
+  +0x10A0 | 74                      |            | t
+  +0x10A1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x10A2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x10A2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x10A4 | D0 FE FF FF             | SOffset32   | 0xFFFFFED0 (-304) Loc: +0x11D4     | offset to vtable
-  +0x10A8 | 39 00                   | uint16_t    | 0x0039 (57)                        | table field `id` (UShort)
-  +0x10AA | 76 00                   | uint16_t    | 0x0076 (118)                       | table field `offset` (UShort)
-  +0x10AC | 48 00 00 00             | UOffset32   | 0x00000048 (72) Loc: +0x10F4       | offset to field `name` (string)
-  +0x10B0 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x10E8       | offset to field `type` (table)
-  +0x10B4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x10C4       | offset to field `attributes` (vector)
-  +0x10B8 | 00 00 00 00 00 00 F0 7F | double      | 0x7FF0000000000000 (inf)           | table field `default_real` (Double)
-  +0x10C0 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x10A4 | D0 FE FF FF             | SOffset32  | 0xFFFFFED0 (-304) Loc: 0x11D4      | offset to vtable
+  +0x10A8 | 39 00                   | uint16_t   | 0x0039 (57)                        | table field `id` (UShort)
+  +0x10AA | 76 00                   | uint16_t   | 0x0076 (118)                       | table field `offset` (UShort)
+  +0x10AC | 48 00 00 00             | UOffset32  | 0x00000048 (72) Loc: 0x10F4        | offset to field `name` (string)
+  +0x10B0 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x10E8        | offset to field `type` (table)
+  +0x10B4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x10C4        | offset to field `attributes` (vector)
+  +0x10B8 | 00 00 00 00 00 00 F0 7F | double     | 0x7FF0000000000000 (inf)           | table field `default_real` (Double)
+  +0x10C0 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 vector (reflection.Field.attributes):
-  +0x10C4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x10C8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x10CC        | offset to table[0]
+  +0x10C4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x10C8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x10CC         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x10CC | 04 D8 FF FF             | SOffset32   | 0xFFFFD804 (-10236) Loc: +0x38C8   | offset to vtable
-  +0x10D0 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x10E0       | offset to field `key` (string)
-  +0x10D4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x10D8        | offset to field `value` (string)
+  +0x10CC | 04 D8 FF FF             | SOffset32  | 0xFFFFD804 (-10236) Loc: 0x38C8    | offset to vtable
+  +0x10D0 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x10E0        | offset to field `key` (string)
+  +0x10D4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x10D8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x10D8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x10DC | 35 37                   | char[2]     | 57                                 | string literal
-  +0x10DE | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x10D8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x10DC | 35 37                   | char[2]    | 57                                 | string literal
+  +0x10DE | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x10E0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x10E4 | 69 64                   | char[2]     | id                                 | string literal
-  +0x10E6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x10E0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x10E4 | 69 64                   | char[2]    | id                                 | string literal
+  +0x10E6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x10E8 | 0C D8 FF FF             | SOffset32   | 0xFFFFD80C (-10228) Loc: +0x38DC   | offset to vtable
-  +0x10EC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x10EF | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x10F0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x10E8 | 0C D8 FF FF             | SOffset32  | 0xFFFFD80C (-10228) Loc: 0x38DC    | offset to vtable
+  +0x10EC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x10EF | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x10F0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x10F4 | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x10F8 | 69 6E 66 69 6E 69 74 79 | char[16]    | infinity                           | string literal
-  +0x1100 | 5F 64 65 66 61 75 6C 74 |             | _default
-  +0x1108 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x10F4 | 10 00 00 00             | uint32_t   | 0x00000010 (16)                    | length of string
+  +0x10F8 | 69 6E 66 69 6E 69 74 79 | char[16]   | infinity                           | string literal
+  +0x1100 | 5F 64 65 66 61 75 6C 74 |            | _default
+  +0x1108 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1109 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1109 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x110C | 38 EF FF FF             | SOffset32   | 0xFFFFEF38 (-4296) Loc: +0x21D4    | offset to vtable
-  +0x1110 | 38 00                   | uint16_t    | 0x0038 (56)                        | table field `id` (UShort)
-  +0x1112 | 74 00                   | uint16_t    | 0x0074 (116)                       | table field `offset` (UShort)
-  +0x1114 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x1158       | offset to field `name` (string)
-  +0x1118 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x114C       | offset to field `type` (table)
-  +0x111C | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x1128       | offset to field `attributes` (vector)
-  +0x1120 | 00 00 00 00 00 00 F0 7F | double      | 0x7FF0000000000000 (inf)           | table field `default_real` (Double)
+  +0x110C | 38 EF FF FF             | SOffset32  | 0xFFFFEF38 (-4296) Loc: 0x21D4     | offset to vtable
+  +0x1110 | 38 00                   | uint16_t   | 0x0038 (56)                        | table field `id` (UShort)
+  +0x1112 | 74 00                   | uint16_t   | 0x0074 (116)                       | table field `offset` (UShort)
+  +0x1114 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x1158        | offset to field `name` (string)
+  +0x1118 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x114C        | offset to field `type` (table)
+  +0x111C | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x1128        | offset to field `attributes` (vector)
+  +0x1120 | 00 00 00 00 00 00 F0 7F | double     | 0x7FF0000000000000 (inf)           | table field `default_real` (Double)
 
 vector (reflection.Field.attributes):
-  +0x1128 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x112C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1130        | offset to table[0]
+  +0x1128 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x112C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1130         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x1130 | 68 D8 FF FF             | SOffset32   | 0xFFFFD868 (-10136) Loc: +0x38C8   | offset to vtable
-  +0x1134 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1144       | offset to field `key` (string)
-  +0x1138 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x113C        | offset to field `value` (string)
+  +0x1130 | 68 D8 FF FF             | SOffset32  | 0xFFFFD868 (-10136) Loc: 0x38C8    | offset to vtable
+  +0x1134 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1144        | offset to field `key` (string)
+  +0x1138 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x113C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x113C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1140 | 35 36                   | char[2]     | 56                                 | string literal
-  +0x1142 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x113C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1140 | 35 36                   | char[2]    | 56                                 | string literal
+  +0x1142 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1144 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1148 | 69 64                   | char[2]     | id                                 | string literal
-  +0x114A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1144 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1148 | 69 64                   | char[2]    | id                                 | string literal
+  +0x114A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x114C | 70 D8 FF FF             | SOffset32   | 0xFFFFD870 (-10128) Loc: +0x38DC   | offset to vtable
-  +0x1150 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1153 | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x1154 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x114C | 70 D8 FF FF             | SOffset32  | 0xFFFFD870 (-10128) Loc: 0x38DC    | offset to vtable
+  +0x1150 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1153 | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x1154 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1158 | 14 00 00 00             | uint32_t    | 0x00000014 (20)                    | length of string
-  +0x115C | 70 6F 73 69 74 69 76 65 | char[20]    | positive                           | string literal
-  +0x1164 | 5F 69 6E 66 5F 64 65 66 |             | _inf_def
-  +0x116C | 61 75 6C 74             |             | ault
-  +0x1170 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1158 | 14 00 00 00             | uint32_t   | 0x00000014 (20)                    | length of string
+  +0x115C | 70 6F 73 69 74 69 76 65 | char[20]   | positive                           | string literal
+  +0x1164 | 5F 69 6E 66 5F 64 65 66 |            | _inf_def
+  +0x116C | 61 75 6C 74             |            | ault
+  +0x1170 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1171 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1171 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x1174 | A0 FF FF FF             | SOffset32   | 0xFFFFFFA0 (-96) Loc: +0x11D4      | offset to vtable
-  +0x1178 | 37 00                   | uint16_t    | 0x0037 (55)                        | table field `id` (UShort)
-  +0x117A | 72 00                   | uint16_t    | 0x0072 (114)                       | table field `offset` (UShort)
-  +0x117C | 48 00 00 00             | UOffset32   | 0x00000048 (72) Loc: +0x11C4       | offset to field `name` (string)
-  +0x1180 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x11B8       | offset to field `type` (table)
-  +0x1184 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1194       | offset to field `attributes` (vector)
-  +0x1188 | 00 00 00 00 00 00 F0 7F | double      | 0x7FF0000000000000 (inf)           | table field `default_real` (Double)
-  +0x1190 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x1174 | A0 FF FF FF             | SOffset32  | 0xFFFFFFA0 (-96) Loc: 0x11D4       | offset to vtable
+  +0x1178 | 37 00                   | uint16_t   | 0x0037 (55)                        | table field `id` (UShort)
+  +0x117A | 72 00                   | uint16_t   | 0x0072 (114)                       | table field `offset` (UShort)
+  +0x117C | 48 00 00 00             | UOffset32  | 0x00000048 (72) Loc: 0x11C4        | offset to field `name` (string)
+  +0x1180 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x11B8        | offset to field `type` (table)
+  +0x1184 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1194        | offset to field `attributes` (vector)
+  +0x1188 | 00 00 00 00 00 00 F0 7F | double     | 0x7FF0000000000000 (inf)           | table field `default_real` (Double)
+  +0x1190 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 vector (reflection.Field.attributes):
-  +0x1194 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x1198 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x119C        | offset to table[0]
+  +0x1194 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x1198 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x119C         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x119C | D4 D8 FF FF             | SOffset32   | 0xFFFFD8D4 (-10028) Loc: +0x38C8   | offset to vtable
-  +0x11A0 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x11B0       | offset to field `key` (string)
-  +0x11A4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x11A8        | offset to field `value` (string)
+  +0x119C | D4 D8 FF FF             | SOffset32  | 0xFFFFD8D4 (-10028) Loc: 0x38C8    | offset to vtable
+  +0x11A0 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x11B0        | offset to field `key` (string)
+  +0x11A4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x11A8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x11A8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x11AC | 35 35                   | char[2]     | 55                                 | string literal
-  +0x11AE | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x11A8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x11AC | 35 35                   | char[2]    | 55                                 | string literal
+  +0x11AE | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x11B0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x11B4 | 69 64                   | char[2]     | id                                 | string literal
-  +0x11B6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x11B0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x11B4 | 69 64                   | char[2]    | id                                 | string literal
+  +0x11B6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x11B8 | DC D8 FF FF             | SOffset32   | 0xFFFFD8DC (-10020) Loc: +0x38DC   | offset to vtable
-  +0x11BC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x11BF | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x11C0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x11B8 | DC D8 FF FF             | SOffset32  | 0xFFFFD8DC (-10020) Loc: 0x38DC    | offset to vtable
+  +0x11BC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x11BF | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x11C0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x11C4 | 0B 00 00 00             | uint32_t    | 0x0000000B (11)                    | length of string
-  +0x11C8 | 69 6E 66 5F 64 65 66 61 | char[11]    | inf_defa                           | string literal
-  +0x11D0 | 75 6C 74                |             | ult
-  +0x11D3 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x11C4 | 0B 00 00 00             | uint32_t   | 0x0000000B (11)                    | length of string
+  +0x11C8 | 69 6E 66 5F 64 65 66 61 | char[11]   | inf_defa                           | string literal
+  +0x11D0 | 75 6C 74                |            | ult
+  +0x11D3 | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Field):
-  +0x11D4 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of this vtable
-  +0x11D6 | 20 00                   | uint16_t    | 0x0020 (32)                        | size of referring table
-  +0x11D8 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x11DA | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x11DC | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `id` (id: 2)
-  +0x11DE | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `offset` (id: 3)
-  +0x11E0 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x11E2 | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `default_real` (id: 5)
-  +0x11E4 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x11E6 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x11E8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x11EA | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 9)
+  +0x11D4 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of this vtable
+  +0x11D6 | 20 00                   | uint16_t   | 0x0020 (32)                        | size of referring table
+  +0x11D8 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x11DA | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x11DC | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `id` (id: 2)
+  +0x11DE | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `offset` (id: 3)
+  +0x11E0 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x11E2 | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `default_real` (id: 5)
+  +0x11E4 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x11E6 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x11E8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x11EA | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 9)
 
 table (reflection.Field):
-  +0x11EC | 18 00 00 00             | SOffset32   | 0x00000018 (24) Loc: +0x11D4       | offset to vtable
-  +0x11F0 | 36 00                   | uint16_t    | 0x0036 (54)                        | table field `id` (UShort)
-  +0x11F2 | 70 00                   | uint16_t    | 0x0070 (112)                       | table field `offset` (UShort)
-  +0x11F4 | 48 00 00 00             | UOffset32   | 0x00000048 (72) Loc: +0x123C       | offset to field `name` (string)
-  +0x11F8 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x1230       | offset to field `type` (table)
-  +0x11FC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x120C       | offset to field `attributes` (vector)
-  +0x1200 | 00 00 00 00 00 00 F8 7F | double      | 0x7FF8000000000000 (nan)           | table field `default_real` (Double)
-  +0x1208 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x11EC | 18 00 00 00             | SOffset32  | 0x00000018 (24) Loc: 0x11D4        | offset to vtable
+  +0x11F0 | 36 00                   | uint16_t   | 0x0036 (54)                        | table field `id` (UShort)
+  +0x11F2 | 70 00                   | uint16_t   | 0x0070 (112)                       | table field `offset` (UShort)
+  +0x11F4 | 48 00 00 00             | UOffset32  | 0x00000048 (72) Loc: 0x123C        | offset to field `name` (string)
+  +0x11F8 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x1230        | offset to field `type` (table)
+  +0x11FC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x120C        | offset to field `attributes` (vector)
+  +0x1200 | 00 00 00 00 00 00 F8 7F | double     | 0x7FF8000000000000 (nan)           | table field `default_real` (Double)
+  +0x1208 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 vector (reflection.Field.attributes):
-  +0x120C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x1210 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1214        | offset to table[0]
+  +0x120C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x1210 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1214         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x1214 | 4C D9 FF FF             | SOffset32   | 0xFFFFD94C (-9908) Loc: +0x38C8    | offset to vtable
-  +0x1218 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1228       | offset to field `key` (string)
-  +0x121C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1220        | offset to field `value` (string)
+  +0x1214 | 4C D9 FF FF             | SOffset32  | 0xFFFFD94C (-9908) Loc: 0x38C8     | offset to vtable
+  +0x1218 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1228        | offset to field `key` (string)
+  +0x121C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1220         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1220 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1224 | 35 34                   | char[2]     | 54                                 | string literal
-  +0x1226 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1220 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1224 | 35 34                   | char[2]    | 54                                 | string literal
+  +0x1226 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1228 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x122C | 69 64                   | char[2]     | id                                 | string literal
-  +0x122E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1228 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x122C | 69 64                   | char[2]    | id                                 | string literal
+  +0x122E | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1230 | 54 D9 FF FF             | SOffset32   | 0xFFFFD954 (-9900) Loc: +0x38DC    | offset to vtable
-  +0x1234 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1237 | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x1238 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1230 | 54 D9 FF FF             | SOffset32  | 0xFFFFD954 (-9900) Loc: 0x38DC     | offset to vtable
+  +0x1234 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1237 | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x1238 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x123C | 0B 00 00 00             | uint32_t    | 0x0000000B (11)                    | length of string
-  +0x1240 | 6E 61 6E 5F 64 65 66 61 | char[11]    | nan_defa                           | string literal
-  +0x1248 | 75 6C 74                |             | ult
-  +0x124B | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x123C | 0B 00 00 00             | uint32_t   | 0x0000000B (11)                    | length of string
+  +0x1240 | 6E 61 6E 5F 64 65 66 61 | char[11]   | nan_defa                           | string literal
+  +0x1248 | 75 6C 74                |            | ult
+  +0x124B | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x124C | 38 E4 FF FF             | SOffset32   | 0xFFFFE438 (-7112) Loc: +0x2E14    | offset to vtable
-  +0x1250 | 35 00                   | uint16_t    | 0x0035 (53)                        | table field `id` (UShort)
-  +0x1252 | 6E 00                   | uint16_t    | 0x006E (110)                       | table field `offset` (UShort)
-  +0x1254 | 4C 00 00 00             | UOffset32   | 0x0000004C (76) Loc: +0x12A0       | offset to field `name` (string)
-  +0x1258 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x128C       | offset to field `type` (table)
-  +0x125C | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x1268       | offset to field `attributes` (vector)
-  +0x1260 | 02 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000002 (2)             | table field `default_integer` (Long)
+  +0x124C | 38 E4 FF FF             | SOffset32  | 0xFFFFE438 (-7112) Loc: 0x2E14     | offset to vtable
+  +0x1250 | 35 00                   | uint16_t   | 0x0035 (53)                        | table field `id` (UShort)
+  +0x1252 | 6E 00                   | uint16_t   | 0x006E (110)                       | table field `offset` (UShort)
+  +0x1254 | 4C 00 00 00             | UOffset32  | 0x0000004C (76) Loc: 0x12A0        | offset to field `name` (string)
+  +0x1258 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x128C        | offset to field `type` (table)
+  +0x125C | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x1268        | offset to field `attributes` (vector)
+  +0x1260 | 02 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000002 (2)             | table field `default_integer` (Long)
 
 vector (reflection.Field.attributes):
-  +0x1268 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x126C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1270        | offset to table[0]
+  +0x1268 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x126C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1270         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x1270 | A8 D9 FF FF             | SOffset32   | 0xFFFFD9A8 (-9816) Loc: +0x38C8    | offset to vtable
-  +0x1274 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1284       | offset to field `key` (string)
-  +0x1278 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x127C        | offset to field `value` (string)
+  +0x1270 | A8 D9 FF FF             | SOffset32  | 0xFFFFD9A8 (-9816) Loc: 0x38C8     | offset to vtable
+  +0x1274 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1284        | offset to field `key` (string)
+  +0x1278 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x127C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x127C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1280 | 35 33                   | char[2]     | 53                                 | string literal
-  +0x1282 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x127C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1280 | 35 33                   | char[2]    | 53                                 | string literal
+  +0x1282 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1284 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1288 | 69 64                   | char[2]     | id                                 | string literal
-  +0x128A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1284 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1288 | 69 64                   | char[2]    | id                                 | string literal
+  +0x128A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x128C | E0 DC FF FF             | SOffset32   | 0xFFFFDCE0 (-8992) Loc: +0x35AC    | offset to vtable
-  +0x1290 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1293 | 0A                      | uint8_t     | 0x0A (10)                          | table field `base_type` (Byte)
-  +0x1294 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `index` (Int)
-  +0x1298 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x129C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x128C | E0 DC FF FF             | SOffset32  | 0xFFFFDCE0 (-8992) Loc: 0x35AC     | offset to vtable
+  +0x1290 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1293 | 0A                      | uint8_t    | 0x0A (10)                          | table field `base_type` (Byte)
+  +0x1294 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `index` (Int)
+  +0x1298 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x129C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x12A0 | 18 00 00 00             | uint32_t    | 0x00000018 (24)                    | length of string
-  +0x12A4 | 6C 6F 6E 67 5F 65 6E 75 | char[24]    | long_enu                           | string literal
-  +0x12AC | 6D 5F 6E 6F 72 6D 61 6C |             | m_normal
-  +0x12B4 | 5F 64 65 66 61 75 6C 74 |             | _default
-  +0x12BC | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x12A0 | 18 00 00 00             | uint32_t   | 0x00000018 (24)                    | length of string
+  +0x12A4 | 6C 6F 6E 67 5F 65 6E 75 | char[24]   | long_enu                           | string literal
+  +0x12AC | 6D 5F 6E 6F 72 6D 61 6C |            | m_normal
+  +0x12B4 | 5F 64 65 66 61 75 6C 74 |            | _default
+  +0x12BC | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x12BD | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x12BD | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x12C0 | C8 E7 FF FF             | SOffset32   | 0xFFFFE7C8 (-6200) Loc: +0x2AF8    | offset to vtable
-  +0x12C4 | 34 00                   | uint16_t    | 0x0034 (52)                        | table field `id` (UShort)
-  +0x12C6 | 6C 00                   | uint16_t    | 0x006C (108)                       | table field `offset` (UShort)
-  +0x12C8 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x130C       | offset to field `name` (string)
-  +0x12CC | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x12F8       | offset to field `type` (table)
-  +0x12D0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x12D4        | offset to field `attributes` (vector)
+  +0x12C0 | C8 E7 FF FF             | SOffset32  | 0xFFFFE7C8 (-6200) Loc: 0x2AF8     | offset to vtable
+  +0x12C4 | 34 00                   | uint16_t   | 0x0034 (52)                        | table field `id` (UShort)
+  +0x12C6 | 6C 00                   | uint16_t   | 0x006C (108)                       | table field `offset` (UShort)
+  +0x12C8 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x130C        | offset to field `name` (string)
+  +0x12CC | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x12F8        | offset to field `type` (table)
+  +0x12D0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x12D4         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x12D4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x12D8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x12DC        | offset to table[0]
+  +0x12D4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x12D8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x12DC         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x12DC | 14 DA FF FF             | SOffset32   | 0xFFFFDA14 (-9708) Loc: +0x38C8    | offset to vtable
-  +0x12E0 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x12F0       | offset to field `key` (string)
-  +0x12E4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x12E8        | offset to field `value` (string)
+  +0x12DC | 14 DA FF FF             | SOffset32  | 0xFFFFDA14 (-9708) Loc: 0x38C8     | offset to vtable
+  +0x12E0 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x12F0        | offset to field `key` (string)
+  +0x12E4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x12E8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x12E8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x12EC | 35 32                   | char[2]     | 52                                 | string literal
-  +0x12EE | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x12E8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x12EC | 35 32                   | char[2]    | 52                                 | string literal
+  +0x12EE | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x12F0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x12F4 | 69 64                   | char[2]     | id                                 | string literal
-  +0x12F6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x12F0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x12F4 | 69 64                   | char[2]    | id                                 | string literal
+  +0x12F6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x12F8 | 4C DD FF FF             | SOffset32   | 0xFFFFDD4C (-8884) Loc: +0x35AC    | offset to vtable
-  +0x12FC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x12FF | 0A                      | uint8_t     | 0x0A (10)                          | table field `base_type` (Byte)
-  +0x1300 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `index` (Int)
-  +0x1304 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x1308 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x12F8 | 4C DD FF FF             | SOffset32  | 0xFFFFDD4C (-8884) Loc: 0x35AC     | offset to vtable
+  +0x12FC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x12FF | 0A                      | uint8_t    | 0x0A (10)                          | table field `base_type` (Byte)
+  +0x1300 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `index` (Int)
+  +0x1304 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x1308 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x130C | 1A 00 00 00             | uint32_t    | 0x0000001A (26)                    | length of string
-  +0x1310 | 6C 6F 6E 67 5F 65 6E 75 | char[26]    | long_enu                           | string literal
-  +0x1318 | 6D 5F 6E 6F 6E 5F 65 6E |             | m_non_en
-  +0x1320 | 75 6D 5F 64 65 66 61 75 |             | um_defau
-  +0x1328 | 6C 74                   |             | lt
-  +0x132A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x130C | 1A 00 00 00             | uint32_t   | 0x0000001A (26)                    | length of string
+  +0x1310 | 6C 6F 6E 67 5F 65 6E 75 | char[26]   | long_enu                           | string literal
+  +0x1318 | 6D 5F 6E 6F 6E 5F 65 6E |            | m_non_en
+  +0x1320 | 75 6D 5F 64 65 66 61 75 |            | um_defau
+  +0x1328 | 6C 74                   |            | lt
+  +0x132A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x132C | 44 E7 FF FF             | SOffset32   | 0xFFFFE744 (-6332) Loc: +0x2BE8    | offset to vtable
-  +0x1330 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1333 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1334 | 33 00                   | uint16_t    | 0x0033 (51)                        | table field `id` (UShort)
-  +0x1336 | 6A 00                   | uint16_t    | 0x006A (106)                       | table field `offset` (UShort)
-  +0x1338 | 6C 00 00 00             | UOffset32   | 0x0000006C (108) Loc: +0x13A4      | offset to field `name` (string)
-  +0x133C | 58 00 00 00             | UOffset32   | 0x00000058 (88) Loc: +0x1394       | offset to field `type` (table)
-  +0x1340 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1344        | offset to field `attributes` (vector)
+  +0x132C | 44 E7 FF FF             | SOffset32  | 0xFFFFE744 (-6332) Loc: 0x2BE8     | offset to vtable
+  +0x1330 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1333 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1334 | 33 00                   | uint16_t   | 0x0033 (51)                        | table field `id` (UShort)
+  +0x1336 | 6A 00                   | uint16_t   | 0x006A (106)                       | table field `offset` (UShort)
+  +0x1338 | 6C 00 00 00             | UOffset32  | 0x0000006C (108) Loc: 0x13A4       | offset to field `name` (string)
+  +0x133C | 58 00 00 00             | UOffset32  | 0x00000058 (88) Loc: 0x1394        | offset to field `type` (table)
+  +0x1340 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1344         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1344 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x1348 | 30 00 00 00             | UOffset32   | 0x00000030 (48) Loc: +0x1378       | offset to table[0]
-  +0x134C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1350        | offset to table[1]
+  +0x1344 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x1348 | 30 00 00 00             | UOffset32  | 0x00000030 (48) Loc: 0x1378        | offset to table[0]
+  +0x134C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1350         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x1350 | 88 DA FF FF             | SOffset32   | 0xFFFFDA88 (-9592) Loc: +0x38C8    | offset to vtable
-  +0x1354 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1364       | offset to field `key` (string)
-  +0x1358 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x135C        | offset to field `value` (string)
+  +0x1350 | 88 DA FF FF             | SOffset32  | 0xFFFFDA88 (-9592) Loc: 0x38C8     | offset to vtable
+  +0x1354 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1364        | offset to field `key` (string)
+  +0x1358 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x135C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x135C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x1360 | 30                      | char[1]     | 0                                  | string literal
-  +0x1361 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x135C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x1360 | 30                      | char[1]    | 0                                  | string literal
+  +0x1361 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1362 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1362 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x1364 | 0D 00 00 00             | uint32_t    | 0x0000000D (13)                    | length of string
-  +0x1368 | 6E 61 74 69 76 65 5F 69 | char[13]    | native_i                           | string literal
-  +0x1370 | 6E 6C 69 6E 65          |             | nline
-  +0x1375 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1364 | 0D 00 00 00             | uint32_t   | 0x0000000D (13)                    | length of string
+  +0x1368 | 6E 61 74 69 76 65 5F 69 | char[13]   | native_i                           | string literal
+  +0x1370 | 6E 6C 69 6E 65          |            | nline
+  +0x1375 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1376 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1376 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.KeyValue):
-  +0x1378 | B0 DA FF FF             | SOffset32   | 0xFFFFDAB0 (-9552) Loc: +0x38C8    | offset to vtable
-  +0x137C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x138C       | offset to field `key` (string)
-  +0x1380 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1384        | offset to field `value` (string)
+  +0x1378 | B0 DA FF FF             | SOffset32  | 0xFFFFDAB0 (-9552) Loc: 0x38C8     | offset to vtable
+  +0x137C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x138C        | offset to field `key` (string)
+  +0x1380 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1384         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1384 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1388 | 35 31                   | char[2]     | 51                                 | string literal
-  +0x138A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1384 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1388 | 35 31                   | char[2]    | 51                                 | string literal
+  +0x138A | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x138C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1390 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1392 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x138C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1390 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1392 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1394 | 7C DB FF FF             | SOffset32   | 0xFFFFDB7C (-9348) Loc: +0x3818    | offset to vtable
-  +0x1398 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x139B | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x139C | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | table field `index` (Int)
-  +0x13A0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1394 | 7C DB FF FF             | SOffset32  | 0xFFFFDB7C (-9348) Loc: 0x3818     | offset to vtable
+  +0x1398 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x139B | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x139C | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | table field `index` (Int)
+  +0x13A0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x13A4 | 0D 00 00 00             | uint32_t    | 0x0000000D (13)                    | length of string
-  +0x13A8 | 6E 61 74 69 76 65 5F 69 | char[13]    | native_i                           | string literal
-  +0x13B0 | 6E 6C 69 6E 65          |             | nline
-  +0x13B5 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x13A4 | 0D 00 00 00             | uint32_t   | 0x0000000D (13)                    | length of string
+  +0x13A8 | 6E 61 74 69 76 65 5F 69 | char[13]   | native_i                           | string literal
+  +0x13B0 | 6E 6C 69 6E 65          |            | nline
+  +0x13B5 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x13B6 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x13B6 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x13B8 | D0 E7 FF FF             | SOffset32   | 0xFFFFE7D0 (-6192) Loc: +0x2BE8    | offset to vtable
-  +0x13BC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x13BF | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x13C0 | 32 00                   | uint16_t    | 0x0032 (50)                        | table field `id` (UShort)
-  +0x13C2 | 68 00                   | uint16_t    | 0x0068 (104)                       | table field `offset` (UShort)
-  +0x13C4 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x1404       | offset to field `name` (string)
-  +0x13C8 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x13F4       | offset to field `type` (table)
-  +0x13CC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x13D0        | offset to field `attributes` (vector)
+  +0x13B8 | D0 E7 FF FF             | SOffset32  | 0xFFFFE7D0 (-6192) Loc: 0x2BE8     | offset to vtable
+  +0x13BC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x13BF | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x13C0 | 32 00                   | uint16_t   | 0x0032 (50)                        | table field `id` (UShort)
+  +0x13C2 | 68 00                   | uint16_t   | 0x0068 (104)                       | table field `offset` (UShort)
+  +0x13C4 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x1404        | offset to field `name` (string)
+  +0x13C8 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x13F4        | offset to field `type` (table)
+  +0x13CC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x13D0         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x13D0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x13D4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x13D8        | offset to table[0]
+  +0x13D0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x13D4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x13D8         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x13D8 | 10 DB FF FF             | SOffset32   | 0xFFFFDB10 (-9456) Loc: +0x38C8    | offset to vtable
-  +0x13DC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x13EC       | offset to field `key` (string)
-  +0x13E0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x13E4        | offset to field `value` (string)
+  +0x13D8 | 10 DB FF FF             | SOffset32  | 0xFFFFDB10 (-9456) Loc: 0x38C8     | offset to vtable
+  +0x13DC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x13EC        | offset to field `key` (string)
+  +0x13E0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x13E4         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x13E4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x13E8 | 35 30                   | char[2]     | 50                                 | string literal
-  +0x13EA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x13E4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x13E8 | 35 30                   | char[2]    | 50                                 | string literal
+  +0x13EA | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x13EC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x13F0 | 69 64                   | char[2]     | id                                 | string literal
-  +0x13F2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x13EC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x13F0 | 69 64                   | char[2]    | id                                 | string literal
+  +0x13F2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x13F4 | 80 E9 FF FF             | SOffset32   | 0xFFFFE980 (-5760) Loc: +0x2A74    | offset to vtable
-  +0x13F8 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x13FA | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x13FB | 0F                      | uint8_t     | 0x0F (15)                          | table field `element` (Byte)
-  +0x13FC | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | table field `index` (Int)
-  +0x1400 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `element_size` (UInt)
+  +0x13F4 | 80 E9 FF FF             | SOffset32  | 0xFFFFE980 (-5760) Loc: 0x2A74     | offset to vtable
+  +0x13F8 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x13FA | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x13FB | 0F                      | uint8_t    | 0x0F (15)                          | table field `element` (Byte)
+  +0x13FC | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | table field `index` (Int)
+  +0x1400 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1404 | 18 00 00 00             | uint32_t    | 0x00000018 (24)                    | length of string
-  +0x1408 | 73 63 61 6C 61 72 5F 6B | char[24]    | scalar_k                           | string literal
-  +0x1410 | 65 79 5F 73 6F 72 74 65 |             | ey_sorte
-  +0x1418 | 64 5F 74 61 62 6C 65 73 |             | d_tables
-  +0x1420 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1404 | 18 00 00 00             | uint32_t   | 0x00000018 (24)                    | length of string
+  +0x1408 | 73 63 61 6C 61 72 5F 6B | char[24]   | scalar_k                           | string literal
+  +0x1410 | 65 79 5F 73 6F 72 74 65 |            | ey_sorte
+  +0x1418 | 64 5F 74 61 62 6C 65 73 |            | d_tables
+  +0x1420 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1421 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1421 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x1424 | 3C E8 FF FF             | SOffset32   | 0xFFFFE83C (-6084) Loc: +0x2BE8    | offset to vtable
-  +0x1428 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x142B | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x142C | 31 00                   | uint16_t    | 0x0031 (49)                        | table field `id` (UShort)
-  +0x142E | 66 00                   | uint16_t    | 0x0066 (102)                       | table field `offset` (UShort)
-  +0x1430 | 70 00 00 00             | UOffset32   | 0x00000070 (112) Loc: +0x14A0      | offset to field `name` (string)
-  +0x1434 | 60 00 00 00             | UOffset32   | 0x00000060 (96) Loc: +0x1494       | offset to field `type` (table)
-  +0x1438 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x143C        | offset to field `attributes` (vector)
+  +0x1424 | 3C E8 FF FF             | SOffset32  | 0xFFFFE83C (-6084) Loc: 0x2BE8     | offset to vtable
+  +0x1428 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x142B | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x142C | 31 00                   | uint16_t   | 0x0031 (49)                        | table field `id` (UShort)
+  +0x142E | 66 00                   | uint16_t   | 0x0066 (102)                       | table field `offset` (UShort)
+  +0x1430 | 70 00 00 00             | UOffset32  | 0x00000070 (112) Loc: 0x14A0       | offset to field `name` (string)
+  +0x1434 | 60 00 00 00             | UOffset32  | 0x00000060 (96) Loc: 0x1494        | offset to field `type` (table)
+  +0x1438 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x143C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x143C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x1440 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x1478       | offset to table[0]
-  +0x1444 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1448        | offset to table[1]
+  +0x143C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x1440 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x1478        | offset to table[0]
+  +0x1444 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1448         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x1448 | 80 DB FF FF             | SOffset32   | 0xFFFFDB80 (-9344) Loc: +0x38C8    | offset to vtable
-  +0x144C | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x1460       | offset to field `key` (string)
-  +0x1450 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1454        | offset to field `value` (string)
+  +0x1448 | 80 DB FF FF             | SOffset32  | 0xFFFFDB80 (-9344) Loc: 0x38C8     | offset to vtable
+  +0x144C | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x1460        | offset to field `key` (string)
+  +0x1450 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1454         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1454 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of string
-  +0x1458 | 4D 6F 6E 73 74 65 72    | char[7]     | Monster                            | string literal
-  +0x145F | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1454 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of string
+  +0x1458 | 4D 6F 6E 73 74 65 72    | char[7]    | Monster                            | string literal
+  +0x145F | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1460 | 11 00 00 00             | uint32_t    | 0x00000011 (17)                    | length of string
-  +0x1464 | 6E 65 73 74 65 64 5F 66 | char[17]    | nested_f                           | string literal
-  +0x146C | 6C 61 74 62 75 66 66 65 |             | latbuffe
-  +0x1474 | 72                      |             | r
-  +0x1475 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1460 | 11 00 00 00             | uint32_t   | 0x00000011 (17)                    | length of string
+  +0x1464 | 6E 65 73 74 65 64 5F 66 | char[17]   | nested_f                           | string literal
+  +0x146C | 6C 61 74 62 75 66 66 65 |            | latbuffe
+  +0x1474 | 72                      |            | r
+  +0x1475 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1476 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1476 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.KeyValue):
-  +0x1478 | B0 DB FF FF             | SOffset32   | 0xFFFFDBB0 (-9296) Loc: +0x38C8    | offset to vtable
-  +0x147C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x148C       | offset to field `key` (string)
-  +0x1480 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1484        | offset to field `value` (string)
+  +0x1478 | B0 DB FF FF             | SOffset32  | 0xFFFFDBB0 (-9296) Loc: 0x38C8     | offset to vtable
+  +0x147C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x148C        | offset to field `key` (string)
+  +0x1480 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1484         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1484 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1488 | 34 39                   | char[2]     | 49                                 | string literal
-  +0x148A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1484 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1488 | 34 39                   | char[2]    | 49                                 | string literal
+  +0x148A | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x148C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1490 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1492 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x148C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1490 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1492 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1494 | 54 E8 FF FF             | SOffset32   | 0xFFFFE854 (-6060) Loc: +0x2C40    | offset to vtable
-  +0x1498 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x149A | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x149B | 04                      | uint8_t     | 0x04 (4)                           | table field `element` (Byte)
-  +0x149C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1494 | 54 E8 FF FF             | SOffset32  | 0xFFFFE854 (-6060) Loc: 0x2C40     | offset to vtable
+  +0x1498 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x149A | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x149B | 04                      | uint8_t    | 0x04 (4)                           | table field `element` (Byte)
+  +0x149C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x14A0 | 1C 00 00 00             | uint32_t    | 0x0000001C (28)                    | length of string
-  +0x14A4 | 74 65 73 74 72 65 71 75 | char[28]    | testrequ                           | string literal
-  +0x14AC | 69 72 65 64 6E 65 73 74 |             | irednest
-  +0x14B4 | 65 64 66 6C 61 74 62 75 |             | edflatbu
-  +0x14BC | 66 66 65 72             |             | ffer
-  +0x14C0 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x14A0 | 1C 00 00 00             | uint32_t   | 0x0000001C (28)                    | length of string
+  +0x14A4 | 74 65 73 74 72 65 71 75 | char[28]   | testrequ                           | string literal
+  +0x14AC | 69 72 65 64 6E 65 73 74 |            | irednest
+  +0x14B4 | 65 64 66 6C 61 74 62 75 |            | edflatbu
+  +0x14BC | 66 66 65 72             |            | ffer
+  +0x14C0 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x14C1 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x14C1 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x14C4 | B0 E6 FF FF             | SOffset32   | 0xFFFFE6B0 (-6480) Loc: +0x2E14    | offset to vtable
-  +0x14C8 | 30 00                   | uint16_t    | 0x0030 (48)                        | table field `id` (UShort)
-  +0x14CA | 64 00                   | uint16_t    | 0x0064 (100)                       | table field `offset` (UShort)
-  +0x14CC | 4C 00 00 00             | UOffset32   | 0x0000004C (76) Loc: +0x1518       | offset to field `name` (string)
-  +0x14D0 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x1504       | offset to field `type` (table)
-  +0x14D4 | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x14E0       | offset to field `attributes` (vector)
-  +0x14D8 | FF FF FF FF FF FF FF FF | int64_t     | 0xFFFFFFFFFFFFFFFF (-1)            | table field `default_integer` (Long)
+  +0x14C4 | B0 E6 FF FF             | SOffset32  | 0xFFFFE6B0 (-6480) Loc: 0x2E14     | offset to vtable
+  +0x14C8 | 30 00                   | uint16_t   | 0x0030 (48)                        | table field `id` (UShort)
+  +0x14CA | 64 00                   | uint16_t   | 0x0064 (100)                       | table field `offset` (UShort)
+  +0x14CC | 4C 00 00 00             | UOffset32  | 0x0000004C (76) Loc: 0x1518        | offset to field `name` (string)
+  +0x14D0 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x1504        | offset to field `type` (table)
+  +0x14D4 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x14E0        | offset to field `attributes` (vector)
+  +0x14D8 | FF FF FF FF FF FF FF FF | int64_t    | 0xFFFFFFFFFFFFFFFF (-1)            | table field `default_integer` (Long)
 
 vector (reflection.Field.attributes):
-  +0x14E0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x14E4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x14E8        | offset to table[0]
+  +0x14E0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x14E4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x14E8         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x14E8 | 20 DC FF FF             | SOffset32   | 0xFFFFDC20 (-9184) Loc: +0x38C8    | offset to vtable
-  +0x14EC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x14FC       | offset to field `key` (string)
-  +0x14F0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x14F4        | offset to field `value` (string)
+  +0x14E8 | 20 DC FF FF             | SOffset32  | 0xFFFFDC20 (-9184) Loc: 0x38C8     | offset to vtable
+  +0x14EC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x14FC        | offset to field `key` (string)
+  +0x14F0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x14F4         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x14F4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x14F8 | 34 38                   | char[2]     | 48                                 | string literal
-  +0x14FA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x14F4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x14F8 | 34 38                   | char[2]    | 48                                 | string literal
+  +0x14FA | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x14FC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1500 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1502 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x14FC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1500 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1502 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1504 | 58 DF FF FF             | SOffset32   | 0xFFFFDF58 (-8360) Loc: +0x35AC    | offset to vtable
-  +0x1508 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x150B | 03                      | uint8_t     | 0x03 (3)                           | table field `base_type` (Byte)
-  +0x150C | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | table field `index` (Int)
-  +0x1510 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x1514 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1504 | 58 DF FF FF             | SOffset32  | 0xFFFFDF58 (-8360) Loc: 0x35AC     | offset to vtable
+  +0x1508 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x150B | 03                      | uint8_t    | 0x03 (3)                           | table field `base_type` (Byte)
+  +0x150C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | table field `index` (Int)
+  +0x1510 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x1514 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1518 | 0B 00 00 00             | uint32_t    | 0x0000000B (11)                    | length of string
-  +0x151C | 73 69 67 6E 65 64 5F 65 | char[11]    | signed_e                           | string literal
-  +0x1524 | 6E 75 6D                |             | num
-  +0x1527 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1518 | 0B 00 00 00             | uint32_t   | 0x0000000B (11)                    | length of string
+  +0x151C | 73 69 67 6E 65 64 5F 65 | char[11]   | signed_e                           | string literal
+  +0x1524 | 6E 75 6D                |            | num
+  +0x1527 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x1528 | 40 E9 FF FF             | SOffset32   | 0xFFFFE940 (-5824) Loc: +0x2BE8    | offset to vtable
-  +0x152C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x152F | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1530 | 2F 00                   | uint16_t    | 0x002F (47)                        | table field `id` (UShort)
-  +0x1532 | 62 00                   | uint16_t    | 0x0062 (98)                        | table field `offset` (UShort)
-  +0x1534 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x1574       | offset to field `name` (string)
-  +0x1538 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x1564       | offset to field `type` (table)
-  +0x153C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1540        | offset to field `attributes` (vector)
+  +0x1528 | 40 E9 FF FF             | SOffset32  | 0xFFFFE940 (-5824) Loc: 0x2BE8     | offset to vtable
+  +0x152C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x152F | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1530 | 2F 00                   | uint16_t   | 0x002F (47)                        | table field `id` (UShort)
+  +0x1532 | 62 00                   | uint16_t   | 0x0062 (98)                        | table field `offset` (UShort)
+  +0x1534 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x1574        | offset to field `name` (string)
+  +0x1538 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x1564        | offset to field `type` (table)
+  +0x153C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1540         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1540 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x1544 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1548        | offset to table[0]
+  +0x1540 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x1544 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1548         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x1548 | 80 DC FF FF             | SOffset32   | 0xFFFFDC80 (-9088) Loc: +0x38C8    | offset to vtable
-  +0x154C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x155C       | offset to field `key` (string)
-  +0x1550 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1554        | offset to field `value` (string)
+  +0x1548 | 80 DC FF FF             | SOffset32  | 0xFFFFDC80 (-9088) Loc: 0x38C8     | offset to vtable
+  +0x154C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x155C        | offset to field `key` (string)
+  +0x1550 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1554         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1554 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1558 | 34 37                   | char[2]     | 47                                 | string literal
-  +0x155A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1554 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1558 | 34 37                   | char[2]    | 47                                 | string literal
+  +0x155A | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x155C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1560 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1562 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x155C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1560 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1562 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1564 | F0 EA FF FF             | SOffset32   | 0xFFFFEAF0 (-5392) Loc: +0x2A74    | offset to vtable
-  +0x1568 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x156A | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x156B | 04                      | uint8_t     | 0x04 (4)                           | table field `element` (Byte)
-  +0x156C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | table field `index` (Int)
-  +0x1570 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1564 | F0 EA FF FF             | SOffset32  | 0xFFFFEAF0 (-5392) Loc: 0x2A74     | offset to vtable
+  +0x1568 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x156A | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x156B | 04                      | uint8_t    | 0x04 (4)                           | table field `element` (Byte)
+  +0x156C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | table field `index` (Int)
+  +0x1570 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1574 | 0F 00 00 00             | uint32_t    | 0x0000000F (15)                    | length of string
-  +0x1578 | 76 65 63 74 6F 72 5F 6F | char[15]    | vector_o                           | string literal
-  +0x1580 | 66 5F 65 6E 75 6D 73    |             | f_enums
-  +0x1587 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1574 | 0F 00 00 00             | uint32_t   | 0x0000000F (15)                    | length of string
+  +0x1578 | 76 65 63 74 6F 72 5F 6F | char[15]   | vector_o                           | string literal
+  +0x1580 | 66 5F 65 6E 75 6D 73    |            | f_enums
+  +0x1587 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x1588 | A0 E9 FF FF             | SOffset32   | 0xFFFFE9A0 (-5728) Loc: +0x2BE8    | offset to vtable
-  +0x158C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x158F | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1590 | 2E 00                   | uint16_t    | 0x002E (46)                        | table field `id` (UShort)
-  +0x1592 | 60 00                   | uint16_t    | 0x0060 (96)                        | table field `offset` (UShort)
-  +0x1594 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x15D4       | offset to field `name` (string)
-  +0x1598 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x15C4       | offset to field `type` (table)
-  +0x159C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x15A0        | offset to field `attributes` (vector)
+  +0x1588 | A0 E9 FF FF             | SOffset32  | 0xFFFFE9A0 (-5728) Loc: 0x2BE8     | offset to vtable
+  +0x158C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x158F | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1590 | 2E 00                   | uint16_t   | 0x002E (46)                        | table field `id` (UShort)
+  +0x1592 | 60 00                   | uint16_t   | 0x0060 (96)                        | table field `offset` (UShort)
+  +0x1594 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x15D4        | offset to field `name` (string)
+  +0x1598 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x15C4        | offset to field `type` (table)
+  +0x159C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x15A0         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x15A0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x15A4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x15A8        | offset to table[0]
+  +0x15A0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x15A4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x15A8         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x15A8 | E0 DC FF FF             | SOffset32   | 0xFFFFDCE0 (-8992) Loc: +0x38C8    | offset to vtable
-  +0x15AC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x15BC       | offset to field `key` (string)
-  +0x15B0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x15B4        | offset to field `value` (string)
+  +0x15A8 | E0 DC FF FF             | SOffset32  | 0xFFFFDCE0 (-8992) Loc: 0x38C8     | offset to vtable
+  +0x15AC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x15BC        | offset to field `key` (string)
+  +0x15B0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x15B4         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x15B4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x15B8 | 34 36                   | char[2]     | 46                                 | string literal
-  +0x15BA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x15B4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x15B8 | 34 36                   | char[2]    | 46                                 | string literal
+  +0x15BA | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x15BC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x15C0 | 69 64                   | char[2]     | id                                 | string literal
-  +0x15C2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x15BC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x15C0 | 69 64                   | char[2]    | id                                 | string literal
+  +0x15C2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x15C4 | AC DD FF FF             | SOffset32   | 0xFFFFDDAC (-8788) Loc: +0x3818    | offset to vtable
-  +0x15C8 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x15CB | 10                      | uint8_t     | 0x10 (16)                          | table field `base_type` (Byte)
-  +0x15CC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `index` (Int)
-  +0x15D0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x15C4 | AC DD FF FF             | SOffset32  | 0xFFFFDDAC (-8788) Loc: 0x3818     | offset to vtable
+  +0x15C8 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x15CB | 10                      | uint8_t    | 0x10 (16)                          | table field `base_type` (Byte)
+  +0x15CC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `index` (Int)
+  +0x15D0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x15D4 | 0D 00 00 00             | uint32_t    | 0x0000000D (13)                    | length of string
-  +0x15D8 | 61 6E 79 5F 61 6D 62 69 | char[13]    | any_ambi                           | string literal
-  +0x15E0 | 67 75 6F 75 73          |             | guous
-  +0x15E5 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x15D4 | 0D 00 00 00             | uint32_t   | 0x0000000D (13)                    | length of string
+  +0x15D8 | 61 6E 79 5F 61 6D 62 69 | char[13]   | any_ambi                           | string literal
+  +0x15E0 | 67 75 6F 75 73          |            | guous
+  +0x15E5 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x15E6 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x15E6 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x15E8 | F0 EA FF FF             | SOffset32   | 0xFFFFEAF0 (-5392) Loc: +0x2AF8    | offset to vtable
-  +0x15EC | 2D 00                   | uint16_t    | 0x002D (45)                        | table field `id` (UShort)
-  +0x15EE | 5E 00                   | uint16_t    | 0x005E (94)                        | table field `offset` (UShort)
-  +0x15F0 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x1634       | offset to field `name` (string)
-  +0x15F4 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x1620       | offset to field `type` (table)
-  +0x15F8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x15FC        | offset to field `attributes` (vector)
+  +0x15E8 | F0 EA FF FF             | SOffset32  | 0xFFFFEAF0 (-5392) Loc: 0x2AF8     | offset to vtable
+  +0x15EC | 2D 00                   | uint16_t   | 0x002D (45)                        | table field `id` (UShort)
+  +0x15EE | 5E 00                   | uint16_t   | 0x005E (94)                        | table field `offset` (UShort)
+  +0x15F0 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x1634        | offset to field `name` (string)
+  +0x15F4 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x1620        | offset to field `type` (table)
+  +0x15F8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x15FC         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x15FC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x1600 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1604        | offset to table[0]
+  +0x15FC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x1600 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1604         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x1604 | 3C DD FF FF             | SOffset32   | 0xFFFFDD3C (-8900) Loc: +0x38C8    | offset to vtable
-  +0x1608 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1618       | offset to field `key` (string)
-  +0x160C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1610        | offset to field `value` (string)
+  +0x1604 | 3C DD FF FF             | SOffset32  | 0xFFFFDD3C (-8900) Loc: 0x38C8     | offset to vtable
+  +0x1608 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1618        | offset to field `key` (string)
+  +0x160C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1610         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1610 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1614 | 34 35                   | char[2]     | 45                                 | string literal
-  +0x1616 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1610 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1614 | 34 35                   | char[2]    | 45                                 | string literal
+  +0x1616 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1618 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x161C | 69 64                   | char[2]     | id                                 | string literal
-  +0x161E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1618 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x161C | 69 64                   | char[2]    | id                                 | string literal
+  +0x161E | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1620 | 74 E0 FF FF             | SOffset32   | 0xFFFFE074 (-8076) Loc: +0x35AC    | offset to vtable
-  +0x1624 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1627 | 01                      | uint8_t     | 0x01 (1)                           | table field `base_type` (Byte)
-  +0x1628 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `index` (Int)
-  +0x162C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x1630 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1620 | 74 E0 FF FF             | SOffset32  | 0xFFFFE074 (-8076) Loc: 0x35AC     | offset to vtable
+  +0x1624 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1627 | 01                      | uint8_t    | 0x01 (1)                           | table field `base_type` (Byte)
+  +0x1628 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `index` (Int)
+  +0x162C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x1630 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1634 | 12 00 00 00             | uint32_t    | 0x00000012 (18)                    | length of string
-  +0x1638 | 61 6E 79 5F 61 6D 62 69 | char[18]    | any_ambi                           | string literal
-  +0x1640 | 67 75 6F 75 73 5F 74 79 |             | guous_ty
-  +0x1648 | 70 65                   |             | pe
-  +0x164A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1634 | 12 00 00 00             | uint32_t   | 0x00000012 (18)                    | length of string
+  +0x1638 | 61 6E 79 5F 61 6D 62 69 | char[18]   | any_ambi                           | string literal
+  +0x1640 | 67 75 6F 75 73 5F 74 79 |            | guous_ty
+  +0x1648 | 70 65                   |            | pe
+  +0x164A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x164C | 64 EA FF FF             | SOffset32   | 0xFFFFEA64 (-5532) Loc: +0x2BE8    | offset to vtable
-  +0x1650 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1653 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1654 | 2C 00                   | uint16_t    | 0x002C (44)                        | table field `id` (UShort)
-  +0x1656 | 5C 00                   | uint16_t    | 0x005C (92)                        | table field `offset` (UShort)
-  +0x1658 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x1698       | offset to field `name` (string)
-  +0x165C | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x1688       | offset to field `type` (table)
-  +0x1660 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1664        | offset to field `attributes` (vector)
+  +0x164C | 64 EA FF FF             | SOffset32  | 0xFFFFEA64 (-5532) Loc: 0x2BE8     | offset to vtable
+  +0x1650 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1653 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1654 | 2C 00                   | uint16_t   | 0x002C (44)                        | table field `id` (UShort)
+  +0x1656 | 5C 00                   | uint16_t   | 0x005C (92)                        | table field `offset` (UShort)
+  +0x1658 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x1698        | offset to field `name` (string)
+  +0x165C | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x1688        | offset to field `type` (table)
+  +0x1660 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1664         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1664 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x1668 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x166C        | offset to table[0]
+  +0x1664 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x1668 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x166C         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x166C | A4 DD FF FF             | SOffset32   | 0xFFFFDDA4 (-8796) Loc: +0x38C8    | offset to vtable
-  +0x1670 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1680       | offset to field `key` (string)
-  +0x1674 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1678        | offset to field `value` (string)
+  +0x166C | A4 DD FF FF             | SOffset32  | 0xFFFFDDA4 (-8796) Loc: 0x38C8     | offset to vtable
+  +0x1670 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1680        | offset to field `key` (string)
+  +0x1674 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1678         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1678 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x167C | 34 34                   | char[2]     | 44                                 | string literal
-  +0x167E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1678 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x167C | 34 34                   | char[2]    | 44                                 | string literal
+  +0x167E | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1680 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1684 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1686 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1680 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1684 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1686 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1688 | 70 DE FF FF             | SOffset32   | 0xFFFFDE70 (-8592) Loc: +0x3818    | offset to vtable
-  +0x168C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x168F | 10                      | uint8_t     | 0x10 (16)                          | table field `base_type` (Byte)
-  +0x1690 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | table field `index` (Int)
-  +0x1694 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1688 | 70 DE FF FF             | SOffset32  | 0xFFFFDE70 (-8592) Loc: 0x3818     | offset to vtable
+  +0x168C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x168F | 10                      | uint8_t    | 0x10 (16)                          | table field `base_type` (Byte)
+  +0x1690 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `index` (Int)
+  +0x1694 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1698 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                    | length of string
-  +0x169C | 61 6E 79 5F 75 6E 69 71 | char[10]    | any_uniq                           | string literal
-  +0x16A4 | 75 65                   |             | ue
-  +0x16A6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1698 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                    | length of string
+  +0x169C | 61 6E 79 5F 75 6E 69 71 | char[10]   | any_uniq                           | string literal
+  +0x16A4 | 75 65                   |            | ue
+  +0x16A6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x16A8 | B0 EB FF FF             | SOffset32   | 0xFFFFEBB0 (-5200) Loc: +0x2AF8    | offset to vtable
-  +0x16AC | 2B 00                   | uint16_t    | 0x002B (43)                        | table field `id` (UShort)
-  +0x16AE | 5A 00                   | uint16_t    | 0x005A (90)                        | table field `offset` (UShort)
-  +0x16B0 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x16F4       | offset to field `name` (string)
-  +0x16B4 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x16E0       | offset to field `type` (table)
-  +0x16B8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x16BC        | offset to field `attributes` (vector)
+  +0x16A8 | B0 EB FF FF             | SOffset32  | 0xFFFFEBB0 (-5200) Loc: 0x2AF8     | offset to vtable
+  +0x16AC | 2B 00                   | uint16_t   | 0x002B (43)                        | table field `id` (UShort)
+  +0x16AE | 5A 00                   | uint16_t   | 0x005A (90)                        | table field `offset` (UShort)
+  +0x16B0 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x16F4        | offset to field `name` (string)
+  +0x16B4 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x16E0        | offset to field `type` (table)
+  +0x16B8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x16BC         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x16BC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x16C0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x16C4        | offset to table[0]
+  +0x16BC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x16C0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x16C4         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x16C4 | FC DD FF FF             | SOffset32   | 0xFFFFDDFC (-8708) Loc: +0x38C8    | offset to vtable
-  +0x16C8 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x16D8       | offset to field `key` (string)
-  +0x16CC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x16D0        | offset to field `value` (string)
+  +0x16C4 | FC DD FF FF             | SOffset32  | 0xFFFFDDFC (-8708) Loc: 0x38C8     | offset to vtable
+  +0x16C8 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x16D8        | offset to field `key` (string)
+  +0x16CC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x16D0         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x16D0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x16D4 | 34 33                   | char[2]     | 43                                 | string literal
-  +0x16D6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x16D0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x16D4 | 34 33                   | char[2]    | 43                                 | string literal
+  +0x16D6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x16D8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x16DC | 69 64                   | char[2]     | id                                 | string literal
-  +0x16DE | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x16D8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x16DC | 69 64                   | char[2]    | id                                 | string literal
+  +0x16DE | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x16E0 | 34 E1 FF FF             | SOffset32   | 0xFFFFE134 (-7884) Loc: +0x35AC    | offset to vtable
-  +0x16E4 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x16E7 | 01                      | uint8_t     | 0x01 (1)                           | table field `base_type` (Byte)
-  +0x16E8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | table field `index` (Int)
-  +0x16EC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x16F0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x16E0 | 34 E1 FF FF             | SOffset32  | 0xFFFFE134 (-7884) Loc: 0x35AC     | offset to vtable
+  +0x16E4 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x16E7 | 01                      | uint8_t    | 0x01 (1)                           | table field `base_type` (Byte)
+  +0x16E8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `index` (Int)
+  +0x16EC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x16F0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x16F4 | 0F 00 00 00             | uint32_t    | 0x0000000F (15)                    | length of string
-  +0x16F8 | 61 6E 79 5F 75 6E 69 71 | char[15]    | any_uniq                           | string literal
-  +0x1700 | 75 65 5F 74 79 70 65    |             | ue_type
-  +0x1707 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x16F4 | 0F 00 00 00             | uint32_t   | 0x0000000F (15)                    | length of string
+  +0x16F8 | 61 6E 79 5F 75 6E 69 71 | char[15]   | any_uniq                           | string literal
+  +0x1700 | 75 65 5F 74 79 70 65    |            | ue_type
+  +0x1707 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x1708 | 20 EB FF FF             | SOffset32   | 0xFFFFEB20 (-5344) Loc: +0x2BE8    | offset to vtable
-  +0x170C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x170F | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1710 | 2A 00                   | uint16_t    | 0x002A (42)                        | table field `id` (UShort)
-  +0x1712 | 58 00                   | uint16_t    | 0x0058 (88)                        | table field `offset` (UShort)
-  +0x1714 | F8 00 00 00             | UOffset32   | 0x000000F8 (248) Loc: +0x180C      | offset to field `name` (string)
-  +0x1718 | E8 00 00 00             | UOffset32   | 0x000000E8 (232) Loc: +0x1800      | offset to field `type` (table)
-  +0x171C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1720        | offset to field `attributes` (vector)
+  +0x1708 | 20 EB FF FF             | SOffset32  | 0xFFFFEB20 (-5344) Loc: 0x2BE8     | offset to vtable
+  +0x170C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x170F | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1710 | 2A 00                   | uint16_t   | 0x002A (42)                        | table field `id` (UShort)
+  +0x1712 | 58 00                   | uint16_t   | 0x0058 (88)                        | table field `offset` (UShort)
+  +0x1714 | F8 00 00 00             | UOffset32  | 0x000000F8 (248) Loc: 0x180C       | offset to field `name` (string)
+  +0x1718 | E8 00 00 00             | UOffset32  | 0x000000E8 (232) Loc: 0x1800       | offset to field `type` (table)
+  +0x171C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1720         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1720 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of vector (# items)
-  +0x1724 | B0 00 00 00             | UOffset32   | 0x000000B0 (176) Loc: +0x17D4      | offset to table[0]
-  +0x1728 | 80 00 00 00             | UOffset32   | 0x00000080 (128) Loc: +0x17A8      | offset to table[1]
-  +0x172C | 50 00 00 00             | UOffset32   | 0x00000050 (80) Loc: +0x177C       | offset to table[2]
-  +0x1730 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x1754       | offset to table[3]
-  +0x1734 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1738        | offset to table[4]
+  +0x1720 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of vector (# items)
+  +0x1724 | B0 00 00 00             | UOffset32  | 0x000000B0 (176) Loc: 0x17D4       | offset to table[0]
+  +0x1728 | 80 00 00 00             | UOffset32  | 0x00000080 (128) Loc: 0x17A8       | offset to table[1]
+  +0x172C | 50 00 00 00             | UOffset32  | 0x00000050 (80) Loc: 0x177C        | offset to table[2]
+  +0x1730 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x1754        | offset to table[3]
+  +0x1734 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1738         | offset to table[4]
 
 table (reflection.KeyValue):
-  +0x1738 | 70 DE FF FF             | SOffset32   | 0xFFFFDE70 (-8592) Loc: +0x38C8    | offset to vtable
-  +0x173C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x174C       | offset to field `key` (string)
-  +0x1740 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1744        | offset to field `value` (string)
+  +0x1738 | 70 DE FF FF             | SOffset32  | 0xFFFFDE70 (-8592) Loc: 0x38C8     | offset to vtable
+  +0x173C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x174C        | offset to field `key` (string)
+  +0x1740 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1744         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1744 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1748 | 34 32                   | char[2]     | 42                                 | string literal
-  +0x174A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1744 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1748 | 34 32                   | char[2]    | 42                                 | string literal
+  +0x174A | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x174C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1750 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1752 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x174C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1750 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1752 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x1754 | 8C DE FF FF             | SOffset32   | 0xFFFFDE8C (-8564) Loc: +0x38C8    | offset to vtable
-  +0x1758 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x1770       | offset to field `key` (string)
-  +0x175C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1760        | offset to field `value` (string)
+  +0x1754 | 8C DE FF FF             | SOffset32  | 0xFFFFDE8C (-8564) Loc: 0x38C8     | offset to vtable
+  +0x1758 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x1770        | offset to field `key` (string)
+  +0x175C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1760         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1760 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x1764 | 66 6E 76 31 61 5F 36 34 | char[8]     | fnv1a_64                           | string literal
-  +0x176C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1760 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x1764 | 66 6E 76 31 61 5F 36 34 | char[8]    | fnv1a_64                           | string literal
+  +0x176C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x176D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x176D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x1770 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x1774 | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x1778 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1770 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x1774 | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x1778 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1779 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1779 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x177C | B4 DE FF FF             | SOffset32   | 0xFFFFDEB4 (-8524) Loc: +0x38C8    | offset to vtable
-  +0x1780 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x1798       | offset to field `key` (string)
-  +0x1784 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1788        | offset to field `value` (string)
+  +0x177C | B4 DE FF FF             | SOffset32  | 0xFFFFDEB4 (-8524) Loc: 0x38C8     | offset to vtable
+  +0x1780 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x1798        | offset to field `key` (string)
+  +0x1784 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1788         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1788 | 0B 00 00 00             | uint32_t    | 0x0000000B (11)                    | length of string
-  +0x178C | 52 65 66 65 72 72 61 62 | char[11]    | Referrab                           | string literal
-  +0x1794 | 6C 65 54                |             | leT
-  +0x1797 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1788 | 0B 00 00 00             | uint32_t   | 0x0000000B (11)                    | length of string
+  +0x178C | 52 65 66 65 72 72 61 62 | char[11]   | Referrab                           | string literal
+  +0x1794 | 6C 65 54                |            | leT
+  +0x1797 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1798 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x179C | 63 70 70 5F 74 79 70 65 | char[8]     | cpp_type                           | string literal
-  +0x17A4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1798 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x179C | 63 70 70 5F 74 79 70 65 | char[8]    | cpp_type                           | string literal
+  +0x17A4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x17A5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x17A5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x17A8 | E0 DE FF FF             | SOffset32   | 0xFFFFDEE0 (-8480) Loc: +0x38C8    | offset to vtable
-  +0x17AC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x17BC       | offset to field `key` (string)
-  +0x17B0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x17B4        | offset to field `value` (string)
+  +0x17A8 | E0 DE FF FF             | SOffset32  | 0xFFFFDEE0 (-8480) Loc: 0x38C8     | offset to vtable
+  +0x17AC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x17BC        | offset to field `key` (string)
+  +0x17B0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x17B4         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x17B4 | 00 00 00 00             | uint32_t    | 0x00000000 (0)                     | length of string
-  +0x17B8 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x17B4 | 00 00 00 00             | uint32_t   | 0x00000000 (0)                     | length of string
+  +0x17B8 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x17B9 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x17B9 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x17BC | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x17C0 | 63 70 70 5F 70 74 72 5F | char[16]    | cpp_ptr_                           | string literal
-  +0x17C8 | 74 79 70 65 5F 67 65 74 |             | type_get
-  +0x17D0 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x17BC | 10 00 00 00             | uint32_t   | 0x00000010 (16)                    | length of string
+  +0x17C0 | 63 70 70 5F 70 74 72 5F | char[16]   | cpp_ptr_                           | string literal
+  +0x17C8 | 74 79 70 65 5F 67 65 74 |            | type_get
+  +0x17D0 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x17D1 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x17D1 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x17D4 | 0C DF FF FF             | SOffset32   | 0xFFFFDF0C (-8436) Loc: +0x38C8    | offset to vtable
-  +0x17D8 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x17EC       | offset to field `key` (string)
-  +0x17DC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x17E0        | offset to field `value` (string)
+  +0x17D4 | 0C DF FF FF             | SOffset32  | 0xFFFFDF0C (-8436) Loc: 0x38C8     | offset to vtable
+  +0x17D8 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x17EC        | offset to field `key` (string)
+  +0x17DC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x17E0         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x17E0 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x17E4 | 6E 61 6B 65 64          | char[5]     | naked                              | string literal
-  +0x17E9 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x17E0 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x17E4 | 6E 61 6B 65 64          | char[5]    | naked                              | string literal
+  +0x17E9 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x17EA | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x17EA | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x17EC | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                    | length of string
-  +0x17F0 | 63 70 70 5F 70 74 72 5F | char[12]    | cpp_ptr_                           | string literal
-  +0x17F8 | 74 79 70 65             |             | type
-  +0x17FC | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x17EC | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                    | length of string
+  +0x17F0 | 63 70 70 5F 70 74 72 5F | char[12]   | cpp_ptr_                           | string literal
+  +0x17F8 | 74 79 70 65             |            | type
+  +0x17FC | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x17FD | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x17FD | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x1800 | C0 EB FF FF             | SOffset32   | 0xFFFFEBC0 (-5184) Loc: +0x2C40    | offset to vtable
-  +0x1804 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x1806 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x1807 | 0A                      | uint8_t     | 0x0A (10)                          | table field `element` (Byte)
-  +0x1808 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `element_size` (UInt)
+  +0x1800 | C0 EB FF FF             | SOffset32  | 0xFFFFEBC0 (-5184) Loc: 0x2C40     | offset to vtable
+  +0x1804 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x1806 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x1807 | 0A                      | uint8_t    | 0x0A (10)                          | table field `element` (Byte)
+  +0x1808 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x180C | 1F 00 00 00             | uint32_t    | 0x0000001F (31)                    | length of string
-  +0x1810 | 76 65 63 74 6F 72 5F 6F | char[31]    | vector_o                           | string literal
-  +0x1818 | 66 5F 6E 6F 6E 5F 6F 77 |             | f_non_ow
-  +0x1820 | 6E 69 6E 67 5F 72 65 66 |             | ning_ref
-  +0x1828 | 65 72 65 6E 63 65 73    |             | erences
-  +0x182F | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x180C | 1F 00 00 00             | uint32_t   | 0x0000001F (31)                    | length of string
+  +0x1810 | 76 65 63 74 6F 72 5F 6F | char[31]   | vector_o                           | string literal
+  +0x1818 | 66 5F 6E 6F 6E 5F 6F 77 |            | f_non_ow
+  +0x1820 | 6E 69 6E 67 5F 72 65 66 |            | ning_ref
+  +0x1828 | 65 72 65 6E 63 65 73    |            | erences
+  +0x182F | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x1830 | 38 ED FF FF             | SOffset32   | 0xFFFFED38 (-4808) Loc: +0x2AF8    | offset to vtable
-  +0x1834 | 29 00                   | uint16_t    | 0x0029 (41)                        | table field `id` (UShort)
-  +0x1836 | 56 00                   | uint16_t    | 0x0056 (86)                        | table field `offset` (UShort)
-  +0x1838 | FC 00 00 00             | UOffset32   | 0x000000FC (252) Loc: +0x1934      | offset to field `name` (string)
-  +0x183C | E8 00 00 00             | UOffset32   | 0x000000E8 (232) Loc: +0x1924      | offset to field `type` (table)
-  +0x1840 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1844        | offset to field `attributes` (vector)
+  +0x1830 | 38 ED FF FF             | SOffset32  | 0xFFFFED38 (-4808) Loc: 0x2AF8     | offset to vtable
+  +0x1834 | 29 00                   | uint16_t   | 0x0029 (41)                        | table field `id` (UShort)
+  +0x1836 | 56 00                   | uint16_t   | 0x0056 (86)                        | table field `offset` (UShort)
+  +0x1838 | FC 00 00 00             | UOffset32  | 0x000000FC (252) Loc: 0x1934       | offset to field `name` (string)
+  +0x183C | E8 00 00 00             | UOffset32  | 0x000000E8 (232) Loc: 0x1924       | offset to field `type` (table)
+  +0x1840 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1844         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1844 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of vector (# items)
-  +0x1848 | B0 00 00 00             | UOffset32   | 0x000000B0 (176) Loc: +0x18F8      | offset to table[0]
-  +0x184C | 80 00 00 00             | UOffset32   | 0x00000080 (128) Loc: +0x18CC      | offset to table[1]
-  +0x1850 | 50 00 00 00             | UOffset32   | 0x00000050 (80) Loc: +0x18A0       | offset to table[2]
-  +0x1854 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x1878       | offset to table[3]
-  +0x1858 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x185C        | offset to table[4]
+  +0x1844 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of vector (# items)
+  +0x1848 | B0 00 00 00             | UOffset32  | 0x000000B0 (176) Loc: 0x18F8       | offset to table[0]
+  +0x184C | 80 00 00 00             | UOffset32  | 0x00000080 (128) Loc: 0x18CC       | offset to table[1]
+  +0x1850 | 50 00 00 00             | UOffset32  | 0x00000050 (80) Loc: 0x18A0        | offset to table[2]
+  +0x1854 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x1878        | offset to table[3]
+  +0x1858 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x185C         | offset to table[4]
 
 table (reflection.KeyValue):
-  +0x185C | 94 DF FF FF             | SOffset32   | 0xFFFFDF94 (-8300) Loc: +0x38C8    | offset to vtable
-  +0x1860 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1870       | offset to field `key` (string)
-  +0x1864 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1868        | offset to field `value` (string)
+  +0x185C | 94 DF FF FF             | SOffset32  | 0xFFFFDF94 (-8300) Loc: 0x38C8     | offset to vtable
+  +0x1860 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1870        | offset to field `key` (string)
+  +0x1864 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1868         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1868 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x186C | 34 31                   | char[2]     | 41                                 | string literal
-  +0x186E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1868 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x186C | 34 31                   | char[2]    | 41                                 | string literal
+  +0x186E | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1870 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1874 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1876 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1870 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1874 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1876 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x1878 | B0 DF FF FF             | SOffset32   | 0xFFFFDFB0 (-8272) Loc: +0x38C8    | offset to vtable
-  +0x187C | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x1894       | offset to field `key` (string)
-  +0x1880 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1884        | offset to field `value` (string)
+  +0x1878 | B0 DF FF FF             | SOffset32  | 0xFFFFDFB0 (-8272) Loc: 0x38C8     | offset to vtable
+  +0x187C | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x1894        | offset to field `key` (string)
+  +0x1880 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1884         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1884 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x1888 | 66 6E 76 31 61 5F 36 34 | char[8]     | fnv1a_64                           | string literal
-  +0x1890 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1884 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x1888 | 66 6E 76 31 61 5F 36 34 | char[8]    | fnv1a_64                           | string literal
+  +0x1890 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1891 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1891 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x1894 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x1898 | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x189C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1894 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x1898 | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x189C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x189D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x189D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x18A0 | D8 DF FF FF             | SOffset32   | 0xFFFFDFD8 (-8232) Loc: +0x38C8    | offset to vtable
-  +0x18A4 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x18BC       | offset to field `key` (string)
-  +0x18A8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x18AC        | offset to field `value` (string)
+  +0x18A0 | D8 DF FF FF             | SOffset32  | 0xFFFFDFD8 (-8232) Loc: 0x38C8     | offset to vtable
+  +0x18A4 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x18BC        | offset to field `key` (string)
+  +0x18A8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x18AC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x18AC | 0B 00 00 00             | uint32_t    | 0x0000000B (11)                    | length of string
-  +0x18B0 | 52 65 66 65 72 72 61 62 | char[11]    | Referrab                           | string literal
-  +0x18B8 | 6C 65 54                |             | leT
-  +0x18BB | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x18AC | 0B 00 00 00             | uint32_t   | 0x0000000B (11)                    | length of string
+  +0x18B0 | 52 65 66 65 72 72 61 62 | char[11]   | Referrab                           | string literal
+  +0x18B8 | 6C 65 54                |            | leT
+  +0x18BB | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x18BC | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x18C0 | 63 70 70 5F 74 79 70 65 | char[8]     | cpp_type                           | string literal
-  +0x18C8 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x18BC | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x18C0 | 63 70 70 5F 74 79 70 65 | char[8]    | cpp_type                           | string literal
+  +0x18C8 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x18C9 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x18C9 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x18CC | 04 E0 FF FF             | SOffset32   | 0xFFFFE004 (-8188) Loc: +0x38C8    | offset to vtable
-  +0x18D0 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x18E0       | offset to field `key` (string)
-  +0x18D4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x18D8        | offset to field `value` (string)
+  +0x18CC | 04 E0 FF FF             | SOffset32  | 0xFFFFE004 (-8188) Loc: 0x38C8     | offset to vtable
+  +0x18D0 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x18E0        | offset to field `key` (string)
+  +0x18D4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x18D8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x18D8 | 00 00 00 00             | uint32_t    | 0x00000000 (0)                     | length of string
-  +0x18DC | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x18D8 | 00 00 00 00             | uint32_t   | 0x00000000 (0)                     | length of string
+  +0x18DC | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x18DD | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x18DD | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x18E0 | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x18E4 | 63 70 70 5F 70 74 72 5F | char[16]    | cpp_ptr_                           | string literal
-  +0x18EC | 74 79 70 65 5F 67 65 74 |             | type_get
-  +0x18F4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x18E0 | 10 00 00 00             | uint32_t   | 0x00000010 (16)                    | length of string
+  +0x18E4 | 63 70 70 5F 70 74 72 5F | char[16]   | cpp_ptr_                           | string literal
+  +0x18EC | 74 79 70 65 5F 67 65 74 |            | type_get
+  +0x18F4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x18F5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x18F5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x18F8 | 30 E0 FF FF             | SOffset32   | 0xFFFFE030 (-8144) Loc: +0x38C8    | offset to vtable
-  +0x18FC | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x1910       | offset to field `key` (string)
-  +0x1900 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1904        | offset to field `value` (string)
+  +0x18F8 | 30 E0 FF FF             | SOffset32  | 0xFFFFE030 (-8144) Loc: 0x38C8     | offset to vtable
+  +0x18FC | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x1910        | offset to field `key` (string)
+  +0x1900 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1904         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1904 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x1908 | 6E 61 6B 65 64          | char[5]     | naked                              | string literal
-  +0x190D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1904 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x1908 | 6E 61 6B 65 64          | char[5]    | naked                              | string literal
+  +0x190D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x190E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x190E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x1910 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                    | length of string
-  +0x1914 | 63 70 70 5F 70 74 72 5F | char[12]    | cpp_ptr_                           | string literal
-  +0x191C | 74 79 70 65             |             | type
-  +0x1920 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1910 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                    | length of string
+  +0x1914 | 63 70 70 5F 70 74 72 5F | char[12]   | cpp_ptr_                           | string literal
+  +0x191C | 74 79 70 65             |            | type
+  +0x1920 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1921 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1921 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x1924 | B0 E2 FF FF             | SOffset32   | 0xFFFFE2B0 (-7504) Loc: +0x3674    | offset to vtable
-  +0x1928 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x192B | 0A                      | uint8_t     | 0x0A (10)                          | table field `base_type` (Byte)
-  +0x192C | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x1930 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1924 | B0 E2 FF FF             | SOffset32  | 0xFFFFE2B0 (-7504) Loc: 0x3674     | offset to vtable
+  +0x1928 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x192B | 0A                      | uint8_t    | 0x0A (10)                          | table field `base_type` (Byte)
+  +0x192C | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x1930 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1934 | 14 00 00 00             | uint32_t    | 0x00000014 (20)                    | length of string
-  +0x1938 | 6E 6F 6E 5F 6F 77 6E 69 | char[20]    | non_owni                           | string literal
-  +0x1940 | 6E 67 5F 72 65 66 65 72 |             | ng_refer
-  +0x1948 | 65 6E 63 65             |             | ence
-  +0x194C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1934 | 14 00 00 00             | uint32_t   | 0x00000014 (20)                    | length of string
+  +0x1938 | 6E 6F 6E 5F 6F 77 6E 69 | char[20]   | non_owni                           | string literal
+  +0x1940 | 6E 67 5F 72 65 66 65 72 |            | ng_refer
+  +0x1948 | 65 6E 63 65             |            | ence
+  +0x194C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x194D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x194D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x1950 | 68 ED FF FF             | SOffset32   | 0xFFFFED68 (-4760) Loc: +0x2BE8    | offset to vtable
-  +0x1954 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1957 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1958 | 28 00                   | uint16_t    | 0x0028 (40)                        | table field `id` (UShort)
-  +0x195A | 54 00                   | uint16_t    | 0x0054 (84)                        | table field `offset` (UShort)
-  +0x195C | 08 01 00 00             | UOffset32   | 0x00000108 (264) Loc: +0x1A64      | offset to field `name` (string)
-  +0x1960 | F8 00 00 00             | UOffset32   | 0x000000F8 (248) Loc: +0x1A58      | offset to field `type` (table)
-  +0x1964 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1968        | offset to field `attributes` (vector)
+  +0x1950 | 68 ED FF FF             | SOffset32  | 0xFFFFED68 (-4760) Loc: 0x2BE8     | offset to vtable
+  +0x1954 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1957 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1958 | 28 00                   | uint16_t   | 0x0028 (40)                        | table field `id` (UShort)
+  +0x195A | 54 00                   | uint16_t   | 0x0054 (84)                        | table field `offset` (UShort)
+  +0x195C | 08 01 00 00             | UOffset32  | 0x00000108 (264) Loc: 0x1A64       | offset to field `name` (string)
+  +0x1960 | F8 00 00 00             | UOffset32  | 0x000000F8 (248) Loc: 0x1A58       | offset to field `type` (table)
+  +0x1964 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1968         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1968 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of vector (# items)
-  +0x196C | B4 00 00 00             | UOffset32   | 0x000000B4 (180) Loc: +0x1A20      | offset to table[0]
-  +0x1970 | 80 00 00 00             | UOffset32   | 0x00000080 (128) Loc: +0x19F0      | offset to table[1]
-  +0x1974 | 50 00 00 00             | UOffset32   | 0x00000050 (80) Loc: +0x19C4       | offset to table[2]
-  +0x1978 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x199C       | offset to table[3]
-  +0x197C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1980        | offset to table[4]
+  +0x1968 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of vector (# items)
+  +0x196C | B4 00 00 00             | UOffset32  | 0x000000B4 (180) Loc: 0x1A20       | offset to table[0]
+  +0x1970 | 80 00 00 00             | UOffset32  | 0x00000080 (128) Loc: 0x19F0       | offset to table[1]
+  +0x1974 | 50 00 00 00             | UOffset32  | 0x00000050 (80) Loc: 0x19C4        | offset to table[2]
+  +0x1978 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x199C        | offset to table[3]
+  +0x197C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1980         | offset to table[4]
 
 table (reflection.KeyValue):
-  +0x1980 | B8 E0 FF FF             | SOffset32   | 0xFFFFE0B8 (-8008) Loc: +0x38C8    | offset to vtable
-  +0x1984 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1994       | offset to field `key` (string)
-  +0x1988 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x198C        | offset to field `value` (string)
+  +0x1980 | B8 E0 FF FF             | SOffset32  | 0xFFFFE0B8 (-8008) Loc: 0x38C8     | offset to vtable
+  +0x1984 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1994        | offset to field `key` (string)
+  +0x1988 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x198C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x198C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1990 | 34 30                   | char[2]     | 40                                 | string literal
-  +0x1992 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x198C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1990 | 34 30                   | char[2]    | 40                                 | string literal
+  +0x1992 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1994 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1998 | 69 64                   | char[2]     | id                                 | string literal
-  +0x199A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1994 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1998 | 69 64                   | char[2]    | id                                 | string literal
+  +0x199A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x199C | D4 E0 FF FF             | SOffset32   | 0xFFFFE0D4 (-7980) Loc: +0x38C8    | offset to vtable
-  +0x19A0 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x19B8       | offset to field `key` (string)
-  +0x19A4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x19A8        | offset to field `value` (string)
+  +0x199C | D4 E0 FF FF             | SOffset32  | 0xFFFFE0D4 (-7980) Loc: 0x38C8     | offset to vtable
+  +0x19A0 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x19B8        | offset to field `key` (string)
+  +0x19A4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x19A8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x19A8 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x19AC | 66 6E 76 31 61 5F 36 34 | char[8]     | fnv1a_64                           | string literal
-  +0x19B4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x19A8 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x19AC | 66 6E 76 31 61 5F 36 34 | char[8]    | fnv1a_64                           | string literal
+  +0x19B4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x19B5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x19B5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x19B8 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x19BC | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x19C0 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x19B8 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x19BC | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x19C0 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x19C1 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x19C1 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x19C4 | FC E0 FF FF             | SOffset32   | 0xFFFFE0FC (-7940) Loc: +0x38C8    | offset to vtable
-  +0x19C8 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x19E0       | offset to field `key` (string)
-  +0x19CC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x19D0        | offset to field `value` (string)
+  +0x19C4 | FC E0 FF FF             | SOffset32  | 0xFFFFE0FC (-7940) Loc: 0x38C8     | offset to vtable
+  +0x19C8 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x19E0        | offset to field `key` (string)
+  +0x19CC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x19D0         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x19D0 | 0B 00 00 00             | uint32_t    | 0x0000000B (11)                    | length of string
-  +0x19D4 | 52 65 66 65 72 72 61 62 | char[11]    | Referrab                           | string literal
-  +0x19DC | 6C 65 54                |             | leT
-  +0x19DF | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x19D0 | 0B 00 00 00             | uint32_t   | 0x0000000B (11)                    | length of string
+  +0x19D4 | 52 65 66 65 72 72 61 62 | char[11]   | Referrab                           | string literal
+  +0x19DC | 6C 65 54                |            | leT
+  +0x19DF | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x19E0 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x19E4 | 63 70 70 5F 74 79 70 65 | char[8]     | cpp_type                           | string literal
-  +0x19EC | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x19E0 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x19E4 | 63 70 70 5F 74 79 70 65 | char[8]    | cpp_type                           | string literal
+  +0x19EC | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x19ED | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x19ED | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x19F0 | 28 E1 FF FF             | SOffset32   | 0xFFFFE128 (-7896) Loc: +0x38C8    | offset to vtable
-  +0x19F4 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x1A08       | offset to field `key` (string)
-  +0x19F8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x19FC        | offset to field `value` (string)
+  +0x19F0 | 28 E1 FF FF             | SOffset32  | 0xFFFFE128 (-7896) Loc: 0x38C8     | offset to vtable
+  +0x19F4 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x1A08        | offset to field `key` (string)
+  +0x19F8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x19FC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x19FC | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | length of string
-  +0x1A00 | 2E 67 65 74 28 29       | char[6]     | .get()                             | string literal
-  +0x1A06 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x19FC | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | length of string
+  +0x1A00 | 2E 67 65 74 28 29       | char[6]    | .get()                             | string literal
+  +0x1A06 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1A08 | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x1A0C | 63 70 70 5F 70 74 72 5F | char[16]    | cpp_ptr_                           | string literal
-  +0x1A14 | 74 79 70 65 5F 67 65 74 |             | type_get
-  +0x1A1C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1A08 | 10 00 00 00             | uint32_t   | 0x00000010 (16)                    | length of string
+  +0x1A0C | 63 70 70 5F 70 74 72 5F | char[16]   | cpp_ptr_                           | string literal
+  +0x1A14 | 74 79 70 65 5F 67 65 74 |            | type_get
+  +0x1A1C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1A1D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1A1D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x1A20 | 58 E1 FF FF             | SOffset32   | 0xFFFFE158 (-7848) Loc: +0x38C8    | offset to vtable
-  +0x1A24 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x1A44       | offset to field `key` (string)
-  +0x1A28 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1A2C        | offset to field `value` (string)
+  +0x1A20 | 58 E1 FF FF             | SOffset32  | 0xFFFFE158 (-7848) Loc: 0x38C8     | offset to vtable
+  +0x1A24 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x1A44        | offset to field `key` (string)
+  +0x1A28 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1A2C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1A2C | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x1A30 | 64 65 66 61 75 6C 74 5F | char[16]    | default_                           | string literal
-  +0x1A38 | 70 74 72 5F 74 79 70 65 |             | ptr_type
-  +0x1A40 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1A2C | 10 00 00 00             | uint32_t   | 0x00000010 (16)                    | length of string
+  +0x1A30 | 64 65 66 61 75 6C 74 5F | char[16]   | default_                           | string literal
+  +0x1A38 | 70 74 72 5F 74 79 70 65 |            | ptr_type
+  +0x1A40 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1A41 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1A41 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x1A44 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                    | length of string
-  +0x1A48 | 63 70 70 5F 70 74 72 5F | char[12]    | cpp_ptr_                           | string literal
-  +0x1A50 | 74 79 70 65             |             | type
-  +0x1A54 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1A44 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                    | length of string
+  +0x1A48 | 63 70 70 5F 70 74 72 5F | char[12]   | cpp_ptr_                           | string literal
+  +0x1A50 | 74 79 70 65             |            | type
+  +0x1A54 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1A55 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1A55 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x1A58 | 18 EE FF FF             | SOffset32   | 0xFFFFEE18 (-4584) Loc: +0x2C40    | offset to vtable
-  +0x1A5C | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x1A5E | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x1A5F | 0A                      | uint8_t     | 0x0A (10)                          | table field `element` (Byte)
-  +0x1A60 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `element_size` (UInt)
+  +0x1A58 | 18 EE FF FF             | SOffset32  | 0xFFFFEE18 (-4584) Loc: 0x2C40     | offset to vtable
+  +0x1A5C | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x1A5E | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x1A5F | 0A                      | uint8_t    | 0x0A (10)                          | table field `element` (Byte)
+  +0x1A60 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1A64 | 1E 00 00 00             | uint32_t    | 0x0000001E (30)                    | length of string
-  +0x1A68 | 76 65 63 74 6F 72 5F 6F | char[30]    | vector_o                           | string literal
-  +0x1A70 | 66 5F 63 6F 5F 6F 77 6E |             | f_co_own
-  +0x1A78 | 69 6E 67 5F 72 65 66 65 |             | ing_refe
-  +0x1A80 | 72 65 6E 63 65 73       |             | rences
-  +0x1A86 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1A64 | 1E 00 00 00             | uint32_t   | 0x0000001E (30)                    | length of string
+  +0x1A68 | 76 65 63 74 6F 72 5F 6F | char[30]   | vector_o                           | string literal
+  +0x1A70 | 66 5F 63 6F 5F 6F 77 6E |            | f_co_own
+  +0x1A78 | 69 6E 67 5F 72 65 66 65 |            | ing_refe
+  +0x1A80 | 72 65 6E 63 65 73       |            | rences
+  +0x1A86 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x1A88 | 90 EF FF FF             | SOffset32   | 0xFFFFEF90 (-4208) Loc: +0x2AF8    | offset to vtable
-  +0x1A8C | 27 00                   | uint16_t    | 0x0027 (39)                        | table field `id` (UShort)
-  +0x1A8E | 52 00                   | uint16_t    | 0x0052 (82)                        | table field `offset` (UShort)
-  +0x1A90 | CC 00 00 00             | UOffset32   | 0x000000CC (204) Loc: +0x1B5C      | offset to field `name` (string)
-  +0x1A94 | B8 00 00 00             | UOffset32   | 0x000000B8 (184) Loc: +0x1B4C      | offset to field `type` (table)
-  +0x1A98 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1A9C        | offset to field `attributes` (vector)
+  +0x1A88 | 90 EF FF FF             | SOffset32  | 0xFFFFEF90 (-4208) Loc: 0x2AF8     | offset to vtable
+  +0x1A8C | 27 00                   | uint16_t   | 0x0027 (39)                        | table field `id` (UShort)
+  +0x1A8E | 52 00                   | uint16_t   | 0x0052 (82)                        | table field `offset` (UShort)
+  +0x1A90 | CC 00 00 00             | UOffset32  | 0x000000CC (204) Loc: 0x1B5C       | offset to field `name` (string)
+  +0x1A94 | B8 00 00 00             | UOffset32  | 0x000000B8 (184) Loc: 0x1B4C       | offset to field `type` (table)
+  +0x1A98 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1A9C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1A9C | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of vector (# items)
-  +0x1AA0 | 80 00 00 00             | UOffset32   | 0x00000080 (128) Loc: +0x1B20      | offset to table[0]
-  +0x1AA4 | 50 00 00 00             | UOffset32   | 0x00000050 (80) Loc: +0x1AF4       | offset to table[1]
-  +0x1AA8 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x1ACC       | offset to table[2]
-  +0x1AAC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1AB0        | offset to table[3]
+  +0x1A9C | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of vector (# items)
+  +0x1AA0 | 80 00 00 00             | UOffset32  | 0x00000080 (128) Loc: 0x1B20       | offset to table[0]
+  +0x1AA4 | 50 00 00 00             | UOffset32  | 0x00000050 (80) Loc: 0x1AF4        | offset to table[1]
+  +0x1AA8 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x1ACC        | offset to table[2]
+  +0x1AAC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1AB0         | offset to table[3]
 
 table (reflection.KeyValue):
-  +0x1AB0 | E8 E1 FF FF             | SOffset32   | 0xFFFFE1E8 (-7704) Loc: +0x38C8    | offset to vtable
-  +0x1AB4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1AC4       | offset to field `key` (string)
-  +0x1AB8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1ABC        | offset to field `value` (string)
+  +0x1AB0 | E8 E1 FF FF             | SOffset32  | 0xFFFFE1E8 (-7704) Loc: 0x38C8     | offset to vtable
+  +0x1AB4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1AC4        | offset to field `key` (string)
+  +0x1AB8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1ABC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1ABC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1AC0 | 33 39                   | char[2]     | 39                                 | string literal
-  +0x1AC2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1ABC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1AC0 | 33 39                   | char[2]    | 39                                 | string literal
+  +0x1AC2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1AC4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1AC8 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1ACA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1AC4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1AC8 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1ACA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x1ACC | 04 E2 FF FF             | SOffset32   | 0xFFFFE204 (-7676) Loc: +0x38C8    | offset to vtable
-  +0x1AD0 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x1AE8       | offset to field `key` (string)
-  +0x1AD4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1AD8        | offset to field `value` (string)
+  +0x1ACC | 04 E2 FF FF             | SOffset32  | 0xFFFFE204 (-7676) Loc: 0x38C8     | offset to vtable
+  +0x1AD0 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x1AE8        | offset to field `key` (string)
+  +0x1AD4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1AD8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1AD8 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x1ADC | 66 6E 76 31 61 5F 36 34 | char[8]     | fnv1a_64                           | string literal
-  +0x1AE4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1AD8 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x1ADC | 66 6E 76 31 61 5F 36 34 | char[8]    | fnv1a_64                           | string literal
+  +0x1AE4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1AE5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1AE5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x1AE8 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x1AEC | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x1AF0 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1AE8 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x1AEC | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x1AF0 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1AF1 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1AF1 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x1AF4 | 2C E2 FF FF             | SOffset32   | 0xFFFFE22C (-7636) Loc: +0x38C8    | offset to vtable
-  +0x1AF8 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x1B10       | offset to field `key` (string)
-  +0x1AFC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1B00        | offset to field `value` (string)
+  +0x1AF4 | 2C E2 FF FF             | SOffset32  | 0xFFFFE22C (-7636) Loc: 0x38C8     | offset to vtable
+  +0x1AF8 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x1B10        | offset to field `key` (string)
+  +0x1AFC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1B00         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1B00 | 0B 00 00 00             | uint32_t    | 0x0000000B (11)                    | length of string
-  +0x1B04 | 52 65 66 65 72 72 61 62 | char[11]    | Referrab                           | string literal
-  +0x1B0C | 6C 65 54                |             | leT
-  +0x1B0F | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1B00 | 0B 00 00 00             | uint32_t   | 0x0000000B (11)                    | length of string
+  +0x1B04 | 52 65 66 65 72 72 61 62 | char[11]   | Referrab                           | string literal
+  +0x1B0C | 6C 65 54                |            | leT
+  +0x1B0F | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1B10 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x1B14 | 63 70 70 5F 74 79 70 65 | char[8]     | cpp_type                           | string literal
-  +0x1B1C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1B10 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x1B14 | 63 70 70 5F 74 79 70 65 | char[8]    | cpp_type                           | string literal
+  +0x1B1C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1B1D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1B1D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x1B20 | 58 E2 FF FF             | SOffset32   | 0xFFFFE258 (-7592) Loc: +0x38C8    | offset to vtable
-  +0x1B24 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x1B38       | offset to field `key` (string)
-  +0x1B28 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1B2C        | offset to field `value` (string)
+  +0x1B20 | 58 E2 FF FF             | SOffset32  | 0xFFFFE258 (-7592) Loc: 0x38C8     | offset to vtable
+  +0x1B24 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x1B38        | offset to field `key` (string)
+  +0x1B28 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1B2C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1B2C | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x1B30 | 6E 61 6B 65 64          | char[5]     | naked                              | string literal
-  +0x1B35 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1B2C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x1B30 | 6E 61 6B 65 64          | char[5]    | naked                              | string literal
+  +0x1B35 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1B36 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1B36 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x1B38 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                    | length of string
-  +0x1B3C | 63 70 70 5F 70 74 72 5F | char[12]    | cpp_ptr_                           | string literal
-  +0x1B44 | 74 79 70 65             |             | type
-  +0x1B48 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1B38 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                    | length of string
+  +0x1B3C | 63 70 70 5F 70 74 72 5F | char[12]   | cpp_ptr_                           | string literal
+  +0x1B44 | 74 79 70 65             |            | type
+  +0x1B48 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1B49 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1B49 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x1B4C | D8 E4 FF FF             | SOffset32   | 0xFFFFE4D8 (-6952) Loc: +0x3674    | offset to vtable
-  +0x1B50 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1B53 | 0A                      | uint8_t     | 0x0A (10)                          | table field `base_type` (Byte)
-  +0x1B54 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x1B58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1B4C | D8 E4 FF FF             | SOffset32  | 0xFFFFE4D8 (-6952) Loc: 0x3674     | offset to vtable
+  +0x1B50 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1B53 | 0A                      | uint8_t    | 0x0A (10)                          | table field `base_type` (Byte)
+  +0x1B54 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x1B58 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1B5C | 13 00 00 00             | uint32_t    | 0x00000013 (19)                    | length of string
-  +0x1B60 | 63 6F 5F 6F 77 6E 69 6E | char[19]    | co_ownin                           | string literal
-  +0x1B68 | 67 5F 72 65 66 65 72 65 |             | g_refere
-  +0x1B70 | 6E 63 65                |             | nce
-  +0x1B73 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1B5C | 13 00 00 00             | uint32_t   | 0x00000013 (19)                    | length of string
+  +0x1B60 | 63 6F 5F 6F 77 6E 69 6E | char[19]   | co_ownin                           | string literal
+  +0x1B68 | 67 5F 72 65 66 65 72 65 |            | g_refere
+  +0x1B70 | 6E 63 65                |            | nce
+  +0x1B73 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x1B74 | 8C EF FF FF             | SOffset32   | 0xFFFFEF8C (-4212) Loc: +0x2BE8    | offset to vtable
-  +0x1B78 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1B7B | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1B7C | 26 00                   | uint16_t    | 0x0026 (38)                        | table field `id` (UShort)
-  +0x1B7E | 50 00                   | uint16_t    | 0x0050 (80)                        | table field `offset` (UShort)
-  +0x1B80 | 7C 00 00 00             | UOffset32   | 0x0000007C (124) Loc: +0x1BFC      | offset to field `name` (string)
-  +0x1B84 | 68 00 00 00             | UOffset32   | 0x00000068 (104) Loc: +0x1BEC      | offset to field `type` (table)
-  +0x1B88 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1B8C        | offset to field `attributes` (vector)
+  +0x1B74 | 8C EF FF FF             | SOffset32  | 0xFFFFEF8C (-4212) Loc: 0x2BE8     | offset to vtable
+  +0x1B78 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1B7B | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1B7C | 26 00                   | uint16_t   | 0x0026 (38)                        | table field `id` (UShort)
+  +0x1B7E | 50 00                   | uint16_t   | 0x0050 (80)                        | table field `offset` (UShort)
+  +0x1B80 | 7C 00 00 00             | UOffset32  | 0x0000007C (124) Loc: 0x1BFC       | offset to field `name` (string)
+  +0x1B84 | 68 00 00 00             | UOffset32  | 0x00000068 (104) Loc: 0x1BEC       | offset to field `type` (table)
+  +0x1B88 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1B8C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1B8C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x1B90 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x1BB4       | offset to table[0]
-  +0x1B94 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1B98        | offset to table[1]
+  +0x1B8C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x1B90 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x1BB4        | offset to table[0]
+  +0x1B94 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1B98         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x1B98 | D0 E2 FF FF             | SOffset32   | 0xFFFFE2D0 (-7472) Loc: +0x38C8    | offset to vtable
-  +0x1B9C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1BAC       | offset to field `key` (string)
-  +0x1BA0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1BA4        | offset to field `value` (string)
+  +0x1B98 | D0 E2 FF FF             | SOffset32  | 0xFFFFE2D0 (-7472) Loc: 0x38C8     | offset to vtable
+  +0x1B9C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1BAC        | offset to field `key` (string)
+  +0x1BA0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1BA4         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1BA4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1BA8 | 33 38                   | char[2]     | 38                                 | string literal
-  +0x1BAA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1BA4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1BA8 | 33 38                   | char[2]    | 38                                 | string literal
+  +0x1BAA | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1BAC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1BB0 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1BB2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1BAC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1BB0 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1BB2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x1BB4 | EC E2 FF FF             | SOffset32   | 0xFFFFE2EC (-7444) Loc: +0x38C8    | offset to vtable
-  +0x1BB8 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x1BD8       | offset to field `key` (string)
-  +0x1BBC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1BC0        | offset to field `value` (string)
+  +0x1BB4 | EC E2 FF FF             | SOffset32  | 0xFFFFE2EC (-7444) Loc: 0x38C8     | offset to vtable
+  +0x1BB8 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x1BD8        | offset to field `key` (string)
+  +0x1BBC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1BC0         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1BC0 | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x1BC4 | 64 65 66 61 75 6C 74 5F | char[16]    | default_                           | string literal
-  +0x1BCC | 70 74 72 5F 74 79 70 65 |             | ptr_type
-  +0x1BD4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1BC0 | 10 00 00 00             | uint32_t   | 0x00000010 (16)                    | length of string
+  +0x1BC4 | 64 65 66 61 75 6C 74 5F | char[16]   | default_                           | string literal
+  +0x1BCC | 70 74 72 5F 74 79 70 65 |            | ptr_type
+  +0x1BD4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1BD5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1BD5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x1BD8 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                    | length of string
-  +0x1BDC | 63 70 70 5F 70 74 72 5F | char[12]    | cpp_ptr_                           | string literal
-  +0x1BE4 | 74 79 70 65             |             | type
-  +0x1BE8 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1BD8 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                    | length of string
+  +0x1BDC | 63 70 70 5F 70 74 72 5F | char[12]   | cpp_ptr_                           | string literal
+  +0x1BE4 | 74 79 70 65             |            | type
+  +0x1BE8 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1BE9 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1BE9 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x1BEC | 78 F1 FF FF             | SOffset32   | 0xFFFFF178 (-3720) Loc: +0x2A74    | offset to vtable
-  +0x1BF0 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x1BF2 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x1BF3 | 0F                      | uint8_t     | 0x0F (15)                          | table field `element` (Byte)
-  +0x1BF4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | table field `index` (Int)
-  +0x1BF8 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `element_size` (UInt)
+  +0x1BEC | 78 F1 FF FF             | SOffset32  | 0xFFFFF178 (-3720) Loc: 0x2A74     | offset to vtable
+  +0x1BF0 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x1BF2 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x1BF3 | 0F                      | uint8_t    | 0x0F (15)                          | table field `element` (Byte)
+  +0x1BF4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `index` (Int)
+  +0x1BF8 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1BFC | 1C 00 00 00             | uint32_t    | 0x0000001C (28)                    | length of string
-  +0x1C00 | 76 65 63 74 6F 72 5F 6F | char[28]    | vector_o                           | string literal
-  +0x1C08 | 66 5F 73 74 72 6F 6E 67 |             | f_strong
-  +0x1C10 | 5F 72 65 66 65 72 72 61 |             | _referra
-  +0x1C18 | 62 6C 65 73             |             | bles
-  +0x1C1C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1BFC | 1C 00 00 00             | uint32_t   | 0x0000001C (28)                    | length of string
+  +0x1C00 | 76 65 63 74 6F 72 5F 6F | char[28]   | vector_o                           | string literal
+  +0x1C08 | 66 5F 73 74 72 6F 6E 67 |            | f_strong
+  +0x1C10 | 5F 72 65 66 65 72 72 61 |            | _referra
+  +0x1C18 | 62 6C 65 73             |            | bles
+  +0x1C1C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1C1D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1C1D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x1C20 | 38 F0 FF FF             | SOffset32   | 0xFFFFF038 (-4040) Loc: +0x2BE8    | offset to vtable
-  +0x1C24 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1C27 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1C28 | 25 00                   | uint16_t    | 0x0025 (37)                        | table field `id` (UShort)
-  +0x1C2A | 4E 00                   | uint16_t    | 0x004E (78)                        | table field `offset` (UShort)
-  +0x1C2C | C8 00 00 00             | UOffset32   | 0x000000C8 (200) Loc: +0x1CF4      | offset to field `name` (string)
-  +0x1C30 | B8 00 00 00             | UOffset32   | 0x000000B8 (184) Loc: +0x1CE8      | offset to field `type` (table)
-  +0x1C34 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1C38        | offset to field `attributes` (vector)
+  +0x1C20 | 38 F0 FF FF             | SOffset32  | 0xFFFFF038 (-4040) Loc: 0x2BE8     | offset to vtable
+  +0x1C24 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1C27 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1C28 | 25 00                   | uint16_t   | 0x0025 (37)                        | table field `id` (UShort)
+  +0x1C2A | 4E 00                   | uint16_t   | 0x004E (78)                        | table field `offset` (UShort)
+  +0x1C2C | C8 00 00 00             | UOffset32  | 0x000000C8 (200) Loc: 0x1CF4       | offset to field `name` (string)
+  +0x1C30 | B8 00 00 00             | UOffset32  | 0x000000B8 (184) Loc: 0x1CE8       | offset to field `type` (table)
+  +0x1C34 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1C38         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1C38 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of vector (# items)
-  +0x1C3C | 80 00 00 00             | UOffset32   | 0x00000080 (128) Loc: +0x1CBC      | offset to table[0]
-  +0x1C40 | 50 00 00 00             | UOffset32   | 0x00000050 (80) Loc: +0x1C90       | offset to table[1]
-  +0x1C44 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x1C68       | offset to table[2]
-  +0x1C48 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1C4C        | offset to table[3]
+  +0x1C38 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of vector (# items)
+  +0x1C3C | 80 00 00 00             | UOffset32  | 0x00000080 (128) Loc: 0x1CBC       | offset to table[0]
+  +0x1C40 | 50 00 00 00             | UOffset32  | 0x00000050 (80) Loc: 0x1C90        | offset to table[1]
+  +0x1C44 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x1C68        | offset to table[2]
+  +0x1C48 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1C4C         | offset to table[3]
 
 table (reflection.KeyValue):
-  +0x1C4C | 84 E3 FF FF             | SOffset32   | 0xFFFFE384 (-7292) Loc: +0x38C8    | offset to vtable
-  +0x1C50 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1C60       | offset to field `key` (string)
-  +0x1C54 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1C58        | offset to field `value` (string)
+  +0x1C4C | 84 E3 FF FF             | SOffset32  | 0xFFFFE384 (-7292) Loc: 0x38C8     | offset to vtable
+  +0x1C50 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1C60        | offset to field `key` (string)
+  +0x1C54 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1C58         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1C58 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1C5C | 33 37                   | char[2]     | 37                                 | string literal
-  +0x1C5E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1C58 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1C5C | 33 37                   | char[2]    | 37                                 | string literal
+  +0x1C5E | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1C60 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1C64 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1C66 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1C60 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1C64 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1C66 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x1C68 | A0 E3 FF FF             | SOffset32   | 0xFFFFE3A0 (-7264) Loc: +0x38C8    | offset to vtable
-  +0x1C6C | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x1C84       | offset to field `key` (string)
-  +0x1C70 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1C74        | offset to field `value` (string)
+  +0x1C68 | A0 E3 FF FF             | SOffset32  | 0xFFFFE3A0 (-7264) Loc: 0x38C8     | offset to vtable
+  +0x1C6C | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x1C84        | offset to field `key` (string)
+  +0x1C70 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1C74         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1C74 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x1C78 | 66 6E 76 31 61 5F 36 34 | char[8]     | fnv1a_64                           | string literal
-  +0x1C80 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1C74 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x1C78 | 66 6E 76 31 61 5F 36 34 | char[8]    | fnv1a_64                           | string literal
+  +0x1C80 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1C81 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1C81 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x1C84 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x1C88 | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x1C8C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1C84 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x1C88 | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x1C8C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1C8D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1C8D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x1C90 | C8 E3 FF FF             | SOffset32   | 0xFFFFE3C8 (-7224) Loc: +0x38C8    | offset to vtable
-  +0x1C94 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x1CAC       | offset to field `key` (string)
-  +0x1C98 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1C9C        | offset to field `value` (string)
+  +0x1C90 | C8 E3 FF FF             | SOffset32  | 0xFFFFE3C8 (-7224) Loc: 0x38C8     | offset to vtable
+  +0x1C94 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x1CAC        | offset to field `key` (string)
+  +0x1C98 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1C9C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1C9C | 0B 00 00 00             | uint32_t    | 0x0000000B (11)                    | length of string
-  +0x1CA0 | 52 65 66 65 72 72 61 62 | char[11]    | Referrab                           | string literal
-  +0x1CA8 | 6C 65 54                |             | leT
-  +0x1CAB | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1C9C | 0B 00 00 00             | uint32_t   | 0x0000000B (11)                    | length of string
+  +0x1CA0 | 52 65 66 65 72 72 61 62 | char[11]   | Referrab                           | string literal
+  +0x1CA8 | 6C 65 54                |            | leT
+  +0x1CAB | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1CAC | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x1CB0 | 63 70 70 5F 74 79 70 65 | char[8]     | cpp_type                           | string literal
-  +0x1CB8 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1CAC | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x1CB0 | 63 70 70 5F 74 79 70 65 | char[8]    | cpp_type                           | string literal
+  +0x1CB8 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1CB9 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1CB9 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x1CBC | F4 E3 FF FF             | SOffset32   | 0xFFFFE3F4 (-7180) Loc: +0x38C8    | offset to vtable
-  +0x1CC0 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x1CD4       | offset to field `key` (string)
-  +0x1CC4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1CC8        | offset to field `value` (string)
+  +0x1CBC | F4 E3 FF FF             | SOffset32  | 0xFFFFE3F4 (-7180) Loc: 0x38C8     | offset to vtable
+  +0x1CC0 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x1CD4        | offset to field `key` (string)
+  +0x1CC4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1CC8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1CC8 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x1CCC | 6E 61 6B 65 64          | char[5]     | naked                              | string literal
-  +0x1CD1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1CC8 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x1CCC | 6E 61 6B 65 64          | char[5]    | naked                              | string literal
+  +0x1CD1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1CD2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1CD2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x1CD4 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                    | length of string
-  +0x1CD8 | 63 70 70 5F 70 74 72 5F | char[12]    | cpp_ptr_                           | string literal
-  +0x1CE0 | 74 79 70 65             |             | type
-  +0x1CE4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1CD4 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                    | length of string
+  +0x1CD8 | 63 70 70 5F 70 74 72 5F | char[12]   | cpp_ptr_                           | string literal
+  +0x1CE0 | 74 79 70 65             |            | type
+  +0x1CE4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1CE5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1CE5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x1CE8 | A8 F0 FF FF             | SOffset32   | 0xFFFFF0A8 (-3928) Loc: +0x2C40    | offset to vtable
-  +0x1CEC | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x1CEE | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x1CEF | 0A                      | uint8_t     | 0x0A (10)                          | table field `element` (Byte)
-  +0x1CF0 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `element_size` (UInt)
+  +0x1CE8 | A8 F0 FF FF             | SOffset32  | 0xFFFFF0A8 (-3928) Loc: 0x2C40     | offset to vtable
+  +0x1CEC | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x1CEE | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x1CEF | 0A                      | uint8_t    | 0x0A (10)                          | table field `element` (Byte)
+  +0x1CF0 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1CF4 | 19 00 00 00             | uint32_t    | 0x00000019 (25)                    | length of string
-  +0x1CF8 | 76 65 63 74 6F 72 5F 6F | char[25]    | vector_o                           | string literal
-  +0x1D00 | 66 5F 77 65 61 6B 5F 72 |             | f_weak_r
-  +0x1D08 | 65 66 65 72 65 6E 63 65 |             | eference
-  +0x1D10 | 73                      |             | s
-  +0x1D11 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1CF4 | 19 00 00 00             | uint32_t   | 0x00000019 (25)                    | length of string
+  +0x1CF8 | 76 65 63 74 6F 72 5F 6F | char[25]   | vector_o                           | string literal
+  +0x1D00 | 66 5F 77 65 61 6B 5F 72 |            | f_weak_r
+  +0x1D08 | 65 66 65 72 65 6E 63 65 |            | eference
+  +0x1D10 | 73                      |            | s
+  +0x1D11 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1D12 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1D12 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x1D14 | 1C F2 FF FF             | SOffset32   | 0xFFFFF21C (-3556) Loc: +0x2AF8    | offset to vtable
-  +0x1D18 | 24 00                   | uint16_t    | 0x0024 (36)                        | table field `id` (UShort)
-  +0x1D1A | 4C 00                   | uint16_t    | 0x004C (76)                        | table field `offset` (UShort)
-  +0x1D1C | CC 00 00 00             | UOffset32   | 0x000000CC (204) Loc: +0x1DE8      | offset to field `name` (string)
-  +0x1D20 | B8 00 00 00             | UOffset32   | 0x000000B8 (184) Loc: +0x1DD8      | offset to field `type` (table)
-  +0x1D24 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1D28        | offset to field `attributes` (vector)
+  +0x1D14 | 1C F2 FF FF             | SOffset32  | 0xFFFFF21C (-3556) Loc: 0x2AF8     | offset to vtable
+  +0x1D18 | 24 00                   | uint16_t   | 0x0024 (36)                        | table field `id` (UShort)
+  +0x1D1A | 4C 00                   | uint16_t   | 0x004C (76)                        | table field `offset` (UShort)
+  +0x1D1C | CC 00 00 00             | UOffset32  | 0x000000CC (204) Loc: 0x1DE8       | offset to field `name` (string)
+  +0x1D20 | B8 00 00 00             | UOffset32  | 0x000000B8 (184) Loc: 0x1DD8       | offset to field `type` (table)
+  +0x1D24 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1D28         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1D28 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of vector (# items)
-  +0x1D2C | 80 00 00 00             | UOffset32   | 0x00000080 (128) Loc: +0x1DAC      | offset to table[0]
-  +0x1D30 | 50 00 00 00             | UOffset32   | 0x00000050 (80) Loc: +0x1D80       | offset to table[1]
-  +0x1D34 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x1D58       | offset to table[2]
-  +0x1D38 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1D3C        | offset to table[3]
+  +0x1D28 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of vector (# items)
+  +0x1D2C | 80 00 00 00             | UOffset32  | 0x00000080 (128) Loc: 0x1DAC       | offset to table[0]
+  +0x1D30 | 50 00 00 00             | UOffset32  | 0x00000050 (80) Loc: 0x1D80        | offset to table[1]
+  +0x1D34 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x1D58        | offset to table[2]
+  +0x1D38 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1D3C         | offset to table[3]
 
 table (reflection.KeyValue):
-  +0x1D3C | 74 E4 FF FF             | SOffset32   | 0xFFFFE474 (-7052) Loc: +0x38C8    | offset to vtable
-  +0x1D40 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1D50       | offset to field `key` (string)
-  +0x1D44 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1D48        | offset to field `value` (string)
+  +0x1D3C | 74 E4 FF FF             | SOffset32  | 0xFFFFE474 (-7052) Loc: 0x38C8     | offset to vtable
+  +0x1D40 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1D50        | offset to field `key` (string)
+  +0x1D44 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1D48         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1D48 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1D4C | 33 36                   | char[2]     | 36                                 | string literal
-  +0x1D4E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1D48 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1D4C | 33 36                   | char[2]    | 36                                 | string literal
+  +0x1D4E | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1D50 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1D54 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1D56 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1D50 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1D54 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1D56 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x1D58 | 90 E4 FF FF             | SOffset32   | 0xFFFFE490 (-7024) Loc: +0x38C8    | offset to vtable
-  +0x1D5C | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x1D74       | offset to field `key` (string)
-  +0x1D60 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1D64        | offset to field `value` (string)
+  +0x1D58 | 90 E4 FF FF             | SOffset32  | 0xFFFFE490 (-7024) Loc: 0x38C8     | offset to vtable
+  +0x1D5C | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x1D74        | offset to field `key` (string)
+  +0x1D60 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1D64         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1D64 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x1D68 | 66 6E 76 31 61 5F 36 34 | char[8]     | fnv1a_64                           | string literal
-  +0x1D70 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1D64 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x1D68 | 66 6E 76 31 61 5F 36 34 | char[8]    | fnv1a_64                           | string literal
+  +0x1D70 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1D71 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1D71 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x1D74 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x1D78 | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x1D7C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1D74 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x1D78 | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x1D7C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1D7D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1D7D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x1D80 | B8 E4 FF FF             | SOffset32   | 0xFFFFE4B8 (-6984) Loc: +0x38C8    | offset to vtable
-  +0x1D84 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x1D9C       | offset to field `key` (string)
-  +0x1D88 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1D8C        | offset to field `value` (string)
+  +0x1D80 | B8 E4 FF FF             | SOffset32  | 0xFFFFE4B8 (-6984) Loc: 0x38C8     | offset to vtable
+  +0x1D84 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x1D9C        | offset to field `key` (string)
+  +0x1D88 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1D8C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1D8C | 0B 00 00 00             | uint32_t    | 0x0000000B (11)                    | length of string
-  +0x1D90 | 52 65 66 65 72 72 61 62 | char[11]    | Referrab                           | string literal
-  +0x1D98 | 6C 65 54                |             | leT
-  +0x1D9B | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1D8C | 0B 00 00 00             | uint32_t   | 0x0000000B (11)                    | length of string
+  +0x1D90 | 52 65 66 65 72 72 61 62 | char[11]   | Referrab                           | string literal
+  +0x1D98 | 6C 65 54                |            | leT
+  +0x1D9B | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1D9C | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x1DA0 | 63 70 70 5F 74 79 70 65 | char[8]     | cpp_type                           | string literal
-  +0x1DA8 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1D9C | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x1DA0 | 63 70 70 5F 74 79 70 65 | char[8]    | cpp_type                           | string literal
+  +0x1DA8 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1DA9 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1DA9 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x1DAC | E4 E4 FF FF             | SOffset32   | 0xFFFFE4E4 (-6940) Loc: +0x38C8    | offset to vtable
-  +0x1DB0 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x1DC4       | offset to field `key` (string)
-  +0x1DB4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1DB8        | offset to field `value` (string)
+  +0x1DAC | E4 E4 FF FF             | SOffset32  | 0xFFFFE4E4 (-6940) Loc: 0x38C8     | offset to vtable
+  +0x1DB0 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x1DC4        | offset to field `key` (string)
+  +0x1DB4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1DB8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1DB8 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x1DBC | 6E 61 6B 65 64          | char[5]     | naked                              | string literal
-  +0x1DC1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1DB8 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x1DBC | 6E 61 6B 65 64          | char[5]    | naked                              | string literal
+  +0x1DC1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1DC2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1DC2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x1DC4 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                    | length of string
-  +0x1DC8 | 63 70 70 5F 70 74 72 5F | char[12]    | cpp_ptr_                           | string literal
-  +0x1DD0 | 74 79 70 65             |             | type
-  +0x1DD4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1DC4 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                    | length of string
+  +0x1DC8 | 63 70 70 5F 70 74 72 5F | char[12]   | cpp_ptr_                           | string literal
+  +0x1DD0 | 74 79 70 65             |            | type
+  +0x1DD4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1DD5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x1DD5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x1DD8 | 64 E7 FF FF             | SOffset32   | 0xFFFFE764 (-6300) Loc: +0x3674    | offset to vtable
-  +0x1DDC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1DDF | 0A                      | uint8_t     | 0x0A (10)                          | table field `base_type` (Byte)
-  +0x1DE0 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x1DE4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1DD8 | 64 E7 FF FF             | SOffset32  | 0xFFFFE764 (-6300) Loc: 0x3674     | offset to vtable
+  +0x1DDC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1DDF | 0A                      | uint8_t    | 0x0A (10)                          | table field `base_type` (Byte)
+  +0x1DE0 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x1DE4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1DE8 | 15 00 00 00             | uint32_t    | 0x00000015 (21)                    | length of string
-  +0x1DEC | 73 69 6E 67 6C 65 5F 77 | char[21]    | single_w                           | string literal
-  +0x1DF4 | 65 61 6B 5F 72 65 66 65 |             | eak_refe
-  +0x1DFC | 72 65 6E 63 65          |             | rence
-  +0x1E01 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1DE8 | 15 00 00 00             | uint32_t   | 0x00000015 (21)                    | length of string
+  +0x1DEC | 73 69 6E 67 6C 65 5F 77 | char[21]   | single_w                           | string literal
+  +0x1DF4 | 65 61 6B 5F 72 65 66 65 |            | eak_refe
+  +0x1DFC | 72 65 6E 63 65          |            | rence
+  +0x1E01 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1E02 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1E02 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x1E04 | 1C F2 FF FF             | SOffset32   | 0xFFFFF21C (-3556) Loc: +0x2BE8    | offset to vtable
-  +0x1E08 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1E0B | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1E0C | 23 00                   | uint16_t    | 0x0023 (35)                        | table field `id` (UShort)
-  +0x1E0E | 4A 00                   | uint16_t    | 0x004A (74)                        | table field `offset` (UShort)
-  +0x1E10 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x1E50       | offset to field `name` (string)
-  +0x1E14 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x1E40       | offset to field `type` (table)
-  +0x1E18 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1E1C        | offset to field `attributes` (vector)
+  +0x1E04 | 1C F2 FF FF             | SOffset32  | 0xFFFFF21C (-3556) Loc: 0x2BE8     | offset to vtable
+  +0x1E08 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1E0B | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1E0C | 23 00                   | uint16_t   | 0x0023 (35)                        | table field `id` (UShort)
+  +0x1E0E | 4A 00                   | uint16_t   | 0x004A (74)                        | table field `offset` (UShort)
+  +0x1E10 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x1E50        | offset to field `name` (string)
+  +0x1E14 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x1E40        | offset to field `type` (table)
+  +0x1E18 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1E1C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1E1C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x1E20 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1E24        | offset to table[0]
+  +0x1E1C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x1E20 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1E24         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x1E24 | 5C E5 FF FF             | SOffset32   | 0xFFFFE55C (-6820) Loc: +0x38C8    | offset to vtable
-  +0x1E28 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1E38       | offset to field `key` (string)
-  +0x1E2C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1E30        | offset to field `value` (string)
+  +0x1E24 | 5C E5 FF FF             | SOffset32  | 0xFFFFE55C (-6820) Loc: 0x38C8     | offset to vtable
+  +0x1E28 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1E38        | offset to field `key` (string)
+  +0x1E2C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1E30         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1E30 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1E34 | 33 35                   | char[2]     | 35                                 | string literal
-  +0x1E36 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1E30 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1E34 | 33 35                   | char[2]    | 35                                 | string literal
+  +0x1E36 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1E38 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1E3C | 69 64                   | char[2]     | id                                 | string literal
-  +0x1E3E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1E38 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1E3C | 69 64                   | char[2]    | id                                 | string literal
+  +0x1E3E | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1E40 | CC F3 FF FF             | SOffset32   | 0xFFFFF3CC (-3124) Loc: +0x2A74    | offset to vtable
-  +0x1E44 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x1E46 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x1E47 | 0F                      | uint8_t     | 0x0F (15)                          | table field `element` (Byte)
-  +0x1E48 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | table field `index` (Int)
-  +0x1E4C | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `element_size` (UInt)
+  +0x1E40 | CC F3 FF FF             | SOffset32  | 0xFFFFF3CC (-3124) Loc: 0x2A74     | offset to vtable
+  +0x1E44 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x1E46 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x1E47 | 0F                      | uint8_t    | 0x0F (15)                          | table field `element` (Byte)
+  +0x1E48 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `index` (Int)
+  +0x1E4C | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1E50 | 15 00 00 00             | uint32_t    | 0x00000015 (21)                    | length of string
-  +0x1E54 | 76 65 63 74 6F 72 5F 6F | char[21]    | vector_o                           | string literal
-  +0x1E5C | 66 5F 72 65 66 65 72 72 |             | f_referr
-  +0x1E64 | 61 62 6C 65 73          |             | ables
-  +0x1E69 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1E50 | 15 00 00 00             | uint32_t   | 0x00000015 (21)                    | length of string
+  +0x1E54 | 76 65 63 74 6F 72 5F 6F | char[21]   | vector_o                           | string literal
+  +0x1E5C | 66 5F 72 65 66 65 72 72 |            | f_referr
+  +0x1E64 | 61 62 6C 65 73          |            | ables
+  +0x1E69 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1E6A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1E6A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x1E6C | 84 F2 FF FF             | SOffset32   | 0xFFFFF284 (-3452) Loc: +0x2BE8    | offset to vtable
-  +0x1E70 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1E73 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1E74 | 22 00                   | uint16_t    | 0x0022 (34)                        | table field `id` (UShort)
-  +0x1E76 | 48 00                   | uint16_t    | 0x0048 (72)                        | table field `offset` (UShort)
-  +0x1E78 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x1EB8       | offset to field `name` (string)
-  +0x1E7C | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x1EA8       | offset to field `type` (table)
-  +0x1E80 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1E84        | offset to field `attributes` (vector)
+  +0x1E6C | 84 F2 FF FF             | SOffset32  | 0xFFFFF284 (-3452) Loc: 0x2BE8     | offset to vtable
+  +0x1E70 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1E73 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1E74 | 22 00                   | uint16_t   | 0x0022 (34)                        | table field `id` (UShort)
+  +0x1E76 | 48 00                   | uint16_t   | 0x0048 (72)                        | table field `offset` (UShort)
+  +0x1E78 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x1EB8        | offset to field `name` (string)
+  +0x1E7C | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x1EA8        | offset to field `type` (table)
+  +0x1E80 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1E84         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1E84 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x1E88 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1E8C        | offset to table[0]
+  +0x1E84 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x1E88 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1E8C         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x1E8C | C4 E5 FF FF             | SOffset32   | 0xFFFFE5C4 (-6716) Loc: +0x38C8    | offset to vtable
-  +0x1E90 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1EA0       | offset to field `key` (string)
-  +0x1E94 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1E98        | offset to field `value` (string)
+  +0x1E8C | C4 E5 FF FF             | SOffset32  | 0xFFFFE5C4 (-6716) Loc: 0x38C8     | offset to vtable
+  +0x1E90 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1EA0        | offset to field `key` (string)
+  +0x1E94 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1E98         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1E98 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1E9C | 33 34                   | char[2]     | 34                                 | string literal
-  +0x1E9E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1E98 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1E9C | 33 34                   | char[2]    | 34                                 | string literal
+  +0x1E9E | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1EA0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1EA4 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1EA6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1EA0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1EA4 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1EA6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1EA8 | 90 E6 FF FF             | SOffset32   | 0xFFFFE690 (-6512) Loc: +0x3818    | offset to vtable
-  +0x1EAC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1EAF | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x1EB0 | 0B 00 00 00             | uint32_t    | 0x0000000B (11)                    | table field `index` (Int)
-  +0x1EB4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x1EA8 | 90 E6 FF FF             | SOffset32  | 0xFFFFE690 (-6512) Loc: 0x3818     | offset to vtable
+  +0x1EAC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1EAF | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x1EB0 | 0B 00 00 00             | uint32_t   | 0x0000000B (11)                    | table field `index` (Int)
+  +0x1EB4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1EB8 | 15 00 00 00             | uint32_t    | 0x00000015 (21)                    | length of string
-  +0x1EBC | 70 61 72 65 6E 74 5F 6E | char[21]    | parent_n                           | string literal
-  +0x1EC4 | 61 6D 65 73 70 61 63 65 |             | amespace
-  +0x1ECC | 5F 74 65 73 74          |             | _test
-  +0x1ED1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1EB8 | 15 00 00 00             | uint32_t   | 0x00000015 (21)                    | length of string
+  +0x1EBC | 70 61 72 65 6E 74 5F 6E | char[21]   | parent_n                           | string literal
+  +0x1EC4 | 61 6D 65 73 70 61 63 65 |            | amespace
+  +0x1ECC | 5F 74 65 73 74          |            | _test
+  +0x1ED1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1ED2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1ED2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x1ED4 | EC F2 FF FF             | SOffset32   | 0xFFFFF2EC (-3348) Loc: +0x2BE8    | offset to vtable
-  +0x1ED8 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1EDB | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1EDC | 21 00                   | uint16_t    | 0x0021 (33)                        | table field `id` (UShort)
-  +0x1EDE | 46 00                   | uint16_t    | 0x0046 (70)                        | table field `offset` (UShort)
-  +0x1EE0 | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x1F1C       | offset to field `name` (string)
-  +0x1EE4 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x1F10       | offset to field `type` (table)
-  +0x1EE8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1EEC        | offset to field `attributes` (vector)
+  +0x1ED4 | EC F2 FF FF             | SOffset32  | 0xFFFFF2EC (-3348) Loc: 0x2BE8     | offset to vtable
+  +0x1ED8 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1EDB | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1EDC | 21 00                   | uint16_t   | 0x0021 (33)                        | table field `id` (UShort)
+  +0x1EDE | 46 00                   | uint16_t   | 0x0046 (70)                        | table field `offset` (UShort)
+  +0x1EE0 | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x1F1C        | offset to field `name` (string)
+  +0x1EE4 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x1F10        | offset to field `type` (table)
+  +0x1EE8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1EEC         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1EEC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x1EF0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1EF4        | offset to table[0]
+  +0x1EEC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x1EF0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1EF4         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x1EF4 | 2C E6 FF FF             | SOffset32   | 0xFFFFE62C (-6612) Loc: +0x38C8    | offset to vtable
-  +0x1EF8 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1F08       | offset to field `key` (string)
-  +0x1EFC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1F00        | offset to field `value` (string)
+  +0x1EF4 | 2C E6 FF FF             | SOffset32  | 0xFFFFE62C (-6612) Loc: 0x38C8     | offset to vtable
+  +0x1EF8 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1F08        | offset to field `key` (string)
+  +0x1EFC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1F00         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1F00 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1F04 | 33 33                   | char[2]     | 33                                 | string literal
-  +0x1F06 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1F00 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1F04 | 33 33                   | char[2]    | 33                                 | string literal
+  +0x1F06 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1F08 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1F0C | 69 64                   | char[2]     | id                                 | string literal
-  +0x1F0E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1F08 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1F0C | 69 64                   | char[2]    | id                                 | string literal
+  +0x1F0E | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1F10 | D0 F2 FF FF             | SOffset32   | 0xFFFFF2D0 (-3376) Loc: +0x2C40    | offset to vtable
-  +0x1F14 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x1F16 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x1F17 | 0C                      | uint8_t     | 0x0C (12)                          | table field `element` (Byte)
-  +0x1F18 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `element_size` (UInt)
+  +0x1F10 | D0 F2 FF FF             | SOffset32  | 0xFFFFF2D0 (-3376) Loc: 0x2C40     | offset to vtable
+  +0x1F14 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x1F16 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x1F17 | 0C                      | uint8_t    | 0x0C (12)                          | table field `element` (Byte)
+  +0x1F18 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1F1C | 11 00 00 00             | uint32_t    | 0x00000011 (17)                    | length of string
-  +0x1F20 | 76 65 63 74 6F 72 5F 6F | char[17]    | vector_o                           | string literal
-  +0x1F28 | 66 5F 64 6F 75 62 6C 65 |             | f_double
-  +0x1F30 | 73                      |             | s
-  +0x1F31 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1F1C | 11 00 00 00             | uint32_t   | 0x00000011 (17)                    | length of string
+  +0x1F20 | 76 65 63 74 6F 72 5F 6F | char[17]   | vector_o                           | string literal
+  +0x1F28 | 66 5F 64 6F 75 62 6C 65 |            | f_double
+  +0x1F30 | 73                      |            | s
+  +0x1F31 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1F32 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1F32 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x1F34 | 4C F3 FF FF             | SOffset32   | 0xFFFFF34C (-3252) Loc: +0x2BE8    | offset to vtable
-  +0x1F38 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1F3B | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1F3C | 20 00                   | uint16_t    | 0x0020 (32)                        | table field `id` (UShort)
-  +0x1F3E | 44 00                   | uint16_t    | 0x0044 (68)                        | table field `offset` (UShort)
-  +0x1F40 | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x1F7C       | offset to field `name` (string)
-  +0x1F44 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x1F70       | offset to field `type` (table)
-  +0x1F48 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1F4C        | offset to field `attributes` (vector)
+  +0x1F34 | 4C F3 FF FF             | SOffset32  | 0xFFFFF34C (-3252) Loc: 0x2BE8     | offset to vtable
+  +0x1F38 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1F3B | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1F3C | 20 00                   | uint16_t   | 0x0020 (32)                        | table field `id` (UShort)
+  +0x1F3E | 44 00                   | uint16_t   | 0x0044 (68)                        | table field `offset` (UShort)
+  +0x1F40 | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x1F7C        | offset to field `name` (string)
+  +0x1F44 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x1F70        | offset to field `type` (table)
+  +0x1F48 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1F4C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1F4C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x1F50 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1F54        | offset to table[0]
+  +0x1F4C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x1F50 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1F54         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x1F54 | 8C E6 FF FF             | SOffset32   | 0xFFFFE68C (-6516) Loc: +0x38C8    | offset to vtable
-  +0x1F58 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1F68       | offset to field `key` (string)
-  +0x1F5C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1F60        | offset to field `value` (string)
+  +0x1F54 | 8C E6 FF FF             | SOffset32  | 0xFFFFE68C (-6516) Loc: 0x38C8     | offset to vtable
+  +0x1F58 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1F68        | offset to field `key` (string)
+  +0x1F5C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1F60         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1F60 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1F64 | 33 32                   | char[2]     | 32                                 | string literal
-  +0x1F66 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1F60 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1F64 | 33 32                   | char[2]    | 32                                 | string literal
+  +0x1F66 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1F68 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1F6C | 69 64                   | char[2]     | id                                 | string literal
-  +0x1F6E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1F68 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1F6C | 69 64                   | char[2]    | id                                 | string literal
+  +0x1F6E | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1F70 | 30 F3 FF FF             | SOffset32   | 0xFFFFF330 (-3280) Loc: +0x2C40    | offset to vtable
-  +0x1F74 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x1F76 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x1F77 | 09                      | uint8_t     | 0x09 (9)                           | table field `element` (Byte)
-  +0x1F78 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `element_size` (UInt)
+  +0x1F70 | 30 F3 FF FF             | SOffset32  | 0xFFFFF330 (-3280) Loc: 0x2C40     | offset to vtable
+  +0x1F74 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x1F76 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x1F77 | 09                      | uint8_t    | 0x09 (9)                           | table field `element` (Byte)
+  +0x1F78 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1F7C | 0F 00 00 00             | uint32_t    | 0x0000000F (15)                    | length of string
-  +0x1F80 | 76 65 63 74 6F 72 5F 6F | char[15]    | vector_o                           | string literal
-  +0x1F88 | 66 5F 6C 6F 6E 67 73    |             | f_longs
-  +0x1F8F | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1F7C | 0F 00 00 00             | uint32_t   | 0x0000000F (15)                    | length of string
+  +0x1F80 | 76 65 63 74 6F 72 5F 6F | char[15]   | vector_o                           | string literal
+  +0x1F88 | 66 5F 6C 6F 6E 67 73    |            | f_longs
+  +0x1F8F | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x1F90 | A8 F3 FF FF             | SOffset32   | 0xFFFFF3A8 (-3160) Loc: +0x2BE8    | offset to vtable
-  +0x1F94 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1F97 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1F98 | 1F 00                   | uint16_t    | 0x001F (31)                        | table field `id` (UShort)
-  +0x1F9A | 42 00                   | uint16_t    | 0x0042 (66)                        | table field `offset` (UShort)
-  +0x1F9C | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x1FDC       | offset to field `name` (string)
-  +0x1FA0 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x1FCC       | offset to field `type` (table)
-  +0x1FA4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1FA8        | offset to field `attributes` (vector)
+  +0x1F90 | A8 F3 FF FF             | SOffset32  | 0xFFFFF3A8 (-3160) Loc: 0x2BE8     | offset to vtable
+  +0x1F94 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1F97 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1F98 | 1F 00                   | uint16_t   | 0x001F (31)                        | table field `id` (UShort)
+  +0x1F9A | 42 00                   | uint16_t   | 0x0042 (66)                        | table field `offset` (UShort)
+  +0x1F9C | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x1FDC        | offset to field `name` (string)
+  +0x1FA0 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x1FCC        | offset to field `type` (table)
+  +0x1FA4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1FA8         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x1FA8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x1FAC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1FB0        | offset to table[0]
+  +0x1FA8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x1FAC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1FB0         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x1FB0 | E8 E6 FF FF             | SOffset32   | 0xFFFFE6E8 (-6424) Loc: +0x38C8    | offset to vtable
-  +0x1FB4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x1FC4       | offset to field `key` (string)
-  +0x1FB8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x1FBC        | offset to field `value` (string)
+  +0x1FB0 | E8 E6 FF FF             | SOffset32  | 0xFFFFE6E8 (-6424) Loc: 0x38C8     | offset to vtable
+  +0x1FB4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x1FC4        | offset to field `key` (string)
+  +0x1FB8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x1FBC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x1FBC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1FC0 | 33 31                   | char[2]     | 31                                 | string literal
-  +0x1FC2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1FBC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1FC0 | 33 31                   | char[2]    | 31                                 | string literal
+  +0x1FC2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x1FC4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x1FC8 | 69 64                   | char[2]     | id                                 | string literal
-  +0x1FCA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1FC4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x1FC8 | 69 64                   | char[2]    | id                                 | string literal
+  +0x1FCA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x1FCC | 58 F5 FF FF             | SOffset32   | 0xFFFFF558 (-2728) Loc: +0x2A74    | offset to vtable
-  +0x1FD0 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x1FD2 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x1FD3 | 0F                      | uint8_t     | 0x0F (15)                          | table field `element` (Byte)
-  +0x1FD4 | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | table field `index` (Int)
-  +0x1FD8 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `element_size` (UInt)
+  +0x1FCC | 58 F5 FF FF             | SOffset32  | 0xFFFFF558 (-2728) Loc: 0x2A74     | offset to vtable
+  +0x1FD0 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x1FD2 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x1FD3 | 0F                      | uint8_t    | 0x0F (15)                          | table field `element` (Byte)
+  +0x1FD4 | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | table field `index` (Int)
+  +0x1FD8 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x1FDC | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x1FE0 | 74 65 73 74 35          | char[5]     | test5                              | string literal
-  +0x1FE5 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x1FDC | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x1FE0 | 74 65 73 74 35          | char[5]    | test5                              | string literal
+  +0x1FE5 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x1FE6 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x1FE6 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x1FE8 | 00 F4 FF FF             | SOffset32   | 0xFFFFF400 (-3072) Loc: +0x2BE8    | offset to vtable
-  +0x1FEC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x1FEF | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x1FF0 | 1E 00                   | uint16_t    | 0x001E (30)                        | table field `id` (UShort)
-  +0x1FF2 | 40 00                   | uint16_t    | 0x0040 (64)                        | table field `offset` (UShort)
-  +0x1FF4 | 64 00 00 00             | UOffset32   | 0x00000064 (100) Loc: +0x2058      | offset to field `name` (string)
-  +0x1FF8 | 54 00 00 00             | UOffset32   | 0x00000054 (84) Loc: +0x204C       | offset to field `type` (table)
-  +0x1FFC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2000        | offset to field `attributes` (vector)
+  +0x1FE8 | 00 F4 FF FF             | SOffset32  | 0xFFFFF400 (-3072) Loc: 0x2BE8     | offset to vtable
+  +0x1FEC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x1FEF | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x1FF0 | 1E 00                   | uint16_t   | 0x001E (30)                        | table field `id` (UShort)
+  +0x1FF2 | 40 00                   | uint16_t   | 0x0040 (64)                        | table field `offset` (UShort)
+  +0x1FF4 | 64 00 00 00             | UOffset32  | 0x00000064 (100) Loc: 0x2058       | offset to field `name` (string)
+  +0x1FF8 | 54 00 00 00             | UOffset32  | 0x00000054 (84) Loc: 0x204C        | offset to field `type` (table)
+  +0x1FFC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2000         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2000 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x2004 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x2028       | offset to table[0]
-  +0x2008 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x200C        | offset to table[1]
+  +0x2000 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x2004 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x2028        | offset to table[0]
+  +0x2008 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x200C         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x200C | 44 E7 FF FF             | SOffset32   | 0xFFFFE744 (-6332) Loc: +0x38C8    | offset to vtable
-  +0x2010 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2020       | offset to field `key` (string)
-  +0x2014 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2018        | offset to field `value` (string)
+  +0x200C | 44 E7 FF FF             | SOffset32  | 0xFFFFE744 (-6332) Loc: 0x38C8     | offset to vtable
+  +0x2010 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2020        | offset to field `key` (string)
+  +0x2014 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2018         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2018 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x201C | 33 30                   | char[2]     | 30                                 | string literal
-  +0x201E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2018 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x201C | 33 30                   | char[2]    | 30                                 | string literal
+  +0x201E | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x2020 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2024 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2026 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2020 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2024 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2026 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x2028 | 60 E7 FF FF             | SOffset32   | 0xFFFFE760 (-6304) Loc: +0x38C8    | offset to vtable
-  +0x202C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x203C       | offset to field `key` (string)
-  +0x2030 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2034        | offset to field `value` (string)
+  +0x2028 | 60 E7 FF FF             | SOffset32  | 0xFFFFE760 (-6304) Loc: 0x38C8     | offset to vtable
+  +0x202C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x203C        | offset to field `key` (string)
+  +0x2030 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2034         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2034 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2038 | 30                      | char[1]     | 0                                  | string literal
-  +0x2039 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2034 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2038 | 30                      | char[1]    | 0                                  | string literal
+  +0x2039 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x203A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x203A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x203C | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                    | length of string
-  +0x2040 | 66 6C 65 78 62 75 66 66 | char[10]    | flexbuff                           | string literal
-  +0x2048 | 65 72                   |             | er
-  +0x204A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x203C | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                    | length of string
+  +0x2040 | 66 6C 65 78 62 75 66 66 | char[10]   | flexbuff                           | string literal
+  +0x2048 | 65 72                   |            | er
+  +0x204A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x204C | 0C F4 FF FF             | SOffset32   | 0xFFFFF40C (-3060) Loc: +0x2C40    | offset to vtable
-  +0x2050 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x2052 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x2053 | 04                      | uint8_t     | 0x04 (4)                           | table field `element` (Byte)
-  +0x2054 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x204C | 0C F4 FF FF             | SOffset32  | 0xFFFFF40C (-3060) Loc: 0x2C40     | offset to vtable
+  +0x2050 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x2052 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x2053 | 04                      | uint8_t    | 0x04 (4)                           | table field `element` (Byte)
+  +0x2054 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2058 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x205C | 66 6C 65 78             | char[4]     | flex                               | string literal
-  +0x2060 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2058 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x205C | 66 6C 65 78             | char[4]    | flex                               | string literal
+  +0x2060 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2061 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2061 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x2064 | 7C F4 FF FF             | SOffset32   | 0xFFFFF47C (-2948) Loc: +0x2BE8    | offset to vtable
-  +0x2068 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x206B | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x206C | 1D 00                   | uint16_t    | 0x001D (29)                        | table field `id` (UShort)
-  +0x206E | 3E 00                   | uint16_t    | 0x003E (62)                        | table field `offset` (UShort)
-  +0x2070 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x20B0       | offset to field `name` (string)
-  +0x2074 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x20A0       | offset to field `type` (table)
-  +0x2078 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x207C        | offset to field `attributes` (vector)
+  +0x2064 | 7C F4 FF FF             | SOffset32  | 0xFFFFF47C (-2948) Loc: 0x2BE8     | offset to vtable
+  +0x2068 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x206B | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x206C | 1D 00                   | uint16_t   | 0x001D (29)                        | table field `id` (UShort)
+  +0x206E | 3E 00                   | uint16_t   | 0x003E (62)                        | table field `offset` (UShort)
+  +0x2070 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x20B0        | offset to field `name` (string)
+  +0x2074 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x20A0        | offset to field `type` (table)
+  +0x2078 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x207C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x207C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2080 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2084        | offset to table[0]
+  +0x207C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2080 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2084         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2084 | BC E7 FF FF             | SOffset32   | 0xFFFFE7BC (-6212) Loc: +0x38C8    | offset to vtable
-  +0x2088 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2098       | offset to field `key` (string)
-  +0x208C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2090        | offset to field `value` (string)
+  +0x2084 | BC E7 FF FF             | SOffset32  | 0xFFFFE7BC (-6212) Loc: 0x38C8     | offset to vtable
+  +0x2088 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2098        | offset to field `key` (string)
+  +0x208C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2090         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2090 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2094 | 32 39                   | char[2]     | 29                                 | string literal
-  +0x2096 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2090 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2094 | 32 39                   | char[2]    | 29                                 | string literal
+  +0x2096 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x2098 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x209C | 69 64                   | char[2]     | id                                 | string literal
-  +0x209E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2098 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x209C | 69 64                   | char[2]    | id                                 | string literal
+  +0x209E | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x20A0 | 2C F6 FF FF             | SOffset32   | 0xFFFFF62C (-2516) Loc: +0x2A74    | offset to vtable
-  +0x20A4 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x20A6 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x20A7 | 0F                      | uint8_t     | 0x0F (15)                          | table field `element` (Byte)
-  +0x20A8 | 00 00 00 00             | uint32_t    | 0x00000000 (0)                     | table field `index` (Int)
-  +0x20AC | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `element_size` (UInt)
+  +0x20A0 | 2C F6 FF FF             | SOffset32  | 0xFFFFF62C (-2516) Loc: 0x2A74     | offset to vtable
+  +0x20A4 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x20A6 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x20A7 | 0F                      | uint8_t    | 0x0F (15)                          | table field `element` (Byte)
+  +0x20A8 | 00 00 00 00             | uint32_t   | 0x00000000 (0)                     | table field `index` (Int)
+  +0x20AC | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x20B0 | 17 00 00 00             | uint32_t    | 0x00000017 (23)                    | length of string
-  +0x20B4 | 74 65 73 74 61 72 72 61 | char[23]    | testarra                           | string literal
-  +0x20BC | 79 6F 66 73 6F 72 74 65 |             | yofsorte
-  +0x20C4 | 64 73 74 72 75 63 74    |             | dstruct
-  +0x20CB | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x20B0 | 17 00 00 00             | uint32_t   | 0x00000017 (23)                    | length of string
+  +0x20B4 | 74 65 73 74 61 72 72 61 | char[23]   | testarra                           | string literal
+  +0x20BC | 79 6F 66 73 6F 72 74 65 |            | yofsorte
+  +0x20C4 | 64 73 74 72 75 63 74    |            | dstruct
+  +0x20CB | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x20CC | E4 F4 FF FF             | SOffset32   | 0xFFFFF4E4 (-2844) Loc: +0x2BE8    | offset to vtable
-  +0x20D0 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x20D3 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x20D4 | 1C 00                   | uint16_t    | 0x001C (28)                        | table field `id` (UShort)
-  +0x20D6 | 3C 00                   | uint16_t    | 0x003C (60)                        | table field `offset` (UShort)
-  +0x20D8 | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x2114       | offset to field `name` (string)
-  +0x20DC | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x2108       | offset to field `type` (table)
-  +0x20E0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x20E4        | offset to field `attributes` (vector)
+  +0x20CC | E4 F4 FF FF             | SOffset32  | 0xFFFFF4E4 (-2844) Loc: 0x2BE8     | offset to vtable
+  +0x20D0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x20D3 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x20D4 | 1C 00                   | uint16_t   | 0x001C (28)                        | table field `id` (UShort)
+  +0x20D6 | 3C 00                   | uint16_t   | 0x003C (60)                        | table field `offset` (UShort)
+  +0x20D8 | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x2114        | offset to field `name` (string)
+  +0x20DC | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x2108        | offset to field `type` (table)
+  +0x20E0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x20E4         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x20E4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x20E8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x20EC        | offset to table[0]
+  +0x20E4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x20E8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x20EC         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x20EC | 24 E8 FF FF             | SOffset32   | 0xFFFFE824 (-6108) Loc: +0x38C8    | offset to vtable
-  +0x20F0 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2100       | offset to field `key` (string)
-  +0x20F4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x20F8        | offset to field `value` (string)
+  +0x20EC | 24 E8 FF FF             | SOffset32  | 0xFFFFE824 (-6108) Loc: 0x38C8     | offset to vtable
+  +0x20F0 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2100        | offset to field `key` (string)
+  +0x20F4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x20F8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x20F8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x20FC | 32 38                   | char[2]     | 28                                 | string literal
-  +0x20FE | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x20F8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x20FC | 32 38                   | char[2]    | 28                                 | string literal
+  +0x20FE | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x2100 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2104 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2106 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2100 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2104 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2106 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2108 | C8 F4 FF FF             | SOffset32   | 0xFFFFF4C8 (-2872) Loc: +0x2C40    | offset to vtable
-  +0x210C | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x210E | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x210F | 0D                      | uint8_t     | 0x0D (13)                          | table field `element` (Byte)
-  +0x2110 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `element_size` (UInt)
+  +0x2108 | C8 F4 FF FF             | SOffset32  | 0xFFFFF4C8 (-2872) Loc: 0x2C40     | offset to vtable
+  +0x210C | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x210E | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x210F | 0D                      | uint8_t    | 0x0D (13)                          | table field `element` (Byte)
+  +0x2110 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2114 | 12 00 00 00             | uint32_t    | 0x00000012 (18)                    | length of string
-  +0x2118 | 74 65 73 74 61 72 72 61 | char[18]    | testarra                           | string literal
-  +0x2120 | 79 6F 66 73 74 72 69 6E |             | yofstrin
-  +0x2128 | 67 32                   |             | g2
-  +0x212A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2114 | 12 00 00 00             | uint32_t   | 0x00000012 (18)                    | length of string
+  +0x2118 | 74 65 73 74 61 72 72 61 | char[18]   | testarra                           | string literal
+  +0x2120 | 79 6F 66 73 74 72 69 6E |            | yofstrin
+  +0x2128 | 67 32                   |            | g2
+  +0x212A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x212C | 34 F6 FF FF             | SOffset32   | 0xFFFFF634 (-2508) Loc: +0x2AF8    | offset to vtable
-  +0x2130 | 1B 00                   | uint16_t    | 0x001B (27)                        | table field `id` (UShort)
-  +0x2132 | 3A 00                   | uint16_t    | 0x003A (58)                        | table field `offset` (UShort)
-  +0x2134 | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x2170       | offset to field `name` (string)
-  +0x2138 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x2164       | offset to field `type` (table)
-  +0x213C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2140        | offset to field `attributes` (vector)
+  +0x212C | 34 F6 FF FF             | SOffset32  | 0xFFFFF634 (-2508) Loc: 0x2AF8     | offset to vtable
+  +0x2130 | 1B 00                   | uint16_t   | 0x001B (27)                        | table field `id` (UShort)
+  +0x2132 | 3A 00                   | uint16_t   | 0x003A (58)                        | table field `offset` (UShort)
+  +0x2134 | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x2170        | offset to field `name` (string)
+  +0x2138 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x2164        | offset to field `type` (table)
+  +0x213C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2140         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2140 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2144 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2148        | offset to table[0]
+  +0x2140 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2144 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2148         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2148 | 80 E8 FF FF             | SOffset32   | 0xFFFFE880 (-6016) Loc: +0x38C8    | offset to vtable
-  +0x214C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x215C       | offset to field `key` (string)
-  +0x2150 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2154        | offset to field `value` (string)
+  +0x2148 | 80 E8 FF FF             | SOffset32  | 0xFFFFE880 (-6016) Loc: 0x38C8     | offset to vtable
+  +0x214C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x215C        | offset to field `key` (string)
+  +0x2150 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2154         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2154 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2158 | 32 37                   | char[2]     | 27                                 | string literal
-  +0x215A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2154 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2158 | 32 37                   | char[2]    | 27                                 | string literal
+  +0x215A | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x215C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2160 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2162 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x215C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2160 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2162 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2164 | 88 E8 FF FF             | SOffset32   | 0xFFFFE888 (-6008) Loc: +0x38DC    | offset to vtable
-  +0x2168 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x216B | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x216C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2164 | 88 E8 FF FF             | SOffset32  | 0xFFFFE888 (-6008) Loc: 0x38DC     | offset to vtable
+  +0x2168 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x216B | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x216C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2170 | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | length of string
-  +0x2174 | 74 65 73 74 66 33       | char[6]     | testf3                             | string literal
-  +0x217A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2170 | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | length of string
+  +0x2174 | 74 65 73 74 66 33       | char[6]    | testf3                             | string literal
+  +0x217A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x217C | A8 FF FF FF             | SOffset32   | 0xFFFFFFA8 (-88) Loc: +0x21D4      | offset to vtable
-  +0x2180 | 1A 00                   | uint16_t    | 0x001A (26)                        | table field `id` (UShort)
-  +0x2182 | 38 00                   | uint16_t    | 0x0038 (56)                        | table field `offset` (UShort)
-  +0x2184 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x21C8       | offset to field `name` (string)
-  +0x2188 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x21BC       | offset to field `type` (table)
-  +0x218C | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x2198       | offset to field `attributes` (vector)
-  +0x2190 | 00 00 00 00 00 00 08 40 | double      | 0x4008000000000000 (3)             | table field `default_real` (Double)
+  +0x217C | A8 FF FF FF             | SOffset32  | 0xFFFFFFA8 (-88) Loc: 0x21D4       | offset to vtable
+  +0x2180 | 1A 00                   | uint16_t   | 0x001A (26)                        | table field `id` (UShort)
+  +0x2182 | 38 00                   | uint16_t   | 0x0038 (56)                        | table field `offset` (UShort)
+  +0x2184 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x21C8        | offset to field `name` (string)
+  +0x2188 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x21BC        | offset to field `type` (table)
+  +0x218C | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x2198        | offset to field `attributes` (vector)
+  +0x2190 | 00 00 00 00 00 00 08 40 | double     | 0x4008000000000000 (3)             | table field `default_real` (Double)
 
 vector (reflection.Field.attributes):
-  +0x2198 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x219C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x21A0        | offset to table[0]
+  +0x2198 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x219C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x21A0         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x21A0 | D8 E8 FF FF             | SOffset32   | 0xFFFFE8D8 (-5928) Loc: +0x38C8    | offset to vtable
-  +0x21A4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x21B4       | offset to field `key` (string)
-  +0x21A8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x21AC        | offset to field `value` (string)
+  +0x21A0 | D8 E8 FF FF             | SOffset32  | 0xFFFFE8D8 (-5928) Loc: 0x38C8     | offset to vtable
+  +0x21A4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x21B4        | offset to field `key` (string)
+  +0x21A8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x21AC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x21AC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x21B0 | 32 36                   | char[2]     | 26                                 | string literal
-  +0x21B2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x21AC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x21B0 | 32 36                   | char[2]    | 26                                 | string literal
+  +0x21B2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x21B4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x21B8 | 69 64                   | char[2]     | id                                 | string literal
-  +0x21BA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x21B4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x21B8 | 69 64                   | char[2]    | id                                 | string literal
+  +0x21BA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x21BC | E0 E8 FF FF             | SOffset32   | 0xFFFFE8E0 (-5920) Loc: +0x38DC    | offset to vtable
-  +0x21C0 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x21C3 | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x21C4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x21BC | E0 E8 FF FF             | SOffset32  | 0xFFFFE8E0 (-5920) Loc: 0x38DC     | offset to vtable
+  +0x21C0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x21C3 | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x21C4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x21C8 | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | length of string
-  +0x21CC | 74 65 73 74 66 32       | char[6]     | testf2                             | string literal
-  +0x21D2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x21C8 | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | length of string
+  +0x21CC | 74 65 73 74 66 32       | char[6]    | testf2                             | string literal
+  +0x21D2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Field):
-  +0x21D4 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of this vtable
-  +0x21D6 | 1C 00                   | uint16_t    | 0x001C (28)                        | size of referring table
-  +0x21D8 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x21DA | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x21DC | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `id` (id: 2)
-  +0x21DE | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `offset` (id: 3)
-  +0x21E0 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x21E2 | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `default_real` (id: 5)
-  +0x21E4 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x21E6 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x21E8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x21EA | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 9)
+  +0x21D4 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of this vtable
+  +0x21D6 | 1C 00                   | uint16_t   | 0x001C (28)                        | size of referring table
+  +0x21D8 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x21DA | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x21DC | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `id` (id: 2)
+  +0x21DE | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `offset` (id: 3)
+  +0x21E0 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x21E2 | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `default_real` (id: 5)
+  +0x21E4 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x21E6 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x21E8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x21EA | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 9)
 
 table (reflection.Field):
-  +0x21EC | 18 00 00 00             | SOffset32   | 0x00000018 (24) Loc: +0x21D4       | offset to vtable
-  +0x21F0 | 19 00                   | uint16_t    | 0x0019 (25)                        | table field `id` (UShort)
-  +0x21F2 | 36 00                   | uint16_t    | 0x0036 (54)                        | table field `offset` (UShort)
-  +0x21F4 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x2238       | offset to field `name` (string)
-  +0x21F8 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x222C       | offset to field `type` (table)
-  +0x21FC | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x2208       | offset to field `attributes` (vector)
-  +0x2200 | 6E 86 1B F0 F9 21 09 40 | double      | 0x400921F9F01B866E (3.14159)       | table field `default_real` (Double)
+  +0x21EC | 18 00 00 00             | SOffset32  | 0x00000018 (24) Loc: 0x21D4        | offset to vtable
+  +0x21F0 | 19 00                   | uint16_t   | 0x0019 (25)                        | table field `id` (UShort)
+  +0x21F2 | 36 00                   | uint16_t   | 0x0036 (54)                        | table field `offset` (UShort)
+  +0x21F4 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x2238        | offset to field `name` (string)
+  +0x21F8 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x222C        | offset to field `type` (table)
+  +0x21FC | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x2208        | offset to field `attributes` (vector)
+  +0x2200 | 6E 86 1B F0 F9 21 09 40 | double     | 0x400921F9F01B866E (3.14159)       | table field `default_real` (Double)
 
 vector (reflection.Field.attributes):
-  +0x2208 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x220C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2210        | offset to table[0]
+  +0x2208 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x220C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2210         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2210 | 48 E9 FF FF             | SOffset32   | 0xFFFFE948 (-5816) Loc: +0x38C8    | offset to vtable
-  +0x2214 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2224       | offset to field `key` (string)
-  +0x2218 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x221C        | offset to field `value` (string)
+  +0x2210 | 48 E9 FF FF             | SOffset32  | 0xFFFFE948 (-5816) Loc: 0x38C8     | offset to vtable
+  +0x2214 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2224        | offset to field `key` (string)
+  +0x2218 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x221C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x221C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2220 | 32 35                   | char[2]     | 25                                 | string literal
-  +0x2222 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x221C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2220 | 32 35                   | char[2]    | 25                                 | string literal
+  +0x2222 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x2224 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2228 | 69 64                   | char[2]     | id                                 | string literal
-  +0x222A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2224 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2228 | 69 64                   | char[2]    | id                                 | string literal
+  +0x222A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x222C | 50 E9 FF FF             | SOffset32   | 0xFFFFE950 (-5808) Loc: +0x38DC    | offset to vtable
-  +0x2230 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2233 | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x2234 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x222C | 50 E9 FF FF             | SOffset32  | 0xFFFFE950 (-5808) Loc: 0x38DC     | offset to vtable
+  +0x2230 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2233 | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x2234 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2238 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x223C | 74 65 73 74 66          | char[5]     | testf                              | string literal
-  +0x2241 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2238 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x223C | 74 65 73 74 66          | char[5]    | testf                              | string literal
+  +0x2241 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2242 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2242 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x2244 | 5C F6 FF FF             | SOffset32   | 0xFFFFF65C (-2468) Loc: +0x2BE8    | offset to vtable
-  +0x2248 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x224B | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x224C | 18 00                   | uint16_t    | 0x0018 (24)                        | table field `id` (UShort)
-  +0x224E | 34 00                   | uint16_t    | 0x0034 (52)                        | table field `offset` (UShort)
-  +0x2250 | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x228C       | offset to field `name` (string)
-  +0x2254 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x2280       | offset to field `type` (table)
-  +0x2258 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x225C        | offset to field `attributes` (vector)
+  +0x2244 | 5C F6 FF FF             | SOffset32  | 0xFFFFF65C (-2468) Loc: 0x2BE8     | offset to vtable
+  +0x2248 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x224B | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x224C | 18 00                   | uint16_t   | 0x0018 (24)                        | table field `id` (UShort)
+  +0x224E | 34 00                   | uint16_t   | 0x0034 (52)                        | table field `offset` (UShort)
+  +0x2250 | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x228C        | offset to field `name` (string)
+  +0x2254 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x2280        | offset to field `type` (table)
+  +0x2258 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x225C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x225C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2260 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2264        | offset to table[0]
+  +0x225C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2260 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2264         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2264 | 9C E9 FF FF             | SOffset32   | 0xFFFFE99C (-5732) Loc: +0x38C8    | offset to vtable
-  +0x2268 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2278       | offset to field `key` (string)
-  +0x226C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2270        | offset to field `value` (string)
+  +0x2264 | 9C E9 FF FF             | SOffset32  | 0xFFFFE99C (-5732) Loc: 0x38C8     | offset to vtable
+  +0x2268 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2278        | offset to field `key` (string)
+  +0x226C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2270         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2270 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2274 | 32 34                   | char[2]     | 24                                 | string literal
-  +0x2276 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2270 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2274 | 32 34                   | char[2]    | 24                                 | string literal
+  +0x2276 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x2278 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x227C | 69 64                   | char[2]     | id                                 | string literal
-  +0x227E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2278 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x227C | 69 64                   | char[2]    | id                                 | string literal
+  +0x227E | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2280 | 40 F6 FF FF             | SOffset32   | 0xFFFFF640 (-2496) Loc: +0x2C40    | offset to vtable
-  +0x2284 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x2286 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x2287 | 02                      | uint8_t     | 0x02 (2)                           | table field `element` (Byte)
-  +0x2288 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2280 | 40 F6 FF FF             | SOffset32  | 0xFFFFF640 (-2496) Loc: 0x2C40     | offset to vtable
+  +0x2284 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x2286 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x2287 | 02                      | uint8_t    | 0x02 (2)                           | table field `element` (Byte)
+  +0x2288 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x228C | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x2290 | 74 65 73 74 61 72 72 61 | char[16]    | testarra                           | string literal
-  +0x2298 | 79 6F 66 62 6F 6F 6C 73 |             | yofbools
-  +0x22A0 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x228C | 10 00 00 00             | uint32_t   | 0x00000010 (16)                    | length of string
+  +0x2290 | 74 65 73 74 61 72 72 61 | char[16]   | testarra                           | string literal
+  +0x2298 | 79 6F 66 62 6F 6F 6C 73 |            | yofbools
+  +0x22A0 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x22A1 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x22A1 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x22A4 | AC F7 FF FF             | SOffset32   | 0xFFFFF7AC (-2132) Loc: +0x2AF8    | offset to vtable
-  +0x22A8 | 17 00                   | uint16_t    | 0x0017 (23)                        | table field `id` (UShort)
-  +0x22AA | 32 00                   | uint16_t    | 0x0032 (50)                        | table field `offset` (UShort)
-  +0x22AC | 6C 00 00 00             | UOffset32   | 0x0000006C (108) Loc: +0x2318      | offset to field `name` (string)
-  +0x22B0 | 58 00 00 00             | UOffset32   | 0x00000058 (88) Loc: +0x2308       | offset to field `type` (table)
-  +0x22B4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x22B8        | offset to field `attributes` (vector)
+  +0x22A4 | AC F7 FF FF             | SOffset32  | 0xFFFFF7AC (-2132) Loc: 0x2AF8     | offset to vtable
+  +0x22A8 | 17 00                   | uint16_t   | 0x0017 (23)                        | table field `id` (UShort)
+  +0x22AA | 32 00                   | uint16_t   | 0x0032 (50)                        | table field `offset` (UShort)
+  +0x22AC | 6C 00 00 00             | UOffset32  | 0x0000006C (108) Loc: 0x2318       | offset to field `name` (string)
+  +0x22B0 | 58 00 00 00             | UOffset32  | 0x00000058 (88) Loc: 0x2308        | offset to field `type` (table)
+  +0x22B4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x22B8         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x22B8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x22BC | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x22E0       | offset to table[0]
-  +0x22C0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x22C4        | offset to table[1]
+  +0x22B8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x22BC | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x22E0        | offset to table[0]
+  +0x22C0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x22C4         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x22C4 | FC E9 FF FF             | SOffset32   | 0xFFFFE9FC (-5636) Loc: +0x38C8    | offset to vtable
-  +0x22C8 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x22D8       | offset to field `key` (string)
-  +0x22CC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x22D0        | offset to field `value` (string)
+  +0x22C4 | FC E9 FF FF             | SOffset32  | 0xFFFFE9FC (-5636) Loc: 0x38C8     | offset to vtable
+  +0x22C8 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x22D8        | offset to field `key` (string)
+  +0x22CC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x22D0         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x22D0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x22D4 | 32 33                   | char[2]     | 23                                 | string literal
-  +0x22D6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x22D0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x22D4 | 32 33                   | char[2]    | 23                                 | string literal
+  +0x22D6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x22D8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x22DC | 69 64                   | char[2]     | id                                 | string literal
-  +0x22DE | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x22D8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x22DC | 69 64                   | char[2]    | id                                 | string literal
+  +0x22DE | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x22E0 | 18 EA FF FF             | SOffset32   | 0xFFFFEA18 (-5608) Loc: +0x38C8    | offset to vtable
-  +0x22E4 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x22FC       | offset to field `key` (string)
-  +0x22E8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x22EC        | offset to field `value` (string)
+  +0x22E0 | 18 EA FF FF             | SOffset32  | 0xFFFFEA18 (-5608) Loc: 0x38C8     | offset to vtable
+  +0x22E4 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x22FC        | offset to field `key` (string)
+  +0x22E8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x22EC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x22EC | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x22F0 | 66 6E 76 31 61 5F 36 34 | char[8]     | fnv1a_64                           | string literal
-  +0x22F8 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x22EC | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x22F0 | 66 6E 76 31 61 5F 36 34 | char[8]    | fnv1a_64                           | string literal
+  +0x22F8 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x22F9 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x22F9 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x22FC | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x2300 | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x2304 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x22FC | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x2300 | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x2304 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2305 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2305 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x2308 | 94 EC FF FF             | SOffset32   | 0xFFFFEC94 (-4972) Loc: +0x3674    | offset to vtable
-  +0x230C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x230F | 0A                      | uint8_t     | 0x0A (10)                          | table field `base_type` (Byte)
-  +0x2310 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x2314 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2308 | 94 EC FF FF             | SOffset32  | 0xFFFFEC94 (-4972) Loc: 0x3674     | offset to vtable
+  +0x230C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x230F | 0A                      | uint8_t    | 0x0A (10)                          | table field `base_type` (Byte)
+  +0x2310 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x2314 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2318 | 11 00 00 00             | uint32_t    | 0x00000011 (17)                    | length of string
-  +0x231C | 74 65 73 74 68 61 73 68 | char[17]    | testhash                           | string literal
-  +0x2324 | 75 36 34 5F 66 6E 76 31 |             | u64_fnv1
-  +0x232C | 61                      |             | a
-  +0x232D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2318 | 11 00 00 00             | uint32_t   | 0x00000011 (17)                    | length of string
+  +0x231C | 74 65 73 74 68 61 73 68 | char[17]   | testhash                           | string literal
+  +0x2324 | 75 36 34 5F 66 6E 76 31 |            | u64_fnv1
+  +0x232C | 61                      |            | a
+  +0x232D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x232E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x232E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x2330 | 38 F8 FF FF             | SOffset32   | 0xFFFFF838 (-1992) Loc: +0x2AF8    | offset to vtable
-  +0x2334 | 16 00                   | uint16_t    | 0x0016 (22)                        | table field `id` (UShort)
-  +0x2336 | 30 00                   | uint16_t    | 0x0030 (48)                        | table field `offset` (UShort)
-  +0x2338 | 6C 00 00 00             | UOffset32   | 0x0000006C (108) Loc: +0x23A4      | offset to field `name` (string)
-  +0x233C | 58 00 00 00             | UOffset32   | 0x00000058 (88) Loc: +0x2394       | offset to field `type` (table)
-  +0x2340 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2344        | offset to field `attributes` (vector)
+  +0x2330 | 38 F8 FF FF             | SOffset32  | 0xFFFFF838 (-1992) Loc: 0x2AF8     | offset to vtable
+  +0x2334 | 16 00                   | uint16_t   | 0x0016 (22)                        | table field `id` (UShort)
+  +0x2336 | 30 00                   | uint16_t   | 0x0030 (48)                        | table field `offset` (UShort)
+  +0x2338 | 6C 00 00 00             | UOffset32  | 0x0000006C (108) Loc: 0x23A4       | offset to field `name` (string)
+  +0x233C | 58 00 00 00             | UOffset32  | 0x00000058 (88) Loc: 0x2394        | offset to field `type` (table)
+  +0x2340 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2344         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2344 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x2348 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x236C       | offset to table[0]
-  +0x234C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2350        | offset to table[1]
+  +0x2344 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x2348 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x236C        | offset to table[0]
+  +0x234C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2350         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x2350 | 88 EA FF FF             | SOffset32   | 0xFFFFEA88 (-5496) Loc: +0x38C8    | offset to vtable
-  +0x2354 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2364       | offset to field `key` (string)
-  +0x2358 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x235C        | offset to field `value` (string)
+  +0x2350 | 88 EA FF FF             | SOffset32  | 0xFFFFEA88 (-5496) Loc: 0x38C8     | offset to vtable
+  +0x2354 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2364        | offset to field `key` (string)
+  +0x2358 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x235C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x235C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2360 | 32 32                   | char[2]     | 22                                 | string literal
-  +0x2362 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x235C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2360 | 32 32                   | char[2]    | 22                                 | string literal
+  +0x2362 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x2364 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2368 | 69 64                   | char[2]     | id                                 | string literal
-  +0x236A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2364 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2368 | 69 64                   | char[2]    | id                                 | string literal
+  +0x236A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x236C | A4 EA FF FF             | SOffset32   | 0xFFFFEAA4 (-5468) Loc: +0x38C8    | offset to vtable
-  +0x2370 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x2388       | offset to field `key` (string)
-  +0x2374 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2378        | offset to field `value` (string)
+  +0x236C | A4 EA FF FF             | SOffset32  | 0xFFFFEAA4 (-5468) Loc: 0x38C8     | offset to vtable
+  +0x2370 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x2388        | offset to field `key` (string)
+  +0x2374 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2378         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2378 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x237C | 66 6E 76 31 61 5F 36 34 | char[8]     | fnv1a_64                           | string literal
-  +0x2384 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2378 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x237C | 66 6E 76 31 61 5F 36 34 | char[8]    | fnv1a_64                           | string literal
+  +0x2384 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2385 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2385 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x2388 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x238C | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x2390 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2388 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x238C | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x2390 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2391 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2391 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x2394 | 20 ED FF FF             | SOffset32   | 0xFFFFED20 (-4832) Loc: +0x3674    | offset to vtable
-  +0x2398 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x239B | 09                      | uint8_t     | 0x09 (9)                           | table field `base_type` (Byte)
-  +0x239C | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x23A0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2394 | 20 ED FF FF             | SOffset32  | 0xFFFFED20 (-4832) Loc: 0x3674     | offset to vtable
+  +0x2398 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x239B | 09                      | uint8_t    | 0x09 (9)                           | table field `base_type` (Byte)
+  +0x239C | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x23A0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x23A4 | 11 00 00 00             | uint32_t    | 0x00000011 (17)                    | length of string
-  +0x23A8 | 74 65 73 74 68 61 73 68 | char[17]    | testhash                           | string literal
-  +0x23B0 | 73 36 34 5F 66 6E 76 31 |             | s64_fnv1
-  +0x23B8 | 61                      |             | a
-  +0x23B9 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x23A4 | 11 00 00 00             | uint32_t   | 0x00000011 (17)                    | length of string
+  +0x23A8 | 74 65 73 74 68 61 73 68 | char[17]   | testhash                           | string literal
+  +0x23B0 | 73 36 34 5F 66 6E 76 31 |            | s64_fnv1
+  +0x23B8 | 61                      |            | a
+  +0x23B9 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x23BA | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x23BA | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x23BC | C4 F8 FF FF             | SOffset32   | 0xFFFFF8C4 (-1852) Loc: +0x2AF8    | offset to vtable
-  +0x23C0 | 15 00                   | uint16_t    | 0x0015 (21)                        | table field `id` (UShort)
-  +0x23C2 | 2E 00                   | uint16_t    | 0x002E (46)                        | table field `offset` (UShort)
-  +0x23C4 | C4 00 00 00             | UOffset32   | 0x000000C4 (196) Loc: +0x2488      | offset to field `name` (string)
-  +0x23C8 | B4 00 00 00             | UOffset32   | 0x000000B4 (180) Loc: +0x247C      | offset to field `type` (table)
-  +0x23CC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x23D0        | offset to field `attributes` (vector)
+  +0x23BC | C4 F8 FF FF             | SOffset32  | 0xFFFFF8C4 (-1852) Loc: 0x2AF8     | offset to vtable
+  +0x23C0 | 15 00                   | uint16_t   | 0x0015 (21)                        | table field `id` (UShort)
+  +0x23C2 | 2E 00                   | uint16_t   | 0x002E (46)                        | table field `offset` (UShort)
+  +0x23C4 | C4 00 00 00             | UOffset32  | 0x000000C4 (196) Loc: 0x2488       | offset to field `name` (string)
+  +0x23C8 | B4 00 00 00             | UOffset32  | 0x000000B4 (180) Loc: 0x247C       | offset to field `type` (table)
+  +0x23CC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x23D0         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x23D0 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of vector (# items)
-  +0x23D4 | 7C 00 00 00             | UOffset32   | 0x0000007C (124) Loc: +0x2450      | offset to table[0]
-  +0x23D8 | 50 00 00 00             | UOffset32   | 0x00000050 (80) Loc: +0x2428       | offset to table[1]
-  +0x23DC | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x2400       | offset to table[2]
-  +0x23E0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x23E4        | offset to table[3]
+  +0x23D0 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of vector (# items)
+  +0x23D4 | 7C 00 00 00             | UOffset32  | 0x0000007C (124) Loc: 0x2450       | offset to table[0]
+  +0x23D8 | 50 00 00 00             | UOffset32  | 0x00000050 (80) Loc: 0x2428        | offset to table[1]
+  +0x23DC | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x2400        | offset to table[2]
+  +0x23E0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x23E4         | offset to table[3]
 
 table (reflection.KeyValue):
-  +0x23E4 | 1C EB FF FF             | SOffset32   | 0xFFFFEB1C (-5348) Loc: +0x38C8    | offset to vtable
-  +0x23E8 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x23F8       | offset to field `key` (string)
-  +0x23EC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x23F0        | offset to field `value` (string)
+  +0x23E4 | 1C EB FF FF             | SOffset32  | 0xFFFFEB1C (-5348) Loc: 0x38C8     | offset to vtable
+  +0x23E8 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x23F8        | offset to field `key` (string)
+  +0x23EC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x23F0         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x23F0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x23F4 | 32 31                   | char[2]     | 21                                 | string literal
-  +0x23F6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x23F0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x23F4 | 32 31                   | char[2]    | 21                                 | string literal
+  +0x23F6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x23F8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x23FC | 69 64                   | char[2]     | id                                 | string literal
-  +0x23FE | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x23F8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x23FC | 69 64                   | char[2]    | id                                 | string literal
+  +0x23FE | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x2400 | 38 EB FF FF             | SOffset32   | 0xFFFFEB38 (-5320) Loc: +0x38C8    | offset to vtable
-  +0x2404 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x241C       | offset to field `key` (string)
-  +0x2408 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x240C        | offset to field `value` (string)
+  +0x2400 | 38 EB FF FF             | SOffset32  | 0xFFFFEB38 (-5320) Loc: 0x38C8     | offset to vtable
+  +0x2404 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x241C        | offset to field `key` (string)
+  +0x2408 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x240C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x240C | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x2410 | 66 6E 76 31 61 5F 33 32 | char[8]     | fnv1a_32                           | string literal
-  +0x2418 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x240C | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x2410 | 66 6E 76 31 61 5F 33 32 | char[8]    | fnv1a_32                           | string literal
+  +0x2418 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2419 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2419 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x241C | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x2420 | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x2424 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x241C | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x2420 | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x2424 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2425 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2425 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x2428 | 60 EB FF FF             | SOffset32   | 0xFFFFEB60 (-5280) Loc: +0x38C8    | offset to vtable
-  +0x242C | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x2440       | offset to field `key` (string)
-  +0x2430 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2434        | offset to field `value` (string)
+  +0x2428 | 60 EB FF FF             | SOffset32  | 0xFFFFEB60 (-5280) Loc: 0x38C8     | offset to vtable
+  +0x242C | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x2440        | offset to field `key` (string)
+  +0x2430 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2434         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2434 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x2438 | 53 74 61 74             | char[4]     | Stat                               | string literal
-  +0x243C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2434 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x2438 | 53 74 61 74             | char[4]    | Stat                               | string literal
+  +0x243C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x243D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x243D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x2440 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x2444 | 63 70 70 5F 74 79 70 65 | char[8]     | cpp_type                           | string literal
-  +0x244C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2440 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x2444 | 63 70 70 5F 74 79 70 65 | char[8]    | cpp_type                           | string literal
+  +0x244C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x244D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x244D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x2450 | 88 EB FF FF             | SOffset32   | 0xFFFFEB88 (-5240) Loc: +0x38C8    | offset to vtable
-  +0x2454 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x2468       | offset to field `key` (string)
-  +0x2458 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x245C        | offset to field `value` (string)
+  +0x2450 | 88 EB FF FF             | SOffset32  | 0xFFFFEB88 (-5240) Loc: 0x38C8     | offset to vtable
+  +0x2454 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x2468        | offset to field `key` (string)
+  +0x2458 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x245C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x245C | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x2460 | 6E 61 6B 65 64          | char[5]     | naked                              | string literal
-  +0x2465 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x245C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x2460 | 6E 61 6B 65 64          | char[5]    | naked                              | string literal
+  +0x2465 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2466 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2466 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2468 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                    | length of string
-  +0x246C | 63 70 70 5F 70 74 72 5F | char[12]    | cpp_ptr_                           | string literal
-  +0x2474 | 74 79 70 65             |             | type
-  +0x2478 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2468 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                    | length of string
+  +0x246C | 63 70 70 5F 70 74 72 5F | char[12]   | cpp_ptr_                           | string literal
+  +0x2474 | 74 79 70 65             |            | type
+  +0x2478 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2479 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2479 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x247C | A0 EB FF FF             | SOffset32   | 0xFFFFEBA0 (-5216) Loc: +0x38DC    | offset to vtable
-  +0x2480 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2483 | 08                      | uint8_t     | 0x08 (8)                           | table field `base_type` (Byte)
-  +0x2484 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x247C | A0 EB FF FF             | SOffset32  | 0xFFFFEBA0 (-5216) Loc: 0x38DC     | offset to vtable
+  +0x2480 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2483 | 08                      | uint8_t    | 0x08 (8)                           | table field `base_type` (Byte)
+  +0x2484 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2488 | 11 00 00 00             | uint32_t    | 0x00000011 (17)                    | length of string
-  +0x248C | 74 65 73 74 68 61 73 68 | char[17]    | testhash                           | string literal
-  +0x2494 | 75 33 32 5F 66 6E 76 31 |             | u32_fnv1
-  +0x249C | 61                      |             | a
-  +0x249D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2488 | 11 00 00 00             | uint32_t   | 0x00000011 (17)                    | length of string
+  +0x248C | 74 65 73 74 68 61 73 68 | char[17]   | testhash                           | string literal
+  +0x2494 | 75 33 32 5F 66 6E 76 31 |            | u32_fnv1
+  +0x249C | 61                      |            | a
+  +0x249D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x249E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x249E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x24A0 | A8 F9 FF FF             | SOffset32   | 0xFFFFF9A8 (-1624) Loc: +0x2AF8    | offset to vtable
-  +0x24A4 | 14 00                   | uint16_t    | 0x0014 (20)                        | table field `id` (UShort)
-  +0x24A6 | 2C 00                   | uint16_t    | 0x002C (44)                        | table field `offset` (UShort)
-  +0x24A8 | 68 00 00 00             | UOffset32   | 0x00000068 (104) Loc: +0x2510      | offset to field `name` (string)
-  +0x24AC | 58 00 00 00             | UOffset32   | 0x00000058 (88) Loc: +0x2504       | offset to field `type` (table)
-  +0x24B0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x24B4        | offset to field `attributes` (vector)
+  +0x24A0 | A8 F9 FF FF             | SOffset32  | 0xFFFFF9A8 (-1624) Loc: 0x2AF8     | offset to vtable
+  +0x24A4 | 14 00                   | uint16_t   | 0x0014 (20)                        | table field `id` (UShort)
+  +0x24A6 | 2C 00                   | uint16_t   | 0x002C (44)                        | table field `offset` (UShort)
+  +0x24A8 | 68 00 00 00             | UOffset32  | 0x00000068 (104) Loc: 0x2510       | offset to field `name` (string)
+  +0x24AC | 58 00 00 00             | UOffset32  | 0x00000058 (88) Loc: 0x2504        | offset to field `type` (table)
+  +0x24B0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x24B4         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x24B4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x24B8 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x24DC       | offset to table[0]
-  +0x24BC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x24C0        | offset to table[1]
+  +0x24B4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x24B8 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x24DC        | offset to table[0]
+  +0x24BC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x24C0         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x24C0 | F8 EB FF FF             | SOffset32   | 0xFFFFEBF8 (-5128) Loc: +0x38C8    | offset to vtable
-  +0x24C4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x24D4       | offset to field `key` (string)
-  +0x24C8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x24CC        | offset to field `value` (string)
+  +0x24C0 | F8 EB FF FF             | SOffset32  | 0xFFFFEBF8 (-5128) Loc: 0x38C8     | offset to vtable
+  +0x24C4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x24D4        | offset to field `key` (string)
+  +0x24C8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x24CC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x24CC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x24D0 | 32 30                   | char[2]     | 20                                 | string literal
-  +0x24D2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x24CC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x24D0 | 32 30                   | char[2]    | 20                                 | string literal
+  +0x24D2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x24D4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x24D8 | 69 64                   | char[2]     | id                                 | string literal
-  +0x24DA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x24D4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x24D8 | 69 64                   | char[2]    | id                                 | string literal
+  +0x24DA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x24DC | 14 EC FF FF             | SOffset32   | 0xFFFFEC14 (-5100) Loc: +0x38C8    | offset to vtable
-  +0x24E0 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x24F8       | offset to field `key` (string)
-  +0x24E4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x24E8        | offset to field `value` (string)
+  +0x24DC | 14 EC FF FF             | SOffset32  | 0xFFFFEC14 (-5100) Loc: 0x38C8     | offset to vtable
+  +0x24E0 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x24F8        | offset to field `key` (string)
+  +0x24E4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x24E8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x24E8 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x24EC | 66 6E 76 31 61 5F 33 32 | char[8]     | fnv1a_32                           | string literal
-  +0x24F4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x24E8 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x24EC | 66 6E 76 31 61 5F 33 32 | char[8]    | fnv1a_32                           | string literal
+  +0x24F4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x24F5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x24F5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x24F8 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x24FC | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x2500 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x24F8 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x24FC | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x2500 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2501 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2501 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x2504 | 28 EC FF FF             | SOffset32   | 0xFFFFEC28 (-5080) Loc: +0x38DC    | offset to vtable
-  +0x2508 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x250B | 07                      | uint8_t     | 0x07 (7)                           | table field `base_type` (Byte)
-  +0x250C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2504 | 28 EC FF FF             | SOffset32  | 0xFFFFEC28 (-5080) Loc: 0x38DC     | offset to vtable
+  +0x2508 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x250B | 07                      | uint8_t    | 0x07 (7)                           | table field `base_type` (Byte)
+  +0x250C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2510 | 11 00 00 00             | uint32_t    | 0x00000011 (17)                    | length of string
-  +0x2514 | 74 65 73 74 68 61 73 68 | char[17]    | testhash                           | string literal
-  +0x251C | 73 33 32 5F 66 6E 76 31 |             | s32_fnv1
-  +0x2524 | 61                      |             | a
-  +0x2525 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2510 | 11 00 00 00             | uint32_t   | 0x00000011 (17)                    | length of string
+  +0x2514 | 74 65 73 74 68 61 73 68 | char[17]   | testhash                           | string literal
+  +0x251C | 73 33 32 5F 66 6E 76 31 |            | s32_fnv1
+  +0x2524 | 61                      |            | a
+  +0x2525 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2526 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2526 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x2528 | 30 FA FF FF             | SOffset32   | 0xFFFFFA30 (-1488) Loc: +0x2AF8    | offset to vtable
-  +0x252C | 13 00                   | uint16_t    | 0x0013 (19)                        | table field `id` (UShort)
-  +0x252E | 2A 00                   | uint16_t    | 0x002A (42)                        | table field `offset` (UShort)
-  +0x2530 | 68 00 00 00             | UOffset32   | 0x00000068 (104) Loc: +0x2598      | offset to field `name` (string)
-  +0x2534 | 54 00 00 00             | UOffset32   | 0x00000054 (84) Loc: +0x2588       | offset to field `type` (table)
-  +0x2538 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x253C        | offset to field `attributes` (vector)
+  +0x2528 | 30 FA FF FF             | SOffset32  | 0xFFFFFA30 (-1488) Loc: 0x2AF8     | offset to vtable
+  +0x252C | 13 00                   | uint16_t   | 0x0013 (19)                        | table field `id` (UShort)
+  +0x252E | 2A 00                   | uint16_t   | 0x002A (42)                        | table field `offset` (UShort)
+  +0x2530 | 68 00 00 00             | UOffset32  | 0x00000068 (104) Loc: 0x2598       | offset to field `name` (string)
+  +0x2534 | 54 00 00 00             | UOffset32  | 0x00000054 (84) Loc: 0x2588        | offset to field `type` (table)
+  +0x2538 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x253C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x253C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x2540 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x2564       | offset to table[0]
-  +0x2544 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2548        | offset to table[1]
+  +0x253C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x2540 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x2564        | offset to table[0]
+  +0x2544 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2548         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x2548 | 80 EC FF FF             | SOffset32   | 0xFFFFEC80 (-4992) Loc: +0x38C8    | offset to vtable
-  +0x254C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x255C       | offset to field `key` (string)
-  +0x2550 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2554        | offset to field `value` (string)
+  +0x2548 | 80 EC FF FF             | SOffset32  | 0xFFFFEC80 (-4992) Loc: 0x38C8     | offset to vtable
+  +0x254C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x255C        | offset to field `key` (string)
+  +0x2550 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2554         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2554 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2558 | 31 39                   | char[2]     | 19                                 | string literal
-  +0x255A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2554 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2558 | 31 39                   | char[2]    | 19                                 | string literal
+  +0x255A | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x255C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2560 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2562 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x255C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2560 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2562 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x2564 | 9C EC FF FF             | SOffset32   | 0xFFFFEC9C (-4964) Loc: +0x38C8    | offset to vtable
-  +0x2568 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x257C       | offset to field `key` (string)
-  +0x256C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2570        | offset to field `value` (string)
+  +0x2564 | 9C EC FF FF             | SOffset32  | 0xFFFFEC9C (-4964) Loc: 0x38C8     | offset to vtable
+  +0x2568 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x257C        | offset to field `key` (string)
+  +0x256C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2570         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2570 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of string
-  +0x2574 | 66 6E 76 31 5F 36 34    | char[7]     | fnv1_64                            | string literal
-  +0x257B | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2570 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of string
+  +0x2574 | 66 6E 76 31 5F 36 34    | char[7]    | fnv1_64                            | string literal
+  +0x257B | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x257C | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x2580 | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x2584 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x257C | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x2580 | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x2584 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2585 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2585 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x2588 | 14 EF FF FF             | SOffset32   | 0xFFFFEF14 (-4332) Loc: +0x3674    | offset to vtable
-  +0x258C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x258F | 0A                      | uint8_t     | 0x0A (10)                          | table field `base_type` (Byte)
-  +0x2590 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x2594 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2588 | 14 EF FF FF             | SOffset32  | 0xFFFFEF14 (-4332) Loc: 0x3674     | offset to vtable
+  +0x258C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x258F | 0A                      | uint8_t    | 0x0A (10)                          | table field `base_type` (Byte)
+  +0x2590 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x2594 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2598 | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x259C | 74 65 73 74 68 61 73 68 | char[16]    | testhash                           | string literal
-  +0x25A4 | 75 36 34 5F 66 6E 76 31 |             | u64_fnv1
-  +0x25AC | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2598 | 10 00 00 00             | uint32_t   | 0x00000010 (16)                    | length of string
+  +0x259C | 74 65 73 74 68 61 73 68 | char[16]   | testhash                           | string literal
+  +0x25A4 | 75 36 34 5F 66 6E 76 31 |            | u64_fnv1
+  +0x25AC | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x25AD | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x25AD | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x25B0 | B8 FA FF FF             | SOffset32   | 0xFFFFFAB8 (-1352) Loc: +0x2AF8    | offset to vtable
-  +0x25B4 | 12 00                   | uint16_t    | 0x0012 (18)                        | table field `id` (UShort)
-  +0x25B6 | 28 00                   | uint16_t    | 0x0028 (40)                        | table field `offset` (UShort)
-  +0x25B8 | 68 00 00 00             | UOffset32   | 0x00000068 (104) Loc: +0x2620      | offset to field `name` (string)
-  +0x25BC | 54 00 00 00             | UOffset32   | 0x00000054 (84) Loc: +0x2610       | offset to field `type` (table)
-  +0x25C0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x25C4        | offset to field `attributes` (vector)
+  +0x25B0 | B8 FA FF FF             | SOffset32  | 0xFFFFFAB8 (-1352) Loc: 0x2AF8     | offset to vtable
+  +0x25B4 | 12 00                   | uint16_t   | 0x0012 (18)                        | table field `id` (UShort)
+  +0x25B6 | 28 00                   | uint16_t   | 0x0028 (40)                        | table field `offset` (UShort)
+  +0x25B8 | 68 00 00 00             | UOffset32  | 0x00000068 (104) Loc: 0x2620       | offset to field `name` (string)
+  +0x25BC | 54 00 00 00             | UOffset32  | 0x00000054 (84) Loc: 0x2610        | offset to field `type` (table)
+  +0x25C0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x25C4         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x25C4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x25C8 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x25EC       | offset to table[0]
-  +0x25CC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x25D0        | offset to table[1]
+  +0x25C4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x25C8 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x25EC        | offset to table[0]
+  +0x25CC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x25D0         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x25D0 | 08 ED FF FF             | SOffset32   | 0xFFFFED08 (-4856) Loc: +0x38C8    | offset to vtable
-  +0x25D4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x25E4       | offset to field `key` (string)
-  +0x25D8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x25DC        | offset to field `value` (string)
+  +0x25D0 | 08 ED FF FF             | SOffset32  | 0xFFFFED08 (-4856) Loc: 0x38C8     | offset to vtable
+  +0x25D4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x25E4        | offset to field `key` (string)
+  +0x25D8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x25DC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x25DC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x25E0 | 31 38                   | char[2]     | 18                                 | string literal
-  +0x25E2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x25DC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x25E0 | 31 38                   | char[2]    | 18                                 | string literal
+  +0x25E2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x25E4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x25E8 | 69 64                   | char[2]     | id                                 | string literal
-  +0x25EA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x25E4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x25E8 | 69 64                   | char[2]    | id                                 | string literal
+  +0x25EA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x25EC | 24 ED FF FF             | SOffset32   | 0xFFFFED24 (-4828) Loc: +0x38C8    | offset to vtable
-  +0x25F0 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x2604       | offset to field `key` (string)
-  +0x25F4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x25F8        | offset to field `value` (string)
+  +0x25EC | 24 ED FF FF             | SOffset32  | 0xFFFFED24 (-4828) Loc: 0x38C8     | offset to vtable
+  +0x25F0 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x2604        | offset to field `key` (string)
+  +0x25F4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x25F8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x25F8 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of string
-  +0x25FC | 66 6E 76 31 5F 36 34    | char[7]     | fnv1_64                            | string literal
-  +0x2603 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x25F8 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of string
+  +0x25FC | 66 6E 76 31 5F 36 34    | char[7]    | fnv1_64                            | string literal
+  +0x2603 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x2604 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x2608 | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x260C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2604 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x2608 | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x260C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x260D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x260D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x2610 | 9C EF FF FF             | SOffset32   | 0xFFFFEF9C (-4196) Loc: +0x3674    | offset to vtable
-  +0x2614 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2617 | 09                      | uint8_t     | 0x09 (9)                           | table field `base_type` (Byte)
-  +0x2618 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x261C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2610 | 9C EF FF FF             | SOffset32  | 0xFFFFEF9C (-4196) Loc: 0x3674     | offset to vtable
+  +0x2614 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2617 | 09                      | uint8_t    | 0x09 (9)                           | table field `base_type` (Byte)
+  +0x2618 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x261C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2620 | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x2624 | 74 65 73 74 68 61 73 68 | char[16]    | testhash                           | string literal
-  +0x262C | 73 36 34 5F 66 6E 76 31 |             | s64_fnv1
-  +0x2634 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2620 | 10 00 00 00             | uint32_t   | 0x00000010 (16)                    | length of string
+  +0x2624 | 74 65 73 74 68 61 73 68 | char[16]   | testhash                           | string literal
+  +0x262C | 73 36 34 5F 66 6E 76 31 |            | s64_fnv1
+  +0x2634 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2635 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2635 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x2638 | 40 FB FF FF             | SOffset32   | 0xFFFFFB40 (-1216) Loc: +0x2AF8    | offset to vtable
-  +0x263C | 11 00                   | uint16_t    | 0x0011 (17)                        | table field `id` (UShort)
-  +0x263E | 26 00                   | uint16_t    | 0x0026 (38)                        | table field `offset` (UShort)
-  +0x2640 | 64 00 00 00             | UOffset32   | 0x00000064 (100) Loc: +0x26A4      | offset to field `name` (string)
-  +0x2644 | 54 00 00 00             | UOffset32   | 0x00000054 (84) Loc: +0x2698       | offset to field `type` (table)
-  +0x2648 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x264C        | offset to field `attributes` (vector)
+  +0x2638 | 40 FB FF FF             | SOffset32  | 0xFFFFFB40 (-1216) Loc: 0x2AF8     | offset to vtable
+  +0x263C | 11 00                   | uint16_t   | 0x0011 (17)                        | table field `id` (UShort)
+  +0x263E | 26 00                   | uint16_t   | 0x0026 (38)                        | table field `offset` (UShort)
+  +0x2640 | 64 00 00 00             | UOffset32  | 0x00000064 (100) Loc: 0x26A4       | offset to field `name` (string)
+  +0x2644 | 54 00 00 00             | UOffset32  | 0x00000054 (84) Loc: 0x2698        | offset to field `type` (table)
+  +0x2648 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x264C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x264C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x2650 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x2674       | offset to table[0]
-  +0x2654 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2658        | offset to table[1]
+  +0x264C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x2650 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x2674        | offset to table[0]
+  +0x2654 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2658         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x2658 | 90 ED FF FF             | SOffset32   | 0xFFFFED90 (-4720) Loc: +0x38C8    | offset to vtable
-  +0x265C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x266C       | offset to field `key` (string)
-  +0x2660 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2664        | offset to field `value` (string)
+  +0x2658 | 90 ED FF FF             | SOffset32  | 0xFFFFED90 (-4720) Loc: 0x38C8     | offset to vtable
+  +0x265C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x266C        | offset to field `key` (string)
+  +0x2660 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2664         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2664 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2668 | 31 37                   | char[2]     | 17                                 | string literal
-  +0x266A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2664 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2668 | 31 37                   | char[2]    | 17                                 | string literal
+  +0x266A | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x266C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2670 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2672 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x266C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2670 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2672 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x2674 | AC ED FF FF             | SOffset32   | 0xFFFFEDAC (-4692) Loc: +0x38C8    | offset to vtable
-  +0x2678 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x268C       | offset to field `key` (string)
-  +0x267C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2680        | offset to field `value` (string)
+  +0x2674 | AC ED FF FF             | SOffset32  | 0xFFFFEDAC (-4692) Loc: 0x38C8     | offset to vtable
+  +0x2678 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x268C        | offset to field `key` (string)
+  +0x267C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2680         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2680 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of string
-  +0x2684 | 66 6E 76 31 5F 33 32    | char[7]     | fnv1_32                            | string literal
-  +0x268B | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2680 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of string
+  +0x2684 | 66 6E 76 31 5F 33 32    | char[7]    | fnv1_32                            | string literal
+  +0x268B | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x268C | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x2690 | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x2694 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x268C | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x2690 | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x2694 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2695 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2695 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x2698 | BC ED FF FF             | SOffset32   | 0xFFFFEDBC (-4676) Loc: +0x38DC    | offset to vtable
-  +0x269C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x269F | 08                      | uint8_t     | 0x08 (8)                           | table field `base_type` (Byte)
-  +0x26A0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2698 | BC ED FF FF             | SOffset32  | 0xFFFFEDBC (-4676) Loc: 0x38DC     | offset to vtable
+  +0x269C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x269F | 08                      | uint8_t    | 0x08 (8)                           | table field `base_type` (Byte)
+  +0x26A0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x26A4 | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x26A8 | 74 65 73 74 68 61 73 68 | char[16]    | testhash                           | string literal
-  +0x26B0 | 75 33 32 5F 66 6E 76 31 |             | u32_fnv1
-  +0x26B8 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x26A4 | 10 00 00 00             | uint32_t   | 0x00000010 (16)                    | length of string
+  +0x26A8 | 74 65 73 74 68 61 73 68 | char[16]   | testhash                           | string literal
+  +0x26B0 | 75 33 32 5F 66 6E 76 31 |            | u32_fnv1
+  +0x26B8 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x26B9 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x26B9 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x26BC | C4 FB FF FF             | SOffset32   | 0xFFFFFBC4 (-1084) Loc: +0x2AF8    | offset to vtable
-  +0x26C0 | 10 00                   | uint16_t    | 0x0010 (16)                        | table field `id` (UShort)
-  +0x26C2 | 24 00                   | uint16_t    | 0x0024 (36)                        | table field `offset` (UShort)
-  +0x26C4 | 64 00 00 00             | UOffset32   | 0x00000064 (100) Loc: +0x2728      | offset to field `name` (string)
-  +0x26C8 | 54 00 00 00             | UOffset32   | 0x00000054 (84) Loc: +0x271C       | offset to field `type` (table)
-  +0x26CC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x26D0        | offset to field `attributes` (vector)
+  +0x26BC | C4 FB FF FF             | SOffset32  | 0xFFFFFBC4 (-1084) Loc: 0x2AF8     | offset to vtable
+  +0x26C0 | 10 00                   | uint16_t   | 0x0010 (16)                        | table field `id` (UShort)
+  +0x26C2 | 24 00                   | uint16_t   | 0x0024 (36)                        | table field `offset` (UShort)
+  +0x26C4 | 64 00 00 00             | UOffset32  | 0x00000064 (100) Loc: 0x2728       | offset to field `name` (string)
+  +0x26C8 | 54 00 00 00             | UOffset32  | 0x00000054 (84) Loc: 0x271C        | offset to field `type` (table)
+  +0x26CC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x26D0         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x26D0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x26D4 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x26F8       | offset to table[0]
-  +0x26D8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x26DC        | offset to table[1]
+  +0x26D0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x26D4 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x26F8        | offset to table[0]
+  +0x26D8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x26DC         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x26DC | 14 EE FF FF             | SOffset32   | 0xFFFFEE14 (-4588) Loc: +0x38C8    | offset to vtable
-  +0x26E0 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x26F0       | offset to field `key` (string)
-  +0x26E4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x26E8        | offset to field `value` (string)
+  +0x26DC | 14 EE FF FF             | SOffset32  | 0xFFFFEE14 (-4588) Loc: 0x38C8     | offset to vtable
+  +0x26E0 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x26F0        | offset to field `key` (string)
+  +0x26E4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x26E8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x26E8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x26EC | 31 36                   | char[2]     | 16                                 | string literal
-  +0x26EE | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x26E8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x26EC | 31 36                   | char[2]    | 16                                 | string literal
+  +0x26EE | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x26F0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x26F4 | 69 64                   | char[2]     | id                                 | string literal
-  +0x26F6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x26F0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x26F4 | 69 64                   | char[2]    | id                                 | string literal
+  +0x26F6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x26F8 | 30 EE FF FF             | SOffset32   | 0xFFFFEE30 (-4560) Loc: +0x38C8    | offset to vtable
-  +0x26FC | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x2710       | offset to field `key` (string)
-  +0x2700 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2704        | offset to field `value` (string)
+  +0x26F8 | 30 EE FF FF             | SOffset32  | 0xFFFFEE30 (-4560) Loc: 0x38C8     | offset to vtable
+  +0x26FC | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x2710        | offset to field `key` (string)
+  +0x2700 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2704         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2704 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of string
-  +0x2708 | 66 6E 76 31 5F 33 32    | char[7]     | fnv1_32                            | string literal
-  +0x270F | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2704 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of string
+  +0x2708 | 66 6E 76 31 5F 33 32    | char[7]    | fnv1_32                            | string literal
+  +0x270F | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x2710 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x2714 | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x2718 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2710 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x2714 | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x2718 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2719 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2719 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x271C | 40 EE FF FF             | SOffset32   | 0xFFFFEE40 (-4544) Loc: +0x38DC    | offset to vtable
-  +0x2720 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2723 | 07                      | uint8_t     | 0x07 (7)                           | table field `base_type` (Byte)
-  +0x2724 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x271C | 40 EE FF FF             | SOffset32  | 0xFFFFEE40 (-4544) Loc: 0x38DC     | offset to vtable
+  +0x2720 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2723 | 07                      | uint8_t    | 0x07 (7)                           | table field `base_type` (Byte)
+  +0x2724 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2728 | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x272C | 74 65 73 74 68 61 73 68 | char[16]    | testhash                           | string literal
-  +0x2734 | 73 33 32 5F 66 6E 76 31 |             | s32_fnv1
-  +0x273C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2728 | 10 00 00 00             | uint32_t   | 0x00000010 (16)                    | length of string
+  +0x272C | 74 65 73 74 68 61 73 68 | char[16]   | testhash                           | string literal
+  +0x2734 | 73 33 32 5F 66 6E 76 31 |            | s32_fnv1
+  +0x273C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x273D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x273D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x2740 | 48 FC FF FF             | SOffset32   | 0xFFFFFC48 (-952) Loc: +0x2AF8     | offset to vtable
-  +0x2744 | 0F 00                   | uint16_t    | 0x000F (15)                        | table field `id` (UShort)
-  +0x2746 | 22 00                   | uint16_t    | 0x0022 (34)                        | table field `offset` (UShort)
-  +0x2748 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x2788       | offset to field `name` (string)
-  +0x274C | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x2778       | offset to field `type` (table)
-  +0x2750 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2754        | offset to field `attributes` (vector)
+  +0x2740 | 48 FC FF FF             | SOffset32  | 0xFFFFFC48 (-952) Loc: 0x2AF8      | offset to vtable
+  +0x2744 | 0F 00                   | uint16_t   | 0x000F (15)                        | table field `id` (UShort)
+  +0x2746 | 22 00                   | uint16_t   | 0x0022 (34)                        | table field `offset` (UShort)
+  +0x2748 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x2788        | offset to field `name` (string)
+  +0x274C | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x2778        | offset to field `type` (table)
+  +0x2750 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2754         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2754 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2758 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x275C        | offset to table[0]
+  +0x2754 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2758 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x275C         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x275C | 94 EE FF FF             | SOffset32   | 0xFFFFEE94 (-4460) Loc: +0x38C8    | offset to vtable
-  +0x2760 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2770       | offset to field `key` (string)
-  +0x2764 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2768        | offset to field `value` (string)
+  +0x275C | 94 EE FF FF             | SOffset32  | 0xFFFFEE94 (-4460) Loc: 0x38C8     | offset to vtable
+  +0x2760 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2770        | offset to field `key` (string)
+  +0x2764 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2768         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2768 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x276C | 31 35                   | char[2]     | 15                                 | string literal
-  +0x276E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2768 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x276C | 31 35                   | char[2]    | 15                                 | string literal
+  +0x276E | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x2770 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2774 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2776 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2770 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2774 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2776 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2778 | 04 F1 FF FF             | SOffset32   | 0xFFFFF104 (-3836) Loc: +0x3674    | offset to vtable
-  +0x277C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x277F | 02                      | uint8_t     | 0x02 (2)                           | table field `base_type` (Byte)
-  +0x2780 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x2784 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2778 | 04 F1 FF FF             | SOffset32  | 0xFFFFF104 (-3836) Loc: 0x3674     | offset to vtable
+  +0x277C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x277F | 02                      | uint8_t    | 0x02 (2)                           | table field `base_type` (Byte)
+  +0x2780 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x2784 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2788 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x278C | 74 65 73 74 62 6F 6F 6C | char[8]     | testbool                           | string literal
-  +0x2794 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2788 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x278C | 74 65 73 74 62 6F 6F 6C | char[8]    | testbool                           | string literal
+  +0x2794 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2795 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2795 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x2798 | B0 FB FF FF             | SOffset32   | 0xFFFFFBB0 (-1104) Loc: +0x2BE8    | offset to vtable
-  +0x279C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x279F | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x27A0 | 0E 00                   | uint16_t    | 0x000E (14)                        | table field `id` (UShort)
-  +0x27A2 | 20 00                   | uint16_t    | 0x0020 (32)                        | table field `offset` (UShort)
-  +0x27A4 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x27E4       | offset to field `name` (string)
-  +0x27A8 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x27D4       | offset to field `type` (table)
-  +0x27AC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x27B0        | offset to field `attributes` (vector)
+  +0x2798 | B0 FB FF FF             | SOffset32  | 0xFFFFFBB0 (-1104) Loc: 0x2BE8     | offset to vtable
+  +0x279C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x279F | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x27A0 | 0E 00                   | uint16_t   | 0x000E (14)                        | table field `id` (UShort)
+  +0x27A2 | 20 00                   | uint16_t   | 0x0020 (32)                        | table field `offset` (UShort)
+  +0x27A4 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x27E4        | offset to field `name` (string)
+  +0x27A8 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x27D4        | offset to field `type` (table)
+  +0x27AC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x27B0         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x27B0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x27B4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x27B8        | offset to table[0]
+  +0x27B0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x27B4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x27B8         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x27B8 | F0 EE FF FF             | SOffset32   | 0xFFFFEEF0 (-4368) Loc: +0x38C8    | offset to vtable
-  +0x27BC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x27CC       | offset to field `key` (string)
-  +0x27C0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x27C4        | offset to field `value` (string)
+  +0x27B8 | F0 EE FF FF             | SOffset32  | 0xFFFFEEF0 (-4368) Loc: 0x38C8     | offset to vtable
+  +0x27BC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x27CC        | offset to field `key` (string)
+  +0x27C0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x27C4         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x27C4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x27C8 | 31 34                   | char[2]     | 14                                 | string literal
-  +0x27CA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x27C4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x27C8 | 31 34                   | char[2]    | 14                                 | string literal
+  +0x27CA | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x27CC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x27D0 | 69 64                   | char[2]     | id                                 | string literal
-  +0x27D2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x27CC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x27D0 | 69 64                   | char[2]    | id                                 | string literal
+  +0x27D2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x27D4 | BC EF FF FF             | SOffset32   | 0xFFFFEFBC (-4164) Loc: +0x3818    | offset to vtable
-  +0x27D8 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x27DB | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x27DC | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | table field `index` (Int)
-  +0x27E0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x27D4 | BC EF FF FF             | SOffset32  | 0xFFFFEFBC (-4164) Loc: 0x3818     | offset to vtable
+  +0x27D8 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x27DB | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x27DC | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | table field `index` (Int)
+  +0x27E0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x27E4 | 09 00 00 00             | uint32_t    | 0x00000009 (9)                     | length of string
-  +0x27E8 | 74 65 73 74 65 6D 70 74 | char[9]     | testempt                           | string literal
-  +0x27F0 | 79                      |             | y
-  +0x27F1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x27E4 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                     | length of string
+  +0x27E8 | 74 65 73 74 65 6D 70 74 | char[9]    | testempt                           | string literal
+  +0x27F0 | 79                      |            | y
+  +0x27F1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x27F2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x27F2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x27F4 | 0C FC FF FF             | SOffset32   | 0xFFFFFC0C (-1012) Loc: +0x2BE8    | offset to vtable
-  +0x27F8 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x27FB | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x27FC | 0D 00                   | uint16_t    | 0x000D (13)                        | table field `id` (UShort)
-  +0x27FE | 1E 00                   | uint16_t    | 0x001E (30)                        | table field `offset` (UShort)
-  +0x2800 | 70 00 00 00             | UOffset32   | 0x00000070 (112) Loc: +0x2870      | offset to field `name` (string)
-  +0x2804 | 60 00 00 00             | UOffset32   | 0x00000060 (96) Loc: +0x2864       | offset to field `type` (table)
-  +0x2808 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x280C        | offset to field `attributes` (vector)
+  +0x27F4 | 0C FC FF FF             | SOffset32  | 0xFFFFFC0C (-1012) Loc: 0x2BE8     | offset to vtable
+  +0x27F8 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x27FB | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x27FC | 0D 00                   | uint16_t   | 0x000D (13)                        | table field `id` (UShort)
+  +0x27FE | 1E 00                   | uint16_t   | 0x001E (30)                        | table field `offset` (UShort)
+  +0x2800 | 70 00 00 00             | UOffset32  | 0x00000070 (112) Loc: 0x2870       | offset to field `name` (string)
+  +0x2804 | 60 00 00 00             | UOffset32  | 0x00000060 (96) Loc: 0x2864        | offset to field `type` (table)
+  +0x2808 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x280C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x280C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x2810 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x2848       | offset to table[0]
-  +0x2814 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2818        | offset to table[1]
+  +0x280C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x2810 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x2848        | offset to table[0]
+  +0x2814 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2818         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x2818 | 50 EF FF FF             | SOffset32   | 0xFFFFEF50 (-4272) Loc: +0x38C8    | offset to vtable
-  +0x281C | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x2830       | offset to field `key` (string)
-  +0x2820 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2824        | offset to field `value` (string)
+  +0x2818 | 50 EF FF FF             | SOffset32  | 0xFFFFEF50 (-4272) Loc: 0x38C8     | offset to vtable
+  +0x281C | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x2830        | offset to field `key` (string)
+  +0x2820 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2824         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2824 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of string
-  +0x2828 | 4D 6F 6E 73 74 65 72    | char[7]     | Monster                            | string literal
-  +0x282F | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2824 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of string
+  +0x2828 | 4D 6F 6E 73 74 65 72    | char[7]    | Monster                            | string literal
+  +0x282F | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x2830 | 11 00 00 00             | uint32_t    | 0x00000011 (17)                    | length of string
-  +0x2834 | 6E 65 73 74 65 64 5F 66 | char[17]    | nested_f                           | string literal
-  +0x283C | 6C 61 74 62 75 66 66 65 |             | latbuffe
-  +0x2844 | 72                      |             | r
-  +0x2845 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2830 | 11 00 00 00             | uint32_t   | 0x00000011 (17)                    | length of string
+  +0x2834 | 6E 65 73 74 65 64 5F 66 | char[17]   | nested_f                           | string literal
+  +0x283C | 6C 61 74 62 75 66 66 65 |            | latbuffe
+  +0x2844 | 72                      |            | r
+  +0x2845 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2846 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2846 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.KeyValue):
-  +0x2848 | 80 EF FF FF             | SOffset32   | 0xFFFFEF80 (-4224) Loc: +0x38C8    | offset to vtable
-  +0x284C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x285C       | offset to field `key` (string)
-  +0x2850 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2854        | offset to field `value` (string)
+  +0x2848 | 80 EF FF FF             | SOffset32  | 0xFFFFEF80 (-4224) Loc: 0x38C8     | offset to vtable
+  +0x284C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x285C        | offset to field `key` (string)
+  +0x2850 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2854         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2854 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2858 | 31 33                   | char[2]     | 13                                 | string literal
-  +0x285A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2854 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2858 | 31 33                   | char[2]    | 13                                 | string literal
+  +0x285A | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x285C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2860 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2862 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x285C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2860 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2862 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2864 | 24 FC FF FF             | SOffset32   | 0xFFFFFC24 (-988) Loc: +0x2C40     | offset to vtable
-  +0x2868 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x286A | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x286B | 04                      | uint8_t     | 0x04 (4)                           | table field `element` (Byte)
-  +0x286C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2864 | 24 FC FF FF             | SOffset32  | 0xFFFFFC24 (-988) Loc: 0x2C40      | offset to vtable
+  +0x2868 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x286A | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x286B | 04                      | uint8_t    | 0x04 (4)                           | table field `element` (Byte)
+  +0x286C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2870 | 14 00 00 00             | uint32_t    | 0x00000014 (20)                    | length of string
-  +0x2874 | 74 65 73 74 6E 65 73 74 | char[20]    | testnest                           | string literal
-  +0x287C | 65 64 66 6C 61 74 62 75 |             | edflatbu
-  +0x2884 | 66 66 65 72             |             | ffer
-  +0x2888 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2870 | 14 00 00 00             | uint32_t   | 0x00000014 (20)                    | length of string
+  +0x2874 | 74 65 73 74 6E 65 73 74 | char[20]   | testnest                           | string literal
+  +0x287C | 65 64 66 6C 61 74 62 75 |            | edflatbu
+  +0x2884 | 66 66 65 72             |            | ffer
+  +0x2888 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2889 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2889 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x288C | A4 FC FF FF             | SOffset32   | 0xFFFFFCA4 (-860) Loc: +0x2BE8     | offset to vtable
-  +0x2890 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2893 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x2894 | 0C 00                   | uint16_t    | 0x000C (12)                        | table field `id` (UShort)
-  +0x2896 | 1C 00                   | uint16_t    | 0x001C (28)                        | table field `offset` (UShort)
-  +0x2898 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x28D8       | offset to field `name` (string)
-  +0x289C | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x28C8       | offset to field `type` (table)
-  +0x28A0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x28A4        | offset to field `attributes` (vector)
+  +0x288C | A4 FC FF FF             | SOffset32  | 0xFFFFFCA4 (-860) Loc: 0x2BE8      | offset to vtable
+  +0x2890 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2893 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x2894 | 0C 00                   | uint16_t   | 0x000C (12)                        | table field `id` (UShort)
+  +0x2896 | 1C 00                   | uint16_t   | 0x001C (28)                        | table field `offset` (UShort)
+  +0x2898 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x28D8        | offset to field `name` (string)
+  +0x289C | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x28C8        | offset to field `type` (table)
+  +0x28A0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x28A4         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x28A4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x28A8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x28AC        | offset to table[0]
+  +0x28A4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x28A8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x28AC         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x28AC | E4 EF FF FF             | SOffset32   | 0xFFFFEFE4 (-4124) Loc: +0x38C8    | offset to vtable
-  +0x28B0 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x28C0       | offset to field `key` (string)
-  +0x28B4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x28B8        | offset to field `value` (string)
+  +0x28AC | E4 EF FF FF             | SOffset32  | 0xFFFFEFE4 (-4124) Loc: 0x38C8     | offset to vtable
+  +0x28B0 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x28C0        | offset to field `key` (string)
+  +0x28B4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x28B8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x28B8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x28BC | 31 32                   | char[2]     | 12                                 | string literal
-  +0x28BE | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x28B8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x28BC | 31 32                   | char[2]    | 12                                 | string literal
+  +0x28BE | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x28C0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x28C4 | 69 64                   | char[2]     | id                                 | string literal
-  +0x28C6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x28C0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x28C4 | 69 64                   | char[2]    | id                                 | string literal
+  +0x28C6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x28C8 | B0 F0 FF FF             | SOffset32   | 0xFFFFF0B0 (-3920) Loc: +0x3818    | offset to vtable
-  +0x28CC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x28CF | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x28D0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `index` (Int)
-  +0x28D4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x28C8 | B0 F0 FF FF             | SOffset32  | 0xFFFFF0B0 (-3920) Loc: 0x3818     | offset to vtable
+  +0x28CC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x28CF | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x28D0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `index` (Int)
+  +0x28D4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x28D8 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x28DC | 65 6E 65 6D 79          | char[5]     | enemy                              | string literal
-  +0x28E1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x28D8 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x28DC | 65 6E 65 6D 79          | char[5]    | enemy                              | string literal
+  +0x28E1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x28E2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x28E2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Field):
-  +0x28E4 | 1C 00                   | uint16_t    | 0x001C (28)                        | size of this vtable
-  +0x28E6 | 1C 00                   | uint16_t    | 0x001C (28)                        | size of referring table
-  +0x28E8 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `name` (id: 0)
-  +0x28EA | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `type` (id: 1)
-  +0x28EC | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `id` (id: 2)
-  +0x28EE | 0A 00                   | VOffset16   | 0x000A (10)                        | offset to field `offset` (id: 3)
-  +0x28F0 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x28F2 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x28F4 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x28F6 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x28F8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x28FA | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `attributes` (id: 9)
-  +0x28FC | 18 00                   | VOffset16   | 0x0018 (24)                        | offset to field `documentation` (id: 10)
-  +0x28FE | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `optional` (id: 11)
+  +0x28E4 | 1C 00                   | uint16_t   | 0x001C (28)                        | size of this vtable
+  +0x28E6 | 1C 00                   | uint16_t   | 0x001C (28)                        | size of referring table
+  +0x28E8 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `name` (id: 0)
+  +0x28EA | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `type` (id: 1)
+  +0x28EC | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `id` (id: 2)
+  +0x28EE | 0A 00                   | VOffset16  | 0x000A (10)                        | offset to field `offset` (id: 3)
+  +0x28F0 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x28F2 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x28F4 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x28F6 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x28F8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x28FA | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `attributes` (id: 9)
+  +0x28FC | 18 00                   | VOffset16  | 0x0018 (24)                        | offset to field `documentation` (id: 10)
+  +0x28FE | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `optional` (id: 11)
 
 table (reflection.Field):
-  +0x2900 | 1C 00 00 00             | SOffset32   | 0x0000001C (28) Loc: +0x28E4       | offset to vtable
-  +0x2904 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2907 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x2908 | 0B 00                   | uint16_t    | 0x000B (11)                        | table field `id` (UShort)
-  +0x290A | 1A 00                   | uint16_t    | 0x001A (26)                        | table field `offset` (UShort)
-  +0x290C | B4 00 00 00             | UOffset32   | 0x000000B4 (180) Loc: +0x29C0      | offset to field `name` (string)
-  +0x2910 | A0 00 00 00             | UOffset32   | 0x000000A0 (160) Loc: +0x29B0      | offset to field `type` (table)
-  +0x2914 | 78 00 00 00             | UOffset32   | 0x00000078 (120) Loc: +0x298C      | offset to field `attributes` (vector)
-  +0x2918 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x291C        | offset to field `documentation` (vector)
+  +0x2900 | 1C 00 00 00             | SOffset32  | 0x0000001C (28) Loc: 0x28E4        | offset to vtable
+  +0x2904 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2907 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x2908 | 0B 00                   | uint16_t   | 0x000B (11)                        | table field `id` (UShort)
+  +0x290A | 1A 00                   | uint16_t   | 0x001A (26)                        | table field `offset` (UShort)
+  +0x290C | B4 00 00 00             | UOffset32  | 0x000000B4 (180) Loc: 0x29C0       | offset to field `name` (string)
+  +0x2910 | A0 00 00 00             | UOffset32  | 0x000000A0 (160) Loc: 0x29B0       | offset to field `type` (table)
+  +0x2914 | 78 00 00 00             | UOffset32  | 0x00000078 (120) Loc: 0x298C       | offset to field `attributes` (vector)
+  +0x2918 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x291C         | offset to field `documentation` (vector)
 
 vector (reflection.Field.documentation):
-  +0x291C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x2920 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0x293C       | offset to string[0]
-  +0x2924 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2928        | offset to string[1]
+  +0x291C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x2920 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: 0x293C        | offset to string[0]
+  +0x2924 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2928         | offset to string[1]
 
 string (reflection.Field.documentation):
-  +0x2928 | 0E 00 00 00             | uint32_t    | 0x0000000E (14)                    | length of string
-  +0x292C | 20 6D 75 6C 74 69 6C 69 | char[14]    |  multili                           | string literal
-  +0x2934 | 6E 65 20 74 6F 6F       |             | ne too
-  +0x293A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2928 | 0E 00 00 00             | uint32_t   | 0x0000000E (14)                    | length of string
+  +0x292C | 20 6D 75 6C 74 69 6C 69 | char[14]   |  multili                           | string literal
+  +0x2934 | 6E 65 20 74 6F 6F       |            | ne too
+  +0x293A | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.Field.documentation):
-  +0x293C | 49 00 00 00             | uint32_t    | 0x00000049 (73)                    | length of string
-  +0x2940 | 20 61 6E 20 65 78 61 6D | char[73]    |  an exam                           | string literal
-  +0x2948 | 70 6C 65 20 64 6F 63 75 |             | ple docu
-  +0x2950 | 6D 65 6E 74 61 74 69 6F |             | mentatio
-  +0x2958 | 6E 20 63 6F 6D 6D 65 6E |             | n commen
-  +0x2960 | 74 3A 20 74 68 69 73 20 |             | t: this 
-  +0x2968 | 77 69 6C 6C 20 65 6E 64 |             | will end
-  +0x2970 | 20 75 70 20 69 6E 20 74 |             |  up in t
-  +0x2978 | 68 65 20 67 65 6E 65 72 |             | he gener
-  +0x2980 | 61 74 65 64 20 63 6F 64 |             | ated cod
-  +0x2988 | 65                      |             | e
-  +0x2989 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x293C | 49 00 00 00             | uint32_t   | 0x00000049 (73)                    | length of string
+  +0x2940 | 20 61 6E 20 65 78 61 6D | char[73]   |  an exam                           | string literal
+  +0x2948 | 70 6C 65 20 64 6F 63 75 |            | ple docu
+  +0x2950 | 6D 65 6E 74 61 74 69 6F |            | mentatio
+  +0x2958 | 6E 20 63 6F 6D 6D 65 6E |            | n commen
+  +0x2960 | 74 3A 20 74 68 69 73 20 |            | t: this 
+  +0x2968 | 77 69 6C 6C 20 65 6E 64 |            | will end
+  +0x2970 | 20 75 70 20 69 6E 20 74 |            |  up in t
+  +0x2978 | 68 65 20 67 65 6E 65 72 |            | he gener
+  +0x2980 | 61 74 65 64 20 63 6F 64 |            | ated cod
+  +0x2988 | 65                      |            | e
+  +0x2989 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x298A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x298A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vector (reflection.Field.attributes):
-  +0x298C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2990 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2994        | offset to table[0]
+  +0x298C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2990 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2994         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2994 | CC F0 FF FF             | SOffset32   | 0xFFFFF0CC (-3892) Loc: +0x38C8    | offset to vtable
-  +0x2998 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x29A8       | offset to field `key` (string)
-  +0x299C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x29A0        | offset to field `value` (string)
+  +0x2994 | CC F0 FF FF             | SOffset32  | 0xFFFFF0CC (-3892) Loc: 0x38C8     | offset to vtable
+  +0x2998 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x29A8        | offset to field `key` (string)
+  +0x299C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x29A0         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x29A0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x29A4 | 31 31                   | char[2]     | 11                                 | string literal
-  +0x29A6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x29A0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x29A4 | 31 31                   | char[2]    | 11                                 | string literal
+  +0x29A6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x29A8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x29AC | 69 64                   | char[2]     | id                                 | string literal
-  +0x29AE | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x29A8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x29AC | 69 64                   | char[2]    | id                                 | string literal
+  +0x29AE | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x29B0 | 3C FF FF FF             | SOffset32   | 0xFFFFFF3C (-196) Loc: +0x2A74     | offset to vtable
-  +0x29B4 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x29B6 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x29B7 | 0F                      | uint8_t     | 0x0F (15)                          | table field `element` (Byte)
-  +0x29B8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `index` (Int)
-  +0x29BC | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `element_size` (UInt)
+  +0x29B0 | 3C FF FF FF             | SOffset32  | 0xFFFFFF3C (-196) Loc: 0x2A74      | offset to vtable
+  +0x29B4 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x29B6 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x29B7 | 0F                      | uint8_t    | 0x0F (15)                          | table field `element` (Byte)
+  +0x29B8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `index` (Int)
+  +0x29BC | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x29C0 | 11 00 00 00             | uint32_t    | 0x00000011 (17)                    | length of string
-  +0x29C4 | 74 65 73 74 61 72 72 61 | char[17]    | testarra                           | string literal
-  +0x29CC | 79 6F 66 74 61 62 6C 65 |             | yoftable
-  +0x29D4 | 73                      |             | s
-  +0x29D5 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x29C0 | 11 00 00 00             | uint32_t   | 0x00000011 (17)                    | length of string
+  +0x29C4 | 74 65 73 74 61 72 72 61 | char[17]   | testarra                           | string literal
+  +0x29CC | 79 6F 66 74 61 62 6C 65 |            | yoftable
+  +0x29D4 | 73                      |            | s
+  +0x29D5 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x29D6 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x29D6 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x29D8 | F0 FD FF FF             | SOffset32   | 0xFFFFFDF0 (-528) Loc: +0x2BE8     | offset to vtable
-  +0x29DC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x29DF | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x29E0 | 0A 00                   | uint16_t    | 0x000A (10)                        | table field `id` (UShort)
-  +0x29E2 | 18 00                   | uint16_t    | 0x0018 (24)                        | table field `offset` (UShort)
-  +0x29E4 | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x2A20       | offset to field `name` (string)
-  +0x29E8 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x2A14       | offset to field `type` (table)
-  +0x29EC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x29F0        | offset to field `attributes` (vector)
+  +0x29D8 | F0 FD FF FF             | SOffset32  | 0xFFFFFDF0 (-528) Loc: 0x2BE8      | offset to vtable
+  +0x29DC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x29DF | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x29E0 | 0A 00                   | uint16_t   | 0x000A (10)                        | table field `id` (UShort)
+  +0x29E2 | 18 00                   | uint16_t   | 0x0018 (24)                        | table field `offset` (UShort)
+  +0x29E4 | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x2A20        | offset to field `name` (string)
+  +0x29E8 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x2A14        | offset to field `type` (table)
+  +0x29EC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x29F0         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x29F0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x29F4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x29F8        | offset to table[0]
+  +0x29F0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x29F4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x29F8         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x29F8 | 30 F1 FF FF             | SOffset32   | 0xFFFFF130 (-3792) Loc: +0x38C8    | offset to vtable
-  +0x29FC | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2A0C       | offset to field `key` (string)
-  +0x2A00 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2A04        | offset to field `value` (string)
+  +0x29F8 | 30 F1 FF FF             | SOffset32  | 0xFFFFF130 (-3792) Loc: 0x38C8     | offset to vtable
+  +0x29FC | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2A0C        | offset to field `key` (string)
+  +0x2A00 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2A04         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2A04 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2A08 | 31 30                   | char[2]     | 10                                 | string literal
-  +0x2A0A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2A04 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2A08 | 31 30                   | char[2]    | 10                                 | string literal
+  +0x2A0A | 00                      | char       | 0x00 (0)                           | string terminator
 
 string (reflection.KeyValue.key):
-  +0x2A0C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2A10 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2A12 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2A0C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2A10 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2A12 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2A14 | D4 FD FF FF             | SOffset32   | 0xFFFFFDD4 (-556) Loc: +0x2C40     | offset to vtable
-  +0x2A18 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x2A1A | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x2A1B | 0D                      | uint8_t     | 0x0D (13)                          | table field `element` (Byte)
-  +0x2A1C | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `element_size` (UInt)
+  +0x2A14 | D4 FD FF FF             | SOffset32  | 0xFFFFFDD4 (-556) Loc: 0x2C40      | offset to vtable
+  +0x2A18 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x2A1A | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x2A1B | 0D                      | uint8_t    | 0x0D (13)                          | table field `element` (Byte)
+  +0x2A1C | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2A20 | 11 00 00 00             | uint32_t    | 0x00000011 (17)                    | length of string
-  +0x2A24 | 74 65 73 74 61 72 72 61 | char[17]    | testarra                           | string literal
-  +0x2A2C | 79 6F 66 73 74 72 69 6E |             | yofstrin
-  +0x2A34 | 67                      |             | g
-  +0x2A35 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2A20 | 11 00 00 00             | uint32_t   | 0x00000011 (17)                    | length of string
+  +0x2A24 | 74 65 73 74 61 72 72 61 | char[17]   | testarra                           | string literal
+  +0x2A2C | 79 6F 66 73 74 72 69 6E |            | yofstrin
+  +0x2A34 | 67                      |            | g
+  +0x2A35 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2A36 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2A36 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x2A38 | 50 FE FF FF             | SOffset32   | 0xFFFFFE50 (-432) Loc: +0x2BE8     | offset to vtable
-  +0x2A3C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2A3F | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x2A40 | 09 00                   | uint16_t    | 0x0009 (9)                         | table field `id` (UShort)
-  +0x2A42 | 16 00                   | uint16_t    | 0x0016 (22)                        | table field `offset` (UShort)
-  +0x2A44 | 50 00 00 00             | UOffset32   | 0x00000050 (80) Loc: +0x2A94       | offset to field `name` (string)
-  +0x2A48 | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x2A84       | offset to field `type` (table)
-  +0x2A4C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2A50        | offset to field `attributes` (vector)
+  +0x2A38 | 50 FE FF FF             | SOffset32  | 0xFFFFFE50 (-432) Loc: 0x2BE8      | offset to vtable
+  +0x2A3C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2A3F | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x2A40 | 09 00                   | uint16_t   | 0x0009 (9)                         | table field `id` (UShort)
+  +0x2A42 | 16 00                   | uint16_t   | 0x0016 (22)                        | table field `offset` (UShort)
+  +0x2A44 | 50 00 00 00             | UOffset32  | 0x00000050 (80) Loc: 0x2A94        | offset to field `name` (string)
+  +0x2A48 | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x2A84        | offset to field `type` (table)
+  +0x2A4C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2A50         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2A50 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2A54 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2A58        | offset to table[0]
+  +0x2A50 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2A54 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2A58         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2A58 | 90 F1 FF FF             | SOffset32   | 0xFFFFF190 (-3696) Loc: +0x38C8    | offset to vtable
-  +0x2A5C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2A6C       | offset to field `key` (string)
-  +0x2A60 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2A64        | offset to field `value` (string)
+  +0x2A58 | 90 F1 FF FF             | SOffset32  | 0xFFFFF190 (-3696) Loc: 0x38C8     | offset to vtable
+  +0x2A5C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2A6C        | offset to field `key` (string)
+  +0x2A60 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2A64         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2A64 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2A68 | 39                      | char[1]     | 9                                  | string literal
-  +0x2A69 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2A64 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2A68 | 39                      | char[1]    | 9                                  | string literal
+  +0x2A69 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2A6A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2A6A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2A6C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2A70 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2A72 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2A6C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2A70 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2A72 | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Type):
-  +0x2A74 | 10 00                   | uint16_t    | 0x0010 (16)                        | size of this vtable
-  +0x2A76 | 10 00                   | uint16_t    | 0x0010 (16)                        | size of referring table
-  +0x2A78 | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `base_type` (id: 0)
-  +0x2A7A | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `element` (id: 1)
-  +0x2A7C | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `index` (id: 2)
-  +0x2A7E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
-  +0x2A80 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `base_size` (id: 4) <defaults to 4> (UInt)
-  +0x2A82 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `element_size` (id: 5)
+  +0x2A74 | 10 00                   | uint16_t   | 0x0010 (16)                        | size of this vtable
+  +0x2A76 | 10 00                   | uint16_t   | 0x0010 (16)                        | size of referring table
+  +0x2A78 | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `base_type` (id: 0)
+  +0x2A7A | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `element` (id: 1)
+  +0x2A7C | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `index` (id: 2)
+  +0x2A7E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
+  +0x2A80 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `base_size` (id: 4) <defaults to 4> (UInt)
+  +0x2A82 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `element_size` (id: 5)
 
 table (reflection.Type):
-  +0x2A84 | 10 00 00 00             | SOffset32   | 0x00000010 (16) Loc: +0x2A74       | offset to vtable
-  +0x2A88 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x2A8A | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x2A8B | 0F                      | uint8_t     | 0x0F (15)                          | table field `element` (Byte)
-  +0x2A8C | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | table field `index` (Int)
-  +0x2A90 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `element_size` (UInt)
+  +0x2A84 | 10 00 00 00             | SOffset32  | 0x00000010 (16) Loc: 0x2A74        | offset to vtable
+  +0x2A88 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x2A8A | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x2A8B | 0F                      | uint8_t    | 0x0F (15)                          | table field `element` (Byte)
+  +0x2A8C | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | table field `index` (Int)
+  +0x2A90 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2A94 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x2A98 | 74 65 73 74 34          | char[5]     | test4                              | string literal
-  +0x2A9D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2A94 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x2A98 | 74 65 73 74 34          | char[5]    | test4                              | string literal
+  +0x2A9D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2A9E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2A9E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x2AA0 | B8 FE FF FF             | SOffset32   | 0xFFFFFEB8 (-328) Loc: +0x2BE8     | offset to vtable
-  +0x2AA4 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2AA7 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x2AA8 | 08 00                   | uint16_t    | 0x0008 (8)                         | table field `id` (UShort)
-  +0x2AAA | 14 00                   | uint16_t    | 0x0014 (20)                        | table field `offset` (UShort)
-  +0x2AAC | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x2AEC       | offset to field `name` (string)
-  +0x2AB0 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x2ADC       | offset to field `type` (table)
-  +0x2AB4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2AB8        | offset to field `attributes` (vector)
+  +0x2AA0 | B8 FE FF FF             | SOffset32  | 0xFFFFFEB8 (-328) Loc: 0x2BE8      | offset to vtable
+  +0x2AA4 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2AA7 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x2AA8 | 08 00                   | uint16_t   | 0x0008 (8)                         | table field `id` (UShort)
+  +0x2AAA | 14 00                   | uint16_t   | 0x0014 (20)                        | table field `offset` (UShort)
+  +0x2AAC | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x2AEC        | offset to field `name` (string)
+  +0x2AB0 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x2ADC        | offset to field `type` (table)
+  +0x2AB4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2AB8         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2AB8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2ABC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2AC0        | offset to table[0]
+  +0x2AB8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2ABC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2AC0         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2AC0 | F8 F1 FF FF             | SOffset32   | 0xFFFFF1F8 (-3592) Loc: +0x38C8    | offset to vtable
-  +0x2AC4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2AD4       | offset to field `key` (string)
-  +0x2AC8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2ACC        | offset to field `value` (string)
+  +0x2AC0 | F8 F1 FF FF             | SOffset32  | 0xFFFFF1F8 (-3592) Loc: 0x38C8     | offset to vtable
+  +0x2AC4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2AD4        | offset to field `key` (string)
+  +0x2AC8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2ACC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2ACC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2AD0 | 38                      | char[1]     | 8                                  | string literal
-  +0x2AD1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2ACC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2AD0 | 38                      | char[1]    | 8                                  | string literal
+  +0x2AD1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2AD2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2AD2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2AD4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2AD8 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2ADA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2AD4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2AD8 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2ADA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2ADC | C4 F2 FF FF             | SOffset32   | 0xFFFFF2C4 (-3388) Loc: +0x3818    | offset to vtable
-  +0x2AE0 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2AE3 | 10                      | uint8_t     | 0x10 (16)                          | table field `base_type` (Byte)
-  +0x2AE4 | 00 00 00 00             | uint32_t    | 0x00000000 (0)                     | table field `index` (Int)
-  +0x2AE8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2ADC | C4 F2 FF FF             | SOffset32  | 0xFFFFF2C4 (-3388) Loc: 0x3818     | offset to vtable
+  +0x2AE0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2AE3 | 10                      | uint8_t    | 0x10 (16)                          | table field `base_type` (Byte)
+  +0x2AE4 | 00 00 00 00             | uint32_t   | 0x00000000 (0)                     | table field `index` (Int)
+  +0x2AE8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2AEC | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x2AF0 | 74 65 73 74             | char[4]     | test                               | string literal
-  +0x2AF4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2AEC | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x2AF0 | 74 65 73 74             | char[4]    | test                               | string literal
+  +0x2AF4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2AF5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2AF5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 vtable (reflection.Field):
-  +0x2AF8 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of this vtable
-  +0x2AFA | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x2AFC | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x2AFE | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x2B00 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `id` (id: 2)
-  +0x2B02 | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `offset` (id: 3)
-  +0x2B04 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x2B06 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x2B08 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x2B0A | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x2B0C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x2B0E | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 9)
+  +0x2AF8 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of this vtable
+  +0x2AFA | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x2AFC | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x2AFE | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x2B00 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `id` (id: 2)
+  +0x2B02 | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `offset` (id: 3)
+  +0x2B04 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x2B06 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x2B08 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x2B0A | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x2B0C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x2B0E | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 9)
 
 table (reflection.Field):
-  +0x2B10 | 18 00 00 00             | SOffset32   | 0x00000018 (24) Loc: +0x2AF8       | offset to vtable
-  +0x2B14 | 07 00                   | uint16_t    | 0x0007 (7)                         | table field `id` (UShort)
-  +0x2B16 | 12 00                   | uint16_t    | 0x0012 (18)                        | table field `offset` (UShort)
-  +0x2B18 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x2B5C       | offset to field `name` (string)
-  +0x2B1C | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x2B48       | offset to field `type` (table)
-  +0x2B20 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2B24        | offset to field `attributes` (vector)
+  +0x2B10 | 18 00 00 00             | SOffset32  | 0x00000018 (24) Loc: 0x2AF8        | offset to vtable
+  +0x2B14 | 07 00                   | uint16_t   | 0x0007 (7)                         | table field `id` (UShort)
+  +0x2B16 | 12 00                   | uint16_t   | 0x0012 (18)                        | table field `offset` (UShort)
+  +0x2B18 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x2B5C        | offset to field `name` (string)
+  +0x2B1C | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x2B48        | offset to field `type` (table)
+  +0x2B20 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2B24         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2B24 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2B28 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2B2C        | offset to table[0]
+  +0x2B24 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2B28 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2B2C         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2B2C | 64 F2 FF FF             | SOffset32   | 0xFFFFF264 (-3484) Loc: +0x38C8    | offset to vtable
-  +0x2B30 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2B40       | offset to field `key` (string)
-  +0x2B34 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2B38        | offset to field `value` (string)
+  +0x2B2C | 64 F2 FF FF             | SOffset32  | 0xFFFFF264 (-3484) Loc: 0x38C8     | offset to vtable
+  +0x2B30 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2B40        | offset to field `key` (string)
+  +0x2B34 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2B38         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2B38 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2B3C | 37                      | char[1]     | 7                                  | string literal
-  +0x2B3D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2B38 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2B3C | 37                      | char[1]    | 7                                  | string literal
+  +0x2B3D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2B3E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2B3E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2B40 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2B44 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2B46 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2B40 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2B44 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2B46 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2B48 | 9C F5 FF FF             | SOffset32   | 0xFFFFF59C (-2660) Loc: +0x35AC    | offset to vtable
-  +0x2B4C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2B4F | 01                      | uint8_t     | 0x01 (1)                           | table field `base_type` (Byte)
-  +0x2B50 | 00 00 00 00             | uint32_t    | 0x00000000 (0)                     | table field `index` (Int)
-  +0x2B54 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x2B58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2B48 | 9C F5 FF FF             | SOffset32  | 0xFFFFF59C (-2660) Loc: 0x35AC     | offset to vtable
+  +0x2B4C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2B4F | 01                      | uint8_t    | 0x01 (1)                           | table field `base_type` (Byte)
+  +0x2B50 | 00 00 00 00             | uint32_t   | 0x00000000 (0)                     | table field `index` (Int)
+  +0x2B54 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x2B58 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2B5C | 09 00 00 00             | uint32_t    | 0x00000009 (9)                     | length of string
-  +0x2B60 | 74 65 73 74 5F 74 79 70 | char[9]     | test_typ                           | string literal
-  +0x2B68 | 65                      |             | e
-  +0x2B69 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2B5C | 09 00 00 00             | uint32_t   | 0x00000009 (9)                     | length of string
+  +0x2B60 | 74 65 73 74 5F 74 79 70 | char[9]    | test_typ                           | string literal
+  +0x2B68 | 65                      |            | e
+  +0x2B69 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2B6A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2B6A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Field):
-  +0x2B6C | 18 00                   | uint16_t    | 0x0018 (24)                        | size of this vtable
-  +0x2B6E | 20 00                   | uint16_t    | 0x0020 (32)                        | size of referring table
-  +0x2B70 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x2B72 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x2B74 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `id` (id: 2)
-  +0x2B76 | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `offset` (id: 3)
-  +0x2B78 | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `default_integer` (id: 4)
-  +0x2B7A | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x2B7C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x2B7E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x2B80 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x2B82 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 9)
+  +0x2B6C | 18 00                   | uint16_t   | 0x0018 (24)                        | size of this vtable
+  +0x2B6E | 20 00                   | uint16_t   | 0x0020 (32)                        | size of referring table
+  +0x2B70 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x2B72 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x2B74 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `id` (id: 2)
+  +0x2B76 | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `offset` (id: 3)
+  +0x2B78 | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `default_integer` (id: 4)
+  +0x2B7A | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x2B7C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x2B7E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x2B80 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x2B82 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 9)
 
 table (reflection.Field):
-  +0x2B84 | 18 00 00 00             | SOffset32   | 0x00000018 (24) Loc: +0x2B6C       | offset to vtable
-  +0x2B88 | 06 00                   | uint16_t    | 0x0006 (6)                         | table field `id` (UShort)
-  +0x2B8A | 10 00                   | uint16_t    | 0x0010 (16)                        | table field `offset` (UShort)
-  +0x2B8C | 50 00 00 00             | UOffset32   | 0x00000050 (80) Loc: +0x2BDC       | offset to field `name` (string)
-  +0x2B90 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x2BC8       | offset to field `type` (table)
-  +0x2B94 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2BA4       | offset to field `attributes` (vector)
-  +0x2B98 | 08 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000008 (8)             | table field `default_integer` (Long)
-  +0x2BA0 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x2B84 | 18 00 00 00             | SOffset32  | 0x00000018 (24) Loc: 0x2B6C        | offset to vtable
+  +0x2B88 | 06 00                   | uint16_t   | 0x0006 (6)                         | table field `id` (UShort)
+  +0x2B8A | 10 00                   | uint16_t   | 0x0010 (16)                        | table field `offset` (UShort)
+  +0x2B8C | 50 00 00 00             | UOffset32  | 0x00000050 (80) Loc: 0x2BDC        | offset to field `name` (string)
+  +0x2B90 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x2BC8        | offset to field `type` (table)
+  +0x2B94 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2BA4        | offset to field `attributes` (vector)
+  +0x2B98 | 08 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000008 (8)             | table field `default_integer` (Long)
+  +0x2BA0 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 vector (reflection.Field.attributes):
-  +0x2BA4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2BA8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2BAC        | offset to table[0]
+  +0x2BA4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2BA8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2BAC         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2BAC | E4 F2 FF FF             | SOffset32   | 0xFFFFF2E4 (-3356) Loc: +0x38C8    | offset to vtable
-  +0x2BB0 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2BC0       | offset to field `key` (string)
-  +0x2BB4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2BB8        | offset to field `value` (string)
+  +0x2BAC | E4 F2 FF FF             | SOffset32  | 0xFFFFF2E4 (-3356) Loc: 0x38C8     | offset to vtable
+  +0x2BB0 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2BC0        | offset to field `key` (string)
+  +0x2BB4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2BB8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2BB8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2BBC | 36                      | char[1]     | 6                                  | string literal
-  +0x2BBD | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2BB8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2BBC | 36                      | char[1]    | 6                                  | string literal
+  +0x2BBD | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2BBE | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2BBE | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2BC0 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2BC4 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2BC6 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2BC0 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2BC4 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2BC6 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2BC8 | 1C F6 FF FF             | SOffset32   | 0xFFFFF61C (-2532) Loc: +0x35AC    | offset to vtable
-  +0x2BCC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2BCF | 04                      | uint8_t     | 0x04 (4)                           | table field `base_type` (Byte)
-  +0x2BD0 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | table field `index` (Int)
-  +0x2BD4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x2BD8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2BC8 | 1C F6 FF FF             | SOffset32  | 0xFFFFF61C (-2532) Loc: 0x35AC     | offset to vtable
+  +0x2BCC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2BCF | 04                      | uint8_t    | 0x04 (4)                           | table field `base_type` (Byte)
+  +0x2BD0 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | table field `index` (Int)
+  +0x2BD4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x2BD8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2BDC | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x2BE0 | 63 6F 6C 6F 72          | char[5]     | color                              | string literal
-  +0x2BE5 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2BDC | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x2BE0 | 63 6F 6C 6F 72          | char[5]    | color                              | string literal
+  +0x2BE5 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2BE6 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2BE6 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Field):
-  +0x2BE8 | 1C 00                   | uint16_t    | 0x001C (28)                        | size of this vtable
-  +0x2BEA | 18 00                   | uint16_t    | 0x0018 (24)                        | size of referring table
-  +0x2BEC | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `name` (id: 0)
-  +0x2BEE | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `type` (id: 1)
-  +0x2BF0 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `id` (id: 2)
-  +0x2BF2 | 0A 00                   | VOffset16   | 0x000A (10)                        | offset to field `offset` (id: 3)
-  +0x2BF4 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x2BF6 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x2BF8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x2BFA | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x2BFC | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x2BFE | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `attributes` (id: 9)
-  +0x2C00 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
-  +0x2C02 | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `optional` (id: 11)
+  +0x2BE8 | 1C 00                   | uint16_t   | 0x001C (28)                        | size of this vtable
+  +0x2BEA | 18 00                   | uint16_t   | 0x0018 (24)                        | size of referring table
+  +0x2BEC | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `name` (id: 0)
+  +0x2BEE | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `type` (id: 1)
+  +0x2BF0 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `id` (id: 2)
+  +0x2BF2 | 0A 00                   | VOffset16  | 0x000A (10)                        | offset to field `offset` (id: 3)
+  +0x2BF4 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x2BF6 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x2BF8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x2BFA | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x2BFC | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x2BFE | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `attributes` (id: 9)
+  +0x2C00 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
+  +0x2C02 | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `optional` (id: 11)
 
 table (reflection.Field):
-  +0x2C04 | 1C 00 00 00             | SOffset32   | 0x0000001C (28) Loc: +0x2BE8       | offset to vtable
-  +0x2C08 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2C0B | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x2C0C | 05 00                   | uint16_t    | 0x0005 (5)                         | table field `id` (UShort)
-  +0x2C0E | 0E 00                   | uint16_t    | 0x000E (14)                        | table field `offset` (UShort)
-  +0x2C10 | 4C 00 00 00             | UOffset32   | 0x0000004C (76) Loc: +0x2C5C       | offset to field `name` (string)
-  +0x2C14 | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x2C50       | offset to field `type` (table)
-  +0x2C18 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2C1C        | offset to field `attributes` (vector)
+  +0x2C04 | 1C 00 00 00             | SOffset32  | 0x0000001C (28) Loc: 0x2BE8        | offset to vtable
+  +0x2C08 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2C0B | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x2C0C | 05 00                   | uint16_t   | 0x0005 (5)                         | table field `id` (UShort)
+  +0x2C0E | 0E 00                   | uint16_t   | 0x000E (14)                        | table field `offset` (UShort)
+  +0x2C10 | 4C 00 00 00             | UOffset32  | 0x0000004C (76) Loc: 0x2C5C        | offset to field `name` (string)
+  +0x2C14 | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x2C50        | offset to field `type` (table)
+  +0x2C18 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2C1C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2C1C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2C20 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2C24        | offset to table[0]
+  +0x2C1C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2C20 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2C24         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2C24 | 5C F3 FF FF             | SOffset32   | 0xFFFFF35C (-3236) Loc: +0x38C8    | offset to vtable
-  +0x2C28 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2C38       | offset to field `key` (string)
-  +0x2C2C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2C30        | offset to field `value` (string)
+  +0x2C24 | 5C F3 FF FF             | SOffset32  | 0xFFFFF35C (-3236) Loc: 0x38C8     | offset to vtable
+  +0x2C28 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2C38        | offset to field `key` (string)
+  +0x2C2C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2C30         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2C30 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2C34 | 35                      | char[1]     | 5                                  | string literal
-  +0x2C35 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2C30 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2C34 | 35                      | char[1]    | 5                                  | string literal
+  +0x2C35 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2C36 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2C36 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2C38 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2C3C | 69 64                   | char[2]     | id                                 | string literal
-  +0x2C3E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2C38 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2C3C | 69 64                   | char[2]    | id                                 | string literal
+  +0x2C3E | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Type):
-  +0x2C40 | 10 00                   | uint16_t    | 0x0010 (16)                        | size of this vtable
-  +0x2C42 | 0C 00                   | uint16_t    | 0x000C (12)                        | size of referring table
-  +0x2C44 | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `base_type` (id: 0)
-  +0x2C46 | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `element` (id: 1)
-  +0x2C48 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `index` (id: 2) <defaults to -1> (Int)
-  +0x2C4A | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
-  +0x2C4C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `base_size` (id: 4) <defaults to 4> (UInt)
-  +0x2C4E | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `element_size` (id: 5)
+  +0x2C40 | 10 00                   | uint16_t   | 0x0010 (16)                        | size of this vtable
+  +0x2C42 | 0C 00                   | uint16_t   | 0x000C (12)                        | size of referring table
+  +0x2C44 | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `base_type` (id: 0)
+  +0x2C46 | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `element` (id: 1)
+  +0x2C48 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `index` (id: 2) <defaults to -1> (Int)
+  +0x2C4A | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
+  +0x2C4C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `base_size` (id: 4) <defaults to 4> (UInt)
+  +0x2C4E | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `element_size` (id: 5)
 
 table (reflection.Type):
-  +0x2C50 | 10 00 00 00             | SOffset32   | 0x00000010 (16) Loc: +0x2C40       | offset to vtable
-  +0x2C54 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x2C56 | 0E                      | uint8_t     | 0x0E (14)                          | table field `base_type` (Byte)
-  +0x2C57 | 04                      | uint8_t     | 0x04 (4)                           | table field `element` (Byte)
-  +0x2C58 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2C50 | 10 00 00 00             | SOffset32  | 0x00000010 (16) Loc: 0x2C40        | offset to vtable
+  +0x2C54 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x2C56 | 0E                      | uint8_t    | 0x0E (14)                          | table field `base_type` (Byte)
+  +0x2C57 | 04                      | uint8_t    | 0x04 (4)                           | table field `element` (Byte)
+  +0x2C58 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2C5C | 09 00 00 00             | uint32_t    | 0x00000009 (9)                     | length of string
-  +0x2C60 | 69 6E 76 65 6E 74 6F 72 | char[9]     | inventor                           | string literal
-  +0x2C68 | 79                      |             | y
-  +0x2C69 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2C5C | 09 00 00 00             | uint32_t   | 0x00000009 (9)                     | length of string
+  +0x2C60 | 69 6E 76 65 6E 74 6F 72 | char[9]    | inventor                           | string literal
+  +0x2C68 | 79                      |            | y
+  +0x2C69 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2C6A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2C6A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Field):
-  +0x2C6C | 18 00                   | uint16_t    | 0x0018 (24)                        | size of this vtable
-  +0x2C6E | 18 00                   | uint16_t    | 0x0018 (24)                        | size of referring table
-  +0x2C70 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `name` (id: 0)
-  +0x2C72 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `type` (id: 1)
-  +0x2C74 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `id` (id: 2)
-  +0x2C76 | 0A 00                   | VOffset16   | 0x000A (10)                        | offset to field `offset` (id: 3)
-  +0x2C78 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x2C7A | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x2C7C | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `deprecated` (id: 6)
-  +0x2C7E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x2C80 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x2C82 | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `attributes` (id: 9)
+  +0x2C6C | 18 00                   | uint16_t   | 0x0018 (24)                        | size of this vtable
+  +0x2C6E | 18 00                   | uint16_t   | 0x0018 (24)                        | size of referring table
+  +0x2C70 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `name` (id: 0)
+  +0x2C72 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `type` (id: 1)
+  +0x2C74 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `id` (id: 2)
+  +0x2C76 | 0A 00                   | VOffset16  | 0x000A (10)                        | offset to field `offset` (id: 3)
+  +0x2C78 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x2C7A | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x2C7C | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `deprecated` (id: 6)
+  +0x2C7E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x2C80 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x2C82 | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `attributes` (id: 9)
 
 table (reflection.Field):
-  +0x2C84 | 18 00 00 00             | SOffset32   | 0x00000018 (24) Loc: +0x2C6C       | offset to vtable
-  +0x2C88 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2C8B | 01                      | uint8_t     | 0x01 (1)                           | table field `deprecated` (Bool)
-  +0x2C8C | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `id` (UShort)
-  +0x2C8E | 0C 00                   | uint16_t    | 0x000C (12)                        | table field `offset` (UShort)
-  +0x2C90 | 90 00 00 00             | UOffset32   | 0x00000090 (144) Loc: +0x2D20      | offset to field `name` (string)
-  +0x2C94 | 7C 00 00 00             | UOffset32   | 0x0000007C (124) Loc: +0x2D10      | offset to field `type` (table)
-  +0x2C98 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2C9C        | offset to field `attributes` (vector)
+  +0x2C84 | 18 00 00 00             | SOffset32  | 0x00000018 (24) Loc: 0x2C6C        | offset to vtable
+  +0x2C88 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2C8B | 01                      | uint8_t    | 0x01 (1)                           | table field `deprecated` (Bool)
+  +0x2C8C | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `id` (UShort)
+  +0x2C8E | 0C 00                   | uint16_t   | 0x000C (12)                        | table field `offset` (UShort)
+  +0x2C90 | 90 00 00 00             | UOffset32  | 0x00000090 (144) Loc: 0x2D20       | offset to field `name` (string)
+  +0x2C94 | 7C 00 00 00             | UOffset32  | 0x0000007C (124) Loc: 0x2D10       | offset to field `type` (table)
+  +0x2C98 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2C9C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2C9C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of vector (# items)
-  +0x2CA0 | 4C 00 00 00             | UOffset32   | 0x0000004C (76) Loc: +0x2CEC       | offset to table[0]
-  +0x2CA4 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x2CD0       | offset to table[1]
-  +0x2CA8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2CAC        | offset to table[2]
+  +0x2C9C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of vector (# items)
+  +0x2CA0 | 4C 00 00 00             | UOffset32  | 0x0000004C (76) Loc: 0x2CEC        | offset to table[0]
+  +0x2CA4 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x2CD0        | offset to table[1]
+  +0x2CA8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2CAC         | offset to table[2]
 
 table (reflection.KeyValue):
-  +0x2CAC | E4 F3 FF FF             | SOffset32   | 0xFFFFF3E4 (-3100) Loc: +0x38C8    | offset to vtable
-  +0x2CB0 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2CC0       | offset to field `key` (string)
-  +0x2CB4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2CB8        | offset to field `value` (string)
+  +0x2CAC | E4 F3 FF FF             | SOffset32  | 0xFFFFF3E4 (-3100) Loc: 0x38C8     | offset to vtable
+  +0x2CB0 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2CC0        | offset to field `key` (string)
+  +0x2CB4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2CB8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2CB8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2CBC | 31                      | char[1]     | 1                                  | string literal
-  +0x2CBD | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2CB8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2CBC | 31                      | char[1]    | 1                                  | string literal
+  +0x2CBD | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2CBE | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2CBE | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2CC0 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x2CC4 | 70 72 69 6F 72 69 74 79 | char[8]     | priority                           | string literal
-  +0x2CCC | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2CC0 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x2CC4 | 70 72 69 6F 72 69 74 79 | char[8]    | priority                           | string literal
+  +0x2CCC | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2CCD | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2CCD | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.KeyValue):
-  +0x2CD0 | 08 F4 FF FF             | SOffset32   | 0xFFFFF408 (-3064) Loc: +0x38C8    | offset to vtable
-  +0x2CD4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2CE4       | offset to field `key` (string)
-  +0x2CD8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2CDC        | offset to field `value` (string)
+  +0x2CD0 | 08 F4 FF FF             | SOffset32  | 0xFFFFF408 (-3064) Loc: 0x38C8     | offset to vtable
+  +0x2CD4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2CE4        | offset to field `key` (string)
+  +0x2CD8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2CDC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2CDC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2CE0 | 34                      | char[1]     | 4                                  | string literal
-  +0x2CE1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2CDC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2CE0 | 34                      | char[1]    | 4                                  | string literal
+  +0x2CE1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2CE2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2CE2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2CE4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2CE8 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2CEA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2CE4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2CE8 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2CEA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x2CEC | 24 F4 FF FF             | SOffset32   | 0xFFFFF424 (-3036) Loc: +0x38C8    | offset to vtable
-  +0x2CF0 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2D00       | offset to field `key` (string)
-  +0x2CF4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2CF8        | offset to field `value` (string)
+  +0x2CEC | 24 F4 FF FF             | SOffset32  | 0xFFFFF424 (-3036) Loc: 0x38C8     | offset to vtable
+  +0x2CF0 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2D00        | offset to field `key` (string)
+  +0x2CF4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2CF8         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2CF8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2CFC | 30                      | char[1]     | 0                                  | string literal
-  +0x2CFD | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2CF8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2CFC | 30                      | char[1]    | 0                                  | string literal
+  +0x2CFD | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2CFE | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2CFE | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2D00 | 0A 00 00 00             | uint32_t    | 0x0000000A (10)                    | length of string
-  +0x2D04 | 64 65 70 72 65 63 61 74 | char[10]    | deprecat                           | string literal
-  +0x2D0C | 65 64                   |             | ed
-  +0x2D0E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2D00 | 0A 00 00 00             | uint32_t   | 0x0000000A (10)                    | length of string
+  +0x2D04 | 64 65 70 72 65 63 61 74 | char[10]   | deprecat                           | string literal
+  +0x2D0C | 65 64                   |            | ed
+  +0x2D0E | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2D10 | 9C F6 FF FF             | SOffset32   | 0xFFFFF69C (-2404) Loc: +0x3674    | offset to vtable
-  +0x2D14 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2D17 | 02                      | uint8_t     | 0x02 (2)                           | table field `base_type` (Byte)
-  +0x2D18 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x2D1C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2D10 | 9C F6 FF FF             | SOffset32  | 0xFFFFF69C (-2404) Loc: 0x3674     | offset to vtable
+  +0x2D14 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2D17 | 02                      | uint8_t    | 0x02 (2)                           | table field `base_type` (Byte)
+  +0x2D18 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x2D1C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2D20 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x2D24 | 66 72 69 65 6E 64 6C 79 | char[8]     | friendly                           | string literal
-  +0x2D2C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2D20 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x2D24 | 66 72 69 65 6E 64 6C 79 | char[8]    | friendly                           | string literal
+  +0x2D2C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2D2D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2D2D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 vtable (reflection.Field):
-  +0x2D30 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of this vtable
-  +0x2D32 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of referring table
-  +0x2D34 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `name` (id: 0)
-  +0x2D36 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `type` (id: 1)
-  +0x2D38 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `id` (id: 2)
-  +0x2D3A | 0A 00                   | VOffset16   | 0x000A (10)                        | offset to field `offset` (id: 3)
-  +0x2D3C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x2D3E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x2D40 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x2D42 | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `required` (id: 7)
-  +0x2D44 | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `key` (id: 8)
-  +0x2D46 | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `attributes` (id: 9)
+  +0x2D30 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of this vtable
+  +0x2D32 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of referring table
+  +0x2D34 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `name` (id: 0)
+  +0x2D36 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `type` (id: 1)
+  +0x2D38 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `id` (id: 2)
+  +0x2D3A | 0A 00                   | VOffset16  | 0x000A (10)                        | offset to field `offset` (id: 3)
+  +0x2D3C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x2D3E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x2D40 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x2D42 | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `required` (id: 7)
+  +0x2D44 | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `key` (id: 8)
+  +0x2D46 | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `attributes` (id: 9)
 
 table (reflection.Field):
-  +0x2D48 | 18 00 00 00             | SOffset32   | 0x00000018 (24) Loc: +0x2D30       | offset to vtable
-  +0x2D4C | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x2D4E | 01                      | uint8_t     | 0x01 (1)                           | table field `required` (Bool)
-  +0x2D4F | 01                      | uint8_t     | 0x01 (1)                           | table field `key` (Bool)
-  +0x2D50 | 03 00                   | uint16_t    | 0x0003 (3)                         | table field `id` (UShort)
-  +0x2D52 | 0A 00                   | uint16_t    | 0x000A (10)                        | table field `offset` (UShort)
-  +0x2D54 | 5C 00 00 00             | UOffset32   | 0x0000005C (92) Loc: +0x2DB0       | offset to field `name` (string)
-  +0x2D58 | 4C 00 00 00             | UOffset32   | 0x0000004C (76) Loc: +0x2DA4       | offset to field `type` (table)
-  +0x2D5C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2D60        | offset to field `attributes` (vector)
+  +0x2D48 | 18 00 00 00             | SOffset32  | 0x00000018 (24) Loc: 0x2D30        | offset to vtable
+  +0x2D4C | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x2D4E | 01                      | uint8_t    | 0x01 (1)                           | table field `required` (Bool)
+  +0x2D4F | 01                      | uint8_t    | 0x01 (1)                           | table field `key` (Bool)
+  +0x2D50 | 03 00                   | uint16_t   | 0x0003 (3)                         | table field `id` (UShort)
+  +0x2D52 | 0A 00                   | uint16_t   | 0x000A (10)                        | table field `offset` (UShort)
+  +0x2D54 | 5C 00 00 00             | UOffset32  | 0x0000005C (92) Loc: 0x2DB0        | offset to field `name` (string)
+  +0x2D58 | 4C 00 00 00             | UOffset32  | 0x0000004C (76) Loc: 0x2DA4        | offset to field `type` (table)
+  +0x2D5C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2D60         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2D60 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x2D64 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x2D88       | offset to table[0]
-  +0x2D68 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2D6C        | offset to table[1]
+  +0x2D60 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x2D64 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x2D88        | offset to table[0]
+  +0x2D68 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2D6C         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x2D6C | A4 F4 FF FF             | SOffset32   | 0xFFFFF4A4 (-2908) Loc: +0x38C8    | offset to vtable
-  +0x2D70 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2D80       | offset to field `key` (string)
-  +0x2D74 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2D78        | offset to field `value` (string)
+  +0x2D6C | A4 F4 FF FF             | SOffset32  | 0xFFFFF4A4 (-2908) Loc: 0x38C8     | offset to vtable
+  +0x2D70 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2D80        | offset to field `key` (string)
+  +0x2D74 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2D78         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2D78 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2D7C | 30                      | char[1]     | 0                                  | string literal
-  +0x2D7D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2D78 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2D7C | 30                      | char[1]    | 0                                  | string literal
+  +0x2D7D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2D7E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2D7E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2D80 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x2D84 | 6B 65 79                | char[3]     | key                                | string literal
-  +0x2D87 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2D80 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x2D84 | 6B 65 79                | char[3]    | key                                | string literal
+  +0x2D87 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x2D88 | C0 F4 FF FF             | SOffset32   | 0xFFFFF4C0 (-2880) Loc: +0x38C8    | offset to vtable
-  +0x2D8C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2D9C       | offset to field `key` (string)
-  +0x2D90 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2D94        | offset to field `value` (string)
+  +0x2D88 | C0 F4 FF FF             | SOffset32  | 0xFFFFF4C0 (-2880) Loc: 0x38C8     | offset to vtable
+  +0x2D8C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2D9C        | offset to field `key` (string)
+  +0x2D90 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2D94         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2D94 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2D98 | 33                      | char[1]     | 3                                  | string literal
-  +0x2D99 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2D94 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2D98 | 33                      | char[1]    | 3                                  | string literal
+  +0x2D99 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2D9A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2D9A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2D9C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2DA0 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2DA2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2D9C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2DA0 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2DA2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2DA4 | C8 F4 FF FF             | SOffset32   | 0xFFFFF4C8 (-2872) Loc: +0x38DC    | offset to vtable
-  +0x2DA8 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2DAB | 0D                      | uint8_t     | 0x0D (13)                          | table field `base_type` (Byte)
-  +0x2DAC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2DA4 | C8 F4 FF FF             | SOffset32  | 0xFFFFF4C8 (-2872) Loc: 0x38DC     | offset to vtable
+  +0x2DA8 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2DAB | 0D                      | uint8_t    | 0x0D (13)                          | table field `base_type` (Byte)
+  +0x2DAC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2DB0 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x2DB4 | 6E 61 6D 65             | char[4]     | name                               | string literal
-  +0x2DB8 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2DB0 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x2DB4 | 6E 61 6D 65             | char[4]    | name                               | string literal
+  +0x2DB8 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2DB9 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2DB9 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Field):
-  +0x2DBC | A8 FF FF FF             | SOffset32   | 0xFFFFFFA8 (-88) Loc: +0x2E14      | offset to vtable
-  +0x2DC0 | 02 00                   | uint16_t    | 0x0002 (2)                         | table field `id` (UShort)
-  +0x2DC2 | 08 00                   | uint16_t    | 0x0008 (8)                         | table field `offset` (UShort)
-  +0x2DC4 | 48 00 00 00             | UOffset32   | 0x00000048 (72) Loc: +0x2E0C       | offset to field `name` (string)
-  +0x2DC8 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x2DFC       | offset to field `type` (table)
-  +0x2DCC | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x2DD8       | offset to field `attributes` (vector)
-  +0x2DD0 | 64 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000064 (100)           | table field `default_integer` (Long)
+  +0x2DBC | A8 FF FF FF             | SOffset32  | 0xFFFFFFA8 (-88) Loc: 0x2E14       | offset to vtable
+  +0x2DC0 | 02 00                   | uint16_t   | 0x0002 (2)                         | table field `id` (UShort)
+  +0x2DC2 | 08 00                   | uint16_t   | 0x0008 (8)                         | table field `offset` (UShort)
+  +0x2DC4 | 48 00 00 00             | UOffset32  | 0x00000048 (72) Loc: 0x2E0C        | offset to field `name` (string)
+  +0x2DC8 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x2DFC        | offset to field `type` (table)
+  +0x2DCC | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x2DD8        | offset to field `attributes` (vector)
+  +0x2DD0 | 64 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000064 (100)           | table field `default_integer` (Long)
 
 vector (reflection.Field.attributes):
-  +0x2DD8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2DDC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2DE0        | offset to table[0]
+  +0x2DD8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2DDC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2DE0         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2DE0 | 18 F5 FF FF             | SOffset32   | 0xFFFFF518 (-2792) Loc: +0x38C8    | offset to vtable
-  +0x2DE4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2DF4       | offset to field `key` (string)
-  +0x2DE8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2DEC        | offset to field `value` (string)
+  +0x2DE0 | 18 F5 FF FF             | SOffset32  | 0xFFFFF518 (-2792) Loc: 0x38C8     | offset to vtable
+  +0x2DE4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2DF4        | offset to field `key` (string)
+  +0x2DE8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2DEC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2DEC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2DF0 | 32                      | char[1]     | 2                                  | string literal
-  +0x2DF1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2DEC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2DF0 | 32                      | char[1]    | 2                                  | string literal
+  +0x2DF1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2DF2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2DF2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2DF4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2DF8 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2DFA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2DF4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2DF8 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2DFA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2DFC | 88 F7 FF FF             | SOffset32   | 0xFFFFF788 (-2168) Loc: +0x3674    | offset to vtable
-  +0x2E00 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2E03 | 05                      | uint8_t     | 0x05 (5)                           | table field `base_type` (Byte)
-  +0x2E04 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | table field `base_size` (UInt)
-  +0x2E08 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2DFC | 88 F7 FF FF             | SOffset32  | 0xFFFFF788 (-2168) Loc: 0x3674     | offset to vtable
+  +0x2E00 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2E03 | 05                      | uint8_t    | 0x05 (5)                           | table field `base_type` (Byte)
+  +0x2E04 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `base_size` (UInt)
+  +0x2E08 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2E0C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2E10 | 68 70                   | char[2]     | hp                                 | string literal
-  +0x2E12 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2E0C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2E10 | 68 70                   | char[2]    | hp                                 | string literal
+  +0x2E12 | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Field):
-  +0x2E14 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of this vtable
-  +0x2E16 | 1C 00                   | uint16_t    | 0x001C (28)                        | size of referring table
-  +0x2E18 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x2E1A | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x2E1C | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `id` (id: 2)
-  +0x2E1E | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `offset` (id: 3)
-  +0x2E20 | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `default_integer` (id: 4)
-  +0x2E22 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x2E24 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x2E26 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x2E28 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x2E2A | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 9)
+  +0x2E14 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of this vtable
+  +0x2E16 | 1C 00                   | uint16_t   | 0x001C (28)                        | size of referring table
+  +0x2E18 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x2E1A | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x2E1C | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `id` (id: 2)
+  +0x2E1E | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `offset` (id: 3)
+  +0x2E20 | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `default_integer` (id: 4)
+  +0x2E22 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x2E24 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x2E26 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x2E28 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x2E2A | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 9)
 
 table (reflection.Field):
-  +0x2E2C | 18 00 00 00             | SOffset32   | 0x00000018 (24) Loc: +0x2E14       | offset to vtable
-  +0x2E30 | 01 00                   | uint16_t    | 0x0001 (1)                         | table field `id` (UShort)
-  +0x2E32 | 06 00                   | uint16_t    | 0x0006 (6)                         | table field `offset` (UShort)
-  +0x2E34 | 48 00 00 00             | UOffset32   | 0x00000048 (72) Loc: +0x2E7C       | offset to field `name` (string)
-  +0x2E38 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x2E6C       | offset to field `type` (table)
-  +0x2E3C | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x2E48       | offset to field `attributes` (vector)
-  +0x2E40 | 96 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000096 (150)           | table field `default_integer` (Long)
+  +0x2E2C | 18 00 00 00             | SOffset32  | 0x00000018 (24) Loc: 0x2E14        | offset to vtable
+  +0x2E30 | 01 00                   | uint16_t   | 0x0001 (1)                         | table field `id` (UShort)
+  +0x2E32 | 06 00                   | uint16_t   | 0x0006 (6)                         | table field `offset` (UShort)
+  +0x2E34 | 48 00 00 00             | UOffset32  | 0x00000048 (72) Loc: 0x2E7C        | offset to field `name` (string)
+  +0x2E38 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x2E6C        | offset to field `type` (table)
+  +0x2E3C | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x2E48        | offset to field `attributes` (vector)
+  +0x2E40 | 96 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000096 (150)           | table field `default_integer` (Long)
 
 vector (reflection.Field.attributes):
-  +0x2E48 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2E4C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2E50        | offset to table[0]
+  +0x2E48 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2E4C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2E50         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2E50 | 88 F5 FF FF             | SOffset32   | 0xFFFFF588 (-2680) Loc: +0x38C8    | offset to vtable
-  +0x2E54 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2E64       | offset to field `key` (string)
-  +0x2E58 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2E5C        | offset to field `value` (string)
+  +0x2E50 | 88 F5 FF FF             | SOffset32  | 0xFFFFF588 (-2680) Loc: 0x38C8     | offset to vtable
+  +0x2E54 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2E64        | offset to field `key` (string)
+  +0x2E58 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2E5C         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2E5C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2E60 | 31                      | char[1]     | 1                                  | string literal
-  +0x2E61 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2E5C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2E60 | 31                      | char[1]    | 1                                  | string literal
+  +0x2E61 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2E62 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2E62 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2E64 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2E68 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2E6A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2E64 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2E68 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2E6A | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2E6C | F8 F7 FF FF             | SOffset32   | 0xFFFFF7F8 (-2056) Loc: +0x3674    | offset to vtable
-  +0x2E70 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2E73 | 05                      | uint8_t     | 0x05 (5)                           | table field `base_type` (Byte)
-  +0x2E74 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | table field `base_size` (UInt)
-  +0x2E78 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2E6C | F8 F7 FF FF             | SOffset32  | 0xFFFFF7F8 (-2056) Loc: 0x3674     | offset to vtable
+  +0x2E70 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2E73 | 05                      | uint8_t    | 0x05 (5)                           | table field `base_type` (Byte)
+  +0x2E74 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `base_size` (UInt)
+  +0x2E78 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2E7C | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x2E80 | 6D 61 6E 61             | char[4]     | mana                               | string literal
-  +0x2E84 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2E7C | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x2E80 | 6D 61 6E 61             | char[4]    | mana                               | string literal
+  +0x2E84 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2E85 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2E85 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 vtable (reflection.Field):
-  +0x2E88 | 1C 00                   | uint16_t    | 0x001C (28)                        | size of this vtable
-  +0x2E8A | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x2E8C | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x2E8E | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x2E90 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
-  +0x2E92 | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `offset` (id: 3)
-  +0x2E94 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x2E96 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x2E98 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x2E9A | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x2E9C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x2E9E | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 9)
-  +0x2EA0 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
-  +0x2EA2 | 05 00                   | VOffset16   | 0x0005 (5)                         | offset to field `optional` (id: 11)
+  +0x2E88 | 1C 00                   | uint16_t   | 0x001C (28)                        | size of this vtable
+  +0x2E8A | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x2E8C | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x2E8E | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x2E90 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
+  +0x2E92 | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `offset` (id: 3)
+  +0x2E94 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x2E96 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x2E98 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x2E9A | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x2E9C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x2E9E | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 9)
+  +0x2EA0 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
+  +0x2EA2 | 05 00                   | VOffset16  | 0x0005 (5)                         | offset to field `optional` (id: 11)
 
 table (reflection.Field):
-  +0x2EA4 | 1C 00 00 00             | SOffset32   | 0x0000001C (28) Loc: +0x2E88       | offset to vtable
-  +0x2EA8 | 00                      | uint8_t[1]  | .                                  | padding
-  +0x2EA9 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x2EAA | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `offset` (UShort)
-  +0x2EAC | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x2EEC       | offset to field `name` (string)
-  +0x2EB0 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x2EDC       | offset to field `type` (table)
-  +0x2EB4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2EB8        | offset to field `attributes` (vector)
+  +0x2EA4 | 1C 00 00 00             | SOffset32  | 0x0000001C (28) Loc: 0x2E88        | offset to vtable
+  +0x2EA8 | 00                      | uint8_t[1] | .                                  | padding
+  +0x2EA9 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x2EAA | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `offset` (UShort)
+  +0x2EAC | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x2EEC        | offset to field `name` (string)
+  +0x2EB0 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x2EDC        | offset to field `type` (table)
+  +0x2EB4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2EB8         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2EB8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2EBC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2EC0        | offset to table[0]
+  +0x2EB8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2EBC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2EC0         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x2EC0 | F8 F5 FF FF             | SOffset32   | 0xFFFFF5F8 (-2568) Loc: +0x38C8    | offset to vtable
-  +0x2EC4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2ED4       | offset to field `key` (string)
-  +0x2EC8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2ECC        | offset to field `value` (string)
+  +0x2EC0 | F8 F5 FF FF             | SOffset32  | 0xFFFFF5F8 (-2568) Loc: 0x38C8     | offset to vtable
+  +0x2EC4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2ED4        | offset to field `key` (string)
+  +0x2EC8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2ECC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2ECC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2ED0 | 30                      | char[1]     | 0                                  | string literal
-  +0x2ED1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2ECC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2ED0 | 30                      | char[1]    | 0                                  | string literal
+  +0x2ED1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2ED2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2ED2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2ED4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2ED8 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2EDA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2ED4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2ED8 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2EDA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x2EDC | C4 F6 FF FF             | SOffset32   | 0xFFFFF6C4 (-2364) Loc: +0x3818    | offset to vtable
-  +0x2EE0 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2EE3 | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x2EE4 | 09 00 00 00             | uint32_t    | 0x00000009 (9)                     | table field `index` (Int)
-  +0x2EE8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2EDC | C4 F6 FF FF             | SOffset32  | 0xFFFFF6C4 (-2364) Loc: 0x3818     | offset to vtable
+  +0x2EE0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2EE3 | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x2EE4 | 09 00 00 00             | uint32_t   | 0x00000009 (9)                     | table field `index` (Int)
+  +0x2EE8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2EEC | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x2EF0 | 70 6F 73                | char[3]     | pos                                | string literal
-  +0x2EF3 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2EEC | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x2EF0 | 70 6F 73                | char[3]    | pos                                | string literal
+  +0x2EF3 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Object):
-  +0x2EF4 | 5C F7 FF FF             | SOffset32   | 0xFFFFF75C (-2212) Loc: +0x3798    | offset to vtable
-  +0x2EF8 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x2F10       | offset to field `name` (string)
-  +0x2EFC | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x2F08       | offset to field `fields` (vector)
-  +0x2F00 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `minalign` (Int)
-  +0x2F04 | E0 07 00 00             | UOffset32   | 0x000007E0 (2016) Loc: +0x36E4     | offset to field `declaration_file` (string)
+  +0x2EF4 | 5C F7 FF FF             | SOffset32  | 0xFFFFF75C (-2212) Loc: 0x3798     | offset to vtable
+  +0x2EF8 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x2F10        | offset to field `name` (string)
+  +0x2EFC | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x2F08        | offset to field `fields` (vector)
+  +0x2F00 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `minalign` (Int)
+  +0x2F04 | E0 07 00 00             | UOffset32  | 0x000007E0 (2016) Loc: 0x36E4      | offset to field `declaration_file` (string)
 
 vector (reflection.Object.fields):
-  +0x2F08 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x2F0C | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x2F48       | offset to table[0]
+  +0x2F08 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x2F0C | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x2F48        | offset to table[0]
 
 string (reflection.Object.name):
-  +0x2F10 | 19 00 00 00             | uint32_t    | 0x00000019 (25)                    | length of string
-  +0x2F14 | 4D 79 47 61 6D 65 2E 45 | char[25]    | MyGame.E                           | string literal
-  +0x2F1C | 78 61 6D 70 6C 65 2E 52 |             | xample.R
-  +0x2F24 | 65 66 65 72 72 61 62 6C |             | eferrabl
-  +0x2F2C | 65                      |             | e
-  +0x2F2D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2F10 | 19 00 00 00             | uint32_t   | 0x00000019 (25)                    | length of string
+  +0x2F14 | 4D 79 47 61 6D 65 2E 45 | char[25]   | MyGame.E                           | string literal
+  +0x2F1C | 78 61 6D 70 6C 65 2E 52 |            | xample.R
+  +0x2F24 | 65 66 65 72 72 61 62 6C |            | eferrabl
+  +0x2F2C | 65                      |            | e
+  +0x2F2D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2F2E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2F2E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Field):
-  +0x2F30 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of this vtable
-  +0x2F32 | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x2F34 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x2F36 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x2F38 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
-  +0x2F3A | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `offset` (id: 3)
-  +0x2F3C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x2F3E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x2F40 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x2F42 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x2F44 | 05 00                   | VOffset16   | 0x0005 (5)                         | offset to field `key` (id: 8)
-  +0x2F46 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 9)
+  +0x2F30 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of this vtable
+  +0x2F32 | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x2F34 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x2F36 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x2F38 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
+  +0x2F3A | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `offset` (id: 3)
+  +0x2F3C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x2F3E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x2F40 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x2F42 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x2F44 | 05 00                   | VOffset16  | 0x0005 (5)                         | offset to field `key` (id: 8)
+  +0x2F46 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 9)
 
 table (reflection.Field):
-  +0x2F48 | 18 00 00 00             | SOffset32   | 0x00000018 (24) Loc: +0x2F30       | offset to vtable
-  +0x2F4C | 00                      | uint8_t[1]  | .                                  | padding
-  +0x2F4D | 01                      | uint8_t     | 0x01 (1)                           | table field `key` (Bool)
-  +0x2F4E | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `offset` (UShort)
-  +0x2F50 | 6C 00 00 00             | UOffset32   | 0x0000006C (108) Loc: +0x2FBC      | offset to field `name` (string)
-  +0x2F54 | 58 00 00 00             | UOffset32   | 0x00000058 (88) Loc: +0x2FAC       | offset to field `type` (table)
-  +0x2F58 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2F5C        | offset to field `attributes` (vector)
+  +0x2F48 | 18 00 00 00             | SOffset32  | 0x00000018 (24) Loc: 0x2F30        | offset to vtable
+  +0x2F4C | 00                      | uint8_t[1] | .                                  | padding
+  +0x2F4D | 01                      | uint8_t    | 0x01 (1)                           | table field `key` (Bool)
+  +0x2F4E | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `offset` (UShort)
+  +0x2F50 | 6C 00 00 00             | UOffset32  | 0x0000006C (108) Loc: 0x2FBC       | offset to field `name` (string)
+  +0x2F54 | 58 00 00 00             | UOffset32  | 0x00000058 (88) Loc: 0x2FAC        | offset to field `type` (table)
+  +0x2F58 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2F5C         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x2F5C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x2F60 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x2F84       | offset to table[0]
-  +0x2F64 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2F68        | offset to table[1]
+  +0x2F5C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x2F60 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x2F84        | offset to table[0]
+  +0x2F64 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2F68         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x2F68 | A0 F6 FF FF             | SOffset32   | 0xFFFFF6A0 (-2400) Loc: +0x38C8    | offset to vtable
-  +0x2F6C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x2F7C       | offset to field `key` (string)
-  +0x2F70 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2F74        | offset to field `value` (string)
+  +0x2F68 | A0 F6 FF FF             | SOffset32  | 0xFFFFF6A0 (-2400) Loc: 0x38C8     | offset to vtable
+  +0x2F6C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x2F7C        | offset to field `key` (string)
+  +0x2F70 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2F74         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2F74 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x2F78 | 30                      | char[1]     | 0                                  | string literal
-  +0x2F79 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2F74 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x2F78 | 30                      | char[1]    | 0                                  | string literal
+  +0x2F79 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2F7A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x2F7A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x2F7C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x2F80 | 6B 65 79                | char[3]     | key                                | string literal
-  +0x2F83 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2F7C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x2F80 | 6B 65 79                | char[3]    | key                                | string literal
+  +0x2F83 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x2F84 | BC F6 FF FF             | SOffset32   | 0xFFFFF6BC (-2372) Loc: +0x38C8    | offset to vtable
-  +0x2F88 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x2FA0       | offset to field `key` (string)
-  +0x2F8C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x2F90        | offset to field `value` (string)
+  +0x2F84 | BC F6 FF FF             | SOffset32  | 0xFFFFF6BC (-2372) Loc: 0x38C8     | offset to vtable
+  +0x2F88 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x2FA0        | offset to field `key` (string)
+  +0x2F8C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x2F90         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x2F90 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x2F94 | 66 6E 76 31 61 5F 36 34 | char[8]     | fnv1a_64                           | string literal
-  +0x2F9C | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2F90 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x2F94 | 66 6E 76 31 61 5F 36 34 | char[8]    | fnv1a_64                           | string literal
+  +0x2F9C | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2F9D | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2F9D | 00 00 00                | uint8_t[3] | ...                                | padding
 
 string (reflection.KeyValue.key):
-  +0x2FA0 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | length of string
-  +0x2FA4 | 68 61 73 68             | char[4]     | hash                               | string literal
-  +0x2FA8 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2FA0 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | length of string
+  +0x2FA4 | 68 61 73 68             | char[4]    | hash                               | string literal
+  +0x2FA8 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x2FA9 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x2FA9 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 table (reflection.Type):
-  +0x2FAC | 38 F9 FF FF             | SOffset32   | 0xFFFFF938 (-1736) Loc: +0x3674    | offset to vtable
-  +0x2FB0 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x2FB3 | 0A                      | uint8_t     | 0x0A (10)                          | table field `base_type` (Byte)
-  +0x2FB4 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x2FB8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x2FAC | 38 F9 FF FF             | SOffset32  | 0xFFFFF938 (-1736) Loc: 0x3674     | offset to vtable
+  +0x2FB0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x2FB3 | 0A                      | uint8_t    | 0x0A (10)                          | table field `base_type` (Byte)
+  +0x2FB4 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x2FB8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x2FBC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x2FC0 | 69 64                   | char[2]     | id                                 | string literal
-  +0x2FC2 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2FBC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x2FC0 | 69 64                   | char[2]    | id                                 | string literal
+  +0x2FC2 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Object):
-  +0x2FC4 | 2C F8 FF FF             | SOffset32   | 0xFFFFF82C (-2004) Loc: +0x3798    | offset to vtable
-  +0x2FC8 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x2FE8       | offset to field `name` (string)
-  +0x2FCC | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x2FD8       | offset to field `fields` (vector)
-  +0x2FD0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `minalign` (Int)
-  +0x2FD4 | 10 07 00 00             | UOffset32   | 0x00000710 (1808) Loc: +0x36E4     | offset to field `declaration_file` (string)
+  +0x2FC4 | 2C F8 FF FF             | SOffset32  | 0xFFFFF82C (-2004) Loc: 0x3798     | offset to vtable
+  +0x2FC8 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x2FE8        | offset to field `name` (string)
+  +0x2FCC | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x2FD8        | offset to field `fields` (vector)
+  +0x2FD0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `minalign` (Int)
+  +0x2FD4 | 10 07 00 00             | UOffset32  | 0x00000710 (1808) Loc: 0x36E4      | offset to field `declaration_file` (string)
 
 vector (reflection.Object.fields):
-  +0x2FD8 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of vector (# items)
-  +0x2FDC | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x3018       | offset to table[0]
-  +0x2FE0 | B8 00 00 00             | UOffset32   | 0x000000B8 (184) Loc: +0x3098      | offset to table[1]
-  +0x2FE4 | 8C 00 00 00             | UOffset32   | 0x0000008C (140) Loc: +0x3070      | offset to table[2]
+  +0x2FD8 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of vector (# items)
+  +0x2FDC | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x3018        | offset to table[0]
+  +0x2FE0 | B8 00 00 00             | UOffset32  | 0x000000B8 (184) Loc: 0x3098       | offset to table[1]
+  +0x2FE4 | 8C 00 00 00             | UOffset32  | 0x0000008C (140) Loc: 0x3070       | offset to table[2]
 
 string (reflection.Object.name):
-  +0x2FE8 | 13 00 00 00             | uint32_t    | 0x00000013 (19)                    | length of string
-  +0x2FEC | 4D 79 47 61 6D 65 2E 45 | char[19]    | MyGame.E                           | string literal
-  +0x2FF4 | 78 61 6D 70 6C 65 2E 53 |             | xample.S
-  +0x2FFC | 74 61 74                |             | tat
-  +0x2FFF | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x2FE8 | 13 00 00 00             | uint32_t   | 0x00000013 (19)                    | length of string
+  +0x2FEC | 4D 79 47 61 6D 65 2E 45 | char[19]   | MyGame.E                           | string literal
+  +0x2FF4 | 78 61 6D 70 6C 65 2E 53 |            | xample.S
+  +0x2FFC | 74 61 74                |            | tat
+  +0x2FFF | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Field):
-  +0x3000 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of this vtable
-  +0x3002 | 18 00                   | uint16_t    | 0x0018 (24)                        | size of referring table
-  +0x3004 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `name` (id: 0)
-  +0x3006 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `type` (id: 1)
-  +0x3008 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `id` (id: 2)
-  +0x300A | 0A 00                   | VOffset16   | 0x000A (10)                        | offset to field `offset` (id: 3)
-  +0x300C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x300E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x3010 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x3012 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x3014 | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `key` (id: 8)
-  +0x3016 | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `attributes` (id: 9)
+  +0x3000 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of this vtable
+  +0x3002 | 18 00                   | uint16_t   | 0x0018 (24)                        | size of referring table
+  +0x3004 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `name` (id: 0)
+  +0x3006 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `type` (id: 1)
+  +0x3008 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `id` (id: 2)
+  +0x300A | 0A 00                   | VOffset16  | 0x000A (10)                        | offset to field `offset` (id: 3)
+  +0x300C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x300E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x3010 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x3012 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x3014 | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `key` (id: 8)
+  +0x3016 | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `attributes` (id: 9)
 
 table (reflection.Field):
-  +0x3018 | 18 00 00 00             | SOffset32   | 0x00000018 (24) Loc: +0x3000       | offset to vtable
-  +0x301C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x301F | 01                      | uint8_t     | 0x01 (1)                           | table field `key` (Bool)
-  +0x3020 | 02 00                   | uint16_t    | 0x0002 (2)                         | table field `id` (UShort)
-  +0x3022 | 08 00                   | uint16_t    | 0x0008 (8)                         | table field `offset` (UShort)
-  +0x3024 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x3064       | offset to field `name` (string)
-  +0x3028 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x3054       | offset to field `type` (table)
-  +0x302C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3030        | offset to field `attributes` (vector)
+  +0x3018 | 18 00 00 00             | SOffset32  | 0x00000018 (24) Loc: 0x3000        | offset to vtable
+  +0x301C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x301F | 01                      | uint8_t    | 0x01 (1)                           | table field `key` (Bool)
+  +0x3020 | 02 00                   | uint16_t   | 0x0002 (2)                         | table field `id` (UShort)
+  +0x3022 | 08 00                   | uint16_t   | 0x0008 (8)                         | table field `offset` (UShort)
+  +0x3024 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x3064        | offset to field `name` (string)
+  +0x3028 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x3054        | offset to field `type` (table)
+  +0x302C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3030         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x3030 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x3034 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3038        | offset to table[0]
+  +0x3030 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x3034 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3038         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x3038 | 70 F7 FF FF             | SOffset32   | 0xFFFFF770 (-2192) Loc: +0x38C8    | offset to vtable
-  +0x303C | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x304C       | offset to field `key` (string)
-  +0x3040 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3044        | offset to field `value` (string)
+  +0x3038 | 70 F7 FF FF             | SOffset32  | 0xFFFFF770 (-2192) Loc: 0x38C8     | offset to vtable
+  +0x303C | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x304C        | offset to field `key` (string)
+  +0x3040 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3044         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x3044 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x3048 | 30                      | char[1]     | 0                                  | string literal
-  +0x3049 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3044 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x3048 | 30                      | char[1]    | 0                                  | string literal
+  +0x3049 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x304A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x304A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x304C | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x3050 | 6B 65 79                | char[3]     | key                                | string literal
-  +0x3053 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x304C | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x3050 | 6B 65 79                | char[3]    | key                                | string literal
+  +0x3053 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x3054 | E0 F9 FF FF             | SOffset32   | 0xFFFFF9E0 (-1568) Loc: +0x3674    | offset to vtable
-  +0x3058 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x305B | 06                      | uint8_t     | 0x06 (6)                           | table field `base_type` (Byte)
-  +0x305C | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | table field `base_size` (UInt)
-  +0x3060 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3054 | E0 F9 FF FF             | SOffset32  | 0xFFFFF9E0 (-1568) Loc: 0x3674     | offset to vtable
+  +0x3058 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x305B | 06                      | uint8_t    | 0x06 (6)                           | table field `base_type` (Byte)
+  +0x305C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `base_size` (UInt)
+  +0x3060 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x3064 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x3068 | 63 6F 75 6E 74          | char[5]     | count                              | string literal
-  +0x306D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3064 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x3068 | 63 6F 75 6E 74          | char[5]    | count                              | string literal
+  +0x306D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x306E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x306E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x3070 | F4 FB FF FF             | SOffset32   | 0xFFFFFBF4 (-1036) Loc: +0x347C    | offset to vtable
-  +0x3074 | 01 00                   | uint16_t    | 0x0001 (1)                         | table field `id` (UShort)
-  +0x3076 | 06 00                   | uint16_t    | 0x0006 (6)                         | table field `offset` (UShort)
-  +0x3078 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x3090       | offset to field `name` (string)
-  +0x307C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3080        | offset to field `type` (table)
+  +0x3070 | F4 FB FF FF             | SOffset32  | 0xFFFFFBF4 (-1036) Loc: 0x347C     | offset to vtable
+  +0x3074 | 01 00                   | uint16_t   | 0x0001 (1)                         | table field `id` (UShort)
+  +0x3076 | 06 00                   | uint16_t   | 0x0006 (6)                         | table field `offset` (UShort)
+  +0x3078 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x3090        | offset to field `name` (string)
+  +0x307C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3080         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x3080 | 0C FA FF FF             | SOffset32   | 0xFFFFFA0C (-1524) Loc: +0x3674    | offset to vtable
-  +0x3084 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x3087 | 09                      | uint8_t     | 0x09 (9)                           | table field `base_type` (Byte)
-  +0x3088 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x308C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3080 | 0C FA FF FF             | SOffset32  | 0xFFFFFA0C (-1524) Loc: 0x3674     | offset to vtable
+  +0x3084 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x3087 | 09                      | uint8_t    | 0x09 (9)                           | table field `base_type` (Byte)
+  +0x3088 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x308C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x3090 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x3094 | 76 61 6C                | char[3]     | val                                | string literal
-  +0x3097 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3090 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x3094 | 76 61 6C                | char[3]    | val                                | string literal
+  +0x3097 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x3098 | AC F8 FF FF             | SOffset32   | 0xFFFFF8AC (-1876) Loc: +0x37EC    | offset to vtable
-  +0x309C | 00                      | uint8_t[1]  | .                                  | padding
-  +0x309D | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x309E | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `offset` (UShort)
-  +0x30A0 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x30B4       | offset to field `name` (string)
-  +0x30A4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x30A8        | offset to field `type` (table)
+  +0x3098 | AC F8 FF FF             | SOffset32  | 0xFFFFF8AC (-1876) Loc: 0x37EC     | offset to vtable
+  +0x309C | 00                      | uint8_t[1] | .                                  | padding
+  +0x309D | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x309E | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `offset` (UShort)
+  +0x30A0 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x30B4        | offset to field `name` (string)
+  +0x30A4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x30A8         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x30A8 | CC F7 FF FF             | SOffset32   | 0xFFFFF7CC (-2100) Loc: +0x38DC    | offset to vtable
-  +0x30AC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x30AF | 0D                      | uint8_t     | 0x0D (13)                          | table field `base_type` (Byte)
-  +0x30B0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x30A8 | CC F7 FF FF             | SOffset32  | 0xFFFFF7CC (-2100) Loc: 0x38DC     | offset to vtable
+  +0x30AC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x30AF | 0D                      | uint8_t    | 0x0D (13)                          | table field `base_type` (Byte)
+  +0x30B0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x30B4 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x30B8 | 69 64                   | char[2]     | id                                 | string literal
-  +0x30BA | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x30B4 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x30B8 | 69 64                   | char[2]    | id                                 | string literal
+  +0x30BA | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Object):
-  +0x30BC | 7C F8 FF FF             | SOffset32   | 0xFFFFF87C (-1924) Loc: +0x3840    | offset to vtable
-  +0x30C0 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x30C3 | 01                      | uint8_t     | 0x01 (1)                           | table field `is_struct` (Bool)
-  +0x30C4 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0x30E0       | offset to field `name` (string)
-  +0x30C8 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x30D8       | offset to field `fields` (vector)
-  +0x30CC | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `minalign` (Int)
-  +0x30D0 | 14 00 00 00             | uint32_t    | 0x00000014 (20)                    | table field `bytesize` (Int)
-  +0x30D4 | 10 06 00 00             | UOffset32   | 0x00000610 (1552) Loc: +0x36E4     | offset to field `declaration_file` (string)
+  +0x30BC | 7C F8 FF FF             | SOffset32  | 0xFFFFF87C (-1924) Loc: 0x3840     | offset to vtable
+  +0x30C0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x30C3 | 01                      | uint8_t    | 0x01 (1)                           | table field `is_struct` (Bool)
+  +0x30C4 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: 0x30E0        | offset to field `name` (string)
+  +0x30C8 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x30D8        | offset to field `fields` (vector)
+  +0x30CC | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `minalign` (Int)
+  +0x30D0 | 14 00 00 00             | uint32_t   | 0x00000014 (20)                    | table field `bytesize` (Int)
+  +0x30D4 | 10 06 00 00             | UOffset32  | 0x00000610 (1552) Loc: 0x36E4      | offset to field `declaration_file` (string)
 
 vector (reflection.Object.fields):
-  +0x30D8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x30DC | 30 00 00 00             | UOffset32   | 0x00000030 (48) Loc: +0x310C       | offset to table[0]
+  +0x30D8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x30DC | 30 00 00 00             | UOffset32  | 0x00000030 (48) Loc: 0x310C        | offset to table[0]
 
 string (reflection.Object.name):
-  +0x30E0 | 27 00 00 00             | uint32_t    | 0x00000027 (39)                    | length of string
-  +0x30E4 | 4D 79 47 61 6D 65 2E 45 | char[39]    | MyGame.E                           | string literal
-  +0x30EC | 78 61 6D 70 6C 65 2E 53 |             | xample.S
-  +0x30F4 | 74 72 75 63 74 4F 66 53 |             | tructOfS
-  +0x30FC | 74 72 75 63 74 73 4F 66 |             | tructsOf
-  +0x3104 | 53 74 72 75 63 74 73    |             | Structs
-  +0x310B | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x30E0 | 27 00 00 00             | uint32_t   | 0x00000027 (39)                    | length of string
+  +0x30E4 | 4D 79 47 61 6D 65 2E 45 | char[39]   | MyGame.E                           | string literal
+  +0x30EC | 78 61 6D 70 6C 65 2E 53 |            | xample.S
+  +0x30F4 | 74 72 75 63 74 4F 66 53 |            | tructOfS
+  +0x30FC | 74 72 75 63 74 73 4F 66 |            | tructsOf
+  +0x3104 | 53 74 72 75 63 74 73    |            | Structs
+  +0x310B | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x310C | 14 FF FF FF             | SOffset32   | 0xFFFFFF14 (-236) Loc: +0x31F8     | offset to vtable
-  +0x3110 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x3113 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x3114 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x312C       | offset to field `name` (string)
-  +0x3118 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x311C        | offset to field `type` (table)
+  +0x310C | 14 FF FF FF             | SOffset32  | 0xFFFFFF14 (-236) Loc: 0x31F8      | offset to vtable
+  +0x3110 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x3113 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x3114 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x312C        | offset to field `name` (string)
+  +0x3118 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x311C         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x311C | 04 F9 FF FF             | SOffset32   | 0xFFFFF904 (-1788) Loc: +0x3818    | offset to vtable
-  +0x3120 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x3123 | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x3124 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `index` (Int)
-  +0x3128 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x311C | 04 F9 FF FF             | SOffset32  | 0xFFFFF904 (-1788) Loc: 0x3818     | offset to vtable
+  +0x3120 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x3123 | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x3124 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `index` (Int)
+  +0x3128 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x312C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x3130 | 61                      | char[1]     | a                                  | string literal
-  +0x3131 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x312C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x3130 | 61                      | char[1]    | a                                  | string literal
+  +0x3131 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x3132 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x3132 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Object):
-  +0x3134 | F4 F8 FF FF             | SOffset32   | 0xFFFFF8F4 (-1804) Loc: +0x3840    | offset to vtable
-  +0x3138 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x313B | 01                      | uint8_t     | 0x01 (1)                           | table field `is_struct` (Bool)
-  +0x313C | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x3160       | offset to field `name` (string)
-  +0x3140 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x3150       | offset to field `fields` (vector)
-  +0x3144 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `minalign` (Int)
-  +0x3148 | 14 00 00 00             | uint32_t    | 0x00000014 (20)                    | table field `bytesize` (Int)
-  +0x314C | 98 05 00 00             | UOffset32   | 0x00000598 (1432) Loc: +0x36E4     | offset to field `declaration_file` (string)
+  +0x3134 | F4 F8 FF FF             | SOffset32  | 0xFFFFF8F4 (-1804) Loc: 0x3840     | offset to vtable
+  +0x3138 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x313B | 01                      | uint8_t    | 0x01 (1)                           | table field `is_struct` (Bool)
+  +0x313C | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x3160        | offset to field `name` (string)
+  +0x3140 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x3150        | offset to field `fields` (vector)
+  +0x3144 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `minalign` (Int)
+  +0x3148 | 14 00 00 00             | uint32_t   | 0x00000014 (20)                    | table field `bytesize` (Int)
+  +0x314C | 98 05 00 00             | UOffset32  | 0x00000598 (1432) Loc: 0x36E4      | offset to field `declaration_file` (string)
 
 vector (reflection.Object.fields):
-  +0x3150 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of vector (# items)
-  +0x3154 | C0 00 00 00             | UOffset32   | 0x000000C0 (192) Loc: +0x3214      | offset to table[0]
-  +0x3158 | 74 00 00 00             | UOffset32   | 0x00000074 (116) Loc: +0x31CC      | offset to table[1]
-  +0x315C | 28 00 00 00             | UOffset32   | 0x00000028 (40) Loc: +0x3184       | offset to table[2]
+  +0x3150 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of vector (# items)
+  +0x3154 | C0 00 00 00             | UOffset32  | 0x000000C0 (192) Loc: 0x3214       | offset to table[0]
+  +0x3158 | 74 00 00 00             | UOffset32  | 0x00000074 (116) Loc: 0x31CC       | offset to table[1]
+  +0x315C | 28 00 00 00             | UOffset32  | 0x00000028 (40) Loc: 0x3184        | offset to table[2]
 
 string (reflection.Object.name):
-  +0x3160 | 1E 00 00 00             | uint32_t    | 0x0000001E (30)                    | length of string
-  +0x3164 | 4D 79 47 61 6D 65 2E 45 | char[30]    | MyGame.E                           | string literal
-  +0x316C | 78 61 6D 70 6C 65 2E 53 |             | xample.S
-  +0x3174 | 74 72 75 63 74 4F 66 53 |             | tructOfS
-  +0x317C | 74 72 75 63 74 73       |             | tructs
-  +0x3182 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3160 | 1E 00 00 00             | uint32_t   | 0x0000001E (30)                    | length of string
+  +0x3164 | 4D 79 47 61 6D 65 2E 45 | char[30]   | MyGame.E                           | string literal
+  +0x316C | 78 61 6D 70 6C 65 2E 53 |            | xample.S
+  +0x3174 | 74 72 75 63 74 4F 66 53 |            | tructOfS
+  +0x317C | 74 72 75 63 74 73       |            | tructs
+  +0x3182 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x3184 | D4 FF FF FF             | SOffset32   | 0xFFFFFFD4 (-44) Loc: +0x31B0      | offset to vtable
-  +0x3188 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x318B | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x318C | 02 00                   | uint16_t    | 0x0002 (2)                         | table field `id` (UShort)
-  +0x318E | 0C 00                   | uint16_t    | 0x000C (12)                        | table field `offset` (UShort)
-  +0x3190 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x31A8       | offset to field `name` (string)
-  +0x3194 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3198        | offset to field `type` (table)
+  +0x3184 | D4 FF FF FF             | SOffset32  | 0xFFFFFFD4 (-44) Loc: 0x31B0       | offset to vtable
+  +0x3188 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x318B | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x318C | 02 00                   | uint16_t   | 0x0002 (2)                         | table field `id` (UShort)
+  +0x318E | 0C 00                   | uint16_t   | 0x000C (12)                        | table field `offset` (UShort)
+  +0x3190 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x31A8        | offset to field `name` (string)
+  +0x3194 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3198         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x3198 | 80 F9 FF FF             | SOffset32   | 0xFFFFF980 (-1664) Loc: +0x3818    | offset to vtable
-  +0x319C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x319F | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x31A0 | 00 00 00 00             | uint32_t    | 0x00000000 (0)                     | table field `index` (Int)
-  +0x31A4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3198 | 80 F9 FF FF             | SOffset32  | 0xFFFFF980 (-1664) Loc: 0x3818     | offset to vtable
+  +0x319C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x319F | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x31A0 | 00 00 00 00             | uint32_t   | 0x00000000 (0)                     | table field `index` (Int)
+  +0x31A4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x31A8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x31AC | 63                      | char[1]     | c                                  | string literal
-  +0x31AD | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x31A8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x31AC | 63                      | char[1]    | c                                  | string literal
+  +0x31AD | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x31AE | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x31AE | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Field):
-  +0x31B0 | 1C 00                   | uint16_t    | 0x001C (28)                        | size of this vtable
-  +0x31B2 | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x31B4 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `name` (id: 0)
-  +0x31B6 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `type` (id: 1)
-  +0x31B8 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `id` (id: 2)
-  +0x31BA | 0A 00                   | VOffset16   | 0x000A (10)                        | offset to field `offset` (id: 3)
-  +0x31BC | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x31BE | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x31C0 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x31C2 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x31C4 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x31C6 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `attributes` (id: 9) <null> (Vector)
-  +0x31C8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
-  +0x31CA | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `optional` (id: 11)
+  +0x31B0 | 1C 00                   | uint16_t   | 0x001C (28)                        | size of this vtable
+  +0x31B2 | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x31B4 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `name` (id: 0)
+  +0x31B6 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `type` (id: 1)
+  +0x31B8 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `id` (id: 2)
+  +0x31BA | 0A 00                   | VOffset16  | 0x000A (10)                        | offset to field `offset` (id: 3)
+  +0x31BC | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x31BE | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x31C0 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x31C2 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x31C4 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x31C6 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `attributes` (id: 9) <null> (Vector)
+  +0x31C8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
+  +0x31CA | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `optional` (id: 11)
 
 table (reflection.Field):
-  +0x31CC | 1C 00 00 00             | SOffset32   | 0x0000001C (28) Loc: +0x31B0       | offset to vtable
-  +0x31D0 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x31D3 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x31D4 | 01 00                   | uint16_t    | 0x0001 (1)                         | table field `id` (UShort)
-  +0x31D6 | 08 00                   | uint16_t    | 0x0008 (8)                         | table field `offset` (UShort)
-  +0x31D8 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x31F0       | offset to field `name` (string)
-  +0x31DC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x31E0        | offset to field `type` (table)
+  +0x31CC | 1C 00 00 00             | SOffset32  | 0x0000001C (28) Loc: 0x31B0        | offset to vtable
+  +0x31D0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x31D3 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x31D4 | 01 00                   | uint16_t   | 0x0001 (1)                         | table field `id` (UShort)
+  +0x31D6 | 08 00                   | uint16_t   | 0x0008 (8)                         | table field `offset` (UShort)
+  +0x31D8 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x31F0        | offset to field `name` (string)
+  +0x31DC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x31E0         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x31E0 | C8 F9 FF FF             | SOffset32   | 0xFFFFF9C8 (-1592) Loc: +0x3818    | offset to vtable
-  +0x31E4 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x31E7 | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x31E8 | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | table field `index` (Int)
-  +0x31EC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x31E0 | C8 F9 FF FF             | SOffset32  | 0xFFFFF9C8 (-1592) Loc: 0x3818     | offset to vtable
+  +0x31E4 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x31E7 | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x31E8 | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | table field `index` (Int)
+  +0x31EC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x31F0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x31F4 | 62                      | char[1]     | b                                  | string literal
-  +0x31F5 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x31F0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x31F4 | 62                      | char[1]    | b                                  | string literal
+  +0x31F5 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x31F6 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x31F6 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Field):
-  +0x31F8 | 1C 00                   | uint16_t    | 0x001C (28)                        | size of this vtable
-  +0x31FA | 10 00                   | uint16_t    | 0x0010 (16)                        | size of referring table
-  +0x31FC | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x31FE | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x3200 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
-  +0x3202 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `offset` (id: 3) <defaults to 0> (UShort)
-  +0x3204 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x3206 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x3208 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x320A | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x320C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x320E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `attributes` (id: 9) <null> (Vector)
-  +0x3210 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
-  +0x3212 | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `optional` (id: 11)
+  +0x31F8 | 1C 00                   | uint16_t   | 0x001C (28)                        | size of this vtable
+  +0x31FA | 10 00                   | uint16_t   | 0x0010 (16)                        | size of referring table
+  +0x31FC | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x31FE | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x3200 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
+  +0x3202 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `offset` (id: 3) <defaults to 0> (UShort)
+  +0x3204 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x3206 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x3208 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x320A | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x320C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x320E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `attributes` (id: 9) <null> (Vector)
+  +0x3210 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
+  +0x3212 | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `optional` (id: 11)
 
 table (reflection.Field):
-  +0x3214 | 1C 00 00 00             | SOffset32   | 0x0000001C (28) Loc: +0x31F8       | offset to vtable
-  +0x3218 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x321B | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x321C | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x3234       | offset to field `name` (string)
-  +0x3220 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3224        | offset to field `type` (table)
+  +0x3214 | 1C 00 00 00             | SOffset32  | 0x0000001C (28) Loc: 0x31F8        | offset to vtable
+  +0x3218 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x321B | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x321C | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x3234        | offset to field `name` (string)
+  +0x3220 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3224         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x3224 | 0C FA FF FF             | SOffset32   | 0xFFFFFA0C (-1524) Loc: +0x3818    | offset to vtable
-  +0x3228 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x322B | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x322C | 00 00 00 00             | uint32_t    | 0x00000000 (0)                     | table field `index` (Int)
-  +0x3230 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3224 | 0C FA FF FF             | SOffset32  | 0xFFFFFA0C (-1524) Loc: 0x3818     | offset to vtable
+  +0x3228 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x322B | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x322C | 00 00 00 00             | uint32_t   | 0x00000000 (0)                     | table field `index` (Int)
+  +0x3230 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x3234 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x3238 | 61                      | char[1]     | a                                  | string literal
-  +0x3239 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3234 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x3238 | 61                      | char[1]    | a                                  | string literal
+  +0x3239 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x323A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x323A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Object):
-  +0x323C | FC F9 FF FF             | SOffset32   | 0xFFFFF9FC (-1540) Loc: +0x3840    | offset to vtable
-  +0x3240 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x3243 | 01                      | uint8_t     | 0x01 (1)                           | table field `is_struct` (Bool)
-  +0x3244 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x3264       | offset to field `name` (string)
-  +0x3248 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x3258       | offset to field `fields` (vector)
-  +0x324C | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `minalign` (Int)
-  +0x3250 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `bytesize` (Int)
-  +0x3254 | 90 04 00 00             | UOffset32   | 0x00000490 (1168) Loc: +0x36E4     | offset to field `declaration_file` (string)
+  +0x323C | FC F9 FF FF             | SOffset32  | 0xFFFFF9FC (-1540) Loc: 0x3840     | offset to vtable
+  +0x3240 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x3243 | 01                      | uint8_t    | 0x01 (1)                           | table field `is_struct` (Bool)
+  +0x3244 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x3264        | offset to field `name` (string)
+  +0x3248 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x3258        | offset to field `fields` (vector)
+  +0x324C | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `minalign` (Int)
+  +0x3250 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `bytesize` (Int)
+  +0x3254 | 90 04 00 00             | UOffset32  | 0x00000490 (1168) Loc: 0x36E4      | offset to field `declaration_file` (string)
 
 vector (reflection.Object.fields):
-  +0x3258 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x325C | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x3280       | offset to table[0]
-  +0x3260 | 64 00 00 00             | UOffset32   | 0x00000064 (100) Loc: +0x32C4      | offset to table[1]
+  +0x3258 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x325C | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x3280        | offset to table[0]
+  +0x3260 | 64 00 00 00             | UOffset32  | 0x00000064 (100) Loc: 0x32C4       | offset to table[1]
 
 string (reflection.Object.name):
-  +0x3264 | 16 00 00 00             | uint32_t    | 0x00000016 (22)                    | length of string
-  +0x3268 | 4D 79 47 61 6D 65 2E 45 | char[22]    | MyGame.E                           | string literal
-  +0x3270 | 78 61 6D 70 6C 65 2E 41 |             | xample.A
-  +0x3278 | 62 69 6C 69 74 79       |             | bility
-  +0x327E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3264 | 16 00 00 00             | uint32_t   | 0x00000016 (22)                    | length of string
+  +0x3268 | 4D 79 47 61 6D 65 2E 45 | char[22]   | MyGame.E                           | string literal
+  +0x3270 | 78 61 6D 70 6C 65 2E 41 |            | xample.A
+  +0x3278 | 62 69 6C 69 74 79       |            | bility
+  +0x327E | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Field):
-  +0x3280 | 04 FE FF FF             | SOffset32   | 0xFFFFFE04 (-508) Loc: +0x347C     | offset to vtable
-  +0x3284 | 01 00                   | uint16_t    | 0x0001 (1)                         | table field `id` (UShort)
-  +0x3286 | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `offset` (UShort)
-  +0x3288 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x329C       | offset to field `name` (string)
-  +0x328C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3290        | offset to field `type` (table)
+  +0x3280 | 04 FE FF FF             | SOffset32  | 0xFFFFFE04 (-508) Loc: 0x347C      | offset to vtable
+  +0x3284 | 01 00                   | uint16_t   | 0x0001 (1)                         | table field `id` (UShort)
+  +0x3286 | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `offset` (UShort)
+  +0x3288 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x329C        | offset to field `name` (string)
+  +0x328C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3290         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x3290 | B4 F9 FF FF             | SOffset32   | 0xFFFFF9B4 (-1612) Loc: +0x38DC    | offset to vtable
-  +0x3294 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x3297 | 08                      | uint8_t     | 0x08 (8)                           | table field `base_type` (Byte)
-  +0x3298 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3290 | B4 F9 FF FF             | SOffset32  | 0xFFFFF9B4 (-1612) Loc: 0x38DC     | offset to vtable
+  +0x3294 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x3297 | 08                      | uint8_t    | 0x08 (8)                           | table field `base_type` (Byte)
+  +0x3298 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x329C | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | length of string
-  +0x32A0 | 64 69 73 74 61 6E 63 65 | char[8]     | distance                           | string literal
-  +0x32A8 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x329C | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | length of string
+  +0x32A0 | 64 69 73 74 61 6E 63 65 | char[8]    | distance                           | string literal
+  +0x32A8 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x32A9 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x32A9 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 vtable (reflection.Field):
-  +0x32AC | 18 00                   | uint16_t    | 0x0018 (24)                        | size of this vtable
-  +0x32AE | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x32B0 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x32B2 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x32B4 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
-  +0x32B6 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `offset` (id: 3) <defaults to 0> (UShort)
-  +0x32B8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x32BA | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x32BC | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x32BE | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x32C0 | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `key` (id: 8)
-  +0x32C2 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 9)
+  +0x32AC | 18 00                   | uint16_t   | 0x0018 (24)                        | size of this vtable
+  +0x32AE | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x32B0 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x32B2 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x32B4 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
+  +0x32B6 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `offset` (id: 3) <defaults to 0> (UShort)
+  +0x32B8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x32BA | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x32BC | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x32BE | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x32C0 | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `key` (id: 8)
+  +0x32C2 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 9)
 
 table (reflection.Field):
-  +0x32C4 | 18 00 00 00             | SOffset32   | 0x00000018 (24) Loc: +0x32AC       | offset to vtable
-  +0x32C8 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x32CB | 01                      | uint8_t     | 0x01 (1)                           | table field `key` (Bool)
-  +0x32CC | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x3308       | offset to field `name` (string)
-  +0x32D0 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x32FC       | offset to field `type` (table)
-  +0x32D4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x32D8        | offset to field `attributes` (vector)
+  +0x32C4 | 18 00 00 00             | SOffset32  | 0x00000018 (24) Loc: 0x32AC        | offset to vtable
+  +0x32C8 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x32CB | 01                      | uint8_t    | 0x01 (1)                           | table field `key` (Bool)
+  +0x32CC | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x3308        | offset to field `name` (string)
+  +0x32D0 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x32FC        | offset to field `type` (table)
+  +0x32D4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x32D8         | offset to field `attributes` (vector)
 
 vector (reflection.Field.attributes):
-  +0x32D8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x32DC | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x32E0        | offset to table[0]
+  +0x32D8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x32DC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x32E0         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x32E0 | 18 FA FF FF             | SOffset32   | 0xFFFFFA18 (-1512) Loc: +0x38C8    | offset to vtable
-  +0x32E4 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x32F4       | offset to field `key` (string)
-  +0x32E8 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x32EC        | offset to field `value` (string)
+  +0x32E0 | 18 FA FF FF             | SOffset32  | 0xFFFFFA18 (-1512) Loc: 0x38C8     | offset to vtable
+  +0x32E4 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x32F4        | offset to field `key` (string)
+  +0x32E8 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x32EC         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x32EC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x32F0 | 30                      | char[1]     | 0                                  | string literal
-  +0x32F1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x32EC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x32F0 | 30                      | char[1]    | 0                                  | string literal
+  +0x32F1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x32F2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x32F2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x32F4 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | length of string
-  +0x32F8 | 6B 65 79                | char[3]     | key                                | string literal
-  +0x32FB | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x32F4 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | length of string
+  +0x32F8 | 6B 65 79                | char[3]    | key                                | string literal
+  +0x32FB | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.Type):
-  +0x32FC | 20 FA FF FF             | SOffset32   | 0xFFFFFA20 (-1504) Loc: +0x38DC    | offset to vtable
-  +0x3300 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x3303 | 08                      | uint8_t     | 0x08 (8)                           | table field `base_type` (Byte)
-  +0x3304 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x32FC | 20 FA FF FF             | SOffset32  | 0xFFFFFA20 (-1504) Loc: 0x38DC     | offset to vtable
+  +0x3300 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x3303 | 08                      | uint8_t    | 0x08 (8)                           | table field `base_type` (Byte)
+  +0x3304 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x3308 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of string
-  +0x330C | 69 64                   | char[2]     | id                                 | string literal
-  +0x330E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3308 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of string
+  +0x330C | 69 64                   | char[2]    | id                                 | string literal
+  +0x330E | 00                      | char       | 0x00 (0)                           | string terminator
 
 vtable (reflection.Object):
-  +0x3310 | 14 00                   | uint16_t    | 0x0014 (20)                        | size of this vtable
-  +0x3312 | 20 00                   | uint16_t    | 0x0020 (32)                        | size of referring table
-  +0x3314 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x3316 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `fields` (id: 1)
-  +0x3318 | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `is_struct` (id: 2)
-  +0x331A | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `minalign` (id: 3)
-  +0x331C | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `bytesize` (id: 4)
-  +0x331E | 18 00                   | VOffset16   | 0x0018 (24)                        | offset to field `attributes` (id: 5)
-  +0x3320 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 6) <null> (Vector)
-  +0x3322 | 1C 00                   | VOffset16   | 0x001C (28)                        | offset to field `declaration_file` (id: 7)
+  +0x3310 | 14 00                   | uint16_t   | 0x0014 (20)                        | size of this vtable
+  +0x3312 | 20 00                   | uint16_t   | 0x0020 (32)                        | size of referring table
+  +0x3314 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x3316 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `fields` (id: 1)
+  +0x3318 | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `is_struct` (id: 2)
+  +0x331A | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `minalign` (id: 3)
+  +0x331C | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `bytesize` (id: 4)
+  +0x331E | 18 00                   | VOffset16  | 0x0018 (24)                        | offset to field `attributes` (id: 5)
+  +0x3320 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 6) <null> (Vector)
+  +0x3322 | 1C 00                   | VOffset16  | 0x001C (28)                        | offset to field `declaration_file` (id: 7)
 
 table (reflection.Object):
-  +0x3324 | 14 00 00 00             | SOffset32   | 0x00000014 (20) Loc: +0x3310       | offset to vtable
-  +0x3328 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x332B | 01                      | uint8_t     | 0x01 (1)                           | table field `is_struct` (Bool)
-  +0x332C | 60 00 00 00             | UOffset32   | 0x00000060 (96) Loc: +0x338C       | offset to field `name` (string)
-  +0x3330 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x3370       | offset to field `fields` (vector)
-  +0x3334 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `minalign` (Int)
-  +0x3338 | 20 00 00 00             | uint32_t    | 0x00000020 (32)                    | table field `bytesize` (Int)
-  +0x333C | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x3344        | offset to field `attributes` (vector)
-  +0x3340 | A4 03 00 00             | UOffset32   | 0x000003A4 (932) Loc: +0x36E4      | offset to field `declaration_file` (string)
+  +0x3324 | 14 00 00 00             | SOffset32  | 0x00000014 (20) Loc: 0x3310        | offset to vtable
+  +0x3328 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x332B | 01                      | uint8_t    | 0x01 (1)                           | table field `is_struct` (Bool)
+  +0x332C | 60 00 00 00             | UOffset32  | 0x00000060 (96) Loc: 0x338C        | offset to field `name` (string)
+  +0x3330 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x3370        | offset to field `fields` (vector)
+  +0x3334 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `minalign` (Int)
+  +0x3338 | 20 00 00 00             | uint32_t   | 0x00000020 (32)                    | table field `bytesize` (Int)
+  +0x333C | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x3344         | offset to field `attributes` (vector)
+  +0x3340 | A4 03 00 00             | UOffset32  | 0x000003A4 (932) Loc: 0x36E4       | offset to field `declaration_file` (string)
 
 vector (reflection.Object.attributes):
-  +0x3344 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x3348 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x334C        | offset to table[0]
+  +0x3344 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x3348 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x334C         | offset to table[0]
 
 table (reflection.KeyValue):
-  +0x334C | 84 FA FF FF             | SOffset32   | 0xFFFFFA84 (-1404) Loc: +0x38C8    | offset to vtable
-  +0x3350 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x3360       | offset to field `key` (string)
-  +0x3354 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3358        | offset to field `value` (string)
+  +0x334C | 84 FA FF FF             | SOffset32  | 0xFFFFFA84 (-1404) Loc: 0x38C8     | offset to vtable
+  +0x3350 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x3360        | offset to field `key` (string)
+  +0x3354 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3358         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x3358 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x335C | 38                      | char[1]     | 8                                  | string literal
-  +0x335D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3358 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x335C | 38                      | char[1]    | 8                                  | string literal
+  +0x335D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x335E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x335E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x3360 | 0B 00 00 00             | uint32_t    | 0x0000000B (11)                    | length of string
-  +0x3364 | 66 6F 72 63 65 5F 61 6C | char[11]    | force_al                           | string literal
-  +0x336C | 69 67 6E                |             | ign
-  +0x336F | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3360 | 0B 00 00 00             | uint32_t   | 0x0000000B (11)                    | length of string
+  +0x3364 | 66 6F 72 63 65 5F 61 6C | char[11]   | force_al                           | string literal
+  +0x336C | 69 67 6E                |            | ign
+  +0x336F | 00                      | char       | 0x00 (0)                           | string terminator
 
 vector (reflection.Object.fields):
-  +0x3370 | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | length of vector (# items)
-  +0x3374 | B4 00 00 00             | UOffset32   | 0x000000B4 (180) Loc: +0x3428      | offset to table[0]
-  +0x3378 | 7C 00 00 00             | UOffset32   | 0x0000007C (124) Loc: +0x33F4      | offset to table[1]
-  +0x337C | 48 00 00 00             | UOffset32   | 0x00000048 (72) Loc: +0x33C4       | offset to table[2]
-  +0x3380 | 2C 01 00 00             | UOffset32   | 0x0000012C (300) Loc: +0x34AC      | offset to table[3]
-  +0x3384 | 04 01 00 00             | UOffset32   | 0x00000104 (260) Loc: +0x3488      | offset to table[4]
-  +0x3388 | CC 00 00 00             | UOffset32   | 0x000000CC (204) Loc: +0x3454      | offset to table[5]
+  +0x3370 | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | length of vector (# items)
+  +0x3374 | B4 00 00 00             | UOffset32  | 0x000000B4 (180) Loc: 0x3428       | offset to table[0]
+  +0x3378 | 7C 00 00 00             | UOffset32  | 0x0000007C (124) Loc: 0x33F4       | offset to table[1]
+  +0x337C | 48 00 00 00             | UOffset32  | 0x00000048 (72) Loc: 0x33C4        | offset to table[2]
+  +0x3380 | 2C 01 00 00             | UOffset32  | 0x0000012C (300) Loc: 0x34AC       | offset to table[3]
+  +0x3384 | 04 01 00 00             | UOffset32  | 0x00000104 (260) Loc: 0x3488       | offset to table[4]
+  +0x3388 | CC 00 00 00             | UOffset32  | 0x000000CC (204) Loc: 0x3454       | offset to table[5]
 
 string (reflection.Object.name):
-  +0x338C | 13 00 00 00             | uint32_t    | 0x00000013 (19)                    | length of string
-  +0x3390 | 4D 79 47 61 6D 65 2E 45 | char[19]    | MyGame.E                           | string literal
-  +0x3398 | 78 61 6D 70 6C 65 2E 56 |             | xample.V
-  +0x33A0 | 65 63 33                |             | ec3
-  +0x33A3 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x338C | 13 00 00 00             | uint32_t   | 0x00000013 (19)                    | length of string
+  +0x3390 | 4D 79 47 61 6D 65 2E 45 | char[19]   | MyGame.E                           | string literal
+  +0x3398 | 78 61 6D 70 6C 65 2E 56 |            | xample.V
+  +0x33A0 | 65 63 33                |            | ec3
+  +0x33A3 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x33A4 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x33A4 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Field):
-  +0x33A6 | 1E 00                   | uint16_t    | 0x001E (30)                        | size of this vtable
-  +0x33A8 | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x33AA | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `name` (id: 0)
-  +0x33AC | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `type` (id: 1)
-  +0x33AE | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `id` (id: 2)
-  +0x33B0 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `offset` (id: 3)
-  +0x33B2 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x33B4 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x33B6 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x33B8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x33BA | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x33BC | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `attributes` (id: 9) <null> (Vector)
-  +0x33BE | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
-  +0x33C0 | 05 00                   | VOffset16   | 0x0005 (5)                         | offset to field `optional` (id: 11)
-  +0x33C2 | 0A 00                   | VOffset16   | 0x000A (10)                        | offset to field `padding` (id: 12)
+  +0x33A6 | 1E 00                   | uint16_t   | 0x001E (30)                        | size of this vtable
+  +0x33A8 | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x33AA | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `name` (id: 0)
+  +0x33AC | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `type` (id: 1)
+  +0x33AE | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `id` (id: 2)
+  +0x33B0 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `offset` (id: 3)
+  +0x33B2 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x33B4 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x33B6 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x33B8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x33BA | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x33BC | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `attributes` (id: 9) <null> (Vector)
+  +0x33BE | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
+  +0x33C0 | 05 00                   | VOffset16  | 0x0005 (5)                         | offset to field `optional` (id: 11)
+  +0x33C2 | 0A 00                   | VOffset16  | 0x000A (10)                        | offset to field `padding` (id: 12)
 
 table (reflection.Field):
-  +0x33C4 | 1E 00 00 00             | SOffset32   | 0x0000001E (30) Loc: +0x33A6       | offset to vtable
-  +0x33C8 | 00                      | uint8_t[1]  | .                                  | padding
-  +0x33C9 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x33CA | 05 00                   | uint16_t    | 0x0005 (5)                         | table field `id` (UShort)
-  +0x33CC | 1A 00                   | uint16_t    | 0x001A (26)                        | table field `offset` (UShort)
-  +0x33CE | 02 00                   | uint16_t    | 0x0002 (2)                         | table field `padding` (UShort)
-  +0x33D0 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x33E8       | offset to field `name` (string)
-  +0x33D4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x33D8        | offset to field `type` (table)
+  +0x33C4 | 1E 00 00 00             | SOffset32  | 0x0000001E (30) Loc: 0x33A6        | offset to vtable
+  +0x33C8 | 00                      | uint8_t[1] | .                                  | padding
+  +0x33C9 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x33CA | 05 00                   | uint16_t   | 0x0005 (5)                         | table field `id` (UShort)
+  +0x33CC | 1A 00                   | uint16_t   | 0x001A (26)                        | table field `offset` (UShort)
+  +0x33CE | 02 00                   | uint16_t   | 0x0002 (2)                         | table field `padding` (UShort)
+  +0x33D0 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x33E8        | offset to field `name` (string)
+  +0x33D4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x33D8         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x33D8 | C0 FB FF FF             | SOffset32   | 0xFFFFFBC0 (-1088) Loc: +0x3818    | offset to vtable
-  +0x33DC | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x33DF | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x33E0 | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | table field `index` (Int)
-  +0x33E4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x33D8 | C0 FB FF FF             | SOffset32  | 0xFFFFFBC0 (-1088) Loc: 0x3818     | offset to vtable
+  +0x33DC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x33DF | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x33E0 | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | table field `index` (Int)
+  +0x33E4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x33E8 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x33EC | 74 65 73 74 33          | char[5]     | test3                              | string literal
-  +0x33F1 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x33E8 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x33EC | 74 65 73 74 33          | char[5]    | test3                              | string literal
+  +0x33F1 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x33F2 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x33F2 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x33F4 | D6 FD FF FF             | SOffset32   | 0xFFFFFDD6 (-554) Loc: +0x361E     | offset to vtable
-  +0x33F8 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x33FA | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `id` (UShort)
-  +0x33FC | 18 00                   | uint16_t    | 0x0018 (24)                        | table field `offset` (UShort)
-  +0x33FE | 01 00                   | uint16_t    | 0x0001 (1)                         | table field `padding` (UShort)
-  +0x3400 | 1C 00 00 00             | UOffset32   | 0x0000001C (28) Loc: +0x341C       | offset to field `name` (string)
-  +0x3404 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3408        | offset to field `type` (table)
+  +0x33F4 | D6 FD FF FF             | SOffset32  | 0xFFFFFDD6 (-554) Loc: 0x361E      | offset to vtable
+  +0x33F8 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x33FA | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `id` (UShort)
+  +0x33FC | 18 00                   | uint16_t   | 0x0018 (24)                        | table field `offset` (UShort)
+  +0x33FE | 01 00                   | uint16_t   | 0x0001 (1)                         | table field `padding` (UShort)
+  +0x3400 | 1C 00 00 00             | UOffset32  | 0x0000001C (28) Loc: 0x341C        | offset to field `name` (string)
+  +0x3404 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3408         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x3408 | 5C FE FF FF             | SOffset32   | 0xFFFFFE5C (-420) Loc: +0x35AC     | offset to vtable
-  +0x340C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x340F | 04                      | uint8_t     | 0x04 (4)                           | table field `base_type` (Byte)
-  +0x3410 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | table field `index` (Int)
-  +0x3414 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x3418 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3408 | 5C FE FF FF             | SOffset32  | 0xFFFFFE5C (-420) Loc: 0x35AC      | offset to vtable
+  +0x340C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x340F | 04                      | uint8_t    | 0x04 (4)                           | table field `base_type` (Byte)
+  +0x3410 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | table field `index` (Int)
+  +0x3414 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x3418 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x341C | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x3420 | 74 65 73 74 32          | char[5]     | test2                              | string literal
-  +0x3425 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x341C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x3420 | 74 65 73 74 32          | char[5]    | test2                              | string literal
+  +0x3425 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x3426 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x3426 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x3428 | AC FF FF FF             | SOffset32   | 0xFFFFFFAC (-84) Loc: +0x347C      | offset to vtable
-  +0x342C | 03 00                   | uint16_t    | 0x0003 (3)                         | table field `id` (UShort)
-  +0x342E | 10 00                   | uint16_t    | 0x0010 (16)                        | table field `offset` (UShort)
-  +0x3430 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x3448       | offset to field `name` (string)
-  +0x3434 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3438        | offset to field `type` (table)
+  +0x3428 | AC FF FF FF             | SOffset32  | 0xFFFFFFAC (-84) Loc: 0x347C       | offset to vtable
+  +0x342C | 03 00                   | uint16_t   | 0x0003 (3)                         | table field `id` (UShort)
+  +0x342E | 10 00                   | uint16_t   | 0x0010 (16)                        | table field `offset` (UShort)
+  +0x3430 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x3448        | offset to field `name` (string)
+  +0x3434 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3438         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x3438 | C4 FD FF FF             | SOffset32   | 0xFFFFFDC4 (-572) Loc: +0x3674     | offset to vtable
-  +0x343C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x343F | 0C                      | uint8_t     | 0x0C (12)                          | table field `base_type` (Byte)
-  +0x3440 | 08 00 00 00             | uint32_t    | 0x00000008 (8)                     | table field `base_size` (UInt)
-  +0x3444 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3438 | C4 FD FF FF             | SOffset32  | 0xFFFFFDC4 (-572) Loc: 0x3674      | offset to vtable
+  +0x343C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x343F | 0C                      | uint8_t    | 0x0C (12)                          | table field `base_type` (Byte)
+  +0x3440 | 08 00 00 00             | uint32_t   | 0x00000008 (8)                     | table field `base_size` (UInt)
+  +0x3444 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x3448 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x344C | 74 65 73 74 31          | char[5]     | test1                              | string literal
-  +0x3451 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3448 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x344C | 74 65 73 74 31          | char[5]    | test1                              | string literal
+  +0x3451 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x3452 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x3452 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x3454 | 36 FE FF FF             | SOffset32   | 0xFFFFFE36 (-458) Loc: +0x361E     | offset to vtable
-  +0x3458 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x345A | 02 00                   | uint16_t    | 0x0002 (2)                         | table field `id` (UShort)
-  +0x345C | 08 00                   | uint16_t    | 0x0008 (8)                         | table field `offset` (UShort)
-  +0x345E | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `padding` (UShort)
-  +0x3460 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x3474       | offset to field `name` (string)
-  +0x3464 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3468        | offset to field `type` (table)
+  +0x3454 | 36 FE FF FF             | SOffset32  | 0xFFFFFE36 (-458) Loc: 0x361E      | offset to vtable
+  +0x3458 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x345A | 02 00                   | uint16_t   | 0x0002 (2)                         | table field `id` (UShort)
+  +0x345C | 08 00                   | uint16_t   | 0x0008 (8)                         | table field `offset` (UShort)
+  +0x345E | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `padding` (UShort)
+  +0x3460 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x3474        | offset to field `name` (string)
+  +0x3464 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3468         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x3468 | 8C FB FF FF             | SOffset32   | 0xFFFFFB8C (-1140) Loc: +0x38DC    | offset to vtable
-  +0x346C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x346F | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x3470 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3468 | 8C FB FF FF             | SOffset32  | 0xFFFFFB8C (-1140) Loc: 0x38DC     | offset to vtable
+  +0x346C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x346F | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x3470 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x3474 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x3478 | 7A                      | char[1]     | z                                  | string literal
-  +0x3479 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3474 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x3478 | 7A                      | char[1]    | z                                  | string literal
+  +0x3479 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x347A | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x347A | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Field):
-  +0x347C | 0C 00                   | uint16_t    | 0x000C (12)                        | size of this vtable
-  +0x347E | 10 00                   | uint16_t    | 0x0010 (16)                        | size of referring table
-  +0x3480 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x3482 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x3484 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `id` (id: 2)
-  +0x3486 | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `offset` (id: 3)
+  +0x347C | 0C 00                   | uint16_t   | 0x000C (12)                        | size of this vtable
+  +0x347E | 10 00                   | uint16_t   | 0x0010 (16)                        | size of referring table
+  +0x3480 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x3482 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x3484 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `id` (id: 2)
+  +0x3486 | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `offset` (id: 3)
 
 table (reflection.Field):
-  +0x3488 | 0C 00 00 00             | SOffset32   | 0x0000000C (12) Loc: +0x347C       | offset to vtable
-  +0x348C | 01 00                   | uint16_t    | 0x0001 (1)                         | table field `id` (UShort)
-  +0x348E | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `offset` (UShort)
-  +0x3490 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x34A4       | offset to field `name` (string)
-  +0x3494 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3498        | offset to field `type` (table)
+  +0x3488 | 0C 00 00 00             | SOffset32  | 0x0000000C (12) Loc: 0x347C        | offset to vtable
+  +0x348C | 01 00                   | uint16_t   | 0x0001 (1)                         | table field `id` (UShort)
+  +0x348E | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `offset` (UShort)
+  +0x3490 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x34A4        | offset to field `name` (string)
+  +0x3494 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3498         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x3498 | BC FB FF FF             | SOffset32   | 0xFFFFFBBC (-1092) Loc: +0x38DC    | offset to vtable
-  +0x349C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x349F | 0B                      | uint8_t     | 0x0B (11)                          | table field `base_type` (Byte)
-  +0x34A0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3498 | BC FB FF FF             | SOffset32  | 0xFFFFFBBC (-1092) Loc: 0x38DC     | offset to vtable
+  +0x349C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x349F | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x34A0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x34A4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x34A8 | 79                      | char[1]     | y                                  | string literal
-  +0x34A9 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x34A4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x34A8 | 79                      | char[1]    | y                                  | string literal
+  +0x34A9 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x34AA | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x34AA | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x34AC | E4 FB FF FF             | SOffset32   | 0xFFFFFBE4 (-1052) Loc: +0x38C8    | offset to vtable
-  +0x34B0 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x34C4       | offset to field `key` (string)
-  +0x34B4 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x34B8        | offset to field `value` (string)
+  +0x34AC | E4 FB FF FF             | SOffset32  | 0xFFFFFBE4 (-1052) Loc: 0x38C8     | offset to vtable
+  +0x34B0 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x34C4        | offset to field `name` (string)
+  +0x34B4 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x34B8         | offset to field `type` (table)
 
-string (reflection.Field.value):
-  +0x34B8 | DC FB FF FF             | uint32_t    | 0xFFFFFBDC (4294966236)            | ERROR: length of string. Longer than the binary.
+table (reflection.Type):
+  +0x34B8 | DC FB FF FF             | SOffset32  | 0xFFFFFBDC (-1060) Loc: 0x38DC     | offset to vtable
+  +0x34BC | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x34BF | 0B                      | uint8_t    | 0x0B (11)                          | table field `base_type` (Byte)
+  +0x34C0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
-unknown (no known references):
-  +0x34BC | 00 00 00 0B 01 00 00 00 | ?uint8_t[8] | ........                           | WARN: nothing refers to this section.
-
-string (reflection.Field.key):
-  +0x34C4 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x34C8 | 78                      | char[1]     | x                                  | string literal
-  +0x34C9 | 00                      | char        | 0x00 (0)                           | string terminator
+string (reflection.Field.name):
+  +0x34C4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x34C8 | 78                      | char[1]    | x                                  | string literal
+  +0x34C9 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x34CA | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x34CA | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Object):
-  +0x34CC | 14 00                   | uint16_t    | 0x0014 (20)                        | size of this vtable
-  +0x34CE | 18 00                   | uint16_t    | 0x0018 (24)                        | size of referring table
-  +0x34D0 | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x34D2 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `fields` (id: 1)
-  +0x34D4 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `is_struct` (id: 2) <defaults to 0> (Bool)
-  +0x34D6 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `minalign` (id: 3)
-  +0x34D8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `bytesize` (id: 4) <defaults to 0> (Int)
-  +0x34DA | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `attributes` (id: 5)
-  +0x34DC | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 6) <null> (Vector)
-  +0x34DE | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `declaration_file` (id: 7)
+  +0x34CC | 14 00                   | uint16_t   | 0x0014 (20)                        | size of this vtable
+  +0x34CE | 18 00                   | uint16_t   | 0x0018 (24)                        | size of referring table
+  +0x34D0 | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x34D2 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `fields` (id: 1)
+  +0x34D4 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `is_struct` (id: 2) <defaults to 0> (Bool)
+  +0x34D6 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `minalign` (id: 3)
+  +0x34D8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `bytesize` (id: 4) <defaults to 0> (Int)
+  +0x34DA | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `attributes` (id: 5)
+  +0x34DC | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 6) <null> (Vector)
+  +0x34DE | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `declaration_file` (id: 7)
 
 table (reflection.Object):
-  +0x34E0 | 14 00 00 00             | SOffset32   | 0x00000014 (20) Loc: +0x34CC       | offset to vtable
-  +0x34E4 | 70 00 00 00             | UOffset32   | 0x00000070 (112) Loc: +0x3554      | offset to field `name` (string)
-  +0x34E8 | 64 00 00 00             | UOffset32   | 0x00000064 (100) Loc: +0x354C      | offset to field `fields` (vector)
-  +0x34EC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `minalign` (Int)
-  +0x34F0 | 08 00 00 00             | UOffset32   | 0x00000008 (8) Loc: +0x34F8        | offset to field `attributes` (vector)
-  +0x34F4 | F0 01 00 00             | UOffset32   | 0x000001F0 (496) Loc: +0x36E4      | offset to field `declaration_file` (string)
+  +0x34E0 | 14 00 00 00             | SOffset32  | 0x00000014 (20) Loc: 0x34CC        | offset to vtable
+  +0x34E4 | 70 00 00 00             | UOffset32  | 0x00000070 (112) Loc: 0x3554       | offset to field `name` (string)
+  +0x34E8 | 64 00 00 00             | UOffset32  | 0x00000064 (100) Loc: 0x354C       | offset to field `fields` (vector)
+  +0x34EC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `minalign` (Int)
+  +0x34F0 | 08 00 00 00             | UOffset32  | 0x00000008 (8) Loc: 0x34F8         | offset to field `attributes` (vector)
+  +0x34F4 | F0 01 00 00             | UOffset32  | 0x000001F0 (496) Loc: 0x36E4       | offset to field `declaration_file` (string)
 
 vector (reflection.Object.attributes):
-  +0x34F8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x34FC | 28 00 00 00             | UOffset32   | 0x00000028 (40) Loc: +0x3524       | offset to table[0]
-  +0x3500 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3504        | offset to table[1]
+  +0x34F8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x34FC | 28 00 00 00             | UOffset32  | 0x00000028 (40) Loc: 0x3524        | offset to table[0]
+  +0x3500 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3504         | offset to table[1]
 
 table (reflection.KeyValue):
-  +0x3504 | 3C FC FF FF             | SOffset32   | 0xFFFFFC3C (-964) Loc: +0x38C8     | offset to vtable
-  +0x3508 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x3518       | offset to field `key` (string)
-  +0x350C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3510        | offset to field `value` (string)
+  +0x3504 | 3C FC FF FF             | SOffset32  | 0xFFFFFC3C (-964) Loc: 0x38C8      | offset to vtable
+  +0x3508 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x3518        | offset to field `key` (string)
+  +0x350C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3510         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x3510 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x3514 | 30                      | char[1]     | 0                                  | string literal
-  +0x3515 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3510 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x3514 | 30                      | char[1]    | 0                                  | string literal
+  +0x3515 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x3516 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x3516 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x3518 | 07 00 00 00             | uint32_t    | 0x00000007 (7)                     | length of string
-  +0x351C | 70 72 69 76 61 74 65    | char[7]     | private                            | string literal
-  +0x3523 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3518 | 07 00 00 00             | uint32_t   | 0x00000007 (7)                     | length of string
+  +0x351C | 70 72 69 76 61 74 65    | char[7]    | private                            | string literal
+  +0x3523 | 00                      | char       | 0x00 (0)                           | string terminator
 
 table (reflection.KeyValue):
-  +0x3524 | 5C FC FF FF             | SOffset32   | 0xFFFFFC5C (-932) Loc: +0x38C8     | offset to vtable
-  +0x3528 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x3538       | offset to field `key` (string)
-  +0x352C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3530        | offset to field `value` (string)
+  +0x3524 | 5C FC FF FF             | SOffset32  | 0xFFFFFC5C (-932) Loc: 0x38C8      | offset to vtable
+  +0x3528 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x3538        | offset to field `key` (string)
+  +0x352C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3530         | offset to field `value` (string)
 
 string (reflection.KeyValue.value):
-  +0x3530 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x3534 | 30                      | char[1]     | 0                                  | string literal
-  +0x3535 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3530 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x3534 | 30                      | char[1]    | 0                                  | string literal
+  +0x3535 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x3536 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x3536 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 string (reflection.KeyValue.key):
-  +0x3538 | 0E 00 00 00             | uint32_t    | 0x0000000E (14)                    | length of string
-  +0x353C | 63 73 68 61 72 70 5F 70 | char[14]    | csharp_p                           | string literal
-  +0x3544 | 61 72 74 69 61 6C       |             | artial
-  +0x354A | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3538 | 0E 00 00 00             | uint32_t   | 0x0000000E (14)                    | length of string
+  +0x353C | 63 73 68 61 72 70 5F 70 | char[14]   | csharp_p                           | string literal
+  +0x3544 | 61 72 74 69 61 6C       |            | artial
+  +0x354A | 00                      | char       | 0x00 (0)                           | string terminator
 
 vector (reflection.Object.fields):
-  +0x354C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x3550 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x3590       | offset to table[0]
+  +0x354C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x3550 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x3590        | offset to table[0]
 
 string (reflection.Object.name):
-  +0x3554 | 26 00 00 00             | uint32_t    | 0x00000026 (38)                    | length of string
-  +0x3558 | 4D 79 47 61 6D 65 2E 45 | char[38]    | MyGame.E                           | string literal
-  +0x3560 | 78 61 6D 70 6C 65 2E 54 |             | xample.T
-  +0x3568 | 65 73 74 53 69 6D 70 6C |             | estSimpl
-  +0x3570 | 65 54 61 62 6C 65 57 69 |             | eTableWi
-  +0x3578 | 74 68 45 6E 75 6D       |             | thEnum
-  +0x357E | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3554 | 26 00 00 00             | uint32_t   | 0x00000026 (38)                    | length of string
+  +0x3558 | 4D 79 47 61 6D 65 2E 45 | char[38]   | MyGame.E                           | string literal
+  +0x3560 | 78 61 6D 70 6C 65 2E 54 |            | xample.T
+  +0x3568 | 65 73 74 53 69 6D 70 6C |            | estSimpl
+  +0x3570 | 65 54 61 62 6C 65 57 69 |            | eTableWi
+  +0x3578 | 74 68 45 6E 75 6D       |            | thEnum
+  +0x357E | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x357F | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x357F | 00 00 00                | uint8_t[3] | ...                                | padding
 
 vtable (reflection.Field):
-  +0x3582 | 0E 00                   | uint16_t    | 0x000E (14)                        | size of this vtable
-  +0x3584 | 1C 00                   | uint16_t    | 0x001C (28)                        | size of referring table
-  +0x3586 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x3588 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x358A | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
-  +0x358C | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `offset` (id: 3)
-  +0x358E | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `default_integer` (id: 4)
+  +0x3582 | 0E 00                   | uint16_t   | 0x000E (14)                        | size of this vtable
+  +0x3584 | 1C 00                   | uint16_t   | 0x001C (28)                        | size of referring table
+  +0x3586 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x3588 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x358A | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
+  +0x358C | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `offset` (id: 3)
+  +0x358E | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `default_integer` (id: 4)
 
 table (reflection.Field):
-  +0x3590 | 0E 00 00 00             | SOffset32   | 0x0000000E (14) Loc: +0x3582       | offset to vtable
-  +0x3594 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x3596 | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `offset` (UShort)
-  +0x3598 | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x35D0       | offset to field `name` (string)
-  +0x359C | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x35BC       | offset to field `type` (table)
-  +0x35A0 | 02 00 00 00 00 00 00 00 | int64_t     | 0x0000000000000002 (2)             | table field `default_integer` (Long)
-  +0x35A8 | 00 00 00 00             | uint8_t[4]  | ....                               | padding
+  +0x3590 | 0E 00 00 00             | SOffset32  | 0x0000000E (14) Loc: 0x3582        | offset to vtable
+  +0x3594 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x3596 | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `offset` (UShort)
+  +0x3598 | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x35D0        | offset to field `name` (string)
+  +0x359C | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x35BC        | offset to field `type` (table)
+  +0x35A0 | 02 00 00 00 00 00 00 00 | int64_t    | 0x0000000000000002 (2)             | table field `default_integer` (Long)
+  +0x35A8 | 00 00 00 00             | uint8_t[4] | ....                               | padding
 
 vtable (reflection.Type):
-  +0x35AC | 10 00                   | uint16_t    | 0x0010 (16)                        | size of this vtable
-  +0x35AE | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x35B0 | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `base_type` (id: 0)
-  +0x35B2 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `element` (id: 1) <defaults to 0> (Byte)
-  +0x35B4 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `index` (id: 2)
-  +0x35B6 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
-  +0x35B8 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `base_size` (id: 4)
-  +0x35BA | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `element_size` (id: 5)
+  +0x35AC | 10 00                   | uint16_t   | 0x0010 (16)                        | size of this vtable
+  +0x35AE | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x35B0 | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `base_type` (id: 0)
+  +0x35B2 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `element` (id: 1) <defaults to 0> (Byte)
+  +0x35B4 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `index` (id: 2)
+  +0x35B6 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
+  +0x35B8 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `base_size` (id: 4)
+  +0x35BA | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `element_size` (id: 5)
 
 table (reflection.Type):
-  +0x35BC | 10 00 00 00             | SOffset32   | 0x00000010 (16) Loc: +0x35AC       | offset to vtable
-  +0x35C0 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x35C3 | 04                      | uint8_t     | 0x04 (4)                           | table field `base_type` (Byte)
-  +0x35C4 | 03 00 00 00             | uint32_t    | 0x00000003 (3)                     | table field `index` (Int)
-  +0x35C8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x35CC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x35BC | 10 00 00 00             | SOffset32  | 0x00000010 (16) Loc: 0x35AC        | offset to vtable
+  +0x35C0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x35C3 | 04                      | uint8_t    | 0x04 (4)                           | table field `base_type` (Byte)
+  +0x35C4 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                     | table field `index` (Int)
+  +0x35C8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x35CC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x35D0 | 05 00 00 00             | uint32_t    | 0x00000005 (5)                     | length of string
-  +0x35D4 | 63 6F 6C 6F 72          | char[5]     | color                              | string literal
-  +0x35D9 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x35D0 | 05 00 00 00             | uint32_t   | 0x00000005 (5)                     | length of string
+  +0x35D4 | 63 6F 6C 6F 72          | char[5]    | color                              | string literal
+  +0x35D9 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x35DA | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x35DA | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Object):
-  +0x35DC | 9C FD FF FF             | SOffset32   | 0xFFFFFD9C (-612) Loc: +0x3840     | offset to vtable
-  +0x35E0 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x35E3 | 01                      | uint8_t     | 0x01 (1)                           | table field `is_struct` (Bool)
-  +0x35E4 | 20 00 00 00             | UOffset32   | 0x00000020 (32) Loc: +0x3604       | offset to field `name` (string)
-  +0x35E8 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x35F8       | offset to field `fields` (vector)
-  +0x35EC | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | table field `minalign` (Int)
-  +0x35F0 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `bytesize` (Int)
-  +0x35F4 | F0 00 00 00             | UOffset32   | 0x000000F0 (240) Loc: +0x36E4      | offset to field `declaration_file` (string)
+  +0x35DC | 9C FD FF FF             | SOffset32  | 0xFFFFFD9C (-612) Loc: 0x3840      | offset to vtable
+  +0x35E0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x35E3 | 01                      | uint8_t    | 0x01 (1)                           | table field `is_struct` (Bool)
+  +0x35E4 | 20 00 00 00             | UOffset32  | 0x00000020 (32) Loc: 0x3604        | offset to field `name` (string)
+  +0x35E8 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x35F8        | offset to field `fields` (vector)
+  +0x35EC | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `minalign` (Int)
+  +0x35F0 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `bytesize` (Int)
+  +0x35F4 | F0 00 00 00             | UOffset32  | 0x000000F0 (240) Loc: 0x36E4       | offset to field `declaration_file` (string)
 
 vector (reflection.Object.fields):
-  +0x35F8 | 02 00 00 00             | uint32_t    | 0x00000002 (2)                     | length of vector (# items)
-  +0x35FC | 6C 00 00 00             | UOffset32   | 0x0000006C (108) Loc: +0x3668      | offset to table[0]
-  +0x3600 | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x363C       | offset to table[1]
+  +0x35F8 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | length of vector (# items)
+  +0x35FC | 6C 00 00 00             | UOffset32  | 0x0000006C (108) Loc: 0x3668       | offset to table[0]
+  +0x3600 | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x363C        | offset to table[1]
 
 string (reflection.Object.name):
-  +0x3604 | 13 00 00 00             | uint32_t    | 0x00000013 (19)                    | length of string
-  +0x3608 | 4D 79 47 61 6D 65 2E 45 | char[19]    | MyGame.E                           | string literal
-  +0x3610 | 78 61 6D 70 6C 65 2E 54 |             | xample.T
-  +0x3618 | 65 73 74                |             | est
-  +0x361B | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3604 | 13 00 00 00             | uint32_t   | 0x00000013 (19)                    | length of string
+  +0x3608 | 4D 79 47 61 6D 65 2E 45 | char[19]   | MyGame.E                           | string literal
+  +0x3610 | 78 61 6D 70 6C 65 2E 54 |            | xample.T
+  +0x3618 | 65 73 74                |            | est
+  +0x361B | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x361C | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x361C | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Field):
-  +0x361E | 1E 00                   | uint16_t    | 0x001E (30)                        | size of this vtable
-  +0x3620 | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x3622 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `name` (id: 0)
-  +0x3624 | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `type` (id: 1)
-  +0x3626 | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `id` (id: 2)
-  +0x3628 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `offset` (id: 3)
-  +0x362A | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x362C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x362E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x3630 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x3632 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x3634 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `attributes` (id: 9) <null> (Vector)
-  +0x3636 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
-  +0x3638 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `optional` (id: 11) <defaults to 0> (Bool)
-  +0x363A | 0A 00                   | VOffset16   | 0x000A (10)                        | offset to field `padding` (id: 12)
+  +0x361E | 1E 00                   | uint16_t   | 0x001E (30)                        | size of this vtable
+  +0x3620 | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x3622 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `name` (id: 0)
+  +0x3624 | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `type` (id: 1)
+  +0x3626 | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `id` (id: 2)
+  +0x3628 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `offset` (id: 3)
+  +0x362A | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x362C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x362E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x3630 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x3632 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x3634 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `attributes` (id: 9) <null> (Vector)
+  +0x3636 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
+  +0x3638 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `optional` (id: 11) <defaults to 0> (Bool)
+  +0x363A | 0A 00                   | VOffset16  | 0x000A (10)                        | offset to field `padding` (id: 12)
 
 table (reflection.Field):
-  +0x363C | 1E 00 00 00             | SOffset32   | 0x0000001E (30) Loc: +0x361E       | offset to vtable
-  +0x3640 | 00 00                   | uint8_t[2]  | ..                                 | padding
-  +0x3642 | 01 00                   | uint16_t    | 0x0001 (1)                         | table field `id` (UShort)
-  +0x3644 | 02 00                   | uint16_t    | 0x0002 (2)                         | table field `offset` (UShort)
-  +0x3646 | 01 00                   | uint16_t    | 0x0001 (1)                         | table field `padding` (UShort)
-  +0x3648 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x3660       | offset to field `name` (string)
-  +0x364C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3650        | offset to field `type` (table)
+  +0x363C | 1E 00 00 00             | SOffset32  | 0x0000001E (30) Loc: 0x361E        | offset to vtable
+  +0x3640 | 00 00                   | uint8_t[2] | ..                                 | padding
+  +0x3642 | 01 00                   | uint16_t   | 0x0001 (1)                         | table field `id` (UShort)
+  +0x3644 | 02 00                   | uint16_t   | 0x0002 (2)                         | table field `offset` (UShort)
+  +0x3646 | 01 00                   | uint16_t   | 0x0001 (1)                         | table field `padding` (UShort)
+  +0x3648 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x3660        | offset to field `name` (string)
+  +0x364C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3650         | offset to field `type` (table)
 
 table (reflection.Type):
-  +0x3650 | DC FF FF FF             | SOffset32   | 0xFFFFFFDC (-36) Loc: +0x3674      | offset to vtable
-  +0x3654 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x3657 | 03                      | uint8_t     | 0x03 (3)                           | table field `base_type` (Byte)
-  +0x3658 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `base_size` (UInt)
-  +0x365C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3650 | DC FF FF FF             | SOffset32  | 0xFFFFFFDC (-36) Loc: 0x3674       | offset to vtable
+  +0x3654 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x3657 | 03                      | uint8_t    | 0x03 (3)                           | table field `base_type` (Byte)
+  +0x3658 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `base_size` (UInt)
+  +0x365C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x3660 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x3664 | 62                      | char[1]     | b                                  | string literal
-  +0x3665 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3660 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x3664 | 62                      | char[1]    | b                                  | string literal
+  +0x3665 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x3666 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x3666 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 table (reflection.Field):
-  +0x3668 | A0 FD FF FF             | SOffset32   | 0xFFFFFDA0 (-608) Loc: +0x38C8     | offset to vtable
-  +0x366C | 28 00 00 00             | UOffset32   | 0x00000028 (40) Loc: +0x3694       | offset to field `key` (string)
-  +0x3670 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x3684       | offset to field `value` (string)
+  +0x3668 | A0 FD FF FF             | SOffset32  | 0xFFFFFDA0 (-608) Loc: 0x38C8      | offset to vtable
+  +0x366C | 28 00 00 00             | UOffset32  | 0x00000028 (40) Loc: 0x3694        | offset to field `name` (string)
+  +0x3670 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x3684        | offset to field `type` (table)
 
 vtable (reflection.Type):
-  +0x3674 | 10 00                   | uint16_t    | 0x0010 (16)                        | size of this vtable
-  +0x3676 | 10 00                   | uint16_t    | 0x0010 (16)                        | size of referring table
-  +0x3678 | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `base_type` (id: 0)
-  +0x367A | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `element` (id: 1) <defaults to 0> (Byte)
-  +0x367C | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `index` (id: 2) <defaults to -1> (Int)
-  +0x367E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
-  +0x3680 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `base_size` (id: 4)
-  +0x3682 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `element_size` (id: 5)
-
-string (reflection.Field.value):
-  +0x3684 | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | length of string
-  +0x3688 | 00 00 00 05 02 00 00 00 | char[16]    |                                  | string literal
-  +0x3690 | 01 00 00 00 01 00 00 00 |             |       
-  +0x3698 | 61                      | char        | 0x61 (97)                          | string terminator
-
-string (reflection.Field.key):
-  +0x3694 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x3698 | 61                      | char[1]     | a                                  | string literal
-  +0x3699 | 00                      | char        | 0x00 (0)                           | string terminator
-
-padding:
-  +0x369A | 00 00                   | uint8_t[2]  | ..                                 | padding
-
-table (reflection.Object):
-  +0x369C | 04 FF FF FF             | SOffset32   | 0xFFFFFF04 (-252) Loc: +0x3798     | offset to vtable
-  +0x36A0 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x36B4       | offset to field `name` (string)
-  +0x36A4 | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x36B0       | offset to field `fields` (vector)
-  +0x36A8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `minalign` (Int)
-  +0x36AC | 38 00 00 00             | UOffset32   | 0x00000038 (56) Loc: +0x36E4       | offset to field `declaration_file` (string)
-
-vector (reflection.Object.fields):
-  +0x36B0 | 00 00 00 00             | uint32_t    | 0x00000000 (0)                     | length of vector (# items)
-
-string (reflection.Object.name):
-  +0x36B4 | 17 00 00 00             | uint32_t    | 0x00000017 (23)                    | length of string
-  +0x36B8 | 4D 79 47 61 6D 65 2E 45 | char[23]    | MyGame.E                           | string literal
-  +0x36C0 | 78 61 6D 70 6C 65 32 2E |             | xample2.
-  +0x36C8 | 4D 6F 6E 73 74 65 72    |             | Monster
-  +0x36CF | 00                      | char        | 0x00 (0)                           | string terminator
-
-table (reflection.Object):
-  +0x36D0 | 38 FF FF FF             | SOffset32   | 0xFFFFFF38 (-200) Loc: +0x3798     | offset to vtable
-  +0x36D4 | 2C 00 00 00             | UOffset32   | 0x0000002C (44) Loc: +0x3700       | offset to field `name` (string)
-  +0x36D8 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x36FC       | offset to field `fields` (vector)
-  +0x36DC | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `minalign` (Int)
-  +0x36E0 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x36E4        | offset to field `declaration_file` (string)
-
-string (reflection.Object.declaration_file):
-  +0x36E4 | 12 00 00 00             | uint32_t    | 0x00000012 (18)                    | length of string
-  +0x36E8 | 2F 2F 6D 6F 6E 73 74 65 | char[18]    | //monste                           | string literal
-  +0x36F0 | 72 5F 74 65 73 74 2E 66 |             | r_test.f
-  +0x36F8 | 62 73                   |             | bs
-  +0x36FA | 00                      | char        | 0x00 (0)                           | string terminator
-
-vector (reflection.Object.fields):
-  +0x36FC | 00 00 00 00             | uint32_t    | 0x00000000 (0)                     | length of vector (# items)
-
-string (reflection.Object.name):
-  +0x3700 | 18 00 00 00             | uint32_t    | 0x00000018 (24)                    | length of string
-  +0x3704 | 4D 79 47 61 6D 65 2E 49 | char[24]    | MyGame.I                           | string literal
-  +0x370C | 6E 50 61 72 65 6E 74 4E |             | nParentN
-  +0x3714 | 61 6D 65 73 70 61 63 65 |             | amespace
-  +0x371C | 00                      | char        | 0x00 (0)                           | string terminator
-
-padding:
-  +0x371D | 00 00 00                | uint8_t[3]  | ...                                | padding
-
-table (reflection.Object):
-  +0x3720 | 88 FF FF FF             | SOffset32   | 0xFFFFFF88 (-120) Loc: +0x3798     | offset to vtable
-  +0x3724 | 40 00 00 00             | UOffset32   | 0x00000040 (64) Loc: +0x3764       | offset to field `name` (string)
-  +0x3728 | 34 00 00 00             | UOffset32   | 0x00000034 (52) Loc: +0x375C       | offset to field `fields` (vector)
-  +0x372C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `minalign` (Int)
-  +0x3730 | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3734        | offset to field `declaration_file` (string)
-
-string (reflection.Object.declaration_file):
-  +0x3734 | 20 00 00 00             | uint32_t    | 0x00000020 (32)                    | length of string
-  +0x3738 | 2F 2F 69 6E 63 6C 75 64 | char[32]    | //includ                           | string literal
-  +0x3740 | 65 5F 74 65 73 74 2F 69 |             | e_test/i
-  +0x3748 | 6E 63 6C 75 64 65 5F 74 |             | nclude_t
-  +0x3750 | 65 73 74 31 2E 66 62 73 |             | est1.fbs
-  +0x3758 | 00                      | char        | 0x00 (0)                           | string terminator
-
-padding:
-  +0x3759 | 00 00 00                | uint8_t[3]  | ...                                | padding
-
-vector (reflection.Object.fields):
-  +0x375C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x3760 | 10 00 00 00             | UOffset32   | 0x00000010 (16) Loc: +0x3770       | offset to table[0]
-
-string (reflection.Object.name):
-  +0x3764 | 06 00 00 00             | uint32_t    | 0x00000006 (6)                     | length of string
-  +0x3768 | 54 61 62 6C 65 41       | char[6]     | TableA                             | string literal
-  +0x376E | 00                      | char        | 0x00 (0)                           | string terminator
-
-table (reflection.Field):
-  +0x3770 | 84 FF FF FF             | SOffset32   | 0xFFFFFF84 (-124) Loc: +0x37EC     | offset to vtable
-  +0x3774 | 00                      | uint8_t[1]  | .                                  | padding
-  +0x3775 | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x3776 | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `offset` (UShort)
-  +0x3778 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x3790       | offset to field `name` (string)
-  +0x377C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3780        | offset to field `type` (table)
+  +0x3674 | 10 00                   | uint16_t   | 0x0010 (16)                        | size of this vtable
+  +0x3676 | 10 00                   | uint16_t   | 0x0010 (16)                        | size of referring table
+  +0x3678 | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `base_type` (id: 0)
+  +0x367A | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `element` (id: 1) <defaults to 0> (Byte)
+  +0x367C | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `index` (id: 2) <defaults to -1> (Int)
+  +0x367E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
+  +0x3680 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `base_size` (id: 4)
+  +0x3682 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `element_size` (id: 5)
 
 table (reflection.Type):
-  +0x3780 | 68 FF FF FF             | SOffset32   | 0xFFFFFF68 (-152) Loc: +0x3818     | offset to vtable
-  +0x3784 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x3787 | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x3788 | 0C 00 00 00             | uint32_t    | 0x0000000C (12)                    | table field `index` (Int)
-  +0x378C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3684 | 10 00 00 00             | SOffset32  | 0x00000010 (16) Loc: 0x3674        | offset to vtable
+  +0x3688 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x368B | 05                      | uint8_t    | 0x05 (5)                           | table field `base_type` (Byte)
+  +0x368C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                     | table field `base_size` (UInt)
+  +0x3690 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x3790 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x3794 | 62                      | char[1]     | b                                  | string literal
-  +0x3795 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3694 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x3698 | 61                      | char[1]    | a                                  | string literal
+  +0x3699 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x3796 | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x369A | 00 00                   | uint8_t[2] | ..                                 | padding
+
+table (reflection.Object):
+  +0x369C | 04 FF FF FF             | SOffset32  | 0xFFFFFF04 (-252) Loc: 0x3798      | offset to vtable
+  +0x36A0 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x36B4        | offset to field `name` (string)
+  +0x36A4 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x36B0        | offset to field `fields` (vector)
+  +0x36A8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `minalign` (Int)
+  +0x36AC | 38 00 00 00             | UOffset32  | 0x00000038 (56) Loc: 0x36E4        | offset to field `declaration_file` (string)
+
+vector (reflection.Object.fields):
+  +0x36B0 | 00 00 00 00             | uint32_t   | 0x00000000 (0)                     | length of vector (# items)
+
+string (reflection.Object.name):
+  +0x36B4 | 17 00 00 00             | uint32_t   | 0x00000017 (23)                    | length of string
+  +0x36B8 | 4D 79 47 61 6D 65 2E 45 | char[23]   | MyGame.E                           | string literal
+  +0x36C0 | 78 61 6D 70 6C 65 32 2E |            | xample2.
+  +0x36C8 | 4D 6F 6E 73 74 65 72    |            | Monster
+  +0x36CF | 00                      | char       | 0x00 (0)                           | string terminator
+
+table (reflection.Object):
+  +0x36D0 | 38 FF FF FF             | SOffset32  | 0xFFFFFF38 (-200) Loc: 0x3798      | offset to vtable
+  +0x36D4 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x3700        | offset to field `name` (string)
+  +0x36D8 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x36FC        | offset to field `fields` (vector)
+  +0x36DC | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `minalign` (Int)
+  +0x36E0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x36E4         | offset to field `declaration_file` (string)
+
+string (reflection.Object.declaration_file):
+  +0x36E4 | 12 00 00 00             | uint32_t   | 0x00000012 (18)                    | length of string
+  +0x36E8 | 2F 2F 6D 6F 6E 73 74 65 | char[18]   | //monste                           | string literal
+  +0x36F0 | 72 5F 74 65 73 74 2E 66 |            | r_test.f
+  +0x36F8 | 62 73                   |            | bs
+  +0x36FA | 00                      | char       | 0x00 (0)                           | string terminator
+
+vector (reflection.Object.fields):
+  +0x36FC | 00 00 00 00             | uint32_t   | 0x00000000 (0)                     | length of vector (# items)
+
+string (reflection.Object.name):
+  +0x3700 | 18 00 00 00             | uint32_t   | 0x00000018 (24)                    | length of string
+  +0x3704 | 4D 79 47 61 6D 65 2E 49 | char[24]   | MyGame.I                           | string literal
+  +0x370C | 6E 50 61 72 65 6E 74 4E |            | nParentN
+  +0x3714 | 61 6D 65 73 70 61 63 65 |            | amespace
+  +0x371C | 00                      | char       | 0x00 (0)                           | string terminator
+
+padding:
+  +0x371D | 00 00 00                | uint8_t[3] | ...                                | padding
+
+table (reflection.Object):
+  +0x3720 | 88 FF FF FF             | SOffset32  | 0xFFFFFF88 (-120) Loc: 0x3798      | offset to vtable
+  +0x3724 | 40 00 00 00             | UOffset32  | 0x00000040 (64) Loc: 0x3764        | offset to field `name` (string)
+  +0x3728 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x375C        | offset to field `fields` (vector)
+  +0x372C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `minalign` (Int)
+  +0x3730 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3734         | offset to field `declaration_file` (string)
+
+string (reflection.Object.declaration_file):
+  +0x3734 | 20 00 00 00             | uint32_t   | 0x00000020 (32)                    | length of string
+  +0x3738 | 2F 2F 69 6E 63 6C 75 64 | char[32]   | //includ                           | string literal
+  +0x3740 | 65 5F 74 65 73 74 2F 69 |            | e_test/i
+  +0x3748 | 6E 63 6C 75 64 65 5F 74 |            | nclude_t
+  +0x3750 | 65 73 74 31 2E 66 62 73 |            | est1.fbs
+  +0x3758 | 00                      | char       | 0x00 (0)                           | string terminator
+
+padding:
+  +0x3759 | 00 00 00                | uint8_t[3] | ...                                | padding
+
+vector (reflection.Object.fields):
+  +0x375C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x3760 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x3770        | offset to table[0]
+
+string (reflection.Object.name):
+  +0x3764 | 06 00 00 00             | uint32_t   | 0x00000006 (6)                     | length of string
+  +0x3768 | 54 61 62 6C 65 41       | char[6]    | TableA                             | string literal
+  +0x376E | 00                      | char       | 0x00 (0)                           | string terminator
+
+table (reflection.Field):
+  +0x3770 | 84 FF FF FF             | SOffset32  | 0xFFFFFF84 (-124) Loc: 0x37EC      | offset to vtable
+  +0x3774 | 00                      | uint8_t[1] | .                                  | padding
+  +0x3775 | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x3776 | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `offset` (UShort)
+  +0x3778 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x3790        | offset to field `name` (string)
+  +0x377C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3780         | offset to field `type` (table)
+
+table (reflection.Type):
+  +0x3780 | 68 FF FF FF             | SOffset32  | 0xFFFFFF68 (-152) Loc: 0x3818      | offset to vtable
+  +0x3784 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x3787 | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x3788 | 0C 00 00 00             | uint32_t   | 0x0000000C (12)                    | table field `index` (Int)
+  +0x378C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
+
+string (reflection.Field.name):
+  +0x3790 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x3794 | 62                      | char[1]    | b                                  | string literal
+  +0x3795 | 00                      | char       | 0x00 (0)                           | string terminator
+
+padding:
+  +0x3796 | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Object):
-  +0x3798 | 14 00                   | uint16_t    | 0x0014 (20)                        | size of this vtable
-  +0x379A | 14 00                   | uint16_t    | 0x0014 (20)                        | size of referring table
-  +0x379C | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `name` (id: 0)
-  +0x379E | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `fields` (id: 1)
-  +0x37A0 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `is_struct` (id: 2) <defaults to 0> (Bool)
-  +0x37A2 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `minalign` (id: 3)
-  +0x37A4 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `bytesize` (id: 4) <defaults to 0> (Int)
-  +0x37A6 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `attributes` (id: 5) <null> (Vector)
-  +0x37A8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 6) <null> (Vector)
-  +0x37AA | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `declaration_file` (id: 7)
+  +0x3798 | 14 00                   | uint16_t   | 0x0014 (20)                        | size of this vtable
+  +0x379A | 14 00                   | uint16_t   | 0x0014 (20)                        | size of referring table
+  +0x379C | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `name` (id: 0)
+  +0x379E | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `fields` (id: 1)
+  +0x37A0 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `is_struct` (id: 2) <defaults to 0> (Bool)
+  +0x37A2 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `minalign` (id: 3)
+  +0x37A4 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `bytesize` (id: 4) <defaults to 0> (Int)
+  +0x37A6 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `attributes` (id: 5) <null> (Vector)
+  +0x37A8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 6) <null> (Vector)
+  +0x37AA | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `declaration_file` (id: 7)
 
 table (reflection.Object):
-  +0x37AC | 14 00 00 00             | SOffset32   | 0x00000014 (20) Loc: +0x3798       | offset to vtable
-  +0x37B0 | 18 00 00 00             | UOffset32   | 0x00000018 (24) Loc: +0x37C8       | offset to field `name` (string)
-  +0x37B4 | 0C 00 00 00             | UOffset32   | 0x0000000C (12) Loc: +0x37C0       | offset to field `fields` (vector)
-  +0x37B8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `minalign` (Int)
-  +0x37BC | B4 00 00 00             | UOffset32   | 0x000000B4 (180) Loc: +0x3870      | offset to field `declaration_file` (string)
+  +0x37AC | 14 00 00 00             | SOffset32  | 0x00000014 (20) Loc: 0x3798        | offset to vtable
+  +0x37B0 | 18 00 00 00             | UOffset32  | 0x00000018 (24) Loc: 0x37C8        | offset to field `name` (string)
+  +0x37B4 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x37C0        | offset to field `fields` (vector)
+  +0x37B8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `minalign` (Int)
+  +0x37BC | B4 00 00 00             | UOffset32  | 0x000000B4 (180) Loc: 0x3870       | offset to field `declaration_file` (string)
 
 vector (reflection.Object.fields):
-  +0x37C0 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x37C4 | 44 00 00 00             | UOffset32   | 0x00000044 (68) Loc: +0x3808       | offset to table[0]
+  +0x37C0 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x37C4 | 44 00 00 00             | UOffset32  | 0x00000044 (68) Loc: 0x3808        | offset to table[0]
 
 string (reflection.Object.name):
-  +0x37C8 | 1C 00 00 00             | uint32_t    | 0x0000001C (28)                    | length of string
-  +0x37CC | 4D 79 47 61 6D 65 2E 4F | char[28]    | MyGame.O                           | string literal
-  +0x37D4 | 74 68 65 72 4E 61 6D 65 |             | therName
-  +0x37DC | 53 70 61 63 65 2E 54 61 |             | Space.Ta
-  +0x37E4 | 62 6C 65 42             |             | bleB
-  +0x37E8 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x37C8 | 1C 00 00 00             | uint32_t   | 0x0000001C (28)                    | length of string
+  +0x37CC | 4D 79 47 61 6D 65 2E 4F | char[28]   | MyGame.O                           | string literal
+  +0x37D4 | 74 68 65 72 4E 61 6D 65 |            | therName
+  +0x37DC | 53 70 61 63 65 2E 54 61 |            | Space.Ta
+  +0x37E4 | 62 6C 65 42             |            | bleB
+  +0x37E8 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x37E9 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x37E9 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 vtable (reflection.Field):
-  +0x37EC | 1C 00                   | uint16_t    | 0x001C (28)                        | size of this vtable
-  +0x37EE | 10 00                   | uint16_t    | 0x0010 (16)                        | size of referring table
-  +0x37F0 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x37F2 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `type` (id: 1)
-  +0x37F4 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
-  +0x37F6 | 06 00                   | VOffset16   | 0x0006 (6)                         | offset to field `offset` (id: 3)
-  +0x37F8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
-  +0x37FA | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
-  +0x37FC | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
-  +0x37FE | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
-  +0x3800 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
-  +0x3802 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `attributes` (id: 9) <null> (Vector)
-  +0x3804 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
-  +0x3806 | 05 00                   | VOffset16   | 0x0005 (5)                         | offset to field `optional` (id: 11)
+  +0x37EC | 1C 00                   | uint16_t   | 0x001C (28)                        | size of this vtable
+  +0x37EE | 10 00                   | uint16_t   | 0x0010 (16)                        | size of referring table
+  +0x37F0 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x37F2 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `type` (id: 1)
+  +0x37F4 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `id` (id: 2) <defaults to 0> (UShort)
+  +0x37F6 | 06 00                   | VOffset16  | 0x0006 (6)                         | offset to field `offset` (id: 3)
+  +0x37F8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_integer` (id: 4) <defaults to 0> (Long)
+  +0x37FA | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `default_real` (id: 5) <defaults to 0.000000> (Double)
+  +0x37FC | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `deprecated` (id: 6) <defaults to 0> (Bool)
+  +0x37FE | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `required` (id: 7) <defaults to 0> (Bool)
+  +0x3800 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `key` (id: 8) <defaults to 0> (Bool)
+  +0x3802 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `attributes` (id: 9) <null> (Vector)
+  +0x3804 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 10) <null> (Vector)
+  +0x3806 | 05 00                   | VOffset16  | 0x0005 (5)                         | offset to field `optional` (id: 11)
 
 table (reflection.Field):
-  +0x3808 | 1C 00 00 00             | SOffset32   | 0x0000001C (28) Loc: +0x37EC       | offset to vtable
-  +0x380C | 00                      | uint8_t[1]  | .                                  | padding
-  +0x380D | 01                      | uint8_t     | 0x01 (1)                           | table field `optional` (Bool)
-  +0x380E | 04 00                   | uint16_t    | 0x0004 (4)                         | table field `offset` (UShort)
-  +0x3810 | 28 00 00 00             | UOffset32   | 0x00000028 (40) Loc: +0x3838       | offset to field `name` (string)
-  +0x3814 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x3828       | offset to field `type` (table)
+  +0x3808 | 1C 00 00 00             | SOffset32  | 0x0000001C (28) Loc: 0x37EC        | offset to vtable
+  +0x380C | 00                      | uint8_t[1] | .                                  | padding
+  +0x380D | 01                      | uint8_t    | 0x01 (1)                           | table field `optional` (Bool)
+  +0x380E | 04 00                   | uint16_t   | 0x0004 (4)                         | table field `offset` (UShort)
+  +0x3810 | 28 00 00 00             | UOffset32  | 0x00000028 (40) Loc: 0x3838        | offset to field `name` (string)
+  +0x3814 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x3828        | offset to field `type` (table)
 
 vtable (reflection.Type):
-  +0x3818 | 10 00                   | uint16_t    | 0x0010 (16)                        | size of this vtable
-  +0x381A | 10 00                   | uint16_t    | 0x0010 (16)                        | size of referring table
-  +0x381C | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `base_type` (id: 0)
-  +0x381E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `element` (id: 1) <defaults to 0> (Byte)
-  +0x3820 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `index` (id: 2)
-  +0x3822 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
-  +0x3824 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `base_size` (id: 4) <defaults to 4> (UInt)
-  +0x3826 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `element_size` (id: 5)
+  +0x3818 | 10 00                   | uint16_t   | 0x0010 (16)                        | size of this vtable
+  +0x381A | 10 00                   | uint16_t   | 0x0010 (16)                        | size of referring table
+  +0x381C | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `base_type` (id: 0)
+  +0x381E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `element` (id: 1) <defaults to 0> (Byte)
+  +0x3820 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `index` (id: 2)
+  +0x3822 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
+  +0x3824 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `base_size` (id: 4) <defaults to 4> (UInt)
+  +0x3826 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `element_size` (id: 5)
 
 table (reflection.Type):
-  +0x3828 | 10 00 00 00             | SOffset32   | 0x00000010 (16) Loc: +0x3818       | offset to vtable
-  +0x382C | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x382F | 0F                      | uint8_t     | 0x0F (15)                          | table field `base_type` (Byte)
-  +0x3830 | 0E 00 00 00             | uint32_t    | 0x0000000E (14)                    | table field `index` (Int)
-  +0x3834 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | table field `element_size` (UInt)
+  +0x3828 | 10 00 00 00             | SOffset32  | 0x00000010 (16) Loc: 0x3818        | offset to vtable
+  +0x382C | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x382F | 0F                      | uint8_t    | 0x0F (15)                          | table field `base_type` (Byte)
+  +0x3830 | 0E 00 00 00             | uint32_t   | 0x0000000E (14)                    | table field `index` (Int)
+  +0x3834 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
 string (reflection.Field.name):
-  +0x3838 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x383C | 61                      | char[1]     | a                                  | string literal
-  +0x383D | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3838 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x383C | 61                      | char[1]    | a                                  | string literal
+  +0x383D | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x383E | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x383E | 00 00                   | uint8_t[2] | ..                                 | padding
 
 vtable (reflection.Object):
-  +0x3840 | 14 00                   | uint16_t    | 0x0014 (20)                        | size of this vtable
-  +0x3842 | 1C 00                   | uint16_t    | 0x001C (28)                        | size of referring table
-  +0x3844 | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `name` (id: 0)
-  +0x3846 | 0C 00                   | VOffset16   | 0x000C (12)                        | offset to field `fields` (id: 1)
-  +0x3848 | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `is_struct` (id: 2)
-  +0x384A | 10 00                   | VOffset16   | 0x0010 (16)                        | offset to field `minalign` (id: 3)
-  +0x384C | 14 00                   | VOffset16   | 0x0014 (20)                        | offset to field `bytesize` (id: 4)
-  +0x384E | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `attributes` (id: 5) <null> (Vector)
-  +0x3850 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `documentation` (id: 6) <null> (Vector)
-  +0x3852 | 18 00                   | VOffset16   | 0x0018 (24)                        | offset to field `declaration_file` (id: 7)
+  +0x3840 | 14 00                   | uint16_t   | 0x0014 (20)                        | size of this vtable
+  +0x3842 | 1C 00                   | uint16_t   | 0x001C (28)                        | size of referring table
+  +0x3844 | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `name` (id: 0)
+  +0x3846 | 0C 00                   | VOffset16  | 0x000C (12)                        | offset to field `fields` (id: 1)
+  +0x3848 | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `is_struct` (id: 2)
+  +0x384A | 10 00                   | VOffset16  | 0x0010 (16)                        | offset to field `minalign` (id: 3)
+  +0x384C | 14 00                   | VOffset16  | 0x0014 (20)                        | offset to field `bytesize` (id: 4)
+  +0x384E | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `attributes` (id: 5) <null> (Vector)
+  +0x3850 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `documentation` (id: 6) <null> (Vector)
+  +0x3852 | 18 00                   | VOffset16  | 0x0018 (24)                        | offset to field `declaration_file` (id: 7)
 
 table (reflection.Object):
-  +0x3854 | 14 00 00 00             | SOffset32   | 0x00000014 (20) Loc: +0x3840       | offset to vtable
-  +0x3858 | 00 00 00                | uint8_t[3]  | ...                                | padding
-  +0x385B | 01                      | uint8_t     | 0x01 (1)                           | table field `is_struct` (Bool)
-  +0x385C | 48 00 00 00             | UOffset32   | 0x00000048 (72) Loc: +0x38A4       | offset to field `name` (string)
-  +0x3860 | 3C 00 00 00             | UOffset32   | 0x0000003C (60) Loc: +0x389C       | offset to field `fields` (vector)
-  +0x3864 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `minalign` (Int)
-  +0x3868 | 04 00 00 00             | uint32_t    | 0x00000004 (4)                     | table field `bytesize` (Int)
-  +0x386C | 04 00 00 00             | UOffset32   | 0x00000004 (4) Loc: +0x3870        | offset to field `declaration_file` (string)
+  +0x3854 | 14 00 00 00             | SOffset32  | 0x00000014 (20) Loc: 0x3840        | offset to vtable
+  +0x3858 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x385B | 01                      | uint8_t    | 0x01 (1)                           | table field `is_struct` (Bool)
+  +0x385C | 48 00 00 00             | UOffset32  | 0x00000048 (72) Loc: 0x38A4        | offset to field `name` (string)
+  +0x3860 | 3C 00 00 00             | UOffset32  | 0x0000003C (60) Loc: 0x389C        | offset to field `fields` (vector)
+  +0x3864 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `minalign` (Int)
+  +0x3868 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                     | table field `bytesize` (Int)
+  +0x386C | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x3870         | offset to field `declaration_file` (string)
 
 string (reflection.Object.declaration_file):
-  +0x3870 | 24 00 00 00             | uint32_t    | 0x00000024 (36)                    | length of string
-  +0x3874 | 2F 2F 69 6E 63 6C 75 64 | char[36]    | //includ                           | string literal
-  +0x387C | 65 5F 74 65 73 74 2F 73 |             | e_test/s
-  +0x3884 | 75 62 2F 69 6E 63 6C 75 |             | ub/inclu
-  +0x388C | 64 65 5F 74 65 73 74 32 |             | de_test2
-  +0x3894 | 2E 66 62 73             |             | .fbs
-  +0x3898 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x3870 | 24 00 00 00             | uint32_t   | 0x00000024 (36)                    | length of string
+  +0x3874 | 2F 2F 69 6E 63 6C 75 64 | char[36]   | //includ                           | string literal
+  +0x387C | 65 5F 74 65 73 74 2F 73 |            | e_test/s
+  +0x3884 | 75 62 2F 69 6E 63 6C 75 |            | ub/inclu
+  +0x388C | 64 65 5F 74 65 73 74 32 |            | de_test2
+  +0x3894 | 2E 66 62 73             |            | .fbs
+  +0x3898 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x3899 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x3899 | 00 00 00                | uint8_t[3] | ...                                | padding
 
 vector (reflection.Object.fields):
-  +0x389C | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of vector (# items)
-  +0x38A0 | 30 00 00 00             | UOffset32   | 0x00000030 (48) Loc: +0x38D0       | offset to table[0]
+  +0x389C | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of vector (# items)
+  +0x38A0 | 30 00 00 00             | UOffset32  | 0x00000030 (48) Loc: 0x38D0        | offset to table[0]
 
 string (reflection.Object.name):
-  +0x38A4 | 1C 00 00 00             | uint32_t    | 0x0000001C (28)                    | length of string
-  +0x38A8 | 4D 79 47 61 6D 65 2E 4F | char[28]    | MyGame.O                           | string literal
-  +0x38B0 | 74 68 65 72 4E 61 6D 65 |             | therName
-  +0x38B8 | 53 70 61 63 65 2E 55 6E |             | Space.Un
-  +0x38C0 | 75 73 65 64             |             | used
-  +0x38C4 | 00                      | char        | 0x00 (0)                           | string terminator
+  +0x38A4 | 1C 00 00 00             | uint32_t   | 0x0000001C (28)                    | length of string
+  +0x38A8 | 4D 79 47 61 6D 65 2E 4F | char[28]   | MyGame.O                           | string literal
+  +0x38B0 | 74 68 65 72 4E 61 6D 65 |            | therName
+  +0x38B8 | 53 70 61 63 65 2E 55 6E |            | Space.Un
+  +0x38C0 | 75 73 65 64             |            | used
+  +0x38C4 | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x38C5 | 00 00 00                | uint8_t[3]  | ...                                | padding
+  +0x38C5 | 00 00 00                | uint8_t[3] | ...                                | padding
 
-vtable (reflection.KeyValue):
-  +0x38C8 | 08 00                   | uint16_t    | 0x0008 (8)                         | size of this vtable
-  +0x38CA | 0C 00                   | uint16_t    | 0x000C (12)                        | size of referring table
-  +0x38CC | 04 00                   | VOffset16   | 0x0004 (4)                         | offset to field `key` (id: 0)
-  +0x38CE | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `value` (id: 1)
+vtable (reflection.KeyValue, reflection.Field, reflection.SchemaFile):
+  +0x38C8 | 08 00                   | uint16_t   | 0x0008 (8)                         | size of this vtable
+  +0x38CA | 0C 00                   | uint16_t   | 0x000C (12)                        | size of referring table
+  +0x38CC | 04 00                   | VOffset16  | 0x0004 (4)                         | offset to field `key` (id: 0)
+  +0x38CE | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `value` (id: 1)
 
 table (reflection.Field):
-  +0x38D0 | 08 00 00 00             | SOffset32   | 0x00000008 (8) Loc: +0x38C8        | offset to vtable
-  +0x38D4 | 24 00 00 00             | UOffset32   | 0x00000024 (36) Loc: +0x38F8       | offset to field `key` (string)
-  +0x38D8 | 14 00 00 00             | UOffset32   | 0x00000014 (20) Loc: +0x38EC       | offset to field `value` (string)
+  +0x38D0 | 08 00 00 00             | SOffset32  | 0x00000008 (8) Loc: 0x38C8         | offset to vtable
+  +0x38D4 | 24 00 00 00             | UOffset32  | 0x00000024 (36) Loc: 0x38F8        | offset to field `name` (string)
+  +0x38D8 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x38EC        | offset to field `type` (table)
 
 vtable (reflection.Type):
-  +0x38DC | 10 00                   | uint16_t    | 0x0010 (16)                        | size of this vtable
-  +0x38DE | 0C 00                   | uint16_t    | 0x000C (12)                        | size of referring table
-  +0x38E0 | 07 00                   | VOffset16   | 0x0007 (7)                         | offset to field `base_type` (id: 0)
-  +0x38E2 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `element` (id: 1) <defaults to 0> (Byte)
-  +0x38E4 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `index` (id: 2) <defaults to -1> (Int)
-  +0x38E6 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
-  +0x38E8 | 00 00                   | VOffset16   | 0x0000 (0)                         | offset to field `base_size` (id: 4) <defaults to 4> (UInt)
-  +0x38EA | 08 00                   | VOffset16   | 0x0008 (8)                         | offset to field `element_size` (id: 5)
+  +0x38DC | 10 00                   | uint16_t   | 0x0010 (16)                        | size of this vtable
+  +0x38DE | 0C 00                   | uint16_t   | 0x000C (12)                        | size of referring table
+  +0x38E0 | 07 00                   | VOffset16  | 0x0007 (7)                         | offset to field `base_type` (id: 0)
+  +0x38E2 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `element` (id: 1) <defaults to 0> (Byte)
+  +0x38E4 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `index` (id: 2) <defaults to -1> (Int)
+  +0x38E6 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `fixed_length` (id: 3) <defaults to 0> (UShort)
+  +0x38E8 | 00 00                   | VOffset16  | 0x0000 (0)                         | offset to field `base_size` (id: 4) <defaults to 4> (UInt)
+  +0x38EA | 08 00                   | VOffset16  | 0x0008 (8)                         | offset to field `element_size` (id: 5)
 
-string (reflection.Field.value):
-  +0x38EC | 10 00 00 00             | uint32_t    | 0x00000010 (16)                    | ERROR: length of string. Longer than the binary.
+table (reflection.Type):
+  +0x38EC | 10 00 00 00             | SOffset32  | 0x00000010 (16) Loc: 0x38DC        | offset to vtable
+  +0x38F0 | 00 00 00                | uint8_t[3] | ...                                | padding
+  +0x38F3 | 07                      | uint8_t    | 0x07 (7)                           | table field `base_type` (Byte)
+  +0x38F4 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | table field `element_size` (UInt)
 
-unknown (no known references):
-  +0x38F0 | 00 00 00 07 01 00 00 00 | ?uint8_t[8] | ........                           | WARN: nothing refers to this section.
-
-string (reflection.Field.key):
-  +0x38F8 | 01 00 00 00             | uint32_t    | 0x00000001 (1)                     | length of string
-  +0x38FC | 61                      | char[1]     | a                                  | string literal
-  +0x38FD | 00                      | char        | 0x00 (0)                           | string terminator
+string (reflection.Field.name):
+  +0x38F8 | 01 00 00 00             | uint32_t   | 0x00000001 (1)                     | length of string
+  +0x38FC | 61                      | char[1]    | a                                  | string literal
+  +0x38FD | 00                      | char       | 0x00 (0)                           | string terminator
 
 padding:
-  +0x38FE | 00 00                   | uint8_t[2]  | ..                                 | padding
+  +0x38FE | 00 00                   | uint8_t[2] | ..                                 | padding

--- a/tests/monsterdata_test.afb
+++ b/tests/monsterdata_test.afb
@@ -4,7 +4,7 @@
 // Binary file: monsterdata_test.mon
 
 header:
-  +0x0000 | 78 00 00 00             | UOffset32  | 0x00000078 (120) Loc: +0x0078            | offset to root table `MyGame.Example.Monster`
+  +0x0000 | 78 00 00 00             | UOffset32  | 0x00000078 (120) Loc: 0x0078             | offset to root table `MyGame.Example.Monster`
   +0x0004 | 4D 4F 4E 53             | char[4]    | MONS                                     | File Identifier
 
 padding:
@@ -67,7 +67,7 @@ vtable (MyGame.Example.Monster):
   +0x0076 | 6C 00                   | VOffset16  | 0x006C (108)                             | offset to field `native_inline` (id: 51)
 
 root_table (MyGame.Example.Monster):
-  +0x0078 | 6C 00 00 00             | SOffset32  | 0x0000006C (108) Loc: +0x000C            | offset to vtable
+  +0x0078 | 6C 00 00 00             | SOffset32  | 0x0000006C (108) Loc: 0x000C             | offset to vtable
   +0x007C | 01                      | UType8     | 0x01 (1)                                 | table field `test_type` (UType)
   +0x007D | 01                      | uint8_t    | 0x01 (1)                                 | table field `testbool` (Bool)
   +0x007E | 50 00                   | int16_t    | 0x0050 (80)                              | table field `hp` (Short)
@@ -83,22 +83,22 @@ root_table (MyGame.Example.Monster):
   +0x009D | 00                      | uint8_t[1] | .                                        | padding
   +0x009E | 00 00                   | uint8_t[2] | ..                                       | padding
   +0x00A0 | 00 00 00 00             | uint8_t[4] | ....                                     | padding
-  +0x00A4 | A4 01 00 00             | UOffset32  | 0x000001A4 (420) Loc: +0x0248            | offset to field `name` (string)
-  +0x00A8 | 94 01 00 00             | UOffset32  | 0x00000194 (404) Loc: +0x023C            | offset to field `inventory` (vector)
-  +0x00AC | 2C 01 00 00             | UOffset32  | 0x0000012C (300) Loc: +0x01D8            | offset to field `test` (union of type `Monster`)
-  +0x00B0 | 10 01 00 00             | UOffset32  | 0x00000110 (272) Loc: +0x01C0            | offset to field `test4` (vector)
-  +0x00B4 | DC 00 00 00             | UOffset32  | 0x000000DC (220) Loc: +0x0190            | offset to field `testarrayofstring` (vector)
-  +0x00B8 | C4 00 00 00             | UOffset32  | 0x000000C4 (196) Loc: +0x017C            | offset to field `enemy` (table)
+  +0x00A4 | A4 01 00 00             | UOffset32  | 0x000001A4 (420) Loc: 0x0248             | offset to field `name` (string)
+  +0x00A8 | 94 01 00 00             | UOffset32  | 0x00000194 (404) Loc: 0x023C             | offset to field `inventory` (vector)
+  +0x00AC | 2C 01 00 00             | UOffset32  | 0x0000012C (300) Loc: 0x01D8             | offset to field `test` (union of type `Monster`)
+  +0x00B0 | 10 01 00 00             | UOffset32  | 0x00000110 (272) Loc: 0x01C0             | offset to field `test4` (vector)
+  +0x00B4 | DC 00 00 00             | UOffset32  | 0x000000DC (220) Loc: 0x0190             | offset to field `testarrayofstring` (vector)
+  +0x00B8 | C4 00 00 00             | UOffset32  | 0x000000C4 (196) Loc: 0x017C             | offset to field `enemy` (table)
   +0x00BC | 41 C9 79 DD             | uint32_t   | 0xDD79C941 (3715746113)                  | table field `testhashs32_fnv1` (Int)
   +0x00C0 | 41 C9 79 DD             | uint32_t   | 0xDD79C941 (3715746113)                  | table field `testhashu32_fnv1` (UInt)
   +0x00C4 | 71 A4 81 8E             | uint32_t   | 0x8E81A471 (2390860913)                  | table field `testhashs32_fnv1a` (Int)
   +0x00C8 | 71 A4 81 8E             | uint32_t   | 0x8E81A471 (2390860913)                  | table field `testhashu32_fnv1a` (UInt)
-  +0x00CC | A8 00 00 00             | UOffset32  | 0x000000A8 (168) Loc: +0x0174            | offset to field `testarrayofbools` (vector)
-  +0x00D0 | 88 00 00 00             | UOffset32  | 0x00000088 (136) Loc: +0x0158            | offset to field `testarrayofsortedstruct` (vector)
-  +0x00D4 | E0 00 00 00             | UOffset32  | 0x000000E0 (224) Loc: +0x01B4            | offset to field `test5` (vector)
-  +0x00D8 | 34 01 00 00             | UOffset32  | 0x00000134 (308) Loc: +0x020C            | offset to field `vector_of_longs` (vector)
-  +0x00DC | 10 01 00 00             | UOffset32  | 0x00000110 (272) Loc: +0x01EC            | offset to field `vector_of_doubles` (vector)
-  +0x00E0 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: +0x010C             | offset to field `scalar_key_sorted_tables` (vector)
+  +0x00CC | A8 00 00 00             | UOffset32  | 0x000000A8 (168) Loc: 0x0174             | offset to field `testarrayofbools` (vector)
+  +0x00D0 | 88 00 00 00             | UOffset32  | 0x00000088 (136) Loc: 0x0158             | offset to field `testarrayofsortedstruct` (vector)
+  +0x00D4 | E0 00 00 00             | UOffset32  | 0x000000E0 (224) Loc: 0x01B4             | offset to field `test5` (vector)
+  +0x00D8 | 34 01 00 00             | UOffset32  | 0x00000134 (308) Loc: 0x020C             | offset to field `vector_of_longs` (vector)
+  +0x00DC | 10 01 00 00             | UOffset32  | 0x00000110 (272) Loc: 0x01EC             | offset to field `vector_of_doubles` (vector)
+  +0x00E0 | 2C 00 00 00             | UOffset32  | 0x0000002C (44) Loc: 0x010C              | offset to field `scalar_key_sorted_tables` (vector)
   +0x00E4 | 01 00                   | int16_t    | 0x0001 (1)                               | struct field `native_inline.a` of 'MyGame.Example.Test' (Short)
   +0x00E6 | 02                      | uint8_t    | 0x02 (2)                                 | struct field `native_inline.b` of 'MyGame.Example.Test' (Byte)
   +0x00E7 | 00                      | uint8_t[1] | .                                        | padding
@@ -110,8 +110,8 @@ root_table (MyGame.Example.Monster):
 
 vector (MyGame.Example.Monster.scalar_key_sorted_tables):
   +0x010C | 02 00 00 00             | uint32_t   | 0x00000002 (2)                           | length of vector (# items)
-  +0x0110 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: +0x0120             | offset to table[0]
-  +0x0114 | 28 00 00 00             | UOffset32  | 0x00000028 (40) Loc: +0x013C             | offset to table[1]
+  +0x0110 | 10 00 00 00             | UOffset32  | 0x00000010 (16) Loc: 0x0120              | offset to table[0]
+  +0x0114 | 28 00 00 00             | UOffset32  | 0x00000028 (40) Loc: 0x013C              | offset to table[1]
 
 padding:
   +0x0118 | 00 00                   | uint8_t[2] | ..                                       | padding
@@ -122,8 +122,8 @@ vtable (MyGame.Example.Stat):
   +0x011E | 04 00                   | VOffset16  | 0x0004 (4)                               | offset to field `id` (id: 0)
 
 table (MyGame.Example.Stat):
-  +0x0120 | 06 00 00 00             | SOffset32  | 0x00000006 (6) Loc: +0x011A              | offset to vtable
-  +0x0124 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x0128              | offset to field `id` (string)
+  +0x0120 | 06 00 00 00             | SOffset32  | 0x00000006 (6) Loc: 0x011A               | offset to vtable
+  +0x0124 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0128               | offset to field `id` (string)
 
 string (MyGame.Example.Stat.id):
   +0x0128 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                           | length of string
@@ -138,10 +138,10 @@ vtable (MyGame.Example.Stat):
   +0x013A | 06 00                   | VOffset16  | 0x0006 (6)                               | offset to field `count` (id: 2)
 
 table (MyGame.Example.Stat):
-  +0x013C | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: +0x0132             | offset to vtable
+  +0x013C | 0A 00 00 00             | SOffset32  | 0x0000000A (10) Loc: 0x0132              | offset to vtable
   +0x0140 | 00 00                   | uint8_t[2] | ..                                       | padding
   +0x0142 | 01 00                   | uint16_t   | 0x0001 (1)                               | table field `count` (UShort)
-  +0x0144 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: +0x0150             | offset to field `id` (string)
+  +0x0144 | 0C 00 00 00             | UOffset32  | 0x0000000C (12) Loc: 0x0150              | offset to field `id` (string)
   +0x0148 | 0A 00 00 00 00 00 00 00 | int64_t    | 0x000000000000000A (10)                  | table field `val` (Long)
 
 string (MyGame.Example.Stat.id):
@@ -165,8 +165,8 @@ vector (MyGame.Example.Monster.testarrayofbools):
   +0x017A | 01                      | uint8_t    | 0x01 (1)                                 | value[2]
 
 table (MyGame.Example.Monster):
-  +0x017C | B0 FF FF FF             | SOffset32  | 0xFFFFFFB0 (-80) Loc: +0x01CC            | offset to vtable
-  +0x0180 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x0184              | offset to field `name` (string)
+  +0x017C | B0 FF FF FF             | SOffset32  | 0xFFFFFFB0 (-80) Loc: 0x01CC             | offset to vtable
+  +0x0180 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x0184               | offset to field `name` (string)
 
 string (MyGame.Example.Monster.name):
   +0x0184 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                           | length of string
@@ -178,8 +178,8 @@ padding:
 
 vector (MyGame.Example.Monster.testarrayofstring):
   +0x0190 | 02 00 00 00             | uint32_t   | 0x00000002 (2)                           | length of vector (# items)
-  +0x0194 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: +0x01A8             | offset to string[0]
-  +0x0198 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x019C              | offset to string[1]
+  +0x0194 | 14 00 00 00             | UOffset32  | 0x00000014 (20) Loc: 0x01A8              | offset to string[0]
+  +0x0198 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x019C               | offset to string[1]
 
 string (MyGame.Example.Monster.testarrayofstring):
   +0x019C | 05 00 00 00             | uint32_t   | 0x00000005 (5)                           | length of string
@@ -224,8 +224,8 @@ vtable (MyGame.Example.Monster):
   +0x01D6 | 04 00                   | VOffset16  | 0x0004 (4)                               | offset to field `name` (id: 3)
 
 table (MyGame.Example.Monster):
-  +0x01D8 | 0C 00 00 00             | SOffset32  | 0x0000000C (12) Loc: +0x01CC             | offset to vtable
-  +0x01DC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: +0x01E0              | offset to field `name` (string)
+  +0x01D8 | 0C 00 00 00             | SOffset32  | 0x0000000C (12) Loc: 0x01CC              | offset to vtable
+  +0x01DC | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x01E0               | offset to field `name` (string)
 
 string (MyGame.Example.Monster.name):
   +0x01E0 | 04 00 00 00             | uint32_t   | 0x00000004 (4)                           | length of string


### PR DESCRIPTION
I found out that vtables could be shared across unique Table types, not just within the same table type. 

This required changing the code in the binary annotator to account for this fact, since I use the vtable's fields to annotate the binary. 

Updated the text output to not include `+` in the offset calculated location, as this produce the same symbol used to refer to the lines. This made finding the offset in a very large file really hard, since find-in-file searching couldn't tell the two part.