### PR TITLE
README.md: PyPI case typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Code generation and runtime libraries for many popular languages.
 1. Lobster
 1. Lua
 1. PHP
-1. Python - [PyPi](https://pypi.org/project/flatbuffers/)
+1. Python - [PyPI](https://pypi.org/project/flatbuffers/)
 1. Rust - [crates.io](https://crates.io/crates/flatbuffers)
 1. Swift - [swiftpackageindex](https://swiftpackageindex.com/google/flatbuffers)
 1. TypeScript - [NPM](https://www.npmjs.com/package/flatbuffers)


### PR DESCRIPTION
PyPI has three capital letters. See the front page of the service: https://pypi.org/
"The Python Package Index (PyPI) ..."

Update the Python link under "Supported programming languages"