### PR TITLE
Added extra functions to fully redefine filesystem access

### DIFF
--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -407,14 +407,34 @@ inline bool StringIsFlatbufferNegativeInfinity(const std::string &s) {
   return s == "-inf" || s == "-infinity";
 }
 
-typedef bool (*LoadFileFunction)(const char *filename, bool binary,
-                                 std::string *dest);
 typedef bool (*FileExistsFunction)(const char *filename);
 
-LoadFileFunction SetLoadFileFunction(LoadFileFunction load_file_function);
+typedef bool (*DirExistsFunction)(const char* dirname);
+
+typedef bool (*LoadFileFunction)(const char *filename, bool binary,
+                                 std::string *dest);
+
+typedef bool (*SaveFileFunction)(const char *filename, const char *buf,
+                                 size_t len, bool binary);
+
+typedef void (*EnsureDirExistsFunction)(const std::string& filepath);
+
+typedef std::string (*AbsolutePathFunction)(const std::string& filepath);
 
 FileExistsFunction SetFileExistsFunction(
     FileExistsFunction file_exists_function);
+
+DirExistsFunction SetDirExistsFunction(DirExistsFunction dir_exists_function);
+
+LoadFileFunction SetLoadFileFunction(LoadFileFunction load_file_function);
+
+SaveFileFunction SetSaveFileFunction(SaveFileFunction save_file_function);
+
+EnsureDirExistsFunction SetEnsureDirExistsFunction(
+    EnsureDirExistsFunction ensure_dir_exists_function);
+
+AbsolutePathFunction SetAbsolutePathFunction(
+    AbsolutePathFunction absolute_path_function);
 
 // Check if file "name" exists.
 bool FileExists(const char *name);


### PR DESCRIPTION
# Added extra functions to fully redefine filesystem access

## Changes

This pull request introduces the new addition: in `include/flatbuffers/utils.hpp` (and `src/utils.cpp` respectively) added the next typedefs and functions:

```cpp
typedef bool (*DirExistsFunction)(const char* dirname);

typedef bool (*SaveFileFunction)(const char *filename, const char *buf,
                                size_t len, bool binary);

typedef void (*EnsureDirExistsFunction)(const std::string& filepath);

typedef std::string (*AbsolutePathFunction)(const std::string& filepath);
```

```cpp
DirExistsFunction SetDirExistsFunction(DirExistsFunction dir_exists_function); 

SaveFileFunction SetSaveFileFunction(SaveFileFunction save_file_function);

EnsureDirExistsFunction SetEnsureDirExistsFunction(
    EnsureDirExistsFunction ensure_dir_exists_function);

AbsolutePathFunction SetAbsolutePathFunction(
    AbsolutePathFunction absolute_path_function);
```

## Reason

We need to be able to **fully** re-define filesystem access functions. Currently we able only to re-define behavior of the next functions:

```cpp
bool FileExists(const char *name);
bool LoadFile(const char *name, bool binary, std::string *buf);
```

Since currently provided setters very limited (provide ability to re-define only file loading & checking-for-existance):

```cpp
typedef bool (*LoadFileFunction)(const char *filename, bool binary,
                                std::string *dest);
typedef bool (*FileExistsFunction)(const char *filename);

LoadFileFunction SetLoadFileFunction(LoadFileFunction load_file_function);

FileExistsFunction SetFileExistsFunction(
    FileExistsFunction file_exists_function);
```

