### PR TITLE
[Android][Kotlin] fixed build after decomission of jcenter and gradle update

### DIFF
--- a/android/.project
+++ b/android/.project
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2014 Google, Inc.
-
-     This software is provided 'as-is', without any express or implied
-     warranty.  In no event will the authors be held liable for any damages
-     arising from the use of this software.
-     Permission is granted to anyone to use this software for any purpose,
-     including commercial applications, and to alter it and redistribute it
-     freely, subject to the following restrictions:
-     1. The origin of this software must not be misrepresented; you must not
-     claim that you wrote the original software. If you use this software
-     in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required.
-     2. Altered source versions must be plainly marked as such, and must not be
-     misrepresented as being the original software.
-     3. This notice may not be removed or altered from any source distribution.
- -->
 <projectDescription>
-    <name>FlatBufferTest</name>
+	<name>FlatBufferTest</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1677235311958</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,15 +1,13 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
-  compileSdkVersion 30
-  buildToolsVersion "30.0.2"
+  compileSdk 33
 
   defaultConfig {
     applicationId "com.flatbuffers.app"
     minSdkVersion 26
-    targetSdkVersion 30
+    targetSdkVersion 33
     versionCode 1
     versionName "1.0"
 
@@ -113,13 +111,13 @@ android {
       dependsOn(generateFbsCpp)
     }
   }
+  namespace 'com.flatbuffers.app'
 }
 
 dependencies {
   implementation fileTree(dir: "libs", include: ["*.jar"])
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'androidx.core:core-ktx:1.3.2'
-  implementation 'androidx.appcompat:appcompat:1.2.0'
+  implementation 'androidx.appcompat:appcompat:1.6.1'
 
   // If you using java runtime you can add its dependency as the example below
   // implementation 'com.google.flatbuffers:flatbuffers-java:$latest_version'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.flatbuffers.app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application
     android:allowBackup="true"
@@ -9,7 +8,8 @@
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
     android:theme="@style/AppTheme">
-    <activity android:name=".MainActivity">
+    <activity android:name=".MainActivity"
+      android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
 

--- a/android/app/src/main/cpp/generated/animal_generated.h
+++ b/android/app/src/main/cpp/generated/animal_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 2 &&
-              FLATBUFFERS_VERSION_MINOR == 0 &&
-              FLATBUFFERS_VERSION_REVISION == 8,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
+              FLATBUFFERS_VERSION_MINOR == 1 &&
+              FLATBUFFERS_VERSION_REVISION == 21,
              "Non-compatible flatbuffers version included");
 
 namespace com {
@@ -20,23 +20,23 @@ namespace app {
 struct Animal;
 struct AnimalBuilder;
 
-struct Animal FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+struct Animal FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef AnimalBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NAME = 4,
     VT_SOUND = 6,
     VT_WEIGHT = 8
   };
-  const flatbuffers::String *name() const {
-    return GetPointer<const flatbuffers::String *>(VT_NAME);
+  const ::flatbuffers::String *name() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_NAME);
   }
-  const flatbuffers::String *sound() const {
-    return GetPointer<const flatbuffers::String *>(VT_SOUND);
+  const ::flatbuffers::String *sound() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_SOUND);
   }
   uint16_t weight() const {
     return GetField<uint16_t>(VT_WEIGHT, 0);
   }
-  bool Verify(flatbuffers::Verifier &verifier) const {
+  bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_NAME) &&
            verifier.VerifyString(name()) &&
