### PR TITLE
Fix BUILD.bazel style violations

### DIFF
--- a/tests/ts/bazel_repository_test_dir/BUILD.bazel
+++ b/tests/ts/bazel_repository_test_dir/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_rules_js//js:defs.bzl", "js_test")
-load("@com_github_google_flatbuffers//:typescript.bzl", "flatbuffer_ts_library")
 load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
+load("@com_github_google_flatbuffers//:typescript.bzl", "flatbuffer_ts_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 
 npm_link_all_packages(name = "node_modules")

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 
 filegroup(
     name = "distribution",


### PR DESCRIPTION
`buildifier` was complaining as follows:

    #### :bazel: buildifier: found 2 lint issues in your WORKSPACE, BUILD and *.bzl files
    <pre><code>tests/ts/bazel_repository_test_dir/BUILD:3:1: <a href="https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#out-of-order-load">out-of-order-load</a>: Load statement is out of its lexicographical order.
    ts/BUILD.bazel:2:1: <a href="https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#out-of-order-load">out-of-order-load</a>: Load statement is out of its lexicographical order.</pre></code>

This can be fixed locally like so:

    $ buildifier -lint fix $(git ls-files | grep -e '/BUILD.bazel$' -e '/BUILD$' -e '\<WORKSPACE$')

I also took this opportunity to fix one of the filenames.

I accidentally introduced these errors in #8078.
