### PR TITLE
Added mapping between enum type and union type for easier typing

### DIFF
--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -962,9 +962,8 @@ class TsGenerator : public BaseGenerator {
       auto ret = "\n\nexport type " + enum_type + "Mapping = {\n";
 
       const auto union_enum_loop = [&](bool object_api) {
-        for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end();
-             ++it) {
-          const auto &ev = **it;
+        for (auto& it : enum_def.Vals()) {
+          const auto &ev = *it;
           if (ev.IsZero()) { continue; }
 
           const auto union_import =


### PR DESCRIPTION
This PR generates a mapping from the enum variant to the union type:

```ts
export type EquipmentMapping = {
  [Equipment.Weapon]: Weapon;
  [Equipment.Armor]: Armor;
};
export type EquipmentMappingT = {
  [Equipment.Weapon]: WeaponT;
  [Equipment.Armor]: ArmorT;
};
```

This allows users to use the mapping for increased type safety when dispatching based on the union variant:
```ts
type EventEmitters =  { [K in keyof EquipmentMappingT]: (equipment: EquipmentMappingT[K]) => void }
```
