### PR TITLE
Fix //tests/ts:bazel_repository_test

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -148,6 +148,7 @@ esbuild_register_toolchains(
 http_file(
     name = "bazel_linux_x86_64",
     downloaded_file_path = "bazel",
+    executable = True,
     sha256 = "e89747d63443e225b140d7d37ded952dacea73aaed896bca01ccd745827c6289",
     urls = [
         "https://github.com/bazelbuild/bazel/releases/download/6.1.2/bazel-6.1.2-linux-x86_64",

--- a/tests/ts/bazel_repository_test.sh
+++ b/tests/ts/bazel_repository_test.sh
@@ -17,7 +17,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 BAZEL_BIN="$(rlocation bazel_linux_x86_64/file/bazel)"
 readonly BAZEL_BIN
 
-if [[ ! -e "${BAZEL_BIN}" ]]; then
+if [[ ! -x "${BAZEL_BIN}" ]]; then
     echo "Failed to find the bazel binary." >&2
     exit 1
 fi


### PR DESCRIPTION
The test was not actually invoking the bazel that was downloaded with
the `http_file` rule. I failed to add `executable = True` to the
`http_file` call. This caused the test to ignore that bazel binary and
went to the next one on the system.

This patch fixes the issue by adding the missing attribute. Also, this
patch changes the check in the test to make sure that the downloaded
file is indeed executable.

Fixes #7937 