### PR TITLE
[Go] [Python] Support union underlying type for Go and Python.

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -1383,7 +1383,11 @@ class GoGenerator : public BaseGenerator {
       #undef FLATBUFFERS_TD
     };
     // clang-format on
-    return ctypename[type.base_type];
+    const Type *actual_type = &type;
+    if (type.enum_def != nullptr) {
+      actual_type = &type.enum_def->underlying_type;
+    }
+    return ctypename[actual_type->base_type];
   }
 
   std::string GenTypePointer(const Type &type) {

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -1945,8 +1945,12 @@ class PythonGenerator : public BaseGenerator {
       #undef FLATBUFFERS_TD
     };
     // clang-format on
-    return ctypename[IsArray(type) ? type.VectorType().base_type
-                                   : type.base_type];
+    const Type *actual_type = &type;
+    if (type.enum_def != nullptr) {
+      actual_type = &type.enum_def->underlying_type;
+    }
+    return ctypename[IsArray(*actual_type) ? actual_type->VectorType().base_type
+                                           : actual_type->base_type];
   }
 
   std::string GenTypePointer(const Type &type) const {

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2719,8 +2719,9 @@ bool Parser::Supports64BitOffsets() const {
 }
 
 bool Parser::SupportsUnionUnderlyingType() const {
-    return (opts.lang_to_generate & ~(IDLOptions::kCpp | IDLOptions::kTs |
-         IDLOptions::kBinary)) == 0;
+    return (opts.lang_to_generate &
+            ~(IDLOptions::kBinary | IDLOptions::kCpp | IDLOptions::kJsonSchema |
+              IDLOptions::kGo | IDLOptions::kPython | IDLOptions::kTs)) == 0;
 }
 
 Namespace *Parser::UniqueNamespace(Namespace *ns) {

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2719,9 +2719,9 @@ bool Parser::Supports64BitOffsets() const {
 }
 
 bool Parser::SupportsUnionUnderlyingType() const {
-    return (opts.lang_to_generate &
-            ~(IDLOptions::kBinary | IDLOptions::kCpp | IDLOptions::kJsonSchema |
-              IDLOptions::kGo | IDLOptions::kPython | IDLOptions::kTs)) == 0;
+  return (opts.lang_to_generate &
+          ~(IDLOptions::kBinary | IDLOptions::kCpp | IDLOptions::kJsonSchema |
+            IDLOptions::kGo | IDLOptions::kPython | IDLOptions::kTs)) == 0;
 }
 
 Namespace *Parser::UniqueNamespace(Namespace *ns) {


### PR DESCRIPTION
This PR adds support for using union underlying type in Go and Python.

I've manually tested the codes on my local machine, but I'm not sure how to add corresponding test cases to this project.