### PR TITLE
fix(TS): fixed incorrect function name when importing unionTo functions

### DIFF
--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -849,8 +849,8 @@ class TsGenerator : public BaseGenerator {
     }
 
     if (enum_def.is_union) {
-      symbols_expression += ", unionTo" + name;
-      symbols_expression += ", unionListTo" + name;
+      symbols_expression += (", " + namer_.Function("unionTo" + name));
+      symbols_expression += (", " + namer_.Function("unionListTo" + name));
     }
 
     return symbols_expression;


### PR DESCRIPTION
![image](https://github.com/google/flatbuffers/assets/4926092/ad41fe02-1a1c-40b0-8004-aa03217ac4c9)

The function name `unionListToSomeType` in the import statement is incorrect. We should use `namer_` to obtain the correct name.