### PR TITLE
use switch statements for BASE_TYPE_ lookups

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -146,12 +146,29 @@ inline bool IsUnsigned(BaseType t) {
          (t == BASE_TYPE_ULONG);
 }
 
+inline size_t SizeOf(const BaseType t) {
+  switch (t) {
+  #define FLATBUFFERS_TD(ENUM, IDLTYPE, CTYPE, ...) \
+    case BASE_TYPE_##ENUM: return sizeof(CTYPE);
+      FLATBUFFERS_GEN_TYPES(FLATBUFFERS_TD)
+  #undef FLATBUFFERS_TD
+    default: FLATBUFFERS_ASSERT(0);
+  }
+  return 0;
+}
+
+inline const char* TypeName(const BaseType t) {
+  switch (t) {
+  #define FLATBUFFERS_TD(ENUM, IDLTYPE, ...) \
+    case BASE_TYPE_##ENUM: return IDLTYPE;
+      FLATBUFFERS_GEN_TYPES(FLATBUFFERS_TD)
+  #undef FLATBUFFERS_TD
+    default: FLATBUFFERS_ASSERT(0);
+  }
+  return nullptr;
+}
+
 // clang-format on
-
-extern const char *const kTypeNames[];
-extern const char kTypeSizes[];
-
-inline size_t SizeOf(BaseType t) { return kTypeSizes[t]; }
 
 struct StructDef;
 struct EnumDef;

--- a/src/idl_gen_fbs.cpp
+++ b/src/idl_gen_fbs.cpp
@@ -37,7 +37,7 @@ static std::string GenType(const Type &type, bool underlying = false) {
         return type.enum_def->defined_namespace->GetFullyQualifiedName(
             type.enum_def->name);
       } else {
-        return kTypeNames[type.base_type];
+        return TypeName(type.base_type);
       }
   }
 }

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -356,23 +356,6 @@ template<typename T> static void AssignIndices(const std::vector<T *> &defvec) {
 
 }  // namespace
 
-// clang-format off
-const char *const kTypeNames[] = {
-  #define FLATBUFFERS_TD(ENUM, IDLTYPE, ...) \
-    IDLTYPE,
-    FLATBUFFERS_GEN_TYPES(FLATBUFFERS_TD)
-  #undef FLATBUFFERS_TD
-  nullptr
-};
-
-const char kTypeSizes[] = {
-  #define FLATBUFFERS_TD(ENUM, IDLTYPE, CTYPE, ...) \
-    sizeof(CTYPE),
-    FLATBUFFERS_GEN_TYPES(FLATBUFFERS_TD)
-  #undef FLATBUFFERS_TD
-};
-// clang-format on
-
 void Parser::Message(const std::string &msg) {
   if (!error_.empty()) error_ += "\n";  // log all warnings and errors
   error_ += file_being_parsed_.length() ? AbsolutePath(file_being_parsed_) : "";
@@ -1947,8 +1930,8 @@ CheckedError Parser::ParseFunction(const std::string *name, Value &e) {
   const auto functionname = attribute_;
   if (!IsFloat(e.type.base_type)) {
     return Error(functionname + ": type of argument mismatch, expecting: " +
-                 kTypeNames[BASE_TYPE_DOUBLE] +
-                 ", found: " + kTypeNames[e.type.base_type] +
+                 TypeName(BASE_TYPE_DOUBLE) +
+                 ", found: " + TypeName(e.type.base_type) +
                  ", name: " + (name ? *name : "") + ", value: " + e.constant);
   }
   NEXT();
@@ -1994,8 +1977,8 @@ CheckedError Parser::TryTypedValue(const std::string *name, int dtoken,
       e.type.base_type = req;
     } else {
       return Error(std::string("type mismatch: expecting: ") +
-                   kTypeNames[e.type.base_type] +
-                   ", found: " + kTypeNames[req] +
+                   TypeName(e.type.base_type) +
+                   ", found: " + TypeName(req) +
                    ", name: " + (name ? *name : "") + ", value: " + e.constant);
     }
   }
@@ -2056,7 +2039,7 @@ CheckedError Parser::ParseSingleValue(const std::string *name, Value &e,
       return Error(
           std::string("type mismatch or invalid value, an initializer of "
                       "non-string field must be trivial ASCII string: type: ") +
-          kTypeNames[in_type] + ", name: " + (name ? *name : "") +
+          TypeName(in_type) + ", name: " + (name ? *name : "") +
           ", value: " + attribute_);
     }
 
@@ -2128,7 +2111,7 @@ CheckedError Parser::ParseSingleValue(const std::string *name, Value &e,
   if (!match) {
     std::string msg;
     msg += "Cannot assign token starting with '" + TokenToStringId(token_) +
-           "' to value of <" + std::string(kTypeNames[in_type]) + "> type.";
+           "' to value of <" + std::string(TypeName(in_type)) + "> type.";
     return Error(msg);
   }
   const auto match_type = e.type.base_type;  // may differ from in_type

--- a/tests/fuzz_test.cpp
+++ b/tests/fuzz_test.cpp
@@ -234,7 +234,7 @@ void FuzzTest2() {
           break;
         default:
           // All the scalar types.
-          schema += flatbuffers::kTypeNames[base_type];
+          schema += flatbuffers::TypeName(base_type);
 
           if (!deprecated) {
             // We want each instance to use its own random value.


### PR DESCRIPTION
Since enums are not defined in enum-value order, some of the mapping to arrays were incorrect. Just switch them out for switch statements.

This is not in any performance related area, so going from index to switch statement should not matter.