### PR TITLE
Fixed native_type generating wrong C++ code.

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -3187,7 +3187,10 @@ class CppGenerator : public BaseGenerator {
             const auto pack_name = struct_attrs.Lookup("native_type_pack_name");
             if (pack_name) { unpack_call += pack_name->constant; }
             unpack_call += "(*" + val + ")";
-            return unpack_call;
+            if (invector || afield.native_inline) { return unpack_call; }
+            const auto name = native_type->constant;
+            const auto ptype = GenTypeNativePtr(name, &afield, true);
+            return ptype + "(new " + name + "(" + unpack_call + "))";
           } else if (invector || afield.native_inline) {
             return "*" + val;
           } else {
@@ -3575,7 +3578,7 @@ class CppGenerator : public BaseGenerator {
             const auto pack_name =
                 struct_attribs.Lookup("native_type_pack_name");
             if (pack_name) { code += pack_name->constant; }
-            code += "(" + value + ")";
+            code += (field.native_inline ? "(" : "(*") + value + ")";
           } else if (field.native_inline) {
             code += "&" + value;
           } else {

--- a/tests/native_type_test.fbs
+++ b/tests/native_type_test.fbs
@@ -15,6 +15,8 @@ struct Vector3DAlt (native_type:"Native::Vector3D", native_type_pack_name:"Vecto
 }
 
 table ApplicationData {
+  position:Vector3D;
+  position_native:Vector3D("native_inline");
   vectors:[Vector3D];
   vectors_alt:[Vector3DAlt];
 }

--- a/tests/native_type_test_generated.h
+++ b/tests/native_type_test_generated.h
@@ -115,8 +115,14 @@ FLATBUFFERS_STRUCT_END(Vector3DAlt, 12);
 
 struct ApplicationDataT : public ::flatbuffers::NativeTable {
   typedef ApplicationData TableType;
+  std::unique_ptr<Native::Vector3D> position{};
+  Native::Vector3D position_native{};
   std::vector<Native::Vector3D> vectors{};
   std::vector<Native::Vector3D> vectors_alt{};
+  ApplicationDataT() = default;
+  ApplicationDataT(const ApplicationDataT &o);
+  ApplicationDataT(ApplicationDataT&&) FLATBUFFERS_NOEXCEPT = default;
+  ApplicationDataT &operator=(ApplicationDataT o) FLATBUFFERS_NOEXCEPT;
 };
 
 struct ApplicationData FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
@@ -126,9 +132,23 @@ struct ApplicationData FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return ApplicationDataTypeTable();
   }
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_VECTORS = 4,
-    VT_VECTORS_ALT = 6
+    VT_POSITION = 4,
+    VT_POSITION_NATIVE = 6,
+    VT_VECTORS = 8,
+    VT_VECTORS_ALT = 10
   };
+  const Geometry::Vector3D *position() const {
+    return GetStruct<const Geometry::Vector3D *>(VT_POSITION);
+  }
+  Geometry::Vector3D *mutable_position() {
+    return GetStruct<Geometry::Vector3D *>(VT_POSITION);
+  }
+  const Geometry::Vector3D *position_native() const {
+    return GetStruct<const Geometry::Vector3D *>(VT_POSITION_NATIVE);
+  }
+  Geometry::Vector3D *mutable_position_native() {
+    return GetStruct<Geometry::Vector3D *>(VT_POSITION_NATIVE);
+  }
   const ::flatbuffers::Vector<const Geometry::Vector3D *> *vectors() const {
     return GetPointer<const ::flatbuffers::Vector<const Geometry::Vector3D *> *>(VT_VECTORS);
   }
@@ -143,6 +163,8 @@ struct ApplicationData FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
+           VerifyField<Geometry::Vector3D>(verifier, VT_POSITION, 4) &&
+           VerifyField<Geometry::Vector3D>(verifier, VT_POSITION_NATIVE, 4) &&
            VerifyOffset(verifier, VT_VECTORS) &&
            verifier.VerifyVector(vectors()) &&
            VerifyOffset(verifier, VT_VECTORS_ALT) &&
