### PR TITLE
Fix warning C4619 regarding C4351 in Visual Studio 2015 or later

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -361,7 +361,9 @@ inline bool VerifyAlignmentRequirements(size_t align, size_t min_align = 1) {
 }
 
 #if defined(_MSC_VER)
-  #pragma warning(disable: 4351) // C4351: new behavior: elements of array ... will be default initialized
+  #if _MSC_VER < 1900
+    #pragma warning(disable: 4351) // C4351: new behavior: elements of array ... will be default initialized
+  #endif
   #pragma warning(push)
   #pragma warning(disable: 4127) // C4127: conditional expression is constant
 #endif


### PR DESCRIPTION
When I build a flatc-generated C++ header in a project with a higher warning level using Visual Studio 2022, I get warning C4619 regarding C4351.

```
1>C:\flatbuffers\include\flatbuffers/base.h(364,11): error C2220: the following warning is treated as an error
1>C:\flatbuffers\include\flatbuffers/base.h(364,11): warning C4619: #pragma warning: there is no warning number '4351'
```

The 'C4351' option appears to be obsolete in Visual Studio 2015 and later. This pull request prevents C4619 from occurring in Visual Studio 2015 and later.

Related comment: https://github.com/google/flatbuffers/pull/5938#issuecomment-636943389