### PR TITLE
Return function to namespace

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -289,10 +289,12 @@ namespace flatbuffers {
   #define FLATBUFFERS_SUPPRESS_UBSAN(type)
 #endif
 
-// This is constexpr function used for checking compile-time constants.
-// Avoid `#pragma warning(disable: 4127) // C4127: expression is constant`.
-template<typename T> FLATBUFFERS_CONSTEXPR inline bool IsConstTrue(T t) {
-  return !!t;
+namespace flatbuffers {
+  // This is constexpr function used for checking compile-time constants.
+  // Avoid `#pragma warning(disable: 4127) // C4127: expression is constant`.
+  template<typename T> FLATBUFFERS_CONSTEXPR inline bool IsConstTrue(T t) {
+    return !!t;
+  }
 }
 
 // Enable C++ attribute [[]] if std:c++17 or higher.

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2118,7 +2118,7 @@ CheckedError Parser::ParseSingleValue(const std::string *name, Value &e,
   auto match = false;
 
   #define IF_ECHECK_(force, dtoken, check, req)    \
-    if (!match && ((dtoken) == token_) && ((check) || IsConstTrue(force))) \
+    if (!match && ((dtoken) == token_) && ((check) || flatbuffers::IsConstTrue(force))) \
       ECHECK(TryTypedValue(name, dtoken, check, e, req, &match))
   #define TRY_ECHECK(dtoken, check, req) IF_ECHECK_(false, dtoken, check, req)
   #define FORCE_ECHECK(dtoken, check, req) IF_ECHECK_(true, dtoken, check, req)

--- a/tests/test_assert.h
+++ b/tests/test_assert.h
@@ -13,7 +13,7 @@
   #define FLATBUFFERS_NO_FILE_TESTS
 #else
   #define TEST_OUTPUT_LINE(...) \
-      do { printf(__VA_ARGS__); printf("\n"); } while(!IsConstTrue(true))
+      do { printf(__VA_ARGS__); printf("\n"); } while(!flatbuffers::IsConstTrue(true))
 #endif
 
 #define TEST_EQ(exp, val) TestEq(exp, val, "'" #exp "' != '" #val "'", __FILE__, __LINE__, "")


### PR DESCRIPTION
IsConstTrue was moved out of the namespace for no apparent reason in https://github.com/google/flatbuffers/pull/5028