### PR TITLE
[cmake] Added GENERATE_<TARGET> to flatbuffers_generate_headers

### DIFF
--- a/CMake/BuildFlatBuffers.cmake
+++ b/CMake/BuildFlatBuffers.cmake
@@ -157,6 +157,10 @@ endfunction()
 # other flagc flags using the FLAGS option to change the behavior of the flatc
 # tool.
 #
+# When the target_link_libraries is done within a different directory than
+# flatbuffers_generate_headers is called, then the target should also be dependent
+# the custom generation target called GENERATE_<TARGET>.
+#
 # Arguments:
 #   TARGET: The name of the target to generate.
 #   SCHEMAS: The list of schema files to generate code for.
@@ -182,6 +186,9 @@ endfunction()
 #     target_link_libraries(MyExecutableTarget
 #         PRIVATE my_generated_headers_target
 #     )
+#
+# Optional (only needed within different directory):
+#     add_dependencies(app GENERATE_my_generated_headers_target)
 function(flatbuffers_generate_headers)
   # Parse function arguments.
   set(options)
@@ -226,6 +233,8 @@ function(flatbuffers_generate_headers)
          "--include-prefix" ${FLATBUFFERS_GENERATE_HEADERS_INCLUDE_PREFIX})
   endif()
 
+  set(generated_custom_commands)
+
   # Create rules to generate the code for each schema.
   foreach(schema ${FLATBUFFERS_GENERATE_HEADERS_SCHEMAS})
     get_filename_component(filename ${schema} NAME_WE)
@@ -254,6 +263,7 @@ function(flatbuffers_generate_headers)
       COMMENT "Building ${schema} flatbuffers...")
     list(APPEND all_generated_header_files ${generated_include})
     list(APPEND all_generated_source_files ${generated_source_file})
+    list(APPEND generated_custom_commands "${generated_include}" "${generated_source_file}")
 
     # Geneate the binary flatbuffers schemas if instructed to.
     if (NOT ${FLATBUFFERS_GENERATE_HEADERS_BINARY_SCHEMAS_DIR} STREQUAL "")
@@ -267,9 +277,16 @@ function(flatbuffers_generate_headers)
         ${schema}
         DEPENDS ${FLATC_TARGET} ${schema}
         WORKING_DIRECTORY "${working_dir}")
+      list(APPEND generated_custom_commands "${binary_schema}")
       list(APPEND all_generated_binary_files ${binary_schema})
     endif()
   endforeach()
+
+  # Create an additional target as add_custom_command scope is only within same directory (CMakeFile.txt)
+  set(generate_target GENERATE_${FLATBUFFERS_GENERATE_HEADERS_TARGET})
+  add_custom_target(${generate_target} ALL
+                    DEPENDS ${generated_custom_commands}
+                    COMMENT "Generating flatbuffer target ${FLATBUFFERS_GENERATE_HEADERS_TARGET}")
 
   # Set up interface library
   add_library(${FLATBUFFERS_GENERATE_HEADERS_TARGET} INTERFACE)


### PR DESCRIPTION
The generation of the library interface supplied by this function only works within the same directory as that the target was defined. By adding a custom target named GENERATE_<TARGET> now also interface files will be generated by making a target dependend on the generate target.

Example:
/CMakeLists.txt
  set(MY_INCL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/fbs/my_incl.fbs)
  flatbuffers_generate_headers(TARGET my_incl
                               SCHEMAS ${MY_INCL_SRC})

  add_subdirectory(app)

/app/CMakeLists.txt
  add_executable(app src/test.cpp)
  target_link_libraries(app my_incl)
  add_dependencies(app GENERATE_my_incl)
