### PR TITLE
Fix TS generation segfault with specific schema file

### DIFF
--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -902,10 +902,14 @@ class TsGenerator : public BaseGenerator {
     std::string bare_file_path;
     std::string rel_file_path;
     const auto &dep_comps = dependent.defined_namespace->components;
-    for (size_t i = 0; i < dep_comps.size(); i++) {
-      rel_file_path += i == 0 ? ".." : (kPathSeparator + std::string(".."));
+    if (dependent.defined_namespace == nullptr || dep_comps.size() == 0) {
+        rel_file_path += ".";
+    } else {
+        for (size_t i = 0; i < dep_comps.size(); i++) {
+            rel_file_path += i == 0 ? ".." : (kPathSeparator + std::string(".."));
+        }
     }
-    if (dep_comps.size() == 0) { rel_file_path += "."; }
+    
 
     bare_file_path +=
         kPathSeparator +

--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -903,13 +903,12 @@ class TsGenerator : public BaseGenerator {
     std::string rel_file_path;
     const auto &dep_comps = dependent.defined_namespace->components;
     if (dependent.defined_namespace == nullptr || dep_comps.size() == 0) {
-        rel_file_path += ".";
+      rel_file_path += ".";
     } else {
-        for (size_t i = 0; i < dep_comps.size(); i++) {
-            rel_file_path += i == 0 ? ".." : (kPathSeparator + std::string(".."));
-        }
+      for (size_t i = 0; i < dep_comps.size(); i++) {
+        rel_file_path += i == 0 ? ".." : (kPathSeparator + std::string(".."));
+      }
     }
-    
 
     bare_file_path +=
         kPathSeparator +


### PR DESCRIPTION
I've found that `flatc` segfaults when generating TypeScript for the following schema:

```
enum ExampleEnum : byte { Value = 0 }

struct ExampleInnerStruct {
    example_enum: ExampleEnum;
}

struct ExampleOuterStruct {
    width: ExampleInnerStruct;
}

table UnrelatedTable {
  
}

root_type UnrelatedTable;
```

When debugging I found the issue was that `dependent.defined_namespace` is null, and so attempts to use `dependent.defined_namespace->components.size()` fail.

This PR simply adds a check to see if `defined_namespace` is null or not. I'm really not familiar with the code here so it might be that the _actual_ answer here is finding out why `defined_namespace` is null in the first place. But this change has gotten things back up and running for me.