@@ -49,32 +49,32 @@ struct Animal FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 
 struct AnimalBuilder {
   typedef Animal Table;
-  flatbuffers::FlatBufferBuilder &fbb_;
-  flatbuffers::uoffset_t start_;
-  void add_name(flatbuffers::Offset<flatbuffers::String> name) {
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
+  void add_name(::flatbuffers::Offset<::flatbuffers::String> name) {
     fbb_.AddOffset(Animal::VT_NAME, name);
   }
-  void add_sound(flatbuffers::Offset<flatbuffers::String> sound) {
+  void add_sound(::flatbuffers::Offset<::flatbuffers::String> sound) {
     fbb_.AddOffset(Animal::VT_SOUND, sound);
   }
   void add_weight(uint16_t weight) {
     fbb_.AddElement<uint16_t>(Animal::VT_WEIGHT, weight, 0);
   }
-  explicit AnimalBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit AnimalBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<Animal> Finish() {
+  ::flatbuffers::Offset<Animal> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<Animal>(end);
+    auto o = ::flatbuffers::Offset<Animal>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<Animal> CreateAnimal(
-    flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::String> name = 0,
-    flatbuffers::Offset<flatbuffers::String> sound = 0,
+inline ::flatbuffers::Offset<Animal> CreateAnimal(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    ::flatbuffers::Offset<::flatbuffers::String> name = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> sound = 0,
     uint16_t weight = 0) {
   AnimalBuilder builder_(_fbb);
   builder_.add_sound(sound);
@@ -83,8 +83,8 @@ inline flatbuffers::Offset<Animal> CreateAnimal(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<Animal> CreateAnimalDirect(
-    flatbuffers::FlatBufferBuilder &_fbb,
+inline ::flatbuffers::Offset<Animal> CreateAnimalDirect(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *name = nullptr,
     const char *sound = nullptr,
     uint16_t weight = 0) {
@@ -98,32 +98,32 @@ inline flatbuffers::Offset<Animal> CreateAnimalDirect(
 }
 
 inline const com::fbs::app::Animal *GetAnimal(const void *buf) {
-  return flatbuffers::GetRoot<com::fbs::app::Animal>(buf);
+  return ::flatbuffers::GetRoot<com::fbs::app::Animal>(buf);
 }
 
 inline const com::fbs::app::Animal *GetSizePrefixedAnimal(const void *buf) {
-  return flatbuffers::GetSizePrefixedRoot<com::fbs::app::Animal>(buf);
+  return ::flatbuffers::GetSizePrefixedRoot<com::fbs::app::Animal>(buf);
 }
 
 inline bool VerifyAnimalBuffer(
-    flatbuffers::Verifier &verifier) {
+    ::flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<com::fbs::app::Animal>(nullptr);
 }
 
 inline bool VerifySizePrefixedAnimalBuffer(
-    flatbuffers::Verifier &verifier) {
+    ::flatbuffers::Verifier &verifier) {
   return verifier.VerifySizePrefixedBuffer<com::fbs::app::Animal>(nullptr);
 }
 
 inline void FinishAnimalBuffer(
-    flatbuffers::FlatBufferBuilder &fbb,
-    flatbuffers::Offset<com::fbs::app::Animal> root) {
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    ::flatbuffers::Offset<com::fbs::app::Animal> root) {
   fbb.Finish(root);
 }
 
 inline void FinishSizePrefixedAnimalBuffer(
-    flatbuffers::FlatBufferBuilder &fbb,
-    flatbuffers::Offset<com::fbs::app::Animal> root) {
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    ::flatbuffers::Offset<com::fbs::app::Animal> root) {
   fbb.FinishSizePrefixed(root);
 }
 

--- a/android/app/src/main/java/generated/com/fbs/app/Animal.kt
+++ b/android/app/src/main/java/generated/com/fbs/app/Animal.kt
@@ -19,6 +19,7 @@ import java.nio.ByteOrder
 import kotlin.math.sign
 
 @Suppress("unused")
+@kotlin.ExperimentalUnsignedTypes
 class Animal : Table() {
 
     fun __init(_i: Int, _bb: ByteBuffer)  {
@@ -31,14 +32,22 @@ class Animal : Table() {
     val name : String?
         get() {
             val o = __offset(4)
-            return if (o != 0) __string(o + bb_pos) else null
+            return if (o != 0) {
+                __string(o + bb_pos)
+            } else {
+                null
+            }
         }
     val nameAsByteBuffer : ByteBuffer get() = __vector_as_bytebuffer(4, 1)
     fun nameInByteBuffer(_bb: ByteBuffer) : ByteBuffer = __vector_in_bytebuffer(_bb, 4, 1)
     val sound : String?
         get() {
             val o = __offset(6)
-            return if (o != 0) __string(o + bb_pos) else null
+            return if (o != 0) {
+                __string(o + bb_pos)
+            } else {
+                null
+            }
         }
     val soundAsByteBuffer : ByteBuffer get() = __vector_as_bytebuffer(6, 1)
     fun soundInByteBuffer(_bb: ByteBuffer) : ByteBuffer = __vector_in_bytebuffer(_bb, 6, 1)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-  ext.kotlin_version = "1.4.10"
+  ext.kotlin_version = "1.7.21"
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.0'
+    classpath 'com.android.tools.build:gradle:7.4.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
     // NOTE: Do not place your application dependencies here; they belong
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlin/benchmark/build.gradle.kts
+++ b/kotlin/benchmark/build.gradle.kts
@@ -2,16 +2,9 @@ import org.jetbrains.kotlin.ir.backend.js.compile
 
 plugins {
   kotlin("multiplatform")
-  id("org.jetbrains.kotlin.plugin.allopen") version "1.4.20"
-  id("org.jetbrains.kotlinx.benchmark") version "0.4.2"
-  id("io.morethan.jmhreport") version "0.9.0"
+  id("org.jetbrains.kotlinx.benchmark")
+  id("io.morethan.jmhreport")
   id("de.undercouch.download")
-}
-
-// allOpen plugin is needed for the benchmark annotations.
-// for more information, see https://github.com/Kotlin/kotlinx-benchmark#gradle-plugin
-allOpen {
-  annotation("org.openjdk.jmh.annotations.State")
 }
 
 group = "com.google.flatbuffers.jmh"
@@ -34,7 +27,7 @@ benchmark {
       iterationTime = 300
       iterationTimeUnit = "ms"
       // uncomment for benchmarking JSON op only
-      // include(".*JsonBenchmark.*")
+      include(".*JsonBenchmark.*")
     }
   }
   targets {
@@ -43,9 +36,7 @@ benchmark {
 }
 
 kotlin {
-  jvm {
-    withJava()
-  }
+  jvm()
 
   sourceSets {
 
@@ -58,7 +49,7 @@ kotlin {
         implementation(kotlin("stdlib-common"))
         implementation(project(":flatbuffers-kotlin"))
         implementation(libs.kotlinx.benchmark.runtime)
-
+        implementation("com.google.flatbuffers:flatbuffers-java:2.0.3")
         // json serializers
         implementation(libs.moshi.kotlin)
         implementation(libs.gson)

--- a/kotlin/benchmark/src/jvmMain/kotlin/com/google/flatbuffers/kotlin/benchmark/FlexBuffersBenchmark.kt
+++ b/kotlin/benchmark/src/jvmMain/kotlin/com/google/flatbuffers/kotlin/benchmark/FlexBuffersBenchmark.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 package com.google.flatbuffers.kotlin.benchmark
-
 import com.google.flatbuffers.ArrayReadWriteBuf
 import com.google.flatbuffers.FlexBuffers
 import com.google.flatbuffers.FlexBuffersBuilder.BUILDER_FLAG_SHARE_ALL
@@ -35,7 +34,7 @@ import java.util.concurrent.TimeUnit
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.NANOSECONDS)
-class FlexBuffersBenchmark {
+open class FlexBuffersBenchmark {
 
   var initialCapacity = 1024
   var value: Double = 0.0
@@ -49,7 +48,7 @@ class FlexBuffersBenchmark {
   }
 
   @Benchmark
-  fun mapKotlin(blackhole: Blackhole) {
+  open fun mapKotlin(blackhole: Blackhole) {
     val kBuilder = FlexBuffersBuilder(initialCapacity, FlexBuffersBuilder.SHARE_KEYS_AND_STRINGS)
     kBuilder.putMap {
       this["hello"] = "world"
@@ -72,7 +71,7 @@ class FlexBuffersBenchmark {
   }
 
   @Benchmark
-  fun mapJava(blackhole: Blackhole) {
+  open fun mapJava(blackhole: Blackhole) {
     val jBuilder = com.google.flatbuffers.FlexBuffersBuilder(ArrayReadWriteBuf(initialCapacity), BUILDER_FLAG_SHARE_ALL)
     val startMap = jBuilder.startMap()
     jBuilder.putString("hello", "world")
@@ -102,7 +101,7 @@ class FlexBuffersBenchmark {
   }
 
   @Benchmark
-  fun intArrayKotlin(blackhole: Blackhole) {
+  open fun intArrayKotlin(blackhole: Blackhole) {
     val kBuilder = FlexBuffersBuilder(initialCapacity, FlexBuffersBuilder.SHARE_KEYS_AND_STRINGS)
     kBuilder.put(bigIntArray)
     val root = getRoot(kBuilder.finish())
@@ -110,7 +109,7 @@ class FlexBuffersBenchmark {
   }
 
   @Benchmark
-  fun intArrayJava(blackhole: Blackhole) {
+  open fun intArrayJava(blackhole: Blackhole) {
     val jBuilder = com.google.flatbuffers.FlexBuffersBuilder(ArrayReadWriteBuf(initialCapacity), BUILDER_FLAG_SHARE_ALL)
     val v = jBuilder.startVector()
     bigIntArray.forEach { jBuilder.putInt(it) }
@@ -126,7 +125,7 @@ class FlexBuffersBenchmark {
   }
 
   @Benchmark
-  fun stringArrayKotlin(blackhole: Blackhole) {
+  open fun stringArrayKotlin(blackhole: Blackhole) {
     val kBuilder = FlexBuffersBuilder(initialCapacity, FlexBuffersBuilder.SHARE_KEYS_AND_STRINGS)
     kBuilder.putVector { stringValue.forEach { kBuilder.put(it) } }
     kBuilder.finish()
@@ -136,7 +135,7 @@ class FlexBuffersBenchmark {
   }
 
   @Benchmark
-  fun stringArrayJava(blackhole: Blackhole) {
+  open fun stringArrayJava(blackhole: Blackhole) {
     val jBuilder = com.google.flatbuffers.FlexBuffersBuilder(ArrayReadWriteBuf(initialCapacity), BUILDER_FLAG_SHARE_ALL)
     val v = jBuilder.startVector()
     stringValue.forEach { jBuilder.putString(it) }
@@ -148,7 +147,7 @@ class FlexBuffersBenchmark {
   }
 
   @Benchmark
-  fun stringMapKotlin(blackhole: Blackhole) {
+  open fun stringMapKotlin(blackhole: Blackhole) {
     val kBuilder = FlexBuffersBuilder(initialCapacity, FlexBuffersBuilder.SHARE_KEYS_AND_STRINGS)
     val pos = kBuilder.startMap()
     for (i in stringKey.indices) {
@@ -165,7 +164,7 @@ class FlexBuffersBenchmark {
   }
 
   @Benchmark
-  fun stringMapBytIndexKotlin(blackhole: Blackhole) {
+  open fun stringMapBytIndexKotlin(blackhole: Blackhole) {
     val kBuilder = FlexBuffersBuilder(initialCapacity, FlexBuffersBuilder.SHARE_KEYS_AND_STRINGS)
     val pos = kBuilder.startMap()
     for (i in stringKey.indices) {
@@ -180,7 +179,7 @@ class FlexBuffersBenchmark {
   }
 
   @Benchmark
-  fun stringMapJava(blackhole: Blackhole) {
+  open fun stringMapJava(blackhole: Blackhole) {
     val jBuilder = com.google.flatbuffers.FlexBuffersBuilder(ArrayReadWriteBuf(initialCapacity), BUILDER_FLAG_SHARE_ALL)
     val v = jBuilder.startMap()
     for (i in stringKey.indices) {

--- a/kotlin/benchmark/src/jvmMain/kotlin/com/google/flatbuffers/kotlin/benchmark/JsonBenchmark.kt
+++ b/kotlin/benchmark/src/jvmMain/kotlin/com/google/flatbuffers/kotlin/benchmark/JsonBenchmark.kt
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Measurement(iterations = 100, time = 1, timeUnit = TimeUnit.MICROSECONDS)
-class JsonBenchmark {
+open class JsonBenchmark {
 
   final val moshi = Moshi.Builder()
     .addLast(KotlinJsonAdapterFactory())
@@ -76,46 +76,46 @@ class JsonBenchmark {
 
   // TWITTER
   @Benchmark
-  fun readTwitterFlexBuffers(hole: Blackhole? = null) = hole?.consume(readFlexBuffers(twitterData))
+  open fun readTwitterFlexBuffers(hole: Blackhole? = null) = hole?.consume(readFlexBuffers(twitterData))
   @Benchmark
-  fun readTwitterMoshi(hole: Blackhole?) = hole?.consume(readMoshi(twitterData))
+  open fun readTwitterMoshi(hole: Blackhole?) = hole?.consume(readMoshi(twitterData))
   @Benchmark
-  fun readTwitterGson(hole: Blackhole?) = hole?.consume(readGson(twitterData))
+  open fun readTwitterGson(hole: Blackhole?) = hole?.consume(readGson(twitterData))
 
   @Benchmark
-  fun roundTripTwitterFlexBuffers(hole: Blackhole? = null) = hole?.consume(readFlexBuffers(twitterData).toJson())
+  open fun roundTripTwitterFlexBuffers(hole: Blackhole? = null) = hole?.consume(readFlexBuffers(twitterData).toJson())
   @Benchmark
-  fun roundTripTwitterMoshi(hole: Blackhole?) = hole?.consume(moshiAdapter.toJson(readMoshi(twitterData)))
+  open fun roundTripTwitterMoshi(hole: Blackhole?) = hole?.consume(moshiAdapter.toJson(readMoshi(twitterData)))
   @Benchmark
-  fun roundTripTwitterGson(hole: Blackhole?) = hole?.consume(gson.toJson(readGson(twitterData)))
+  open fun roundTripTwitterGson(hole: Blackhole?) = hole?.consume(gson.toJson(readGson(twitterData)))
 
   // CITM
   @Benchmark
-  fun readCITMFlexBuffers(hole: Blackhole? = null) = hole?.consume(readFlexBuffers(citmData))
+  open fun readCITMFlexBuffers(hole: Blackhole? = null) = hole?.consume(readFlexBuffers(citmData))
   @Benchmark
-  fun readCITMMoshi(hole: Blackhole?) = hole?.consume(moshiAdapter.toJson(readMoshi(citmData)))
+  open fun readCITMMoshi(hole: Blackhole?) = hole?.consume(moshiAdapter.toJson(readMoshi(citmData)))
   @Benchmark
-  fun readCITMGson(hole: Blackhole?) = hole?.consume(gson.toJson(readGson(citmData)))
+  open fun readCITMGson(hole: Blackhole?) = hole?.consume(gson.toJson(readGson(citmData)))
 
   @Benchmark
-  fun roundTripCITMFlexBuffers(hole: Blackhole? = null) = hole?.consume(readFlexBuffers(citmData).toJson())
+  open fun roundTripCITMFlexBuffers(hole: Blackhole? = null) = hole?.consume(readFlexBuffers(citmData).toJson())
   @Benchmark
-  fun roundTripCITMMoshi(hole: Blackhole?) = hole?.consume(moshiAdapter.toJson(readMoshi(citmData)))
+  open fun roundTripCITMMoshi(hole: Blackhole?) = hole?.consume(moshiAdapter.toJson(readMoshi(citmData)))
   @Benchmark
-  fun roundTripCITMGson(hole: Blackhole?) = hole?.consume(gson.toJson(readGson(citmData)))
+  open fun roundTripCITMGson(hole: Blackhole?) = hole?.consume(gson.toJson(readGson(citmData)))
 
   @Benchmark
-  fun writeCITMFlexBuffers(hole: Blackhole? = null) = hole?.consume(fbCitmRef.toJson())
+  open fun writeCITMFlexBuffers(hole: Blackhole? = null) = hole?.consume(fbCitmRef.toJson())
   @Benchmark
-  fun writeCITMMoshi(hole: Blackhole?) = hole?.consume(moshiAdapter.toJson(moshiCitmRef))
+  open fun writeCITMMoshi(hole: Blackhole?) = hole?.consume(moshiAdapter.toJson(moshiCitmRef))
   @Benchmark
-  fun writeCITMGson(hole: Blackhole?) = hole?.consume(gson.toJson(gsonCitmRef))
+  open fun writeCITMGson(hole: Blackhole?) = hole?.consume(gson.toJson(gsonCitmRef))
 
   // CANADA
   @Benchmark
-  fun readCanadaFlexBuffers(hole: Blackhole? = null) = hole?.consume(readFlexBuffers(canadaData))
+  open fun readCanadaFlexBuffers(hole: Blackhole? = null) = hole?.consume(readFlexBuffers(canadaData))
   @Benchmark
-  fun readCanadaMoshi(hole: Blackhole?) = hole?.consume(readMoshi(canadaData))
+  open fun readCanadaMoshi(hole: Blackhole?) = hole?.consume(readMoshi(canadaData))
   @Benchmark
-  fun readCanadaGson(hole: Blackhole?) = hole?.consume(readGson(canadaData))
+  open fun readCanadaGson(hole: Blackhole?) = hole?.consume(readGson(canadaData))
 }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-  id("com.diffplug.spotless") version "6.3.0"
-}
-
 group = "com.google.flatbuffers"
 version = "2.0.0-SNAPSHOT"
 
@@ -12,7 +8,10 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath(libs.bundles.plugins)
+    classpath(libs.plugin.kotlin.gradle)
+    classpath(libs.plugin.kotlinx.benchmark)
+    classpath(libs.plugin.jmhreport)
+    classpath(libs.plugin.download)
   }
 }
 
@@ -20,23 +19,5 @@ allprojects {
   repositories {
     google()
     mavenCentral()
-  }
-}
-
-// plugin used to enforce code style
-spotless {
-  val klintConfig = mapOf("indent_size" to "2", "continuation_indent_size" to "2")
-  kotlin {
-    target("**/*.kt")
-    ktlint("0.40.0").userData(klintConfig)
-    trimTrailingWhitespace()
-    indentWithSpaces()
-    endWithNewline()
-    licenseHeaderFile("$rootDir/spotless/spotless.kt").updateYearWithLatest(false)
-    targetExclude("**/spotless.kt", "**/build/**")
-  }
-  kotlinGradle {
-    target("*.gradle.kts")
-    ktlint().userData(klintConfig)
   }
 }

--- a/kotlin/gradle/libs.versions.toml
+++ b/kotlin/gradle/libs.versions.toml
@@ -1,20 +1,19 @@
 [versions]
-plugin-kotlin = "1.6.10"
+kotlin = "1.7.21"
 plugin-gver = "0.42.0"
-kotlinx-benchmark-runtime = "0.4.2"
+kotlinx-benchmark = "0.4.6"
 junit = "4.12"
 gson = "2.8.5"
 moshi-kotlin = "1.11.0"
 
 [libraries]
+kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi-kotlin" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
-kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark-runtime" }
-plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "plugin-kotlin" }
-plugin-kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "plugin-kotlin" }
+kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }
 plugin-gver = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "plugin-gver" }
-
+plugin-kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+plugin-kotlinx-benchmark = { module="org.jetbrains.kotlinx:kotlinx-benchmark-plugin", version.ref="kotlinx-benchmark"}
+plugin-jmhreport = { module = "gradle.plugin.io.morethan.jmhreport:gradle-jmh-report", version="0.9.0" }
+plugin-download = { module = "de.undercouch:gradle-download-task", version = "5.3.0"}
 junit = { module="junit:junit", version.ref="junit"}
-
-[bundles]
-plugins = ["plugin-kotlin",  "plugin-kotlin-serialization", "plugin-gver"]

--- a/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
JCenter[1] has been removed and now is failing android build. This change updates the configuration to remove this and few other warnings.

1 - https://developer.android.com/studio/build/jcenter-migration

Also fix kotlin build for latest gradle version 8.0.1 (in use by CI)