### PR TITLE
 Update java pom.xml file to allow java 8 compatibility

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -59,15 +59,91 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
+        <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <release>8</release>
-          <testExcludes>
-            <testExclude>MyGame/Example/MonsterStorageGrpc.java</testExclude>
-            <testExclude>MyGame/OtherNameSpace/TableBT.java</testExclude>
-          </testExcludes>
+          <includes>
+            <include>**/*Test.java</include>
+          </includes>
         </configuration>
-        <version>3.8.1</version>
+        <version>2.22.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <additionalparam>-Xdoclint:none</additionalparam>
+          <additionalOptions>-Xdoclint:none</additionalOptions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.8</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>3.0.1</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+            <configuration>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>release</releaseProfiles>
+          <goals>deploy</goals>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -80,91 +156,39 @@
       <build>
         <plugins>
           <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
+            <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <includes>
-                <include>**/*Test.java</include>
-              </includes>
+              <release>8</release>
+              <testExcludes>
+                <testExclude>MyGame/Example/MonsterStorageGrpc.java</testExclude>
+                <testExclude>MyGame/OtherNameSpace/TableBT.java</testExclude>
+              </testExcludes>
             </configuration>
-            <version>2.22.2</version>
+            <version>3.8.1</version>
           </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+      </properties>
+      <build>
+        <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>3.2.1</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.3.0</version>
+            <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
-              <additionalOptions>-Xdoclint:none</additionalOptions>
+              <testExcludes>
+                <testExclude>MyGame/Example/MonsterStorageGrpc.java</testExclude>
+                <testExclude>MyGame/OtherNameSpace/TableBT.java</testExclude>
+              </testExcludes>
             </configuration>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>maven-bundle-plugin</artifactId>
-            <version>5.1.2</version>
-            <extensions>true</extensions>
-          </plugin>
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <configuration>
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-release-plugin</artifactId>
-            <version>2.5.3</version>
-            <configuration>
-              <autoVersionSubmodules>true</autoVersionSubmodules>
-              <useReleaseProfile>false</useReleaseProfile>
-              <releaseProfiles>release</releaseProfiles>
-              <goals>deploy</goals>
-            </configuration>
+            <version>3.8.1</version>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
We are trying to upgrade from Flatbuffers 1.x to 2.0.8. Some of our products still use java 8.

With this change https://github.com/google/flatbuffers/commit/a7b527d9427485c9758a36e1ffdb148ac2b0124a the pom file only includes the bundle plugin (and others) if it is java 9 or later. This causes the maven-dependency plugin to fail under java 8, because the "bundle" isn't known unless the plugin is defined.

One solution is to move the bundle plugin out of the java 9 profile, and directly into the build section in the flat buffers pom.xml, but that would require an update in flatbuffers.

How is this working for anyone using java 8 for flat buffers 2.0.3 forward, or was that the point of this. But reading through the pull request thread (https://github.com/google/flatbuffers/pull/6764), it looks like the point was to regain java 8 compatibility not disable it.

Also no matter what I do to try and add the plugin, from my own project, I still get the unknown bundle error:

Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.1.2:copy-dependencies (copy-dependencies) on project icore-release: Some problems were encountered while processing the POMs:
[ERROR] [ERROR] Unknown packaging: bundle @ line 7, column 14
[ERROR] : 1 problem was encountered while building the effective model for com.google.flatbuffers:flatbuffers-java:2.0.8

[ERROR] [ERROR] Unknown packaging: bundle @ line 7, column 14

Anyone have flat buffers 2.0.3 onwards working in a project pulling it in through the maven dependency and using java 8?

Can the bundle plugin be moved out into the main build section instead of the jdk9 profile?

Can the profile be switched to jdk8 instead?

If the updates were for java 8 bytecode compatibility, why is java 8 excluded?

This pull request fixes the pom.xml file to allow flatbuffers-java to compile under jdk8, as well as allow for it to be pulled in as a dependency to a project using jdk8.