### PR TITLE
[Kotlin] Add java source on benchmark module instead of using version…

### DIFF
--- a/kotlin/benchmark/build.gradle.kts
+++ b/kotlin/benchmark/build.gradle.kts
@@ -55,13 +55,13 @@ kotlin {
         implementation(kotlin("stdlib-common"))
         implementation(project(":flatbuffers-kotlin"))
         implementation(libs.kotlinx.benchmark.runtime)
-        implementation("com.google.flatbuffers:flatbuffers-java:23.5.9")
         // json serializers
         implementation(libs.moshi.kotlin)
         implementation(libs.gson)
       }
       kotlin.srcDir("src/jvmMain/generated/kotlin/")
       kotlin.srcDir("src/jvmMain/generated/java/")
+      kotlin.srcDir("../../java/src/main/java")
     }
   }
 }


### PR DESCRIPTION
… jar

By using specific jar version to use java's runtime on the benchmark module we let CI break when new versions are released. So we are using source directly instead