**Why?** To expand possible architectures/places where flatbuffers compiler may be used. For example (and it's my primary target) - WebAssembly, when c++ code runs in browser, without real filesystem access, but with virtual in-memory alternative. 

Since flatbuffers compiler is 'text generator' (read text --> generate --> output text), it may be useful to fully re-define that i/o interface - to be able to use arbitrary input & output.

**Why it's important?** - popularization. It's may allow us to provide `flatc` to users without installation in their PC. Imagine simple single-page web app (with `flatc` built with WASM), which allow us (serverless) generate code from their schemas in browser and next simply save then into PC. Seems like perfect solution as 'playground' for education, without any 'build from source' or 'apt install' to try it.

As I can see, in the web already exists some forms of such web apps, but its unclear - server or servless them. Serverless (generate in user browser, dont send requests anywhere) is important for privacy.

Also it's important to promote lightweight & fast techologies, instead fat & slow. I use FlatBuffers for 5+ years in production (in various restricted, agressive enviroments, from desktop to web, but primarely for C++ lang) & love it. Since it header-only library it's easy to integrate, I even use it just4fun (with some-patches for compiler detection) in IAR IDE (yep, on embedded devices, microcontrollers) to send data packets over UART - I know FlatBuffers not designed for this, but it works like a charm.

To **prove my point**, I spend few hours and made a small web-demo (c++, Dear ImGui-based application, with all Flatbuffers c++ sources built as library (including changes in this PR). Built with emscripten into WASM + WebGL). It is not too fancy, if not to say "sloppy hastily concocted", without beautiful UI, files drag-n-drop, zipping generated files into singe archive before saving (all of it easily possible, but currently I havent time for it), BUT it's working **Proof of Concept**, and anyone can create your own.

## [→ Web Demo ←](https://inobelar.github.io/emscripten_samples/sample_FlatBuffers_Compiler.html) ([sources](https://github.com/inobelar/emscripten_samples/tree/main/samples/sample_FlatBuffers_Compiler))

## Detailed explanation

I understand that the diff can be a little confusing or unclear, so I'm adding 2 sections (how it was and how it became) to clarify the changes. Also I added explanation comments, and to separate them from regular comments, prefixed them with: `// @inobelar: ...`

- How it was (current state) :

    <details>
      <summary>include/flatbuffers/utils.hpp</summary>

    ```cpp
    // ...

    // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

    // @inobelar: As we can see, currently we can re-define only file
    // loading and existance-checking functions, but not writing, and other
    // filesystem-access functions, like 'EnsureDirExists' (which call
    // `mkdir()` internally).

    typedef bool (*LoadFileFunction)(const char *filename, bool binary,
                                std::string *dest);
    typedef bool (*FileExistsFunction)(const char *filename);

    LoadFileFunction SetLoadFileFunction(LoadFileFunction load_file_function);

    FileExistsFunction SetFileExistsFunction(
        FileExistsFunction file_exists_function);

    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


    // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

    // @inobelar: Here is 4 most widely used (in `flatc`) filesystem-access 
    // functions. Currently we can re-define only 'LoadFile' and 'DirExists'

    // Check if file "name" exists.
    bool FileExists(const char *name);

    // Check if "name" exists and it is also a directory.
    bool DirExists(const char *name);

    // Load file "name" into "buf" returning true if successful
    // false otherwise.  If "binary" is false data is read
    // using ifstream's text mode, otherwise data is read with
    // no transcoding.
    bool LoadFile(const char *name, bool binary, std::string *buf);

    // Save data "buf" of length "len" bytes into a file
    // "name" returning true if successful, false otherwise.
    // If "binary" is false data is written using ifstream's
    // text mode, otherwise data is written with no
    // transcoding.
    bool SaveFile(const char *name, const char *buf, size_t len, bool binary);

    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    // ...

    // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

    // @inobelar: Additional filesystem-access function, which must be
    // re-difinable too, since them (even used not only in few places) 
    // provides access to real filesystem (via `mkdir()` or `realpath()`).

    // This function ensure a directory exists, by recursively
    // creating dirs for any parts of the path that don't exist yet.
    void EnsureDirExists(const std::string &filepath);

    // Obtains the absolute path from any other path.
    // Returns the input path if the absolute path couldn't be resolved.
    std::string AbsolutePath(const std::string &filepath);

    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    // ...
    ```
    
    </details>

    <details>
        <summary>src/utils.hpp</summary>

    ```cpp
    // ...

    // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

    // @inobelar: 'Raw' versions of functions, means 'Default' implementation

    static bool FileExistsRaw(const char *name) {
      std::ifstream ifs(name);
      return ifs.good();
    }

    static bool LoadFileRaw(const char *name, bool binary, std::string *buf) {
      if (DirExists(name)) return false;
      std::ifstream ifs(name, binary ? std::ifstream::binary : std::ifstream::in);
      if (!ifs.is_open()) return false;
      if (binary) {
          // The fastest way to read a file into a string.
          ifs.seekg(0, std::ios::end);
          auto size = ifs.tellg();
          (*buf).resize(static_cast<size_t>(size));
          ifs.seekg(0, std::ios::beg);
          ifs.read(&(*buf)[0], (*buf).size());
      } else {
          // This is slower, but works correctly on all platforms for text files.
          std::ostringstream oss;
          oss << ifs.rdbuf();
          *buf = oss.str();
      }
      return !ifs.bad();
    }

    LoadFileFunction g_load_file_function = LoadFileRaw;
    FileExistsFunction g_file_exists_function = FileExistsRaw;

    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    // ...

    // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

    // @inobelar: as we clearly can see below, `DirExists` and `SaveFile`
    // may be trivailly made re-definable, even simply for 'consistency'
    // reason (if we can re-define reading, we must be able to re-define
    // writing)

    bool LoadFile(const char *name, bool binary, std::string *buf) {
      FLATBUFFERS_ASSERT(g_load_file_function);
      return g_load_file_function(name, binary, buf);
    }

    bool FileExists(const char *name) {
      FLATBUFFERS_ASSERT(g_file_exists_function);
      return g_file_exists_function(name);
    }

    bool DirExists(const char *name) {
      // clang-format off

      #ifdef _WIN32
        #define flatbuffers_stat _stat
        #define FLATBUFFERS_S_IFDIR _S_IFDIR
      #else
        #define flatbuffers_stat stat
        #define FLATBUFFERS_S_IFDIR S_IFDIR
      #endif
      // clang-format on
      struct flatbuffers_stat file_info;
      if (flatbuffers_stat(name, &file_info) != 0) return false;
      return (file_info.st_mode & FLATBUFFERS_S_IFDIR) != 0;
    }

    LoadFileFunction SetLoadFileFunction(LoadFileFunction load_file_function) {
      LoadFileFunction previous_function = g_load_file_function;
      g_load_file_function = load_file_function ? load_file_function : LoadFileRaw;
      return previous_function;
    }

    FileExistsFunction SetFileExistsFunction(
        FileExistsFunction file_exists_function) {
      FileExistsFunction previous_function = g_file_exists_function;
      g_file_exists_function =
          file_exists_function ? file_exists_function : FileExistsRaw;
      return previous_function;
    }

    bool SaveFile(const char *name, const char *buf, size_t len, bool binary) {
      std::ofstream ofs(name, binary ? std::ofstream::binary : std::ofstream::out);
      if (!ofs.is_open()) return false;
      ofs.write(buf, len);
      return !ofs.bad();
    }

    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    // ...

    // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

    // @inobelar: here is 2 additional functions, which access to real
    // filesystem (via `mkdir()` and `realpath()`), and must be able to 
    // be re-definable too.

    void EnsureDirExists(const std::string &filepath) {
      auto parent = StripFileName(filepath);
      if (parent.length()) EnsureDirExists(parent);
        // clang-format off

      #ifdef _WIN32
        (void)_mkdir(filepath.c_str());
      #else
        mkdir(filepath.c_str(), S_IRWXU|S_IRGRP|S_IXGRP);
      #endif
      // clang-format on
    }

    std::string AbsolutePath(const std::string &filepath) {
      // clang-format off

      #ifdef FLATBUFFERS_NO_ABSOLUTE_PATH_RESOLUTION
        return filepath;
      #else
        #if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
          char abs_path[MAX_PATH];
          return GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr)
        #else
          char *abs_path_temp = realpath(filepath.c_str(), nullptr);
          bool success = abs_path_temp != nullptr;
          std::string abs_path;
          if(success) {
            abs_path = abs_path_temp;
            free(abs_path_temp);
          }
          return success
        #endif
          ? abs_path
          : filepath;
      #endif // FLATBUFFERS_NO_ABSOLUTE_PATH_RESOLUTION
      // clang-format on
    }

    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ```

    </details>

- How it became (changes of this PR):

    <details>
      <summary>include/flatbuffers/utils.hpp</summary>

    ```cpp
    // ...

    // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

    // @inobelar: Now we extened function-setters by the next new ones:
    //   - SetDirExistsFunction()
    //   - SetSaveFileFunction()
    //   - SetEnsureDirExistsFunction()
    //   - SetAbsolutePathFunction()
    // Notice, that the next typedefs ordered the same as re-definable 
    // functions declarations: 
    //   [FileExists, DirExist, LoadFile, SaveFile, EnsureDirDirExists, AbsolutePath]

    typedef bool (*FileExistsFunction)(const char *filename);                      // | Dont changed

    typedef bool (*DirExistsFunction)(const char* dirname);

    typedef bool (*LoadFileFunction)(const char *filename, bool binary,            // | Dont changed
                                    std::string *dest);                            // |

    typedef bool (*SaveFileFunction)(const char *filename, const char *buf,
                                    size_t len, bool binary);

    typedef void (*EnsureDirExistsFunction)(const std::string& filepath);

    typedef std::string (*AbsolutePathFunction)(const std::string& filepath);

    FileExistsFunction SetFileExistsFunction(                                      // | Dont changed
        FileExistsFunction file_exists_function);                                  // |

    DirExistsFunction SetDirExistsFunction(DirExistsFunction dir_exists_function); 

    LoadFileFunction SetLoadFileFunction(LoadFileFunction load_file_function);     // | Dont changed

    SaveFileFunction SetSaveFileFunction(SaveFileFunction save_file_function);

    EnsureDirExistsFunction SetEnsureDirExistsFunction(
        EnsureDirExistsFunction ensure_dir_exists_function);

    AbsolutePathFunction SetAbsolutePathFunction(
        AbsolutePathFunction absolute_path_function);

    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    // Check if file "name" exists.                                            // |
    bool FileExists(const char *name);                                         // |
                                                                               // |
    // Check if "name" exists and it is also a directory.                      // |
    bool DirExists(const char *name);                                          // |
                                                                               // |
    // Load file "name" into "buf" returning true if successful                // |
    // false otherwise.  If "binary" is false data is read                     // |
    // using ifstream's text mode, otherwise data is read with                 // | Dont changed
    // no transcoding.                                                         // |
    bool LoadFile(const char *name, bool binary, std::string *buf);            // |
                                                                               // |
    // Save data "buf" of length "len" bytes into a file                       // |
    // "name" returning true if successful, false otherwise.                   // |
    // If "binary" is false data is written using ifstream's                   // |
    // text mode, otherwise data is written with no                            // |
    // transcoding.                                                            // |
    bool SaveFile(const char *name, const char *buf, size_t len, bool binary); // |

    // ...

    // This function ensure a directory exists, by recursively                 // |
    // creating dirs for any parts of the path that don't exist yet.           // |
    void EnsureDirExists(const std::string &filepath);                         // |
                                                                               // | Dont changed
    // Obtains the absolute path from any other path.                          // |
    // Returns the input path if the absolute path couldn't be resolved.       // |
    std::string AbsolutePath(const std::string &filepath);                     // |
    ```

    </details>

    <details>
      <summary>src/utils.cpp</summary>

    ```cpp

    // ...

    // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

    // @inobelar: 'Raw' or 'Default' version now contains a little bit more
    // functions - they are exactly the same copy-pasted implementation of
    // old functions.

    static bool FileExistsRaw(const char *name) { // |
      std::ifstream ifs(name);                    // | Dont changed
      return ifs.good();                          // |
    }

    // @inobelar: previosly it was 'DirExists()'
    static bool DirExistsRaw(const char *name) {
      // clang-format off                                        // |
                                                                 // |
      #ifdef _WIN32                                              // |
        #define flatbuffers_stat _stat                           // |
        #define FLATBUFFERS_S_IFDIR _S_IFDIR                     // |
      #else                                                      // |
        #define flatbuffers_stat stat                            // | Dont changed
        #define FLATBUFFERS_S_IFDIR S_IFDIR                      // |
      #endif                                                     // |
      // clang-format on                                         // |
      struct flatbuffers_stat file_info;                         // |
      if (flatbuffers_stat(name, &file_info) != 0) return false; // |
      return (file_info.st_mode & FLATBUFFERS_S_IFDIR) != 0;     // |
    }

    // @inobelar: important note: in implementation of original `LoadFileRaw()` 
    // function was used non-re-definable `DirExists()` function call, but now 
    // it may be re-defined ... so for consistency, in this 'Raw' (aka 'Default')
    // function, we also use `DirExistsRaw()` call instead - to make sure, that
    // when we 'for some reason accidentally re-define fs-functions PARTIALLY'
    // (for example - only `DirExists()` function), in this part (function which 
    // operate with real fs), we also use func for real fs, not some ... another, 
    // virtual, etc.
    static bool LoadFileRaw(const char *name, bool binary, std::string *buf) {
      if (DirExistsRaw(name)) return false; // @inobelar: <-- here is difference: `DirExistsRaw()` call, not re-definable `DirExists()`
      std::ifstream ifs(name, binary ? std::ifstream::binary : std::ifstream::in); // |
      if (!ifs.is_open()) return false;                                            // |
      if (binary) {                                                                // |
        // The fastest way to read a file into a string.                           // |
        ifs.seekg(0, std::ios::end);                                               // |
        auto size = ifs.tellg();                                                   // |
        (*buf).resize(static_cast<size_t>(size));                                  // |
        ifs.seekg(0, std::ios::beg);                                               // |
        ifs.read(&(*buf)[0], (*buf).size());                                       // | Dont changed
      } else {                                                                     // |
        // This is slower, but works correctly on all platforms for text files.    // |
        std::ostringstream oss;                                                    // |
        oss << ifs.rdbuf();                                                        // |
        *buf = oss.str();                                                          // |
      }                                                                            // |
      return !ifs.bad();                                                           // |
    }

    // @inobelar: previosly it was 'SaveFile()'
    static bool SaveFileRaw(const char *name, const char *buf, size_t len, bool binary) {
      std::ofstream ofs(name, binary ? std::ofstream::binary : std::ofstream::out); // |
      if (!ofs.is_open()) return false;                                             // | Dont changed
      ofs.write(buf, len);                                                          // |
      return !ofs.bad();                                                            // |
    }

    // @inobelar: previosly it was 'EnsureDirExists()'
    static void EnsureDirExistsRaw(const std::string &filepath) {
      auto parent = StripFileName(filepath);               // |
      if (parent.length()) EnsureDirExists(parent);        // |
        // clang-format off                                // |
                                                           // |
      #ifdef _WIN32                                        // | Dont changed
        (void)_mkdir(filepath.c_str());                    // |
      #else                                                // |
        mkdir(filepath.c_str(), S_IRWXU|S_IRGRP|S_IXGRP);  // |
      #endif                                               // |
      // clang-format on                                   // |
    }

  // @inobelar: previosly it was 'AbsolutePath()'
    static std::string AbsolutePathRaw(const std::string &filepath) {
      // clang-format off                                                                          // |
                                                                                                   // |
      #ifdef FLATBUFFERS_NO_ABSOLUTE_PATH_RESOLUTION                                               // |
        return filepath;                                                                           // |
      #else                                                                                        // |
        #if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__) // |
          char abs_path[MAX_PATH];                                                                 // | 
          return GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr)                   // |
        #else                                                                                      // |
          char *abs_path_temp = realpath(filepath.c_str(), nullptr);                               // |
          bool success = abs_path_temp != nullptr;                                                 // | Dont changed
          std::string abs_path;                                                                    // |
          if(success) {                                                                            // |
            abs_path = abs_path_temp;                                                              // |
            free(abs_path_temp);                                                                   // |
          }                                                                                        // |
          return success                                                                           // |
        #endif                                                                                     // |
          ? abs_path                                                                               // |
          : filepath;                                                                              // |
      #endif // FLATBUFFERS_NO_ABSOLUTE_PATH_RESOLUTION                                            // |
      // clang-format on                                                                           // |
    }

    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    FileExistsFunction g_file_exists_function = FileExistsRaw;                 // | Dont changed
    DirExistsFunction g_dir_exists_function = DirExistsRaw;
    LoadFileFunction g_load_file_function = LoadFileRaw;                       // | Dont changed
    SaveFileFunction g_save_file_function = SaveFileRaw;
    EnsureDirExistsFunction g_ensure_dir_exists_function = EnsureDirExistsRaw;
    AbsolutePathFunction g_absolute_path_function = AbsolutePathRaw;

    // ...

    // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

    // @inobelar: pattern is pretty clear now

    FileExistsFunction SetFileExistsFunction(                          // |
        FileExistsFunction file_exists_function) {                     // |
      FileExistsFunction previous_function = g_file_exists_function;   // |
      g_file_exists_function =                                         // | Dont changed
          file_exists_function ? file_exists_function : FileExistsRaw; // |
      return previous_function;                                        // |
    }                                                                  // |

    DirExistsFunction SetDirExistsFunction(DirExistsFunction dir_exists_function) {
      DirExistsFunction previous_function = g_dir_exists_function;
      g_dir_exists_function =
          dir_exists_function ? dir_exists_function : DirExistsRaw;
      return previous_function;
    }

    LoadFileFunction SetLoadFileFunction(LoadFileFunction load_file_function) {     // |
      LoadFileFunction previous_function = g_load_file_function;                    // |
      g_load_file_function = load_file_function ? load_file_function : LoadFileRaw; // | Dont changed
      return previous_function;                                                     // |
    }                                                                               // |

    SaveFileFunction SetSaveFileFunction(SaveFileFunction save_file_function) {
      SaveFileFunction previous_function = g_save_file_function;
      g_save_file_function =
          save_file_function ? save_file_function : SaveFileRaw;
      return previous_function;
    }

    EnsureDirExistsFunction SetEnsureDirExistsFunction(
        EnsureDirExistsFunction ensure_dir_exists_function)
    {
      EnsureDirExistsFunction previous_function = g_ensure_dir_exists_function;
      g_ensure_dir_exists_function =
          ensure_dir_exists_function
            ? ensure_dir_exists_function : EnsureDirExistsRaw;
      return previous_function;
    }

    AbsolutePathFunction SetAbsolutePathFunction(
        AbsolutePathFunction absolute_path_function)
    {
      AbsolutePathFunction previous_function = g_absolute_path_function;
      g_absolute_path_function =
          absolute_path_function ? absolute_path_function : AbsolutePathRaw;
      return previous_function;
    }

    bool FileExists(const char *name) {           // |
      FLATBUFFERS_ASSERT(g_file_exists_function); // | Dont changed
      return g_file_exists_function(name);        // |
    }                                             // |

    bool DirExists(const char *name) {
      FLATBUFFERS_ASSERT(g_dir_exists_function);
      return g_dir_exists_function(name);
    }

    bool LoadFile(const char *name, bool binary, std::string *buf) { // |
      FLATBUFFERS_ASSERT(g_load_file_function);                      // | Dont changed
      return g_load_file_function(name, binary, buf);                // |
    }                                                                // |

    bool SaveFile(const char *name, const char *buf, size_t len, bool binary) {
      FLATBUFFERS_ASSERT(g_save_file_function);
      return g_save_file_function(name, buf, len, binary);
    }

    // ...

    void EnsureDirExists(const std::string &filepath) {
      FLATBUFFERS_ASSERT(g_ensure_dir_exists_function);
      return g_ensure_dir_exists_function(filepath);
    }

    std::string AbsolutePath(const std::string &filepath) {
      FLATBUFFERS_ASSERT(g_absolute_path_function);
      return g_absolute_path_function(filepath);
    }

    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    // ...
    ```

    </details>

----

## Post Scriptum

I also seached for some cases of filesystem access 'directly' (without using functions from `utils.h`) and found some. Reminder: as far as I can see, for `flatc` build used sources from the next directories:
  - `./include/flatbuffers/`
  - `./src/`
  - `./grpc/src/compiler/`

so we can look only into them.

Searches:
- search for [`ofstream`](https://github.com/search?q=repo%3Agoogle%2Fflatbuffers%20ofstream&type=code):
  - [`src/file_writer.cpp`](https://github.com/google/flatbuffers/blob/3fda20d7c7fe1f8006210bddae8cb55bc7a74c3b/src/file_writer.cpp#L29) (in `FileWriter::SaveFile()`)
  - [`src/annotated_binary_text_gen.cpp`](https://github.com/google/flatbuffers/blob/3fda20d7c7fe1f8006210bddae8cb55bc7a74c3b/src/annotated_binary_text_gen.cpp#L437) (in `AnnotatedBinaryTextGenerator::Generate()`)
  - [`src/file_binary_writer.cpp`](https://github.com/google/flatbuffers/blob/3fda20d7c7fe1f8006210bddae8cb55bc7a74c3b/src/file_binary_writer.cpp#L29) (in `FileBinaryWriter::SaveFile()`)
- search for [`ifstream`](https://github.com/search?q=repo%3Agoogle%2Fflatbuffers%20ifstream&type=code)
  - [`src/file_writer.cpp`](https://github.com/google/flatbuffers/blob/3fda20d7c7fe1f8006210bddae8cb55bc7a74c3b/src/file_writer.cpp#L37) (in `FileWriter::LoadFile()`)
  - [`src/file_binary_writer.cpp`](https://github.com/google/flatbuffers/blob/3fda20d7c7fe1f8006210bddae8cb55bc7a74c3b/src/file_binary_writer.cpp#L37) (in `FileBinaryWriter::Loadfile()`)
- search for `fopen` or `fclose` usage dont found anything :)

As I can see, the next class hierarchy:

```mermaid
graph TD;
FileManager --> FileWriter;
FileManager --> FileNameSavingFileManager;
FileManager --> FileBinaryWriter;
```

- [`FileManager`](https://github.com/search?q=repo%3Agoogle%2Fflatbuffers+FileManager&type=code) simple 'interface' class, not used anywhere, but present in:
  - public headers: [`include/flatbuffers/file_manager.h`](https://github.com/google/flatbuffers/blob/3fda20d7c7fe1f8006210bddae8cb55bc7a74c3b/include/flatbuffers/file_manager.h#L29)
- [`FileWriter`](https://github.com/search?q=repo%3Agoogle%2Fflatbuffers+FileWriter&type=code)
  - not present in headers anywhere ... and it's looks strange. Present in [`src/file_writer.cpp`](https://github.com/google/flatbuffers/blob/3fda20d7c7fe1f8006210bddae8cb55bc7a74c3b/src/file_writer.cpp#L25)
- [`FileNameSavingFileManager`](https://github.com/search?q=repo%3Agoogle%2Fflatbuffers%20FileNameSavingFileManager&type=code)
  - not present in headers anywhere too ... it's looks strange, and it's *purpose unclear*. Present in [`src/file_name_saving_file_manager.cpp`](https://github.com/google/flatbuffers/blob/3fda20d7c7fe1f8006210bddae8cb55bc7a74c3b/src/file_name_saving_file_manager.cpp#L25)
- [`FileBinaryWriter`](https://github.com/search?q=repo%3Agoogle%2Fflatbuffers%20FileBinaryWriter&type=code)
  - not present in headers anywhere too ... and it's looks strange. Present in [`src/file_binary_writer.cpp`](https://github.com/google/flatbuffers/blob/3fda20d7c7fe1f8006210bddae8cb55bc7a74c3b/src/file_binary_writer.cpp#L25)

### Possible solutions

- Remove {`include/flatbuffers/file_manager.h`, `src/file_writer.cpp`, `src/file_name_saving_file_manager.cpp`, `src/file_binary_writer.cpp`} as unused and garbage files.
- Dont remove that files, but add descriptive comments to clarify their purpose and fix `ofstream` & `ifstream` inside of them.

- **Dont forget about** `ofstream` in `src/annotated_binary_text_gen.cpp` - it must be fixed!

Since, technically, this has nothing to do with the current commit, it all should be fixed in the next one. But I cant choose the right decision - need your comments about it.