### PR TITLE
[Rust] Adding builder methods for chaining setter calls

### DIFF
--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -2155,6 +2155,22 @@ class RustGenerator : public BaseGenerator {
         code_ += "  {{FUNC_BODY}}({{FIELD_OFFSET}}, {{FIELD}});";
       }
       code_ += "}";
+
+      // Generate functions to set data, consuming and returning the builder,
+      // allowing for chaining calls. These take one of two forms.
+      code_ += "#[inline]";
+      code_ +=
+          "pub fn {{FIELD}}(self, {{FIELD}}: "
+          "{{FIELD_TYPE}}) -> Self {";
+      if (is_scalar && !field.IsOptional()) {
+        code_ +=
+            "  {{FUNC_BODY}}({{FIELD_OFFSET}}, {{FIELD}}, "
+            "{{BLDR_DEF_VAL}});";
+      } else {
+        code_ += "  {{FUNC_BODY}}({{FIELD_OFFSET}}, {{FIELD}});";
+      }
+      code_ += "  self";
+      code_ += "}";
     });
 
     // Struct initializer (all fields required);


### PR DESCRIPTION
This adds the changes, proposed in  #7980.

Generated code for builders now also includes:

```rs
impl<'a: 'b, 'b> MonsterBuilderNew<'a, 'b> {
  #[inline]
  pub fn mana(self, mana: i16) -> Self {
    self.fbb_.push_slot::<i16>(Monster::VT_MANA, mana, 150);
    self
  }
  #[inline]
  pub fn hp(self, hp: i16) -> Self {
    self.fbb_.push_slot::<i16>(Monster::VT_HP, hp, 100);
    self
  }
  #[inline]
  pub fn name(self, name: flatbuffers::WIPOffset<&'b  str>) -> Self {
    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Monster::VT_NAME, name);
    self
  }
```

The difference between the example code in the issue and what's implemented in this branch is methods are just `self` instead of `mut self`.