### PR TITLE
Fix help output for --java-checkerframework

### DIFF
--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -117,7 +117,7 @@ const static FlatCOption flatc_options[] = {
     "Add Clang _Nullable for C++ pointer. or @Nullable for Java" },
   { "", "java-package-prefix", "",
     "Add a prefix to the generated package name for Java." },
-  { "", "java-checkerframe", "", "Add @Pure for Java." },
+  { "", "java-checkerframework", "", "Add @Pure for Java." },
   { "", "gen-generated", "", "Add @Generated annotation for Java." },
   { "", "gen-jvmstatic", "",
     "Add @JvmStatic annotation for Kotlin methods in companion object for "


### PR DESCRIPTION
This fixes the `flatc --help` output to document the `--java-checkerframework` option as actually implemented (vs. `--java-checkerframe`).

https://github.com/google/flatbuffers/blob/32a67442865703704a8d382743eddcd92a0917f3/src/flatc.cpp#L120

https://github.com/google/flatbuffers/blob/32a67442865703704a8d382743eddcd92a0917f3/src/flatc.cpp#L524