### PR TITLE
[Swift] Overall Improvements 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.6
 /*
  * Copyright 2020 Google Inc. All rights reserved.
  *
@@ -32,6 +32,5 @@ let package = Package(
     .target(
       name: "FlatBuffers",
       dependencies: [],
-      path: "swift/Sources",
-      exclude: ["Documentation.docc/Resources/code/swift"]),
+      path: "swift/Sources"),
   ])

--- a/tests/swift/tests/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
+++ b/tests/swift/tests/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersMonsterWriterTests.swift
@@ -154,6 +154,64 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
           byteBuffer: &byteBuffer) as MyGame_Example_Monster))
   }
 
+  func testUnalignedRead() {
+    // Aligned read
+    let fbb = createMonster(withPrefix: false)
+    let testAligned: () -> Bool = {
+      var buffer = fbb.sizedBuffer
+      var monster: Monster = getRoot(byteBuffer: &buffer)
+      self.readFlatbufferMonster(monster: &monster)
+      return true
+    }
+    XCTAssertEqual(testAligned(), true)
+    let testUnaligned: () -> Bool = {
+      var bytes: [UInt8] = [0x00]
+      bytes.append(contentsOf: fbb.sizedByteArray)
+      return bytes.withUnsafeMutableBytes { ptr in
+        guard var baseAddress = ptr.baseAddress else {
+          XCTFail("Base pointer is not defined")
+          return false
+        }
+        baseAddress = baseAddress.advanced(by: 1)
+        let unlignedPtr = UnsafeMutableRawPointer(baseAddress)
+        var bytes = ByteBuffer(
+          assumingMemoryBound: unlignedPtr,
+          capacity: ptr.count - 1,
+          allowReadingUnalignedBuffers: true)
+        var monster: Monster = getRoot(byteBuffer: &bytes)
+        self.readFlatbufferMonster(monster: &monster)
+        return true
+      }
+    }
+    XCTAssertEqual(testUnaligned(), true)
+  }
+
+  func testCopyUnalignedToAlignedBuffers() {
+    // Aligned read
+    let fbb = createMonster(withPrefix: true)
+    let testUnaligned: () -> Bool = {
+      var bytes: [UInt8] = [0x00]
+      bytes.append(contentsOf: fbb.sizedByteArray)
+      return bytes.withUnsafeMutableBytes { ptr in
+        guard var baseAddress = ptr.baseAddress else {
+          XCTFail("Base pointer is not defined")
+          return false
+        }
+        baseAddress = baseAddress.advanced(by: 1)
+        let unlignedPtr = UnsafeMutableRawPointer(baseAddress)
+        let bytes = ByteBuffer(
+          assumingMemoryBound: unlignedPtr,
+          capacity: ptr.count - 1,
+          allowReadingUnalignedBuffers: false)
+        var newBuf = FlatBuffersUtils.removeSizePrefix(bb: bytes)
+        var monster: Monster = getRoot(byteBuffer: &newBuf)
+        self.readFlatbufferMonster(monster: &monster)
+        return true
+      }
+    }
+    XCTAssertEqual(testUnaligned(), true)
+  }
+
   func readMonster(monster: Monster) {
     var monster = monster
     readFlatbufferMonster(monster: &monster)


### PR DESCRIPTION
The following PR adds the following:
- Removes a warning that has shown up within Xcode 15, and swift 5.9. Closes #8064

Benchmarks are impressive compared to what we used to have:

Updated code:

```
running 10Strings... done! (1522.66 ms)
running 100Strings... done! (1781.41 ms)
running FlatBufferBuilder.add... done! (1542.41 ms)
running structs... done! (1478.57 ms)
```

Old code:

```
running 10Strings... done! (1422.76 ms)
running 100Strings... done! (1705.70 ms)
running FlatBufferBuilder.add... done! (2309.38 ms)
running structs... done! (2305.26 ms)
```

- Upgrades minimum version of swift to 5.5
- Allow reading unaligned buffers starting from swift 5.7, while keeping the creating aligned since it's created by the library.

Unfortunately, swift package manager doesn't allow custom compiler flags so I had to use a normal if statement to resolve this. the flag is false by default so it shouldn't be an issue most of the time, however when needed users can enable it like this:

```
var buffer = ByteBuffer(data: dataFromInternet)
buffer.readUnalignedBuffers = true
...
```

@mr-swifter @ser-0xff @hassila a quick review here would be nice!