### PR TITLE
Don't use `using namespace` according to style-guide.

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -19,6 +19,7 @@ cc_test(
         "flexbuffers_test.h",
         "fuzz_test.cpp",
         "fuzz_test.h",
+        "infinity_constants.h",
         "is_quiet_nan.h",
         "json_test.cpp",
         "json_test.h",

--- a/tests/flexbuffers_test.cpp
+++ b/tests/flexbuffers_test.cpp
@@ -1,17 +1,13 @@
-#include <limits>
-
 #include "flexbuffers_test.h"
 
 #include "flatbuffers/flexbuffers.h"
 #include "flatbuffers/idl.h"
+#include "infinity_constants.h"
 #include "is_quiet_nan.h"
 #include "test_assert.h"
 
 namespace flatbuffers {
 namespace tests {
-
-// Shortcuts for the infinity.
-static const auto infinity_d = std::numeric_limits<double>::infinity();
 
 void FlexBuffersTest() {
   flexbuffers::Builder slb(512,
@@ -182,11 +178,11 @@ void FlexBuffersFloatingPointTest() {
   TEST_EQ(8, jvec.size());
   TEST_EQ(1.0, jvec[0].AsDouble());
   TEST_ASSERT(is_quiet_nan(jvec[1].AsDouble()));
-  TEST_EQ(infinity_d, jvec[2].AsDouble());
-  TEST_EQ(infinity_d, jvec[3].AsDouble());
-  TEST_EQ(-infinity_d, jvec[4].AsDouble());
-  TEST_EQ(+infinity_d, jvec[5].AsDouble());
-  TEST_EQ(-infinity_d, jvec[6].AsDouble());
+  TEST_EQ(infinity_d(), jvec[2].AsDouble());
+  TEST_EQ(infinity_d(), jvec[3].AsDouble());
+  TEST_EQ(-infinity_d(), jvec[4].AsDouble());
+  TEST_EQ(+infinity_d(), jvec[5].AsDouble());
+  TEST_EQ(-infinity_d(), jvec[6].AsDouble());
   TEST_EQ(8.0, jvec[7].AsDouble());
 #endif
 }

--- a/tests/infinity_constants.h
+++ b/tests/infinity_constants.h
@@ -1,0 +1,14 @@
+#ifndef TESTS_INFINITY_CONSTANTS_H
+#define TESTS_INFINITY_CONSTANTS_H
+
+#include <limits>
+
+namespace flatbuffers {
+namespace tests {
+// Shortcuts for the infinity.
+inline float infinity_f() { return std::numeric_limits<float>::infinity(); }
+inline double infinity_d() { return std::numeric_limits<double>::infinity(); }
+}  // namespace tests
+}  // namespace flatbuffers
+
+#endif  // TESTS_INFINITY_CONSTANTS_H

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -2,18 +2,16 @@
 
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
+#include "monster_test_bfbs_generated.h"
 #include "monster_test_generated.h"
-#include "monster_test_bfbs_generated.h"  
 #include "optional_scalars_generated.h"
 #include "test_assert.h"
 
 namespace flatbuffers {
 namespace tests {
 
-using namespace MyGame::Example;
-
 // Check stringify of an default enum value to json
-void JsonDefaultTest(const std::string& tests_data_path) {
+void JsonDefaultTest(const std::string &tests_data_path) {
   // load FlatBuffer schema (.fbs) from disk
   std::string schemafile;
   TEST_EQ(flatbuffers::LoadFile((tests_data_path + "monster_test.fbs").c_str(),
@@ -32,7 +30,7 @@ void JsonDefaultTest(const std::string& tests_data_path) {
   parser.opts.output_enum_identifiers = true;
   flatbuffers::FlatBufferBuilder builder;
   auto name = builder.CreateString("default_enum");
-  MonsterBuilder color_monster(builder);
+  MyGame::Example::MonsterBuilder color_monster(builder);
   color_monster.add_name(name);
   FinishMonsterBuffer(builder, color_monster.Finish());
   std::string jsongen;
@@ -44,7 +42,11 @@ void JsonDefaultTest(const std::string& tests_data_path) {
   TEST_EQ(std::string::npos != jsongen.find("testf: 3.14159"), true);
 }
 
-void JsonEnumsTest(const std::string& tests_data_path) {
+void JsonEnumsTest(const std::string &tests_data_path) {
+  using MyGame::Example::Color;
+  using MyGame::Example::Color_Blue;
+  using MyGame::Example::Color_Red;
+
   // load FlatBuffer schema (.fbs) from disk
   std::string schemafile;
   TEST_EQ(flatbuffers::LoadFile((tests_data_path + "monster_test.fbs").c_str(),
@@ -60,7 +62,7 @@ void JsonEnumsTest(const std::string& tests_data_path) {
   TEST_EQ(parser.Parse(schemafile.c_str(), include_directories), true);
   flatbuffers::FlatBufferBuilder builder;
   auto name = builder.CreateString("bitflag_enum");
-  MonsterBuilder color_monster(builder);
+  MyGame::Example::MonsterBuilder color_monster(builder);
   color_monster.add_name(name);
   color_monster.add_color(Color(Color_Blue | Color_Red));
   FinishMonsterBuffer(builder, color_monster.Finish());
@@ -73,7 +75,7 @@ void JsonEnumsTest(const std::string& tests_data_path) {
   builder.Clear();
   std::string future_json;
   auto future_name = builder.CreateString("future bitflag_enum");
-  MonsterBuilder future_color(builder);
+  MyGame::Example::MonsterBuilder future_color(builder);
   future_color.add_name(future_name);
   future_color.add_color(
       static_cast<Color>((1u << 2) | Color_Blue | Color_Red));
@@ -83,7 +85,8 @@ void JsonEnumsTest(const std::string& tests_data_path) {
   TEST_EQ(std::string::npos != future_json.find("color: 13"), true);
 }
 
-void JsonOptionalTest(const std::string& tests_data_path, bool default_scalars) {
+void JsonOptionalTest(const std::string &tests_data_path,
+                      bool default_scalars) {
   // load FlatBuffer schema (.fbs) and JSON from disk
   std::string schemafile;
   std::string jsonfile;
@@ -124,7 +127,7 @@ void JsonOptionalTest(const std::string& tests_data_path, bool default_scalars) 
   TEST_EQ_STR(jsongen.c_str(), jsonfile.c_str());
 }
 
-void ParseIncorrectMonsterJsonTest(const std::string& tests_data_path) {
+void ParseIncorrectMonsterJsonTest(const std::string &tests_data_path) {
   std::string schemafile;
   TEST_EQ(flatbuffers::LoadFile((tests_data_path + "monster_test.bfbs").c_str(),
                                 true, &schemafile),

--- a/tests/key_field_test.cpp
+++ b/tests/key_field_test.cpp
@@ -10,9 +10,10 @@
 namespace flatbuffers {
 namespace tests {
 
-using namespace keyfield::sample;
-
 void FixedSizedScalarKeyInStructTest() {
+  using keyfield::sample::Bar;
+  using keyfield::sample::Baz;
+
   flatbuffers::FlatBufferBuilder fbb;
   std::vector<Baz> bazs;
   uint8_t test_array1[4] = { 8, 2, 3, 0 };
@@ -38,28 +39,23 @@ void FixedSizedScalarKeyInStructTest() {
   bars.push_back(Bar(flatbuffers::make_span(test_float_array4), 1));
   auto bar_vec = fbb.CreateVectorOfSortedStructs(&bars);
 
-
   auto t = CreateFooTable(fbb, 1, 2, test_string, baz_vec, bar_vec);
 
   fbb.Finish(t);
 
   uint8_t *buf = fbb.GetBufferPointer();
-  auto foo_table = GetFooTable(buf);
+  auto foo_table = keyfield::sample::GetFooTable(buf);
 
   auto sorted_baz_vec = foo_table->d();
   TEST_EQ(sorted_baz_vec->Get(0)->b(), 1);
   TEST_EQ(sorted_baz_vec->Get(3)->b(), 4);
 
   uint8_t test_array[4];
-  auto* key_array = &flatbuffers::CastToArray(test_array);
+  auto *key_array = &flatbuffers::CastToArray(test_array);
   key_array->CopyFromSpan(flatbuffers::make_span(test_array1));
 
-
-  TEST_NOTNULL(
-      sorted_baz_vec->LookupByKey(key_array));
-  TEST_EQ(
-      sorted_baz_vec->LookupByKey(key_array)->b(),
-      4);
+  TEST_NOTNULL(sorted_baz_vec->LookupByKey(key_array));
+  TEST_EQ(sorted_baz_vec->LookupByKey(key_array)->b(), 4);
   uint8_t array_int[4] = { 7, 2, 3, 0 };
   key_array->CopyFromSpan(flatbuffers::make_span(array_int));
   TEST_EQ(sorted_baz_vec->LookupByKey(key_array),
@@ -70,7 +66,7 @@ void FixedSizedScalarKeyInStructTest() {
   TEST_EQ(sorted_bar_vec->Get(3)->b(), 4);
 
   float test_float_array[3];
-  auto* key_float_array = &flatbuffers::CastToArray(test_float_array);
+  auto *key_float_array = &flatbuffers::CastToArray(test_float_array);
   key_float_array->CopyFromSpan(flatbuffers::make_span(test_float_array1));
   TEST_NOTNULL(sorted_bar_vec->LookupByKey(key_float_array));
   TEST_EQ(sorted_bar_vec->LookupByKey(key_float_array)->b(), 3);
@@ -81,6 +77,9 @@ void FixedSizedScalarKeyInStructTest() {
 }
 
 void StructKeyInStructTest() {
+  using keyfield::sample::Apple;
+  using keyfield::sample::Color;
+
   flatbuffers::FlatBufferBuilder fbb;
   std::vector<Apple> apples;
   float test_float_array1[3] = { 1.5, 2.5, 0 };
@@ -96,7 +95,7 @@ void StructKeyInStructTest() {
   auto apples_vec = fbb.CreateVectorOfSortedStructs(&apples);
   auto test_string = fbb.CreateString("TEST");
 
-  FooTableBuilder foo_builder(fbb);
+  keyfield::sample::FooTableBuilder foo_builder(fbb);
   foo_builder.add_a(1);
   foo_builder.add_c(test_string);
 
@@ -105,9 +104,8 @@ void StructKeyInStructTest() {
   auto orc = foo_builder.Finish();
   fbb.Finish(orc);
 
-
   uint8_t *buf = fbb.GetBufferPointer();
-  auto foo_table = GetFooTable(buf);
+  auto foo_table = keyfield::sample::GetFooTable(buf);
 
   auto sorted_apple_vec = foo_table->f();
   TEST_EQ(sorted_apple_vec->Get(0)->tag(), 1);
@@ -123,6 +121,10 @@ void StructKeyInStructTest() {
 }
 
 void NestedStructKeyInStructTest() {
+  using keyfield::sample::Apple;
+  using keyfield::sample::Color;
+  using keyfield::sample::Fruit;
+
   flatbuffers::FlatBufferBuilder fbb;
   std::vector<Fruit> fruits;
   float test_float_array1[3] = { 1.5, 2.5, 0 };
@@ -139,7 +141,7 @@ void NestedStructKeyInStructTest() {
   auto test_string = fbb.CreateString("TEST");
   auto fruits_vec = fbb.CreateVectorOfSortedStructs(&fruits);
 
-  FooTableBuilder foo_builder(fbb);
+  keyfield::sample::FooTableBuilder foo_builder(fbb);
   foo_builder.add_a(1);
   foo_builder.add_c(test_string);
   foo_builder.add_g(fruits_vec);
@@ -147,18 +149,26 @@ void NestedStructKeyInStructTest() {
   auto orc = foo_builder.Finish();
   fbb.Finish(orc);
   uint8_t *buf = fbb.GetBufferPointer();
-  auto foo_table = GetFooTable(buf);
+  auto foo_table = keyfield::sample::GetFooTable(buf);
 
   auto sorted_fruit_vec = foo_table->g();
   TEST_EQ(sorted_fruit_vec->Get(0)->b(), 3);
   TEST_EQ(sorted_fruit_vec->Get(1)->b(), 1);
   TEST_EQ(sorted_fruit_vec->Get(2)->b(), 2);
-  TEST_EQ(sorted_fruit_vec->LookupByKey(Apple(2, Color(flatbuffers::make_span(test_float_array2), 1)))->b(), 1);
-  TEST_EQ(sorted_fruit_vec->LookupByKey(Apple(1, Color(flatbuffers::make_span(test_float_array2), 1))), static_cast<const Fruit *>(nullptr));
-
+  TEST_EQ(sorted_fruit_vec
+              ->LookupByKey(
+                  Apple(2, Color(flatbuffers::make_span(test_float_array2), 1)))
+              ->b(),
+          1);
+  TEST_EQ(sorted_fruit_vec->LookupByKey(
+              Apple(1, Color(flatbuffers::make_span(test_float_array2), 1))),
+          static_cast<const Fruit *>(nullptr));
 }
 
 void FixedSizedStructArrayKeyInStructTest() {
+  using keyfield::sample::Grain;
+  using keyfield::sample::Rice;
+
   flatbuffers::FlatBufferBuilder fbb;
   std::vector<Grain> grains;
   uint8_t test_char_array1[3] = { 'u', 's', 'a' };
@@ -190,7 +200,7 @@ void FixedSizedStructArrayKeyInStructTest() {
 
   auto test_string = fbb.CreateString("TEST");
   auto grains_vec = fbb.CreateVectorOfSortedStructs(&grains);
-  FooTableBuilder foo_builder(fbb);
+  keyfield::sample::FooTableBuilder foo_builder(fbb);
   foo_builder.add_a(1);
   foo_builder.add_c(test_string);
   foo_builder.add_h(grains_vec);
@@ -198,7 +208,7 @@ void FixedSizedStructArrayKeyInStructTest() {
   auto orc = foo_builder.Finish();
   fbb.Finish(orc);
   uint8_t *buf = fbb.GetBufferPointer();
-  auto foo_table = GetFooTable(buf);
+  auto foo_table = keyfield::sample::GetFooTable(buf);
 
   auto sorted_grain_vec = foo_table->h();
   TEST_EQ(sorted_grain_vec->Get(0)->tag(), 1);

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -1,23 +1,20 @@
 #include "parser_test.h"
 
 #include <cmath>
-#include <limits>
 #include <string>
 
 #include "flatbuffers/idl.h"
+#include "infinity_constants.h"
 #include "test_assert.h"
 
 namespace flatbuffers {
 namespace tests {
 namespace {
 
-// Shortcuts for the infinity.
-static const auto infinity_f = std::numeric_limits<float>::infinity();
-static const auto infinity_d = std::numeric_limits<double>::infinity();
-
 // Test that parser errors are actually generated.
-static void TestError_(const char *src, const char *error_substr, bool strict_json,
-                const char *file, int line, const char *func) {
+static void TestError_(const char *src, const char *error_substr,
+                       bool strict_json, const char *file, int line,
+                       const char *func) {
   flatbuffers::IDLOptions opts;
   opts.strict_json = strict_json;
   flatbuffers::Parser parser(opts);
@@ -32,8 +29,8 @@ static void TestError_(const char *src, const char *error_substr, bool strict_js
   }
 }
 
-static void TestError_(const char *src, const char *error_substr, const char *file,
-                int line, const char *func) {
+static void TestError_(const char *src, const char *error_substr,
+                       const char *file, int line, const char *func) {
   TestError_(src, error_substr, false, file, line, func);
 }
 
@@ -47,7 +44,7 @@ static void TestError_(const char *src, const char *error_substr, const char *fi
 
 static bool FloatCompare(float a, float b) { return fabs(a - b) < 0.001; }
 
-} // namespace
+}  // namespace
 
 // Test that parsing errors occur as we'd expect.
 // Also useful for coverage, making sure these paths are run.
@@ -618,10 +615,10 @@ void IntegerBoundaryTest() {
 
 void ValidFloatTest() {
   // check rounding to infinity
-  TEST_EQ(TestValue<float>("{ y:+3.4029e+38 }", "float"), +infinity_f);
-  TEST_EQ(TestValue<float>("{ y:-3.4029e+38 }", "float"), -infinity_f);
-  TEST_EQ(TestValue<double>("{ y:+1.7977e+308 }", "double"), +infinity_d);
-  TEST_EQ(TestValue<double>("{ y:-1.7977e+308 }", "double"), -infinity_d);
+  TEST_EQ(TestValue<float>("{ y:+3.4029e+38 }", "float"), +infinity_f());
+  TEST_EQ(TestValue<float>("{ y:-3.4029e+38 }", "float"), -infinity_f());
+  TEST_EQ(TestValue<double>("{ y:+1.7977e+308 }", "double"), +infinity_d());
+  TEST_EQ(TestValue<double>("{ y:-1.7977e+308 }", "double"), -infinity_d());
 
   TEST_EQ(
       FloatCompare(TestValue<float>("{ y:0.0314159e+2 }", "float"), 3.14159f),
@@ -662,14 +659,14 @@ void ValidFloatTest() {
   TEST_EQ(std::isnan(TestValue<float>(nullptr, "float=nan")), true);
   TEST_EQ(std::isnan(TestValue<float>(nullptr, "float=-nan")), true);
   // check inf
-  TEST_EQ(TestValue<float>("{ y:inf }", "float"), infinity_f);
-  TEST_EQ(TestValue<float>("{ y:\"inf\" }", "float"), infinity_f);
-  TEST_EQ(TestValue<float>("{ y:\"-inf\" }", "float"), -infinity_f);
-  TEST_EQ(TestValue<float>("{ y:\"+inf\" }", "float"), infinity_f);
-  TEST_EQ(TestValue<float>("{ y:+inf }", "float"), infinity_f);
-  TEST_EQ(TestValue<float>("{ y:-inf }", "float"), -infinity_f);
-  TEST_EQ(TestValue<float>(nullptr, "float=inf"), infinity_f);
-  TEST_EQ(TestValue<float>(nullptr, "float=-inf"), -infinity_f);
+  TEST_EQ(TestValue<float>("{ y:inf }", "float"), infinity_f());
+  TEST_EQ(TestValue<float>("{ y:\"inf\" }", "float"), infinity_f());
+  TEST_EQ(TestValue<float>("{ y:\"-inf\" }", "float"), -infinity_f());
+  TEST_EQ(TestValue<float>("{ y:\"+inf\" }", "float"), infinity_f());
+  TEST_EQ(TestValue<float>("{ y:+inf }", "float"), infinity_f());
+  TEST_EQ(TestValue<float>("{ y:-inf }", "float"), -infinity_f());
+  TEST_EQ(TestValue<float>(nullptr, "float=inf"), infinity_f());
+  TEST_EQ(TestValue<float>(nullptr, "float=-inf"), -infinity_f());
   TestValue<double>(
       "{ y: [0.2, .2, 1.0, -1.0, -2., 2., 1e0, -1e0, 1.0e0, -1.0e0, -3.e2, "
       "3.0e2] }",
@@ -775,8 +772,6 @@ void UnicodeSurrogatesTest() {
       flatbuffers::FieldIndexToOffset(0));
   TEST_EQ_STR(string->c_str(), "\xF0\x9F\x92\xA9");
 }
-
-
 
 void UnknownFieldsTest() {
   flatbuffers::IDLOptions opts;

--- a/tests/reflection_test.cpp
+++ b/tests/reflection_test.cpp
@@ -1,19 +1,19 @@
 #include "reflection_test.h"
+
 #include "arrays_test_generated.h"
 #include "flatbuffers/minireflect.h"
 #include "flatbuffers/reflection.h"
 #include "flatbuffers/reflection_generated.h"
 #include "flatbuffers/verifier.h"
-#include "test_assert.h"
 #include "monster_test.h"
 #include "monster_test_generated.h"
+#include "test_assert.h"
 
 namespace flatbuffers {
 namespace tests {
 
-using namespace MyGame::Example;
-
-void ReflectionTest(const std::string& tests_data_path, uint8_t *flatbuf, size_t length) {
+void ReflectionTest(const std::string &tests_data_path, uint8_t *flatbuf,
+                    size_t length) {
   // Load a binary schema.
   std::string bfbsfile;
   TEST_EQ(flatbuffers::LoadFile((tests_data_path + "monster_test.bfbs").c_str(),
@@ -218,7 +218,7 @@ void ReflectionTest(const std::string& tests_data_path, uint8_t *flatbuf, size_t
   flatbuffers::Verifier resize_verifier(
       reinterpret_cast<const uint8_t *>(resizingbuf.data()),
       resizingbuf.size());
-  TEST_EQ(VerifyMonsterBuffer(resize_verifier), true);
+  TEST_EQ(MyGame::Example::VerifyMonsterBuffer(resize_verifier), true);
 
   // Test buffer is valid using reflection as well
   TEST_EQ(flatbuffers::Verify(schema, *schema.root_table(), resizingbuf.data(),
@@ -237,7 +237,7 @@ void ReflectionTest(const std::string& tests_data_path, uint8_t *flatbuf, size_t
   flatbuffers::FlatBufferBuilder fbb;
   auto root_offset = flatbuffers::CopyTable(
       fbb, schema, *root_table, *flatbuffers::GetAnyRoot(flatbuf), true);
-  fbb.Finish(root_offset, MonsterIdentifier());
+  fbb.Finish(root_offset, MyGame::Example::MonsterIdentifier());
   // Test that it was copied correctly:
   AccessFlatBufferTest(fbb.GetBufferPointer(), fbb.GetSize());
 
@@ -248,8 +248,8 @@ void ReflectionTest(const std::string& tests_data_path, uint8_t *flatbuf, size_t
 }
 
 void MiniReflectFlatBuffersTest(uint8_t *flatbuf) {
-  auto s =
-      flatbuffers::FlatBufferToString(flatbuf, Monster::MiniReflectTypeTable());
+  auto s = flatbuffers::FlatBufferToString(
+      flatbuf, MyGame::Example::Monster::MiniReflectTypeTable());
   TEST_EQ_STR(
       s.c_str(),
       "{ "
@@ -285,8 +285,9 @@ void MiniReflectFlatBuffersTest(uint8_t *flatbuf) {
       "nan_default: nan "
       "}");
 
-  Test test(16, 32);
-  Vec3 vec(1, 2, 3, 1.5, Color_Red, test);
+  MyGame::Example::Test test(16, 32);
+  using MyGame::Example::Vec3;
+  Vec3 vec(1, 2, 3, 1.5, MyGame::Example::Color_Red, test);
   flatbuffers::FlatBufferBuilder vec_builder;
   vec_builder.Finish(vec_builder.CreateStruct(vec));
   auto vec_buffer = vec_builder.Release();

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -70,16 +70,14 @@ static_assert(flatbuffers::is_same<uint8_t, char>::value ||
 #endif
 // clang-format on
 
-using namespace MyGame::Example;
-
 void TriviallyCopyableTest() {
 // clang-format off
   #if __GNUG__ && __GNUC__ < 5 && \
       !(defined(__clang__) && __clang_major__ >= 16)
-    TEST_EQ(__has_trivial_copy(Vec3), true);
+    TEST_EQ(__has_trivial_copy(MyGame::Example::Vec3), true);
   #else
     #if __cplusplus >= 201103L
-      TEST_EQ(std::is_trivially_copyable<Vec3>::value, true);
+      TEST_EQ(std::is_trivially_copyable<MyGame::Example::Vec3>::value, true);
     #endif
   #endif
   // clang-format on
@@ -88,6 +86,11 @@ void TriviallyCopyableTest() {
 // Guard against -Wunused-function on platforms without file tests.
 #ifndef FLATBUFFERS_NO_FILE_TESTS
 void GenerateTableTextTest(const std::string &tests_data_path) {
+  using MyGame::Example::GetMonster;
+  using MyGame::Example::Monster;
+  using MyGame::Example::Test;
+  using MyGame::Example::Vec3;
+
   std::string schemafile;
   std::string jsonfile;
   bool ok =
@@ -393,6 +396,10 @@ void EndianSwapTest() {
 }
 
 void UninitializedVectorTest() {
+  using MyGame::Example::Monster;
+  using MyGame::Example::MonsterBuilder;
+  using MyGame::Example::Test;
+
   flatbuffers::FlatBufferBuilder builder;
 
   Test *buf = nullptr;
@@ -423,6 +430,9 @@ void UninitializedVectorTest() {
 }
 
 void EqualOperatorTest() {
+  using MyGame::Example::Any_Monster;
+  using MyGame::Example::MonsterT;
+
   MonsterT a;
   MonsterT b;
   // We have to reset the fields that are NaN to zero to allow the equality
@@ -554,14 +564,14 @@ void CreateSharedStringTest() {
   };
   const auto vector_offset =
       builder.CreateVector<flatbuffers::Offset<flatbuffers::String>>(array);
-  MonsterBuilder monster_builder(builder);
+  MyGame::Example::MonsterBuilder monster_builder(builder);
   monster_builder.add_name(two);
   monster_builder.add_testarrayofstring(vector_offset);
   builder.Finish(monster_builder.Finish());
 
   // Read the Monster back.
-  const auto *monster =
-      flatbuffers::GetRoot<Monster>(builder.GetBufferPointer());
+  const auto *monster = flatbuffers::GetRoot<MyGame::Example::Monster>(
+      builder.GetBufferPointer());
   TEST_EQ_STR(monster->name()->c_str(), "two");
   const auto *testarrayofstring = monster->testarrayofstring();
   TEST_EQ(testarrayofstring->size(), flatbuffers::uoffset_t(7));
@@ -912,7 +922,7 @@ void NativeTypeTest() {
 // Guard against -Wunused-function on platforms without file tests.
 #ifndef FLATBUFFERS_NO_FILE_TESTS
 // VS10 does not support typed enums, exclude from tests
-#if !defined(_MSC_VER) || _MSC_VER >= 1700
+#  if !defined(_MSC_VER) || _MSC_VER >= 1700
 void FixedLengthArrayJsonTest(const std::string &tests_data_path, bool binary) {
   // load FlatBuffer schema (.fbs) and JSON from disk
   std::string schemafile;
@@ -951,7 +961,7 @@ void FixedLengthArrayJsonTest(const std::string &tests_data_path, bool binary) {
   // First, verify it, just in case:
   flatbuffers::Verifier verifierOrg(parserOrg.builder_.GetBufferPointer(),
                                     parserOrg.builder_.GetSize());
-  TEST_EQ(VerifyArrayTableBuffer(verifierOrg), true);
+  TEST_EQ(MyGame::Example::VerifyArrayTableBuffer(verifierOrg), true);
 
   // Export to JSON
   std::string jsonGen;
@@ -965,7 +975,7 @@ void FixedLengthArrayJsonTest(const std::string &tests_data_path, bool binary) {
   // Verify buffer from generated JSON
   flatbuffers::Verifier verifierGen(parserGen.builder_.GetBufferPointer(),
                                     parserGen.builder_.GetSize());
-  TEST_EQ(VerifyArrayTableBuffer(verifierGen), true);
+  TEST_EQ(MyGame::Example::VerifyArrayTableBuffer(verifierGen), true);
 
   // Compare generated buffer to original
   TEST_EQ(parserOrg.builder_.GetSize(), parserGen.builder_.GetSize());
@@ -993,7 +1003,7 @@ void FixedLengthArraySpanTest(const std::string &tests_data_path) {
   TEST_EQ(parser.Parse(jsonfile.c_str()), true);
   auto &fbb = parser.builder_;
   auto verifier = flatbuffers::Verifier(fbb.GetBufferPointer(), fbb.GetSize());
-  TEST_EQ(true, VerifyArrayTableBuffer(verifier));
+  TEST_EQ(true, MyGame::Example::VerifyArrayTableBuffer(verifier));
 
   auto p = MyGame::Example::GetMutableArrayTable(fbb.GetBufferPointer());
   TEST_NOTNULL(p);
@@ -1032,7 +1042,7 @@ void FixedLengthArraySpanTest(const std::string &tests_data_path) {
         std::equal(const_d_c.begin(), const_d_c.end(), mutable_d_c.begin()));
   }
   // test little endian array of int32
-#  if FLATBUFFERS_LITTLEENDIAN
+#    if FLATBUFFERS_LITTLEENDIAN
   {
     flatbuffers::span<const int32_t, 2> const_d_a =
         flatbuffers::make_span(*const_nested.a());
@@ -1047,12 +1057,12 @@ void FixedLengthArraySpanTest(const std::string &tests_data_path) {
     TEST_ASSERT(
         std::equal(const_d_a.begin(), const_d_a.end(), mutable_d_a.begin()));
   }
-#  endif
+#    endif
 }
-#else
+#  else
 void FixedLengthArrayJsonTest(bool /*binary*/) {}
 void FixedLengthArraySpanTest() {}
-#endif
+#  endif
 
 void TestEmbeddedBinarySchema(const std::string &tests_data_path) {
   // load JSON from disk
@@ -1078,7 +1088,7 @@ void TestEmbeddedBinarySchema(const std::string &tests_data_path) {
   // First, verify it, just in case:
   flatbuffers::Verifier verifierOrg(parserOrg.builder_.GetBufferPointer(),
                                     parserOrg.builder_.GetSize());
-  TEST_EQ(VerifyMonsterBuffer(verifierOrg), true);
+  TEST_EQ(MyGame::Example::VerifyMonsterBuffer(verifierOrg), true);
 
   // Export to JSON
   std::string jsonGen;
@@ -1092,7 +1102,7 @@ void TestEmbeddedBinarySchema(const std::string &tests_data_path) {
   // Verify buffer from generated JSON
   flatbuffers::Verifier verifierGen(parserGen.builder_.GetBufferPointer(),
                                     parserGen.builder_.GetSize());
-  TEST_EQ(VerifyMonsterBuffer(verifierGen), true);
+  TEST_EQ(MyGame::Example::VerifyMonsterBuffer(verifierGen), true);
 
   // Compare generated buffer to original
   TEST_EQ(parserOrg.builder_.GetSize(), parserGen.builder_.GetSize());
@@ -1106,15 +1116,15 @@ void TestEmbeddedBinarySchema(const std::string &tests_data_path) {
 void NestedVerifierTest() {
   // Create a nested monster.
   flatbuffers::FlatBufferBuilder nested_builder;
-  FinishMonsterBuffer(
-      nested_builder,
-      CreateMonster(nested_builder, nullptr, 0, 0,
-                    nested_builder.CreateString("NestedMonster")));
+  FinishMonsterBuffer(nested_builder,
+                      MyGame::Example::CreateMonster(
+                          nested_builder, nullptr, 0, 0,
+                          nested_builder.CreateString("NestedMonster")));
 
   // Verify the nested monster
   flatbuffers::Verifier verifier(nested_builder.GetBufferPointer(),
                                  nested_builder.GetSize());
-  TEST_EQ(true, VerifyMonsterBuffer(verifier));
+  TEST_EQ(true, MyGame::Example::VerifyMonsterBuffer(verifier));
 
   {
     // Create the outer monster.
@@ -1126,7 +1136,7 @@ void NestedVerifierTest() {
 
     auto name = builder.CreateString("OuterMonster");
 
-    MonsterBuilder mon_builder(builder);
+    MyGame::Example::MonsterBuilder mon_builder(builder);
     mon_builder.add_name(name);
     mon_builder.add_testnestedflatbuffer(nested_monster_bytes);
     FinishMonsterBuffer(builder, mon_builder.Finish());
@@ -1134,7 +1144,7 @@ void NestedVerifierTest() {
     // Verify the root monster, which includes verifing the nested monster
     flatbuffers::Verifier verifier(builder.GetBufferPointer(),
                                    builder.GetSize());
-    TEST_EQ(true, VerifyMonsterBuffer(verifier));
+    TEST_EQ(true, MyGame::Example::VerifyMonsterBuffer(verifier));
   }
 
   {
@@ -1148,7 +1158,7 @@ void NestedVerifierTest() {
 
     auto name = builder.CreateString("OuterMonster");
 
-    MonsterBuilder mon_builder(builder);
+    MyGame::Example::MonsterBuilder mon_builder(builder);
     mon_builder.add_name(name);
     mon_builder.add_testnestedflatbuffer(nested_monster_bytes);
     FinishMonsterBuffer(builder, mon_builder.Finish());
@@ -1156,7 +1166,7 @@ void NestedVerifierTest() {
     // Verify the root monster fails, since the included nested monster fails.
     flatbuffers::Verifier verifier(builder.GetBufferPointer(),
                                    builder.GetSize());
-    TEST_EQ(false, VerifyMonsterBuffer(verifier));
+    TEST_EQ(false, MyGame::Example::VerifyMonsterBuffer(verifier));
 
     // Verify the root monster succeeds, since we've disabled checking nested
     // flatbuffers
@@ -1164,7 +1174,7 @@ void NestedVerifierTest() {
     options.check_nested_flatbuffers = false;
     flatbuffers::Verifier no_check_nested(builder.GetBufferPointer(),
                                           builder.GetSize(), options);
-    TEST_EQ(true, VerifyMonsterBuffer(no_check_nested));
+    TEST_EQ(true, MyGame::Example::VerifyMonsterBuffer(no_check_nested));
   }
 
   {
@@ -1178,7 +1188,7 @@ void NestedVerifierTest() {
 
     auto name = builder.CreateString("OuterMonster");
 
-    MonsterBuilder mon_builder(builder);
+    MyGame::Example::MonsterBuilder mon_builder(builder);
     mon_builder.add_name(name);
     mon_builder.add_testnestedflatbuffer(nested_monster_bytes);
     FinishMonsterBuffer(builder, mon_builder.Finish());
@@ -1186,7 +1196,7 @@ void NestedVerifierTest() {
     // Verify the root monster fails, since the included nested monster fails.
     flatbuffers::Verifier verifier(builder.GetBufferPointer(),
                                    builder.GetSize());
-    TEST_EQ(false, VerifyMonsterBuffer(verifier));
+    TEST_EQ(false, MyGame::Example::VerifyMonsterBuffer(verifier));
   }
 }
 
@@ -1213,6 +1223,9 @@ void TestIterators(const std::vector<T> &expected, const Container &tested) {
 }
 
 void FlatbuffersIteratorsTest() {
+  using MyGame::Example::ArrayTable;
+  using MyGame::Example::Monster;
+
   {
     flatbuffers::FlatBufferBuilder fbb;
     const std::vector<unsigned char> inv_data = { 1, 2, 3 };
@@ -1221,7 +1234,7 @@ void FlatbuffersIteratorsTest() {
       auto inv_vec = fbb.CreateVector(inv_data);
       auto empty_i64_vec =
           fbb.CreateVector(static_cast<const int64_t *>(nullptr), 0);
-      MonsterBuilder mb(fbb);
+      MyGame::Example::MonsterBuilder mb(fbb);
       mb.add_name(mon_name);
       mb.add_inventory(inv_vec);
       mb.add_vector_of_longs(empty_i64_vec);
@@ -1373,6 +1386,10 @@ void PrivateAnnotationsLeaks() {
 }
 
 void VectorSpanTest() {
+  using MyGame::Example::CreateMonster;
+  using MyGame::Example::GetMonster;
+  using MyGame::Example::GetMutableMonster;
+
   flatbuffers::FlatBufferBuilder builder;
 
   auto mloc = CreateMonster(
@@ -1460,9 +1477,7 @@ void NativeInlineTableVectorTest() {
   TestNativeInlineTableT unpacked;
   root->UnPackTo(&unpacked);
 
-  for (int i = 0; i < 10; ++i) {
-    TEST_ASSERT(unpacked.t[i] == test.t[i]);
-  }
+  for (int i = 0; i < 10; ++i) { TEST_ASSERT(unpacked.t[i] == test.t[i]); }
 
   TEST_ASSERT(unpacked.t == test.t);
 }
@@ -1470,6 +1485,9 @@ void NativeInlineTableVectorTest() {
 // Guard against -Wunused-function on platforms without file tests.
 #ifndef FLATBUFFERS_NO_FILE_TESTS
 void DoNotRequireEofTest(const std::string &tests_data_path) {
+  using MyGame::Example::GetMonster;
+  using MyGame::Example::Monster;
+
   std::string schemafile;
   bool ok = flatbuffers::LoadFile(
       (tests_data_path + "monster_test.fbs").c_str(), false, &schemafile);

--- a/tests/test_builder.cpp
+++ b/tests/test_builder.cpp
@@ -3,8 +3,6 @@
 #include "flatbuffers/stl_emulation.h"
 #include "monster_test_generated.h"
 
-using namespace MyGame::Example;
-
 struct OwnedAllocator : public flatbuffers::DefaultAllocator {};
 
 class TestHeapBuilder : public flatbuffers::FlatBufferBuilder {
@@ -142,7 +140,7 @@ void FlatBufferBuilderTest() {
 }
 
 // forward-declared in test_builder.h
-void CheckTestGeneratedIsValid(const MyGame::Example::Color&);
+void CheckTestGeneratedIsValid(const MyGame::Example::Color &);
 
 // Link-time check using pointer type.
 void CheckTestGeneratedIsValid(const MyGame::Example::Color &) {}


### PR DESCRIPTION
In tests/ directory.

Style guide reference:
https://google.github.io/styleguide/cppguide.html#Namespaces

This also helps the reader of the test code wondering where certain symbols are coming from. Thus, tests also acting a bit more as documentation.

While at it: more repeately used shortcut constants for 'infinity' in the tests to its own header.

Ran clang-format with the provided .clang-format on the modified files.
