### PR TITLE
[Python] fixed path being ignored in GeneratePythonGRPC

### DIFF
--- a/src/idl_gen_grpc.cpp
+++ b/src/idl_gen_grpc.cpp
@@ -441,7 +441,7 @@ class PythonGRPCGenerator : public flatbuffers::BaseGenerator {
           NamespaceDir(*def->defined_namespace) + file_name_ + "_grpc_fb.py";
       return SaveFile(filename.c_str(), final_code, false);
     }
-    return true
+    return true;
   }
 };
 


### PR DESCRIPTION
Hi,

The Python gRPC code generator was ignoring `-o <output_dir>` option in `flatc`. With this, it generates all the services within the `<output_dir>` and under the correct `namespace`(s), i.e., Python sub-modules.

I had to remove the custom logic and use `BaseGenerator`'s file prefix logic, which seems to work as expected.

I believe this closes #7397.

Thanks.