### PR TITLE
don't emit flatbuffers include in bfbs generated output

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -377,10 +377,8 @@ class CppGenerator : public BaseGenerator {
         code_ += "#pragma clang system_header\n\n";
       }
 
-      code_ += "#include \"flatbuffers/flatbuffers.h\"";
-      code_ += "";
-      GenFlatbuffersVersionCheck();
-      code_ += "";
+      code_ += "#include <cstddef>";
+      code_ += "#include <cstdint>";
 
       SetNameSpace(struct_def.defined_namespace);
       auto name = Name(struct_def);

--- a/tests/64bit/test_64bit_bfbs_generated.h
+++ b/tests/64bit/test_64bit_bfbs_generated.h
@@ -4,15 +4,8 @@
 #ifndef FLATBUFFERS_GENERATED_TEST64BIT_BFBS_H_
 #define FLATBUFFERS_GENERATED_TEST64BIT_BFBS_H_
 
-#include "flatbuffers/flatbuffers.h"
-
-// Ensure the included flatbuffers.h is the same version as when this file was
-// generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 5 &&
-              FLATBUFFERS_VERSION_REVISION == 9,
-             "Non-compatible flatbuffers version included");
-
+#include <cstddef>
+#include <cstdint>
 struct RootTableBinarySchema {
   static const uint8_t *data() {
     // Buffer containing the binary schema.

--- a/tests/monster_test_bfbs_generated.h
+++ b/tests/monster_test_bfbs_generated.h
@@ -4,15 +4,8 @@
 #ifndef FLATBUFFERS_GENERATED_MONSTERTEST_MYGAME_EXAMPLE_BFBS_H_
 #define FLATBUFFERS_GENERATED_MONSTERTEST_MYGAME_EXAMPLE_BFBS_H_
 
-#include "flatbuffers/flatbuffers.h"
-
-// Ensure the included flatbuffers.h is the same version as when this file was
-// generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 5 &&
-              FLATBUFFERS_VERSION_REVISION == 9,
-             "Non-compatible flatbuffers version included");
-
+#include <cstddef>
+#include <cstdint>
 namespace MyGame {
 namespace Example {
 


### PR DESCRIPTION
Only basic types are in the generated output, so we don't need to do the whole include of flatbuffers and version check.