### PR TITLE
Only use absl headers if C++14 is available.

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -233,7 +233,7 @@ namespace flatbuffers {
       }
       #define FLATBUFFERS_HAS_STRING_VIEW 1
     // Check for absl::string_view
-    #elif __has_include("absl/strings/string_view.h")
+    #elif __has_include("absl/strings/string_view.h") && (__cplusplus >= 201411)
       #include "absl/strings/string_view.h"
       namespace flatbuffers {
         typedef absl::string_view string_view;


### PR DESCRIPTION
If flatbuffers is built in C++11 mode, but there is a recent version of absl which requires C++14, the build will fail.
Cf https://github.com/MapServer/MapServer/issues/6822 for the use case that triggered this.