@@ -158,6 +180,12 @@ struct ApplicationDataBuilder {
   typedef ApplicationData Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
+  void add_position(const Geometry::Vector3D *position) {
+    fbb_.AddStruct(ApplicationData::VT_POSITION, position);
+  }
+  void add_position_native(const Geometry::Vector3D *position_native) {
+    fbb_.AddStruct(ApplicationData::VT_POSITION_NATIVE, position_native);
+  }
   void add_vectors(::flatbuffers::Offset<::flatbuffers::Vector<const Geometry::Vector3D *>> vectors) {
     fbb_.AddOffset(ApplicationData::VT_VECTORS, vectors);
   }
@@ -177,27 +205,50 @@ struct ApplicationDataBuilder {
 
 inline ::flatbuffers::Offset<ApplicationData> CreateApplicationData(
     ::flatbuffers::FlatBufferBuilder &_fbb,
+    const Geometry::Vector3D *position = nullptr,
+    const Geometry::Vector3D *position_native = nullptr,
     ::flatbuffers::Offset<::flatbuffers::Vector<const Geometry::Vector3D *>> vectors = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<const Geometry::Vector3DAlt *>> vectors_alt = 0) {
   ApplicationDataBuilder builder_(_fbb);
   builder_.add_vectors_alt(vectors_alt);
   builder_.add_vectors(vectors);
+  builder_.add_position_native(position_native);
+  builder_.add_position(position);
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<ApplicationData> CreateApplicationDataDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
+    const Geometry::Vector3D *position = nullptr,
+    const Geometry::Vector3D *position_native = nullptr,
     const std::vector<Geometry::Vector3D> *vectors = nullptr,
     const std::vector<Geometry::Vector3DAlt> *vectors_alt = nullptr) {
   auto vectors__ = vectors ? _fbb.CreateVectorOfStructs<Geometry::Vector3D>(*vectors) : 0;
   auto vectors_alt__ = vectors_alt ? _fbb.CreateVectorOfStructs<Geometry::Vector3DAlt>(*vectors_alt) : 0;
   return Geometry::CreateApplicationData(
       _fbb,
+      position,
+      position_native,
       vectors__,
       vectors_alt__);
 }
 
 ::flatbuffers::Offset<ApplicationData> CreateApplicationData(::flatbuffers::FlatBufferBuilder &_fbb, const ApplicationDataT *_o, const ::flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
+inline ApplicationDataT::ApplicationDataT(const ApplicationDataT &o)
+      : position((o.position) ? new Native::Vector3D(*o.position) : nullptr),
+        position_native(o.position_native),
+        vectors(o.vectors),
+        vectors_alt(o.vectors_alt) {
+}
+
+inline ApplicationDataT &ApplicationDataT::operator=(ApplicationDataT o) FLATBUFFERS_NOEXCEPT {
+  std::swap(position, o.position);
+  std::swap(position_native, o.position_native);
+  std::swap(vectors, o.vectors);
+  std::swap(vectors_alt, o.vectors_alt);
+  return *this;
+}
 
 inline ApplicationDataT *ApplicationData::UnPack(const ::flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::unique_ptr<ApplicationDataT>(new ApplicationDataT());
@@ -208,6 +259,8 @@ inline ApplicationDataT *ApplicationData::UnPack(const ::flatbuffers::resolver_f
 inline void ApplicationData::UnPackTo(ApplicationDataT *_o, const ::flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
+  { auto _e = position(); if (_e) _o->position = std::unique_ptr<Native::Vector3D>(new Native::Vector3D(::flatbuffers::UnPack(*_e))); }
+  { auto _e = position_native(); if (_e) _o->position_native = ::flatbuffers::UnPack(*_e); }
   { auto _e = vectors(); if (_e) { _o->vectors.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->vectors[_i] = ::flatbuffers::UnPack(*_e->Get(_i)); } } else { _o->vectors.resize(0); } }
   { auto _e = vectors_alt(); if (_e) { _o->vectors_alt.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->vectors_alt[_i] = ::flatbuffers::UnPackVector3DAlt(*_e->Get(_i)); } } else { _o->vectors_alt.resize(0); } }
 }
@@ -220,10 +273,14 @@ inline ::flatbuffers::Offset<ApplicationData> CreateApplicationData(::flatbuffer
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const ApplicationDataT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _position = ::flatbuffers::Pack(*_o->position);
+  auto _position_native = ::flatbuffers::Pack(_o->position_native);
   auto _vectors = _o->vectors.size() ? _fbb.CreateVectorOfNativeStructs<Geometry::Vector3D, Native::Vector3D>(_o->vectors) : 0;
   auto _vectors_alt = _o->vectors_alt.size() ? _fbb.CreateVectorOfNativeStructs<Geometry::Vector3DAlt, Native::Vector3D>(_o->vectors_alt, ::flatbuffers::PackVector3DAlt) : 0;
   return Geometry::CreateApplicationData(
       _fbb,
+      &_position,
+      &_position_native,
       _vectors,
       _vectors_alt);
 }
@@ -266,6 +323,8 @@ inline const ::flatbuffers::TypeTable *Vector3DAltTypeTable() {
 
 inline const ::flatbuffers::TypeTable *ApplicationDataTypeTable() {
   static const ::flatbuffers::TypeCode type_codes[] = {
+    { ::flatbuffers::ET_SEQUENCE, 0, 0 },
+    { ::flatbuffers::ET_SEQUENCE, 0, 0 },
     { ::flatbuffers::ET_SEQUENCE, 1, 0 },
     { ::flatbuffers::ET_SEQUENCE, 1, 1 }
   };
@@ -274,11 +333,13 @@ inline const ::flatbuffers::TypeTable *ApplicationDataTypeTable() {
     Geometry::Vector3DAltTypeTable
   };
   static const char * const names[] = {
+    "position",
+    "position_native",
     "vectors",
     "vectors_alt"
   };
   static const ::flatbuffers::TypeTable tt = {
-    ::flatbuffers::ST_TABLE, 2, type_codes, type_refs, nullptr, nullptr, names
+    ::flatbuffers::ST_TABLE, 4, type_codes, type_refs, nullptr, nullptr, names
   };
   return &tt;
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -784,6 +784,9 @@ void FixedLengthArrayTest() {
   (void)ap;
   for (size_t i = 0; i < arr_size; ++i) { TEST_EQ(non_zero_memory[i], 0); }
 }
+#  if defined(_MSC_VER) && defined(_DEBUG)
+#    undef new
+#  endif
 #else
 void FixedLengthArrayTest() {}
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1700
@@ -891,8 +894,8 @@ void NativeTypeTest() {
   const int N = 3;
 
   Geometry::ApplicationDataT src_data;
-  src_data.position =
-      std::make_unique<Native::Vector3D>(Native::Vector3D(1.0f, 2.0f, 3.0f));
+  src_data.position = flatbuffers::unique_ptr<Native::Vector3D>(
+      new Native::Vector3D(1.0f, 2.0f, 3.0f));
   src_data.position_native = Native::Vector3D(4.0f, 5.0f, 6.0f);
   src_data.vectors.reserve(N);
   src_data.vectors_alt.reserve(N);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -891,6 +891,9 @@ void NativeTypeTest() {
   const int N = 3;
 
   Geometry::ApplicationDataT src_data;
+  src_data.position =
+      std::make_unique<Native::Vector3D>(Native::Vector3D(1.0f, 2.0f, 3.0f));
+  src_data.position_native = Native::Vector3D(4.0f, 5.0f, 6.0f);
   src_data.vectors.reserve(N);
   src_data.vectors_alt.reserve(N);
 
@@ -917,6 +920,13 @@ void NativeTypeTest() {
     TEST_EQ(v2.y, 20 * i + 0.2f);
     TEST_EQ(v2.z, 20 * i + 0.3f);
   }
+
+  TEST_EQ(dstDataT->position->x, 1.0f);
+  TEST_EQ(dstDataT->position->y, 2.0f);
+  TEST_EQ(dstDataT->position->z, 3.0f);
+  TEST_EQ(dstDataT->position_native.x, 4.0f);
+  TEST_EQ(dstDataT->position_native.y, 5.0f);
+  TEST_EQ(dstDataT->position_native.z, 6.0f);
 }
 
 // Guard against -Wunused-function on platforms without file tests.


### PR DESCRIPTION
native_type generated C++ code that couldn't be compiled when used without native_inline.

Related to issue #6770, which never got fixed. 

Before, a schema like this would generate code that couldn't be compiled:
```
native_include "native_type_test_impl.h";

namespace Geometry;

struct Vector3D (native_type:"Native::Vector3D") {
  x:float;
  y:float;
  z:float;
}

table ApplicationData {
  position:Vector3D;
}

root_type ApplicationData;
```

Using the `Vector3D` as an array or with the "native_inline" attribute did work as expected.
I've added some code to the C++ generator to fix the issue so it works by itself. It has to create a `unique_ptr` correctly when unpacking and de-referencing one when packing. 

I also added some test cases for the `native_type`, one with the `native_inline` attribute and one without to `NativeTypeTest`.