### PR TITLE
Add alwayslink=1 to //src:flatc to fix Windows build failure.

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -147,6 +147,7 @@ cc_library(
     ],
     strip_include_prefix = "/include",
     visibility = ["//:__pkg__"],
+    alwayslink = 1,
     deps = [
         ":flatc_library",
         "//grpc/src/compiler:cpp_generator",


### PR DESCRIPTION
When built on Windows, the main() symbol ends up stripped out of the //:flatc binary unless the library containing main() is tagged alwayslink=1.