### PR TITLE
Fully qualify the offset type in FLATBUFFERS_VTABLE_UNDERLYING_TYPE

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -155,7 +155,7 @@ namespace flatbuffers {
   #define FLATBUFFERS_FINAL_CLASS final
   #define FLATBUFFERS_OVERRIDE override
   #define FLATBUFFERS_EXPLICIT_CPP11 explicit
-  #define FLATBUFFERS_VTABLE_UNDERLYING_TYPE : flatbuffers::voffset_t
+  #define FLATBUFFERS_VTABLE_UNDERLYING_TYPE : ::flatbuffers::voffset_t
 #else
   #define FLATBUFFERS_FINAL_CLASS
   #define FLATBUFFERS_OVERRIDE


### PR DESCRIPTION
Currently, when the generated code is used from a namespace that contains `flatbuffers` in it, the code fails to compile due to the collision.