### PR TITLE
inject no long for FBS generation to remove logs in flattests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,6 +634,7 @@ if(FLATBUFFERS_BUILD_TESTS)
   add_executable(flattests ${FlatBuffers_Tests_SRCS})
   target_link_libraries(flattests PRIVATE $<BUILD_INTERFACE:ProjectConfig>)
 
+  target_include_directories(flattests PUBLIC src)
   add_dependencies(flattests generated_code)
 
   if(FLATBUFFERS_CODE_SANITIZE)

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -1287,9 +1287,10 @@ extern bool GenerateSwift(const Parser &parser, const std::string &path,
 // Generate a schema file from the internal representation, useful after
 // parsing a .proto schema.
 extern std::string GenerateFBS(const Parser &parser,
-                               const std::string &file_name);
+                               const std::string &file_name,
+                               bool no_log);
 extern bool GenerateFBS(const Parser &parser, const std::string &path,
-                        const std::string &file_name);
+                        const std::string &file_name, bool no_log);
 
 // Generate a make rule for the generated TypeScript code.
 // See idl_gen_ts.cpp.

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -5,20 +5,38 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
+cc_library(
+    name = "code_generators",
+    srcs = ["code_generators.cpp"],
+    hdrs = [
+        "//:public_headers",
+    ],
+    strip_include_prefix = "/include",
+    visibility = ["//:__subpackages__"],
+)
+
+cc_library(
+    name = "generate_fbs",
+    srcs = ["idl_gen_fbs.cpp"],
+    hdrs = ["idl_gen_fbs.h"],
+    strip_include_prefix = "/src",
+    visibility = ["//:__subpackages__"],
+    deps = [":code_generators"],
+)
+
 # Public flatc library to compile flatbuffer files at runtime.
 cc_library(
     name = "flatbuffers",
     srcs = [
-        "code_generators.cpp",
-        "idl_gen_fbs.cpp",
-        "idl_gen_fbs.h",
         "idl_gen_text.cpp",
         "idl_gen_text.h",
         "idl_parser.cpp",
         "reflection.cpp",
         "util.cpp",
     ],
-    hdrs = ["//:public_headers"],
+    hdrs = [
+        "//:public_headers",
+    ],
     linkopts = select({
         # TODO: Bazel uses `clang` instead of `clang++` to link
         # C++ code on BSD. Temporarily adding these linker flags while
@@ -30,6 +48,10 @@ cc_library(
     }),
     strip_include_prefix = "/include",
     visibility = ["//:__subpackages__"],
+    deps = [
+        ":code_generators",
+        ":generate_fbs",
+    ],
 )
 
 # Public flatc compiler library.

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -29,7 +29,7 @@ cc_library(
         "//conditions:default": [],
     }),
     strip_include_prefix = "/include",
-    visibility = ["//:__pkg__"],
+    visibility = ["//:__subpackages__"],
 )
 
 # Public flatc compiler library.

