### PR TITLE
Add global attribute syntax

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -237,6 +237,7 @@ template<typename T> class SymbolTable {
 
   bool Add(const std::string &name, T *e) {
     vec.emplace_back(e);
+    vec_keys.emplace_back(name);
     auto it = dict.find(name);
     if (it != dict.end()) return true;
     dict[name] = e;
@@ -249,6 +250,11 @@ template<typename T> class SymbolTable {
       auto obj = it->second;
       dict.erase(it);
       dict[newname] = obj;
+
+      // replace the name in vec_keys
+      auto it2 = std::find(vec_keys.begin(), vec_keys.end(), oldname);
+      FLATBUFFERS_ASSERT(it2 != vec_keys.end());
+      *it2 = newname;
     } else {
       FLATBUFFERS_ASSERT(false);
     }
@@ -262,6 +268,7 @@ template<typename T> class SymbolTable {
  public:
   std::map<std::string, T *> dict;  // quick lookup
   std::vector<T *> vec;             // Used to iterate in order of insertion
+  std::vector<std::string> vec_keys; // Same, but by key
 };
 
 // A name space, as set in the schema.
@@ -1164,6 +1171,7 @@ class Parser : public ParserState {
   std::vector<std::string> native_included_files_;
 
   std::map<std::string, bool> known_attributes_;
+  SymbolTable<Value> global_attributes_;
 
   IDLOptions opts;
   bool uses_flexbuffers_;


### PR DESCRIPTION
While doing #7874, I realized it would be useful (for us at least?) to be able to specify some set of "global attributes".  This PR implements that functionality.  Putting it up for discussion before I add tests.  The syntax is:

```
attribute "my_attribute";
attribute "my_other_attribute";

global (my_attribute, my_other_attribute: 50);
```

I'm not at all married to this syntax, but it seems to mirror existing syntax the best.  I considered `global attribute "foo";` to both declare it and make it global, but there's no way to specify a value.  Global attributes only apply to any declarations that come _after_ they are parsed.  This might be surprising (maybe a better keyword than "global"?), but is useful, especially when used with includes.  Global attributes are implemented by simply appending them to every single attribute list wherever attributes are parsed (after the in-place declarations are parsed).  If an attribute of the same name is already present, then the global version is skipped. I had to add some grossness to SymbolTable to be able to iterate in order by name.

If this looks good, I'll add some tests. Also, now that there's a way to have attributes come from a global location, I'd maybe also implement an attribute removal syntax, e.g. `table foo (-my_attribute) { ... }` which would remove `my_attribute` from the table's metadata, if present. (likewise `global (-my_attribute);` to remove it from the global set)