### PR TITLE
fix using null string in vector

### DIFF
--- a/net/FlatBuffers/FlatBufferBuilder.cs
+++ b/net/FlatBuffers/FlatBufferBuilder.cs
@@ -438,7 +438,8 @@ namespace Google.FlatBuffers
             if (off > Offset)
                 throw new ArgumentException();
 
-            off = Offset - off + sizeof(int);
+            if (off != 0)
+                off = Offset - off + sizeof(int);
             PutInt(off);
         }
 

--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -65,7 +65,11 @@ namespace Google.FlatBuffers
         // Create a .NET String from UTF-8 data stored inside the flatbuffer.
         public string __string(int offset)
         {
-            offset += bb.GetInt(offset);
+            int stringOffset = bb.GetInt(offset);
+            if (stringOffset == 0)
+                return null;
+
+            offset += stringOffset;
             var len = bb.GetInt(offset);
             var startPos = offset + sizeof(int);
             return bb.GetStringUTF8(startPos, len);


### PR DESCRIPTION
Use 0 offset as special value. 0 offset is not a valid relative offset, so it's safe to use 0 offset to indicate value is null.

https://github.com/google/flatbuffers/issues/7846

