### PR TITLE
Fix clang `-Wdocumentation` warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,7 @@ else()
 
       # This isn't working for some reason: $<$<CXX_COMPILER_ID:CLANG>:
       $<$<BOOL:${IS_CLANG}>:
+        -Wdocumentation
         -Wnewline-eof
         -Wno-unknown-warning-option
         -Wmissing-declarations

--- a/include/flatbuffers/flatbuffer_builder.h
+++ b/include/flatbuffers/flatbuffer_builder.h
@@ -1371,7 +1371,6 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const char pointer to the data to be stored as a string.
   /// @param[in] len The number of bytes that should be stored from `str`.
-  /// @return Returns the offset in the buffer where the string starts.
   void CreateStringImpl(const char *str, size_t len) {
     NotNested();
     PreAlign<uoffset_t>(len + 1);  // Always 0-terminated.


### PR DESCRIPTION
When I build a program that includes a flatc-generated C++ header file with the `-Wdocumentation` option enabled, I get the following warning:
```
flatbuffers/include/flatbuffers/flatbuffer_builder.h:1374:8: error: '@return' command
      used in a comment that is attached to a function returning void [-Werror,-Wdocumentation]
  /// @return Returns the offset in the buffer where the string starts.
      ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

This pull request removes the warned line and enables the `-Wdocumentation` option.