### PR TITLE
[Annotated Buffers] Improve efficiency

### DIFF
--- a/include/flatbuffers/flatc.h
+++ b/include/flatbuffers/flatc.h
@@ -49,6 +49,7 @@ struct FlatCOptions {
   size_t binary_files_from = std::numeric_limits<size_t>::max();
   std::string conform_to_schema;
   std::string annotate_schema;
+  bool annotate_include_vector_contents = true;
   bool any_generator = false;
   bool print_make_rules = false;
   bool raw_binary = false;
@@ -110,8 +111,7 @@ class FlatCompiler {
 
   void AnnotateBinaries(const uint8_t *binary_schema,
                         uint64_t binary_schema_size,
-                        const std::string &schema_filename,
-                        const std::vector<std::string> &binary_files);
+                        const FlatCOptions &options);
 
   void ValidateOptions(const FlatCOptions &options);
 

--- a/src/annotated_binary_text_gen.cpp
+++ b/src/annotated_binary_text_gen.cpp
@@ -1,6 +1,8 @@
 #include "annotated_binary_text_gen.h"
 
 #include <algorithm>
+#include <fstream>
+#include <ostream>
 #include <sstream>
 #include <string>
 
@@ -257,84 +259,75 @@ static std::string GenerateComment(const BinaryRegionComment &comment,
   return s;
 }
 
-static std::string GenerateDocumentation(const BinaryRegion &region,
-                                         const BinarySection &section,
-                                         const uint8_t *binary,
-                                         DocContinuation &continuation,
-                                         const OutputConfig &output_config) {
-  std::string s;
+static void GenerateDocumentation(std::ostream &os, const BinaryRegion &region,
+                                  const BinarySection &section,
+                                  const uint8_t *binary,
+                                  DocContinuation &continuation,
+                                  const OutputConfig &output_config) {
 
   // Check if there is a doc continuation that should be prioritized.
   if (continuation.value_start_column) {
-    s += std::string(continuation.value_start_column - 2, ' ');
-    s += output_config.delimiter;
-    s += " ";
+    os << std::string(continuation.value_start_column - 2, ' ');
+    os << output_config.delimiter << " ";
 
-    s += continuation.value.substr(0, output_config.max_bytes_per_line);
+    os << continuation.value.substr(0, output_config.max_bytes_per_line);
     continuation.value = continuation.value.substr(
         std::min(output_config.max_bytes_per_line, continuation.value.size()));
-    return s;
+    return;
   }
 
+  size_t size_of = 0;
   {
     std::stringstream ss;
-    ss << std::setw(static_cast<int>(output_config.largest_type_string)) << std::left;
+    ss << std::setw(static_cast<int>(output_config.largest_type_string))
+       << std::left;
     ss << GenerateTypeString(region);
-    s += ss.str();
+    os << ss.str();
+    size_of = ss.str().size();
   }
-  s += " ";
-  s += output_config.delimiter;
-  s += " ";
+  os << " " << output_config.delimiter << " ";
   if (region.array_length) {
     // Record where the value is first being outputted.
-    continuation.value_start_column = s.size();
-
+    continuation.value_start_column = 3 + size_of;
+ 
     // Get the full-length value, which we will chunk below.
     const std::string value = ToValueString(region, binary, output_config);
 
     std::stringstream ss;
-    ss << std::setw(static_cast<int>(output_config.largest_value_string)) << std::left;
+    ss << std::setw(static_cast<int>(output_config.largest_value_string))
+       << std::left;
     ss << value.substr(0, output_config.max_bytes_per_line);
-    s += ss.str();
+    os << ss.str();
 
     continuation.value =
         value.substr(std::min(output_config.max_bytes_per_line, value.size()));
   } else {
     std::stringstream ss;
-    ss << std::setw(static_cast<int>(output_config.largest_value_string)) << std::left;
+    ss << std::setw(static_cast<int>(output_config.largest_value_string))
+       << std::left;
     ss << ToValueString(region, binary, output_config);
-    s += ss.str();
+    os << ss.str();
   }
 
-  s += " ";
-  s += output_config.delimiter;
-  s += " ";
-  s += GenerateComment(region.comment, section);
-
-  return s;
+  os << " " << output_config.delimiter << " ";
+  os << GenerateComment(region.comment, section);
 }
 
-static std::string GenerateRegion(const BinaryRegion &region,
-                                  const BinarySection &section,
-                                  const uint8_t *binary,
-                                  const OutputConfig &output_config) {
-  std::string s;
+static void GenerateRegion(std::ostream &os, const BinaryRegion &region,
+                           const BinarySection &section, const uint8_t *binary,
+                           const OutputConfig &output_config) {
   bool doc_generated = false;
   DocContinuation doc_continuation;
   for (uint64_t i = 0; i < region.length; ++i) {
     if ((i % output_config.max_bytes_per_line) == 0) {
       // Start a new line of output
-      s += '\n';
-      s += "  ";
-      s += "+0x";
-      s += ToHex(region.offset + i, output_config.offset_max_char);
-      s += " ";
-      s += output_config.delimiter;
+      os << std::endl;
+      os << "  +0x" << ToHex(region.offset + i, output_config.offset_max_char);
+      os << " " << output_config.delimiter;
     }
 
     // Add each byte
-    s += " ";
-    s += ToHex(binary[region.offset + i]);
+    os << " " << ToHex(binary[region.offset + i]);
 
     // Check for end of line or end of region conditions.
     if (((i + 1) % output_config.max_bytes_per_line == 0) ||
@@ -344,17 +337,16 @@ static std::string GenerateRegion(const BinaryRegion &region,
         // zero those out to align everything globally.
         for (uint64_t j = i + 1; (j % output_config.max_bytes_per_line) != 0;
              ++j) {
-          s += "   ";
+          os << "   ";
         }
       }
-      s += " ";
-      s += output_config.delimiter;
+      os << " " << output_config.delimiter;
       // This is the end of the first line or its the last byte of the region,
       // generate the end-of-line documentation.
       if (!doc_generated) {
-        s += " ";
-        s += GenerateDocumentation(region, section, binary, doc_continuation,
-                                   output_config);
+        os << " ";
+        GenerateDocumentation(os, region, section, binary, doc_continuation,
+                              output_config);
 
         // If we have a value in the doc continuation, that means the doc is
         // being printed on multiple lines.
@@ -362,22 +354,19 @@ static std::string GenerateRegion(const BinaryRegion &region,
       }
     }
   }
-
-  return s;
 }
 
-static std::string GenerateSection(const BinarySection &section,
-                                   const uint8_t *binary,
-                                   const OutputConfig &output_config) {
-  std::string s;
-  s += "\n";
-  s += ToString(section.type);
-  if (!section.name.empty()) { s += " (" + section.name + ")"; }
-  s += ":";
+static void GenerateSection(std::ostream &os, const BinarySection &section,
+                            const uint8_t *binary,
+                            const OutputConfig &output_config) {
+  os << std::endl;
+  os << ToString(section.type);
+  if (!section.name.empty()) { os << " (" + section.name + ")"; }
+  os << ":";
   for (const BinaryRegion &region : section.regions) {
-    s += GenerateRegion(region, section, binary, output_config);
+    GenerateRegion(os, region, section, binary, output_config);
   }
-  return s;
+  os << std::endl;
 }
 }  // namespace
 
@@ -414,19 +403,6 @@ bool AnnotatedBinaryTextGenerator::Generate(
     }
   }
 
-  // Generate each of the binary sections
-  std::string s;
-
-  s += "// Annotated Flatbuffer Binary\n";
-  s += "//\n";
-  s += "// Schema file: " + schema_filename + "\n";
-  s += "// Binary file: " + filename + "\n";
-
-  for (const auto &section : annotations_) {
-    s += GenerateSection(section.second, binary_, output_config);
-    s += "\n";
-  }
-
   // Modify the output filename.
   std::string output_filename = StripExtension(filename);
   output_filename += options_.output_postfix;
@@ -434,7 +410,20 @@ bool AnnotatedBinaryTextGenerator::Generate(
       "." + (options_.output_extension.empty() ? GetExtension(filename)
                                                : options_.output_extension);
 
-  return SaveFile(output_filename.c_str(), s, false);
+  std::ofstream ofs(output_filename.c_str());
+
+  ofs << "// Annotated Flatbuffer Binary" << std::endl;
+  ofs << "//" << std::endl;
+  ofs << "// Schema file: " << schema_filename << std::endl;
+  ofs << "// Binary file: " << filename << std::endl;
+
+  // Generate each of the binary sections
+  for (const auto &section : annotations_) {
+    GenerateSection(ofs, section.second, binary_, output_config);
+  }
+
+  ofs.close();
+  return true;
 }
 
 }  // namespace flatbuffers

--- a/src/annotated_binary_text_gen.h
+++ b/src/annotated_binary_text_gen.h
@@ -41,6 +41,9 @@ class AnnotatedBinaryTextGenerator {
     //
     // Example: binary1.bin -> binary1.afb
     std::string output_extension = "afb";
+
+    // Controls.
+    bool include_vector_contents = true;
   };
 
   explicit AnnotatedBinaryTextGenerator(


### PR DESCRIPTION
Changed the bulk of the text-based annnoted buffers to use a `std::ofstream` instead of building a giant `std::string` in memory and flushing the whole thing. It was easy to do since we build in file order.

Added `--annotate-sparse-vector` option which, when set, will exclude all but the first/last vector element:

Example:

```
vector (AnnotatedBinary.Foo.foobars):
  +0x00D4 | 03 00 00 00             | uint32_t   | 0x00000003 (3)                | length of vector (# items)
  +0x00D8 | 34 00 00 00             | UOffset32  | 0x00000034 (52) Loc: 0x010C   | offset to union[0] (`Bar`)
  <2 regions omitted>
  +0x00E0 | 04 00 00 00             | UOffset32  | 0x00000004 (4) Loc: 0x00E4    | offset to union[2] (`Bar`)
```

This will be useful when annotating giant files that are just vectors, where the contents don't really matter to the end user.