--- a/src/idl_gen_fbs.cpp
+++ b/src/idl_gen_fbs.cpp
@@ -129,34 +129,43 @@ static bool HasGapInProtoId(const std::vector<FieldDef *> &fields) {
 }
 
 static bool ProtobufIdSanityCheck(const StructDef &struct_def,
-                                  IDLOptions::ProtoIdGapAction gap_action) {
+                                  IDLOptions::ProtoIdGapAction gap_action,
+                                  bool no_log = false) {
   const auto &fields = struct_def.fields.vec;
   if (HasNonPositiveFieldId(fields)) {
     // TODO: Use LogCompilerWarn
-    fprintf(stderr, "Field id in struct %s has a non positive number value\n",
-            struct_def.name.c_str());
+    if (!no_log) {
+      fprintf(stderr, "Field id in struct %s has a non positive number value\n",
+              struct_def.name.c_str());
+    }
     return false;
   }
 
   if (HasTwiceUsedId(fields)) {
     // TODO: Use LogCompilerWarn
-    fprintf(stderr, "Fields in struct %s have used an id twice\n",
-            struct_def.name.c_str());
+    if (!no_log) {
+      fprintf(stderr, "Fields in struct %s have used an id twice\n",
+              struct_def.name.c_str());
+    }
     return false;
   }
 
   if (HasFieldIdFromReservedIds(fields, struct_def.reserved_ids)) {
     // TODO: Use LogCompilerWarn
-    fprintf(stderr, "Fields in struct %s use id from reserved ids\n",
-            struct_def.name.c_str());
+    if (!no_log) {
+      fprintf(stderr, "Fields in struct %s use id from reserved ids\n",
+              struct_def.name.c_str());
+    }
     return false;
   }
 
   if (gap_action != IDLOptions::ProtoIdGapAction::NO_OP) {
     if (HasGapInProtoId(fields)) {
       // TODO: Use LogCompilerWarn
-      fprintf(stderr, "Fields in struct %s have gap between ids\n",
-              struct_def.name.c_str());
+      if (!no_log) {
+        fprintf(stderr, "Fields in struct %s have gap between ids\n",
+                struct_def.name.c_str());
+      }
       if (gap_action == IDLOptions::ProtoIdGapAction::ERROR) { return false; }
     }
   }
@@ -174,7 +183,8 @@ struct ProtobufToFbsIdMap {
 };
 
 static ProtobufToFbsIdMap MapProtoIdsToFieldsId(
-    const StructDef &struct_def, IDLOptions::ProtoIdGapAction gap_action) {
+    const StructDef &struct_def, IDLOptions::ProtoIdGapAction gap_action,
+    bool no_log) {
   const auto &fields = struct_def.fields.vec;
 
   if (!HasFieldWithId(fields)) {
@@ -183,7 +193,7 @@ static ProtobufToFbsIdMap MapProtoIdsToFieldsId(
     return result;
   }
 
-  if (!ProtobufIdSanityCheck(struct_def, gap_action)) { return {}; }
+  if (!ProtobufIdSanityCheck(struct_def, gap_action, no_log)) { return {}; }
 
   static constexpr int UNION_ID = -1;
   using ProtoIdFieldNamePair = std::pair<int, std::string>;
@@ -203,8 +213,10 @@ static ProtobufToFbsIdMap MapProtoIdsToFieldsId(
       }
     } else {
       // TODO: Use LogCompilerWarn
-      fprintf(stderr, "Fields id in struct %s is missing\n",
-              struct_def.name.c_str());
+      if (!no_log) {
+        fprintf(stderr, "Fields id in struct %s is missing\n",
+                struct_def.name.c_str());
+      }
       return {};
     }
   }
@@ -240,7 +252,8 @@ static void GenNameSpace(const Namespace &name_space, std::string *_schema,
 }
 
 // Generate a flatbuffer schema from the Parser's internal representation.
-std::string GenerateFBS(const Parser &parser, const std::string &file_name) {
+std::string GenerateFBS(const Parser &parser, const std::string &file_name,
+                        bool no_log = false) {
   // Proto namespaces may clash with table names, escape the ones that were
   // generated from a table:
   for (auto it = parser.namespaces_.begin(); it != parser.namespaces_.end();
@@ -315,8 +328,8 @@ std::string GenerateFBS(const Parser &parser, const std::string &file_name) {
   for (auto it = parser.structs_.vec.begin(); it != parser.structs_.vec.end();
        ++it) {
     StructDef &struct_def = **it;
-    const auto proto_fbs_ids =
-        MapProtoIdsToFieldsId(struct_def, parser.opts.proto_id_gap_action);
+    const auto proto_fbs_ids = MapProtoIdsToFieldsId(
+        struct_def, parser.opts.proto_id_gap_action, no_log);
     if (!proto_fbs_ids.successful) { return {}; }
 
     if (parser.opts.include_dependence_headers && struct_def.generated) {
@@ -362,13 +375,15 @@ std::string GenerateFBS(const Parser &parser, const std::string &file_name) {
 }
 
 bool GenerateFBS(const Parser &parser, const std::string &path,
-                 const std::string &file_name) {
-  const std::string fbs = GenerateFBS(parser, file_name);
+                 const std::string &file_name, bool no_log = false) {
+  const std::string fbs = GenerateFBS(parser, file_name, no_log);
   if (fbs.empty()) { return false; }
   // TODO: Use LogCompilerWarn
-  fprintf(stderr,
-          "When you use --proto, that you should check for conformity "
-          "yourself, using the existing --conform");
+  if (!no_log) {
+    fprintf(stderr,
+            "When you use --proto, that you should check for conformity "
+            "yourself, using the existing --conform");
+  }
   return SaveFile((path + file_name + ".fbs").c_str(), fbs, false);
 }
 
@@ -376,9 +391,11 @@ namespace {
 
 class FBSCodeGenerator : public CodeGenerator {
  public:
+  explicit FBSCodeGenerator(const bool no_log) : no_log_(no_log) {}
+
   Status GenerateCode(const Parser &parser, const std::string &path,
                       const std::string &filename) override {
-    if (!GenerateFBS(parser, path, filename)) { return Status::ERROR; }
+    if (!GenerateFBS(parser, path, filename, no_log_)) { return Status::ERROR; }
     return Status::OK;
   }
 
@@ -424,12 +441,15 @@ class FBSCodeGenerator : public CodeGenerator {
   IDLOptions::Language Language() const override { return IDLOptions::kProto; }
 
   std::string LanguageName() const override { return "proto"; }
+
+ protected:
+  const bool no_log_;
 };
 
 }  // namespace
 
-std::unique_ptr<CodeGenerator> NewFBSCodeGenerator() {
-  return std::unique_ptr<FBSCodeGenerator>(new FBSCodeGenerator());
+std::unique_ptr<CodeGenerator> NewFBSCodeGenerator(const bool no_log) {
+  return std::unique_ptr<FBSCodeGenerator>(new FBSCodeGenerator(no_log));
 }
 
 }  // namespace flatbuffers

--- a/src/idl_gen_fbs.h
+++ b/src/idl_gen_fbs.h
@@ -21,7 +21,7 @@
 
 namespace flatbuffers {
 
-std::unique_ptr<CodeGenerator> NewFBSCodeGenerator();
+std::unique_ptr<CodeGenerator> NewFBSCodeGenerator(bool no_log = false);
 
 }  // namespace flatbuffers
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -105,6 +105,7 @@ cc_test(
     includes = [
         "",
         "include/",
+        "//src",
     ],
     deps = [
         ":alignment_test_cc_fbs",
@@ -113,6 +114,7 @@ cc_test(
         ":monster_test_cc_fbs",
         ":native_type_test_cc_fbs",
         "//:flatbuffers",
+        "//src:flatbuffers",
     ],
 )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -105,7 +105,6 @@ cc_test(
     includes = [
         "",
         "include/",
-        "//src",
     ],
     deps = [
         ":alignment_test_cc_fbs",
@@ -114,7 +113,7 @@ cc_test(
         ":monster_test_cc_fbs",
         ":native_type_test_cc_fbs",
         "//:flatbuffers",
-        "//src:flatbuffers",
+        "//src:generate_fbs",
     ],
 )
 

--- a/tests/test_assert.h
+++ b/tests/test_assert.h
@@ -17,6 +17,7 @@
 #endif
 
 #define TEST_EQ(exp, val) TestEq(exp, val, "'" #exp "' != '" #val "'", __FILE__, __LINE__, "")
+#define TEST_NE(exp, val) TestNe(exp, val, "'" #exp "' == '" #val "'", __FILE__, __LINE__, "")
 #define TEST_ASSERT(val)  TestEq(true, !!(val), "'" "true" "' != '" #val "'", __FILE__, __LINE__, "")
 #define TEST_NOTNULL(val) TestEq(true, (val) != nullptr, "'" "nullptr" "' == '" #val "'", __FILE__, __LINE__, "")
 #define TEST_EQ_STR(exp, val) TestEqStr(exp, val, "'" #exp "' != '" #val "'", __FILE__, __LINE__, "")
@@ -102,6 +103,26 @@ inline void TestEq<std::string, std::string>(std::string expval,
                                              const char *file, int line,
                                              const char *func) {
   if (expval != val) {
+    TestFail(expval.c_str(), val.c_str(), exp, file, line, func);
+  }
+}
+
+template<typename T, typename U>
+void TestNe(T expval, U val, const char *exp, const char *file, int line,
+            const char *func) {
+  if (static_cast<U>(expval) == val) {
+    TestFail(flatbuffers::NumToString(scalar_as_underlying(expval)).c_str(),
+             flatbuffers::NumToString(scalar_as_underlying(val)).c_str(), exp,
+             file, line, func);
+  }
+}
+
+template<>
+inline void TestNe<std::string, std::string>(std::string expval,
+                                             std::string val, const char *exp,
+                                             const char *file, int line,
+                                             const char *func) {
+  if (expval == val) {
     TestFail(expval.c_str(), val.c_str(), exp, file, line, func);
   }
 }


### PR DESCRIPTION
Whenever `flattest` was ran, it was printing errors out to `stderr` as part of the test. Added the ability to inject a no log to the FBS generator to suppress this.