### PR TITLE
Table string getter returns a bytes type

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -375,7 +375,7 @@ class PythonGenerator : public BaseGenerator {
     code += namer_.Method(field);
 
     if (parser_.opts.python_typing) {
-      code += "(self) -> Optional[str]:";
+      code += "(self) -> Optional[bytes]:";
       imports.insert(ImportMapEntry{ "typing", "Optional" });
     } else {
       code += "(self):";

--- a/tests/MyGame/Example/NestedUnion/NestedUnionTest.py
+++ b/tests/MyGame/Example/NestedUnion/NestedUnionTest.py
@@ -28,7 +28,7 @@ class NestedUnionTest(object):
         self._tab = flatbuffers.table.Table(buf, pos)
 
     # NestedUnionTest
-    def Name(self) -> Optional[str]:
+    def Name(self) -> Optional[bytes]:
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.String(o + self._tab.Pos)


### PR DESCRIPTION
The getter for string values in the Table actually returns bytes, not str.