### PR TITLE
[Rust] Add the Allocator trait for the builder API

### DIFF
--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -48,7 +48,7 @@ mod vtable;
 mod vtable_writer;
 
 pub use crate::array::{array_init, emplace_scalar_array, Array};
-pub use crate::builder::FlatBufferBuilder;
+pub use crate::builder::{Allocator, DefaultAllocator, FlatBufferBuilder};
 pub use crate::endian_scalar::{emplace_scalar, read_scalar, read_scalar_at, EndianScalar};
 pub use crate::follow::{Follow, FollowStart};
 pub use crate::primitives::*;

--- a/samples/rust_generated/my_game/sample/equipment_generated.rs
+++ b/samples/rust_generated/my_game/sample/equipment_generated.rs
@@ -115,7 +115,7 @@ impl EquipmentT {
       Self::Weapon(_) => Equipment::Weapon,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::Weapon(v) => Some(v.pack(fbb).as_union_value()),

--- a/samples/rust_generated/my_game/sample/monster_generated.rs
+++ b/samples/rust_generated/my_game/sample/monster_generated.rs
@@ -45,8 +45,8 @@ impl<'a> Monster<'a> {
     Monster { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args MonsterArgs<'args>
   ) -> flatbuffers::WIPOffset<Monster<'bldr>> {
     let mut builder = MonsterBuilder::new(_fbb);
@@ -246,11 +246,11 @@ impl<'a> Default for MonsterArgs<'a> {
   }
 }
 
-pub struct MonsterBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct MonsterBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> MonsterBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_pos(&mut self, pos: &Vec3) {
     self.fbb_.push_slot_always::<&Vec3>(Monster::VT_POS, pos);
@@ -292,7 +292,7 @@ impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Monster::VT_PATH, path);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> MonsterBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> MonsterBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     MonsterBuilder {
       fbb_: _fbb,
@@ -363,9 +363,9 @@ impl Default for MonsterT {
   }
 }
 impl MonsterT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Monster<'b>> {
     let pos_tmp = self.pos.as_ref().map(|x| x.pack());
     let pos = pos_tmp.as_ref();
@@ -461,13 +461,13 @@ pub unsafe fn size_prefixed_root_as_monster_unchecked(buf: &[u8]) -> Monster {
   flatbuffers::size_prefixed_root_unchecked::<Monster>(buf)
 }
 #[inline]
-pub fn finish_monster_buffer<'a, 'b>(
-    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub fn finish_monster_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
     root: flatbuffers::WIPOffset<Monster<'a>>) {
   fbb.finish(root, None);
 }
 
 #[inline]
-pub fn finish_size_prefixed_monster_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<Monster<'a>>) {
+pub fn finish_size_prefixed_monster_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>, root: flatbuffers::WIPOffset<Monster<'a>>) {
   fbb.finish_size_prefixed(root, None);
 }

--- a/samples/rust_generated/my_game/sample/weapon_generated.rs
+++ b/samples/rust_generated/my_game/sample/weapon_generated.rs
@@ -37,8 +37,8 @@ impl<'a> Weapon<'a> {
     Weapon { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args WeaponArgs<'args>
   ) -> flatbuffers::WIPOffset<Weapon<'bldr>> {
     let mut builder = WeaponBuilder::new(_fbb);
@@ -101,11 +101,11 @@ impl<'a> Default for WeaponArgs<'a> {
   }
 }
 
-pub struct WeaponBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct WeaponBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> WeaponBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> WeaponBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Weapon::VT_NAME, name);
@@ -115,7 +115,7 @@ impl<'a: 'b, 'b> WeaponBuilder<'a, 'b> {
     self.fbb_.push_slot::<i16>(Weapon::VT_DAMAGE, damage, 0);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> WeaponBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> WeaponBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     WeaponBuilder {
       fbb_: _fbb,
@@ -152,9 +152,9 @@ impl Default for WeaponT {
   }
 }
 impl WeaponT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Weapon<'b>> {
     let name = self.name.as_ref().map(|x|{
       _fbb.create_string(x)

--- a/tests/arrays_test/my_game/example/array_table_generated.rs
+++ b/tests/arrays_test/my_game/example/array_table_generated.rs
@@ -36,8 +36,8 @@ impl<'a> ArrayTable<'a> {
     ArrayTable { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args ArrayTableArgs<'args>
   ) -> flatbuffers::WIPOffset<ArrayTable<'bldr>> {
     let mut builder = ArrayTableBuilder::new(_fbb);
@@ -87,17 +87,17 @@ impl<'a> Default for ArrayTableArgs<'a> {
   }
 }
 
-pub struct ArrayTableBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct ArrayTableBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> ArrayTableBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ArrayTableBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_a(&mut self, a: &ArrayStruct) {
     self.fbb_.push_slot_always::<&ArrayStruct>(ArrayTable::VT_A, a);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ArrayTableBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> ArrayTableBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     ArrayTableBuilder {
       fbb_: _fbb,
@@ -131,9 +131,9 @@ impl Default for ArrayTableT {
   }
 }
 impl ArrayTableT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<ArrayTable<'b>> {
     let a_tmp = self.a.as_ref().map(|x| x.pack());
     let a = a_tmp.as_ref();
@@ -217,13 +217,13 @@ pub fn array_table_size_prefixed_buffer_has_identifier(buf: &[u8]) -> bool {
 pub const ARRAY_TABLE_EXTENSION: &str = "mon";
 
 #[inline]
-pub fn finish_array_table_buffer<'a, 'b>(
-    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub fn finish_array_table_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
     root: flatbuffers::WIPOffset<ArrayTable<'a>>) {
   fbb.finish(root, Some(ARRAY_TABLE_IDENTIFIER));
 }
 
 #[inline]
-pub fn finish_size_prefixed_array_table_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<ArrayTable<'a>>) {
+pub fn finish_size_prefixed_array_table_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>, root: flatbuffers::WIPOffset<ArrayTable<'a>>) {
   fbb.finish_size_prefixed(root, Some(ARRAY_TABLE_IDENTIFIER));
 }

--- a/tests/include_test1/my_game/other_name_space/table_b_generated.rs
+++ b/tests/include_test1/my_game/other_name_space/table_b_generated.rs
@@ -36,8 +36,8 @@ impl<'a> TableB<'a> {
     TableB { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TableBArgs<'args>
   ) -> flatbuffers::WIPOffset<TableB<'bldr>> {
     let mut builder = TableBBuilder::new(_fbb);
@@ -87,17 +87,17 @@ impl<'a> Default for TableBArgs<'a> {
   }
 }
 
-pub struct TableBBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableBBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableBBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TableBBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_a(&mut self, a: flatbuffers::WIPOffset<super::super::TableA<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<super::super::TableA>>(TableB::VT_A, a);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableBBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TableBBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TableBBuilder {
       fbb_: _fbb,
@@ -131,9 +131,9 @@ impl Default for TableBT {
   }
 }
 impl TableBT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TableB<'b>> {
     let a = self.a.as_ref().map(|x|{
       x.pack(_fbb)

--- a/tests/include_test1/table_a_generated.rs
+++ b/tests/include_test1/table_a_generated.rs
@@ -36,8 +36,8 @@ impl<'a> TableA<'a> {
     TableA { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TableAArgs<'args>
   ) -> flatbuffers::WIPOffset<TableA<'bldr>> {
     let mut builder = TableABuilder::new(_fbb);
@@ -87,17 +87,17 @@ impl<'a> Default for TableAArgs<'a> {
   }
 }
 
-pub struct TableABuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableABuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableABuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TableABuilder<'a, 'b, A> {
   #[inline]
   pub fn add_b(&mut self, b: flatbuffers::WIPOffset<my_game::other_name_space::TableB<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<my_game::other_name_space::TableB>>(TableA::VT_B, b);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableABuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TableABuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TableABuilder {
       fbb_: _fbb,
@@ -131,9 +131,9 @@ impl Default for TableAT {
   }
 }
 impl TableAT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TableA<'b>> {
     let b = self.b.as_ref().map(|x|{
       x.pack(_fbb)

--- a/tests/include_test2/my_game/other_name_space/table_b_generated.rs
+++ b/tests/include_test2/my_game/other_name_space/table_b_generated.rs
@@ -36,8 +36,8 @@ impl<'a> TableB<'a> {
     TableB { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TableBArgs<'args>
   ) -> flatbuffers::WIPOffset<TableB<'bldr>> {
     let mut builder = TableBBuilder::new(_fbb);
@@ -87,17 +87,17 @@ impl<'a> Default for TableBArgs<'a> {
   }
 }
 
-pub struct TableBBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableBBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableBBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TableBBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_a(&mut self, a: flatbuffers::WIPOffset<super::super::TableA<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<super::super::TableA>>(TableB::VT_A, a);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableBBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TableBBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TableBBuilder {
       fbb_: _fbb,
@@ -131,9 +131,9 @@ impl Default for TableBT {
   }
 }
 impl TableBT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TableB<'b>> {
     let a = self.a.as_ref().map(|x|{
       x.pack(_fbb)

--- a/tests/include_test2/table_a_generated.rs
+++ b/tests/include_test2/table_a_generated.rs
@@ -36,8 +36,8 @@ impl<'a> TableA<'a> {
     TableA { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TableAArgs<'args>
   ) -> flatbuffers::WIPOffset<TableA<'bldr>> {
     let mut builder = TableABuilder::new(_fbb);
@@ -87,17 +87,17 @@ impl<'a> Default for TableAArgs<'a> {
   }
 }
 
-pub struct TableABuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableABuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableABuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TableABuilder<'a, 'b, A> {
   #[inline]
   pub fn add_b(&mut self, b: flatbuffers::WIPOffset<my_game::other_name_space::TableB<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<my_game::other_name_space::TableB>>(TableA::VT_B, b);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableABuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TableABuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TableABuilder {
       fbb_: _fbb,
@@ -131,9 +131,9 @@ impl Default for TableAT {
   }
 }
 impl TableAT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TableA<'b>> {
     let b = self.b.as_ref().map(|x|{
       x.pack(_fbb)

--- a/tests/keyword_test/keyword_test/keywords_in_table_generated.rs
+++ b/tests/keyword_test/keyword_test/keywords_in_table_generated.rs
@@ -39,8 +39,8 @@ impl<'a> KeywordsInTable<'a> {
     KeywordsInTable { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args KeywordsInTableArgs
   ) -> flatbuffers::WIPOffset<KeywordsInTable<'bldr>> {
     let mut builder = KeywordsInTableBuilder::new(_fbb);
@@ -127,11 +127,11 @@ impl<'a> Default for KeywordsInTableArgs {
   }
 }
 
-pub struct KeywordsInTableBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct KeywordsInTableBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> KeywordsInTableBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> KeywordsInTableBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_is(&mut self, is: ABC) {
     self.fbb_.push_slot::<ABC>(KeywordsInTable::VT_IS, is, ABC::void);
@@ -149,7 +149,7 @@ impl<'a: 'b, 'b> KeywordsInTableBuilder<'a, 'b> {
     self.fbb_.push_slot::<bool>(KeywordsInTable::VT_DEFAULT, default, false);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> KeywordsInTableBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> KeywordsInTableBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     KeywordsInTableBuilder {
       fbb_: _fbb,
@@ -192,9 +192,9 @@ impl Default for KeywordsInTableT {
   }
 }
 impl KeywordsInTableT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<KeywordsInTable<'b>> {
     let is = self.is;
     let private = self.private;

--- a/tests/keyword_test/keyword_test/keywords_in_union_generated.rs
+++ b/tests/keyword_test/keyword_test/keywords_in_union_generated.rs
@@ -121,7 +121,7 @@ impl KeywordsInUnionT {
       Self::Internal(_) => KeywordsInUnion::internal,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::Static_(v) => Some(v.pack(fbb).as_union_value()),

--- a/tests/keyword_test/keyword_test/table_2_generated.rs
+++ b/tests/keyword_test/keyword_test/table_2_generated.rs
@@ -37,8 +37,8 @@ impl<'a> Table2<'a> {
     Table2 { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args Table2Args
   ) -> flatbuffers::WIPOffset<Table2<'bldr>> {
     let mut builder = Table2Builder::new(_fbb);
@@ -145,11 +145,11 @@ impl<'a> Default for Table2Args {
   }
 }
 
-pub struct Table2Builder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct Table2Builder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> Table2Builder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> Table2Builder<'a, 'b, A> {
   #[inline]
   pub fn add_type_type(&mut self, type_type: KeywordsInUnion) {
     self.fbb_.push_slot::<KeywordsInUnion>(Table2::VT_TYPE_TYPE, type_type, KeywordsInUnion::NONE);
@@ -159,7 +159,7 @@ impl<'a: 'b, 'b> Table2Builder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Table2::VT_TYPE_, type_);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> Table2Builder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> Table2Builder<'a, 'b, A> {
     let start = _fbb.start_table();
     Table2Builder {
       fbb_: _fbb,
@@ -213,9 +213,9 @@ impl Default for Table2T {
   }
 }
 impl Table2T {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Table2<'b>> {
     let type_type = self.type_.keywords_in_union_type();
     let type_ = self.type_.pack(_fbb);

--- a/tests/monster_test/my_game/example/any_ambiguous_aliases_generated.rs
+++ b/tests/monster_test/my_game/example/any_ambiguous_aliases_generated.rs
@@ -127,7 +127,7 @@ impl AnyAmbiguousAliasesT {
       Self::M3(_) => AnyAmbiguousAliases::M3,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::M1(v) => Some(v.pack(fbb).as_union_value()),

--- a/tests/monster_test/my_game/example/any_generated.rs
+++ b/tests/monster_test/my_game/example/any_generated.rs
@@ -127,7 +127,7 @@ impl AnyT {
       Self::MyGameExample2Monster(_) => Any::MyGame_Example2_Monster,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::Monster(v) => Some(v.pack(fbb).as_union_value()),

--- a/tests/monster_test/my_game/example/any_unique_aliases_generated.rs
+++ b/tests/monster_test/my_game/example/any_unique_aliases_generated.rs
@@ -127,7 +127,7 @@ impl AnyUniqueAliasesT {
       Self::M2(_) => AnyUniqueAliases::M2,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::M(v) => Some(v.pack(fbb).as_union_value()),

--- a/tests/monster_test/my_game/example/monster_generated.rs
+++ b/tests/monster_test/my_game/example/monster_generated.rs
@@ -97,8 +97,8 @@ impl<'a> Monster<'a> {
     Monster { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args MonsterArgs<'args>
   ) -> flatbuffers::WIPOffset<Monster<'bldr>> {
     let mut builder = MonsterBuilder::new(_fbb);
@@ -1210,11 +1210,11 @@ impl<'a> Default for MonsterArgs<'a> {
   }
 }
 
-pub struct MonsterBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct MonsterBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> MonsterBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_pos(&mut self, pos: &Vec3) {
     self.fbb_.push_slot_always::<&Vec3>(Monster::VT_POS, pos);
@@ -1460,7 +1460,7 @@ impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
     self.fbb_.push_slot::<f64>(Monster::VT_DOUBLE_INF_DEFAULT, double_inf_default, f64::INFINITY);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> MonsterBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> MonsterBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     MonsterBuilder {
       fbb_: _fbb,
@@ -1747,9 +1747,9 @@ impl Default for MonsterT {
   }
 }
 impl MonsterT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Monster<'b>> {
     let pos_tmp = self.pos.as_ref().map(|x| x.pack());
     let pos = pos_tmp.as_ref();
@@ -2003,13 +2003,13 @@ pub fn monster_size_prefixed_buffer_has_identifier(buf: &[u8]) -> bool {
 pub const MONSTER_EXTENSION: &str = "mon";
 
 #[inline]
-pub fn finish_monster_buffer<'a, 'b>(
-    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub fn finish_monster_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
     root: flatbuffers::WIPOffset<Monster<'a>>) {
   fbb.finish(root, Some(MONSTER_IDENTIFIER));
 }
 
 #[inline]
-pub fn finish_size_prefixed_monster_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<Monster<'a>>) {
+pub fn finish_size_prefixed_monster_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>, root: flatbuffers::WIPOffset<Monster<'a>>) {
   fbb.finish_size_prefixed(root, Some(MONSTER_IDENTIFIER));
 }

--- a/tests/monster_test/my_game/example/referrable_generated.rs
+++ b/tests/monster_test/my_game/example/referrable_generated.rs
@@ -36,8 +36,8 @@ impl<'a> Referrable<'a> {
     Referrable { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args ReferrableArgs
   ) -> flatbuffers::WIPOffset<Referrable<'bldr>> {
     let mut builder = ReferrableBuilder::new(_fbb);
@@ -95,17 +95,17 @@ impl<'a> Default for ReferrableArgs {
   }
 }
 
-pub struct ReferrableBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct ReferrableBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> ReferrableBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ReferrableBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_id(&mut self, id: u64) {
     self.fbb_.push_slot::<u64>(Referrable::VT_ID, id, 0);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ReferrableBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> ReferrableBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     ReferrableBuilder {
       fbb_: _fbb,
@@ -139,9 +139,9 @@ impl Default for ReferrableT {
   }
 }
 impl ReferrableT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Referrable<'b>> {
     let id = self.id;
     Referrable::create(_fbb, &ReferrableArgs{

--- a/tests/monster_test/my_game/example/stat_generated.rs
+++ b/tests/monster_test/my_game/example/stat_generated.rs
@@ -38,8 +38,8 @@ impl<'a> Stat<'a> {
     Stat { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args StatArgs<'args>
   ) -> flatbuffers::WIPOffset<Stat<'bldr>> {
     let mut builder = StatBuilder::new(_fbb);
@@ -125,11 +125,11 @@ impl<'a> Default for StatArgs<'a> {
   }
 }
 
-pub struct StatBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct StatBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> StatBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> StatBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_id(&mut self, id: flatbuffers::WIPOffset<&'b  str>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Stat::VT_ID, id);
@@ -143,7 +143,7 @@ impl<'a: 'b, 'b> StatBuilder<'a, 'b> {
     self.fbb_.push_slot::<u16>(Stat::VT_COUNT, count, 0);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> StatBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> StatBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     StatBuilder {
       fbb_: _fbb,
@@ -183,9 +183,9 @@ impl Default for StatT {
   }
 }
 impl StatT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Stat<'b>> {
     let id = self.id.as_ref().map(|x|{
       _fbb.create_string(x)

--- a/tests/monster_test/my_game/example/test_simple_table_with_enum_generated.rs
+++ b/tests/monster_test/my_game/example/test_simple_table_with_enum_generated.rs
@@ -36,8 +36,8 @@ impl<'a> TestSimpleTableWithEnum<'a> {
     TestSimpleTableWithEnum { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TestSimpleTableWithEnumArgs
   ) -> flatbuffers::WIPOffset<TestSimpleTableWithEnum<'bldr>> {
     let mut builder = TestSimpleTableWithEnumBuilder::new(_fbb);
@@ -85,17 +85,17 @@ impl<'a> Default for TestSimpleTableWithEnumArgs {
   }
 }
 
-pub struct TestSimpleTableWithEnumBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TestSimpleTableWithEnumBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TestSimpleTableWithEnumBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TestSimpleTableWithEnumBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_color(&mut self, color: Color) {
     self.fbb_.push_slot::<Color>(TestSimpleTableWithEnum::VT_COLOR, color, Color::Green);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TestSimpleTableWithEnumBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TestSimpleTableWithEnumBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TestSimpleTableWithEnumBuilder {
       fbb_: _fbb,
@@ -129,9 +129,9 @@ impl Default for TestSimpleTableWithEnumT {
   }
 }
 impl TestSimpleTableWithEnumT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TestSimpleTableWithEnum<'b>> {
     let color = self.color;
     TestSimpleTableWithEnum::create(_fbb, &TestSimpleTableWithEnumArgs{

--- a/tests/monster_test/my_game/example/type_aliases_generated.rs
+++ b/tests/monster_test/my_game/example/type_aliases_generated.rs
@@ -47,8 +47,8 @@ impl<'a> TypeAliases<'a> {
     TypeAliases { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TypeAliasesArgs<'args>
   ) -> flatbuffers::WIPOffset<TypeAliases<'bldr>> {
     let mut builder = TypeAliasesBuilder::new(_fbb);
@@ -243,11 +243,11 @@ impl<'a> Default for TypeAliasesArgs<'a> {
   }
 }
 
-pub struct TypeAliasesBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TypeAliasesBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TypeAliasesBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TypeAliasesBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_i8_(&mut self, i8_: i8) {
     self.fbb_.push_slot::<i8>(TypeAliases::VT_I8_, i8_, 0);
@@ -297,7 +297,7 @@ impl<'a: 'b, 'b> TypeAliasesBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TypeAliases::VT_VF64, vf64);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TypeAliasesBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TypeAliasesBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TypeAliasesBuilder {
       fbb_: _fbb,
@@ -364,9 +364,9 @@ impl Default for TypeAliasesT {
   }
 }
 impl TypeAliasesT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TypeAliases<'b>> {
     let i8_ = self.i8_;
     let u8_ = self.u8_;

--- a/tests/monster_test/my_game/example_2/monster_generated.rs
+++ b/tests/monster_test/my_game/example_2/monster_generated.rs
@@ -35,8 +35,8 @@ impl<'a> Monster<'a> {
     Monster { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     _args: &'args MonsterArgs
   ) -> flatbuffers::WIPOffset<Monster<'bldr>> {
     let mut builder = MonsterBuilder::new(_fbb);
@@ -70,13 +70,13 @@ impl<'a> Default for MonsterArgs {
   }
 }
 
-pub struct MonsterBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct MonsterBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> MonsterBuilder<'a, 'b, A> {
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> MonsterBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> MonsterBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     MonsterBuilder {
       fbb_: _fbb,
@@ -107,9 +107,9 @@ impl Default for MonsterT {
   }
 }
 impl MonsterT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Monster<'b>> {
     Monster::create(_fbb, &MonsterArgs{
     })

--- a/tests/monster_test/my_game/in_parent_namespace_generated.rs
+++ b/tests/monster_test/my_game/in_parent_namespace_generated.rs
@@ -35,8 +35,8 @@ impl<'a> InParentNamespace<'a> {
     InParentNamespace { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     _args: &'args InParentNamespaceArgs
   ) -> flatbuffers::WIPOffset<InParentNamespace<'bldr>> {
     let mut builder = InParentNamespaceBuilder::new(_fbb);
@@ -70,13 +70,13 @@ impl<'a> Default for InParentNamespaceArgs {
   }
 }
 
-pub struct InParentNamespaceBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct InParentNamespaceBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> InParentNamespaceBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> InParentNamespaceBuilder<'a, 'b, A> {
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> InParentNamespaceBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> InParentNamespaceBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     InParentNamespaceBuilder {
       fbb_: _fbb,
@@ -107,9 +107,9 @@ impl Default for InParentNamespaceT {
   }
 }
 impl InParentNamespaceT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<InParentNamespace<'b>> {
     InParentNamespace::create(_fbb, &InParentNamespaceArgs{
     })

--- a/tests/monster_test/my_game/other_name_space/table_b_generated.rs
+++ b/tests/monster_test/my_game/other_name_space/table_b_generated.rs
@@ -36,8 +36,8 @@ impl<'a> TableB<'a> {
     TableB { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TableBArgs<'args>
   ) -> flatbuffers::WIPOffset<TableB<'bldr>> {
     let mut builder = TableBBuilder::new(_fbb);
@@ -87,17 +87,17 @@ impl<'a> Default for TableBArgs<'a> {
   }
 }
 
-pub struct TableBBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableBBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableBBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TableBBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_a(&mut self, a: flatbuffers::WIPOffset<super::super::TableA<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<super::super::TableA>>(TableB::VT_A, a);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableBBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TableBBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TableBBuilder {
       fbb_: _fbb,
@@ -131,9 +131,9 @@ impl Default for TableBT {
   }
 }
 impl TableBT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TableB<'b>> {
     let a = self.a.as_ref().map(|x|{
       x.pack(_fbb)

--- a/tests/monster_test/table_a_generated.rs
+++ b/tests/monster_test/table_a_generated.rs
@@ -36,8 +36,8 @@ impl<'a> TableA<'a> {
     TableA { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TableAArgs<'args>
   ) -> flatbuffers::WIPOffset<TableA<'bldr>> {
     let mut builder = TableABuilder::new(_fbb);
@@ -87,17 +87,17 @@ impl<'a> Default for TableAArgs<'a> {
   }
 }
 
-pub struct TableABuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableABuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableABuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TableABuilder<'a, 'b, A> {
   #[inline]
   pub fn add_b(&mut self, b: flatbuffers::WIPOffset<my_game::other_name_space::TableB<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<my_game::other_name_space::TableB>>(TableA::VT_B, b);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableABuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TableABuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TableABuilder {
       fbb_: _fbb,
@@ -131,9 +131,9 @@ impl Default for TableAT {
   }
 }
 impl TableAT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TableA<'b>> {
     let b = self.b.as_ref().map(|x|{
       x.pack(_fbb)

--- a/tests/monster_test_serialize/my_game/example/any_ambiguous_aliases_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/any_ambiguous_aliases_generated.rs
@@ -138,7 +138,7 @@ impl AnyAmbiguousAliasesT {
       Self::M3(_) => AnyAmbiguousAliases::M3,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::M1(v) => Some(v.pack(fbb).as_union_value()),

--- a/tests/monster_test_serialize/my_game/example/any_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/any_generated.rs
@@ -138,7 +138,7 @@ impl AnyT {
       Self::MyGameExample2Monster(_) => Any::MyGame_Example2_Monster,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::Monster(v) => Some(v.pack(fbb).as_union_value()),

--- a/tests/monster_test_serialize/my_game/example/any_unique_aliases_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/any_unique_aliases_generated.rs
@@ -138,7 +138,7 @@ impl AnyUniqueAliasesT {
       Self::M2(_) => AnyUniqueAliases::M2,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::M(v) => Some(v.pack(fbb).as_union_value()),

--- a/tests/monster_test_serialize/my_game/example/monster_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/monster_generated.rs
@@ -99,8 +99,8 @@ impl<'a> Monster<'a> {
     Monster { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args MonsterArgs<'args>
   ) -> flatbuffers::WIPOffset<Monster<'bldr>> {
     let mut builder = MonsterBuilder::new(_fbb);
@@ -1437,11 +1437,11 @@ impl Serialize for Monster<'_> {
   }
 }
 
-pub struct MonsterBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct MonsterBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> MonsterBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_pos(&mut self, pos: &Vec3) {
     self.fbb_.push_slot_always::<&Vec3>(Monster::VT_POS, pos);
@@ -1687,7 +1687,7 @@ impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
     self.fbb_.push_slot::<f64>(Monster::VT_DOUBLE_INF_DEFAULT, double_inf_default, f64::INFINITY);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> MonsterBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> MonsterBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     MonsterBuilder {
       fbb_: _fbb,
@@ -1974,9 +1974,9 @@ impl Default for MonsterT {
   }
 }
 impl MonsterT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Monster<'b>> {
     let pos_tmp = self.pos.as_ref().map(|x| x.pack());
     let pos = pos_tmp.as_ref();
@@ -2230,13 +2230,13 @@ pub fn monster_size_prefixed_buffer_has_identifier(buf: &[u8]) -> bool {
 pub const MONSTER_EXTENSION: &str = "mon";
 
 #[inline]
-pub fn finish_monster_buffer<'a, 'b>(
-    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub fn finish_monster_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
     root: flatbuffers::WIPOffset<Monster<'a>>) {
   fbb.finish(root, Some(MONSTER_IDENTIFIER));
 }
 
 #[inline]
-pub fn finish_size_prefixed_monster_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<Monster<'a>>) {
+pub fn finish_size_prefixed_monster_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>, root: flatbuffers::WIPOffset<Monster<'a>>) {
   fbb.finish_size_prefixed(root, Some(MONSTER_IDENTIFIER));
 }

--- a/tests/monster_test_serialize/my_game/example/referrable_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/referrable_generated.rs
@@ -38,8 +38,8 @@ impl<'a> Referrable<'a> {
     Referrable { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args ReferrableArgs
   ) -> flatbuffers::WIPOffset<Referrable<'bldr>> {
     let mut builder = ReferrableBuilder::new(_fbb);
@@ -108,17 +108,17 @@ impl Serialize for Referrable<'_> {
   }
 }
 
-pub struct ReferrableBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct ReferrableBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> ReferrableBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ReferrableBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_id(&mut self, id: u64) {
     self.fbb_.push_slot::<u64>(Referrable::VT_ID, id, 0);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ReferrableBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> ReferrableBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     ReferrableBuilder {
       fbb_: _fbb,
@@ -152,9 +152,9 @@ impl Default for ReferrableT {
   }
 }
 impl ReferrableT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Referrable<'b>> {
     let id = self.id;
     Referrable::create(_fbb, &ReferrableArgs{

--- a/tests/monster_test_serialize/my_game/example/stat_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/stat_generated.rs
@@ -40,8 +40,8 @@ impl<'a> Stat<'a> {
     Stat { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args StatArgs<'args>
   ) -> flatbuffers::WIPOffset<Stat<'bldr>> {
     let mut builder = StatBuilder::new(_fbb);
@@ -144,11 +144,11 @@ impl Serialize for Stat<'_> {
   }
 }
 
-pub struct StatBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct StatBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> StatBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> StatBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_id(&mut self, id: flatbuffers::WIPOffset<&'b  str>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Stat::VT_ID, id);
@@ -162,7 +162,7 @@ impl<'a: 'b, 'b> StatBuilder<'a, 'b> {
     self.fbb_.push_slot::<u16>(Stat::VT_COUNT, count, 0);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> StatBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> StatBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     StatBuilder {
       fbb_: _fbb,
@@ -202,9 +202,9 @@ impl Default for StatT {
   }
 }
 impl StatT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Stat<'b>> {
     let id = self.id.as_ref().map(|x|{
       _fbb.create_string(x)

--- a/tests/monster_test_serialize/my_game/example/test_simple_table_with_enum_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/test_simple_table_with_enum_generated.rs
@@ -38,8 +38,8 @@ impl<'a> TestSimpleTableWithEnum<'a> {
     TestSimpleTableWithEnum { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TestSimpleTableWithEnumArgs
   ) -> flatbuffers::WIPOffset<TestSimpleTableWithEnum<'bldr>> {
     let mut builder = TestSimpleTableWithEnumBuilder::new(_fbb);
@@ -98,17 +98,17 @@ impl Serialize for TestSimpleTableWithEnum<'_> {
   }
 }
 
-pub struct TestSimpleTableWithEnumBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TestSimpleTableWithEnumBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TestSimpleTableWithEnumBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TestSimpleTableWithEnumBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_color(&mut self, color: Color) {
     self.fbb_.push_slot::<Color>(TestSimpleTableWithEnum::VT_COLOR, color, Color::Green);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TestSimpleTableWithEnumBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TestSimpleTableWithEnumBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TestSimpleTableWithEnumBuilder {
       fbb_: _fbb,
@@ -142,9 +142,9 @@ impl Default for TestSimpleTableWithEnumT {
   }
 }
 impl TestSimpleTableWithEnumT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TestSimpleTableWithEnum<'b>> {
     let color = self.color;
     TestSimpleTableWithEnum::create(_fbb, &TestSimpleTableWithEnumArgs{

--- a/tests/monster_test_serialize/my_game/example/type_aliases_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/type_aliases_generated.rs
@@ -49,8 +49,8 @@ impl<'a> TypeAliases<'a> {
     TypeAliases { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TypeAliasesArgs<'args>
   ) -> flatbuffers::WIPOffset<TypeAliases<'bldr>> {
     let mut builder = TypeAliasesBuilder::new(_fbb);
@@ -275,11 +275,11 @@ impl Serialize for TypeAliases<'_> {
   }
 }
 
-pub struct TypeAliasesBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TypeAliasesBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TypeAliasesBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TypeAliasesBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_i8_(&mut self, i8_: i8) {
     self.fbb_.push_slot::<i8>(TypeAliases::VT_I8_, i8_, 0);
@@ -329,7 +329,7 @@ impl<'a: 'b, 'b> TypeAliasesBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TypeAliases::VT_VF64, vf64);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TypeAliasesBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TypeAliasesBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TypeAliasesBuilder {
       fbb_: _fbb,
@@ -396,9 +396,9 @@ impl Default for TypeAliasesT {
   }
 }
 impl TypeAliasesT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TypeAliases<'b>> {
     let i8_ = self.i8_;
     let u8_ = self.u8_;

--- a/tests/monster_test_serialize/my_game/example_2/monster_generated.rs
+++ b/tests/monster_test_serialize/my_game/example_2/monster_generated.rs
@@ -37,8 +37,8 @@ impl<'a> Monster<'a> {
     Monster { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     _args: &'args MonsterArgs
   ) -> flatbuffers::WIPOffset<Monster<'bldr>> {
     let mut builder = MonsterBuilder::new(_fbb);
@@ -82,13 +82,13 @@ impl Serialize for Monster<'_> {
   }
 }
 
-pub struct MonsterBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct MonsterBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> MonsterBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> MonsterBuilder<'a, 'b, A> {
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> MonsterBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> MonsterBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     MonsterBuilder {
       fbb_: _fbb,
@@ -119,9 +119,9 @@ impl Default for MonsterT {
   }
 }
 impl MonsterT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Monster<'b>> {
     Monster::create(_fbb, &MonsterArgs{
     })

--- a/tests/monster_test_serialize/my_game/in_parent_namespace_generated.rs
+++ b/tests/monster_test_serialize/my_game/in_parent_namespace_generated.rs
@@ -37,8 +37,8 @@ impl<'a> InParentNamespace<'a> {
     InParentNamespace { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     _args: &'args InParentNamespaceArgs
   ) -> flatbuffers::WIPOffset<InParentNamespace<'bldr>> {
     let mut builder = InParentNamespaceBuilder::new(_fbb);
@@ -82,13 +82,13 @@ impl Serialize for InParentNamespace<'_> {
   }
 }
 
-pub struct InParentNamespaceBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct InParentNamespaceBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> InParentNamespaceBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> InParentNamespaceBuilder<'a, 'b, A> {
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> InParentNamespaceBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> InParentNamespaceBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     InParentNamespaceBuilder {
       fbb_: _fbb,
@@ -119,9 +119,9 @@ impl Default for InParentNamespaceT {
   }
 }
 impl InParentNamespaceT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<InParentNamespace<'b>> {
     InParentNamespace::create(_fbb, &InParentNamespaceArgs{
     })

--- a/tests/monster_test_serialize/my_game/other_name_space/table_b_generated.rs
+++ b/tests/monster_test_serialize/my_game/other_name_space/table_b_generated.rs
@@ -38,8 +38,8 @@ impl<'a> TableB<'a> {
     TableB { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TableBArgs<'args>
   ) -> flatbuffers::WIPOffset<TableB<'bldr>> {
     let mut builder = TableBBuilder::new(_fbb);
@@ -104,17 +104,17 @@ impl Serialize for TableB<'_> {
   }
 }
 
-pub struct TableBBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableBBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableBBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TableBBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_a(&mut self, a: flatbuffers::WIPOffset<super::super::TableA<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<super::super::TableA>>(TableB::VT_A, a);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableBBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TableBBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TableBBuilder {
       fbb_: _fbb,
@@ -148,9 +148,9 @@ impl Default for TableBT {
   }
 }
 impl TableBT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TableB<'b>> {
     let a = self.a.as_ref().map(|x|{
       x.pack(_fbb)

--- a/tests/monster_test_serialize/table_a_generated.rs
+++ b/tests/monster_test_serialize/table_a_generated.rs
@@ -38,8 +38,8 @@ impl<'a> TableA<'a> {
     TableA { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TableAArgs<'args>
   ) -> flatbuffers::WIPOffset<TableA<'bldr>> {
     let mut builder = TableABuilder::new(_fbb);
@@ -104,17 +104,17 @@ impl Serialize for TableA<'_> {
   }
 }
 
-pub struct TableABuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableABuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableABuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TableABuilder<'a, 'b, A> {
   #[inline]
   pub fn add_b(&mut self, b: flatbuffers::WIPOffset<my_game::other_name_space::TableB<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<my_game::other_name_space::TableB>>(TableA::VT_B, b);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableABuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TableABuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TableABuilder {
       fbb_: _fbb,
@@ -148,9 +148,9 @@ impl Default for TableAT {
   }
 }
 impl TableAT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TableA<'b>> {
     let b = self.b.as_ref().map(|x|{
       x.pack(_fbb)

--- a/tests/more_defaults/more_defaults_generated.rs
+++ b/tests/more_defaults/more_defaults_generated.rs
@@ -41,8 +41,8 @@ impl<'a> MoreDefaults<'a> {
     MoreDefaults { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args MoreDefaultsArgs<'args>
   ) -> flatbuffers::WIPOffset<MoreDefaults<'bldr>> {
     let mut builder = MoreDefaultsBuilder::new(_fbb);
@@ -173,11 +173,11 @@ impl<'a> Default for MoreDefaultsArgs<'a> {
   }
 }
 
-pub struct MoreDefaultsBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct MoreDefaultsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> MoreDefaultsBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> MoreDefaultsBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_ints(&mut self, ints: flatbuffers::WIPOffset<flatbuffers::Vector<'b , i32>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(MoreDefaults::VT_INTS, ints);
@@ -203,7 +203,7 @@ impl<'a: 'b, 'b> MoreDefaultsBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(MoreDefaults::VT_BOOLS, bools);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> MoreDefaultsBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> MoreDefaultsBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     MoreDefaultsBuilder {
       fbb_: _fbb,
@@ -252,9 +252,9 @@ impl Default for MoreDefaultsT {
   }
 }
 impl MoreDefaultsT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<MoreDefaults<'b>> {
     let ints = Some({
       let x = &self.ints;

--- a/tests/namespace_test/namespace_a/namespace_b/table_in_nested_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/namespace_b/table_in_nested_ns_generated.rs
@@ -36,8 +36,8 @@ impl<'a> TableInNestedNS<'a> {
     TableInNestedNS { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TableInNestedNSArgs
   ) -> flatbuffers::WIPOffset<TableInNestedNS<'bldr>> {
     let mut builder = TableInNestedNSBuilder::new(_fbb);
@@ -85,17 +85,17 @@ impl<'a> Default for TableInNestedNSArgs {
   }
 }
 
-pub struct TableInNestedNSBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableInNestedNSBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableInNestedNSBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TableInNestedNSBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_foo(&mut self, foo: i32) {
     self.fbb_.push_slot::<i32>(TableInNestedNS::VT_FOO, foo, 0);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableInNestedNSBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TableInNestedNSBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TableInNestedNSBuilder {
       fbb_: _fbb,
@@ -129,9 +129,9 @@ impl Default for TableInNestedNST {
   }
 }
 impl TableInNestedNST {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TableInNestedNS<'b>> {
     let foo = self.foo;
     TableInNestedNS::create(_fbb, &TableInNestedNSArgs{

--- a/tests/namespace_test/namespace_a/namespace_b/union_in_nested_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/namespace_b/union_in_nested_ns_generated.rs
@@ -115,7 +115,7 @@ impl UnionInNestedNST {
       Self::TableInNestedNS(_) => UnionInNestedNS::TableInNestedNS,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::TableInNestedNS(v) => Some(v.pack(fbb).as_union_value()),

--- a/tests/namespace_test/namespace_a/second_table_in_a_generated.rs
+++ b/tests/namespace_test/namespace_a/second_table_in_a_generated.rs
@@ -36,8 +36,8 @@ impl<'a> SecondTableInA<'a> {
     SecondTableInA { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args SecondTableInAArgs<'args>
   ) -> flatbuffers::WIPOffset<SecondTableInA<'bldr>> {
     let mut builder = SecondTableInABuilder::new(_fbb);
@@ -87,17 +87,17 @@ impl<'a> Default for SecondTableInAArgs<'a> {
   }
 }
 
-pub struct SecondTableInABuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct SecondTableInABuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> SecondTableInABuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> SecondTableInABuilder<'a, 'b, A> {
   #[inline]
   pub fn add_refer_to_c(&mut self, refer_to_c: flatbuffers::WIPOffset<super::namespace_c::TableInC<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<super::namespace_c::TableInC>>(SecondTableInA::VT_REFER_TO_C, refer_to_c);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> SecondTableInABuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> SecondTableInABuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     SecondTableInABuilder {
       fbb_: _fbb,
@@ -131,9 +131,9 @@ impl Default for SecondTableInAT {
   }
 }
 impl SecondTableInAT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<SecondTableInA<'b>> {
     let refer_to_c = self.refer_to_c.as_ref().map(|x|{
       x.pack(_fbb)

--- a/tests/namespace_test/namespace_a/table_in_first_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/table_in_first_ns_generated.rs
@@ -40,8 +40,8 @@ impl<'a> TableInFirstNS<'a> {
     TableInFirstNS { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TableInFirstNSArgs<'args>
   ) -> flatbuffers::WIPOffset<TableInFirstNS<'bldr>> {
     let mut builder = TableInFirstNSBuilder::new(_fbb);
@@ -170,11 +170,11 @@ impl<'a> Default for TableInFirstNSArgs<'a> {
   }
 }
 
-pub struct TableInFirstNSBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableInFirstNSBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableInFirstNSBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TableInFirstNSBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_foo_table(&mut self, foo_table: flatbuffers::WIPOffset<namespace_b::TableInNestedNS<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<namespace_b::TableInNestedNS>>(TableInFirstNS::VT_FOO_TABLE, foo_table);
@@ -196,7 +196,7 @@ impl<'a: 'b, 'b> TableInFirstNSBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<&namespace_b::StructInNestedNS>(TableInFirstNS::VT_FOO_STRUCT, foo_struct);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableInFirstNSBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TableInFirstNSBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TableInFirstNSBuilder {
       fbb_: _fbb,
@@ -252,9 +252,9 @@ impl Default for TableInFirstNST {
   }
 }
 impl TableInFirstNST {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TableInFirstNS<'b>> {
     let foo_table = self.foo_table.as_ref().map(|x|{
       x.pack(_fbb)

--- a/tests/namespace_test/namespace_c/table_in_c_generated.rs
+++ b/tests/namespace_test/namespace_c/table_in_c_generated.rs
@@ -37,8 +37,8 @@ impl<'a> TableInC<'a> {
     TableInC { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args TableInCArgs<'args>
   ) -> flatbuffers::WIPOffset<TableInC<'bldr>> {
     let mut builder = TableInCBuilder::new(_fbb);
@@ -103,11 +103,11 @@ impl<'a> Default for TableInCArgs<'a> {
   }
 }
 
-pub struct TableInCBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct TableInCBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> TableInCBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TableInCBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_refer_to_a1(&mut self, refer_to_a1: flatbuffers::WIPOffset<super::namespace_a::TableInFirstNS<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<super::namespace_a::TableInFirstNS>>(TableInC::VT_REFER_TO_A1, refer_to_a1);
@@ -117,7 +117,7 @@ impl<'a: 'b, 'b> TableInCBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<super::namespace_a::SecondTableInA>>(TableInC::VT_REFER_TO_A2, refer_to_a2);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TableInCBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TableInCBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TableInCBuilder {
       fbb_: _fbb,
@@ -154,9 +154,9 @@ impl Default for TableInCT {
   }
 }
 impl TableInCT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<TableInC<'b>> {
     let refer_to_a1 = self.refer_to_a1.as_ref().map(|x|{
       x.pack(_fbb)

--- a/tests/optional_scalars/optional_scalars/scalar_stuff_generated.rs
+++ b/tests/optional_scalars/optional_scalars/scalar_stuff_generated.rs
@@ -71,8 +71,8 @@ impl<'a> ScalarStuff<'a> {
     ScalarStuff { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args ScalarStuffArgs
   ) -> flatbuffers::WIPOffset<ScalarStuff<'bldr>> {
     let mut builder = ScalarStuffBuilder::new(_fbb);
@@ -575,11 +575,11 @@ impl<'a> Default for ScalarStuffArgs {
   }
 }
 
-pub struct ScalarStuffBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct ScalarStuffBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> ScalarStuffBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ScalarStuffBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_just_i8(&mut self, just_i8: i8) {
     self.fbb_.push_slot::<i8>(ScalarStuff::VT_JUST_I8, just_i8, 0);
@@ -725,7 +725,7 @@ impl<'a: 'b, 'b> ScalarStuffBuilder<'a, 'b> {
     self.fbb_.push_slot::<OptionalByte>(ScalarStuff::VT_DEFAULT_ENUM, default_enum, OptionalByte::One);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ScalarStuffBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> ScalarStuffBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     ScalarStuffBuilder {
       fbb_: _fbb,
@@ -864,9 +864,9 @@ impl Default for ScalarStuffT {
   }
 }
 impl ScalarStuffT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<ScalarStuff<'b>> {
     let just_i8 = self.just_i8;
     let maybe_i8 = self.maybe_i8;
@@ -1019,13 +1019,13 @@ pub fn scalar_stuff_size_prefixed_buffer_has_identifier(buf: &[u8]) -> bool {
 pub const SCALAR_STUFF_EXTENSION: &str = "mon";
 
 #[inline]
-pub fn finish_scalar_stuff_buffer<'a, 'b>(
-    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub fn finish_scalar_stuff_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
     root: flatbuffers::WIPOffset<ScalarStuff<'a>>) {
   fbb.finish(root, Some(SCALAR_STUFF_IDENTIFIER));
 }
 
 #[inline]
-pub fn finish_size_prefixed_scalar_stuff_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<ScalarStuff<'a>>) {
+pub fn finish_size_prefixed_scalar_stuff_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>, root: flatbuffers::WIPOffset<ScalarStuff<'a>>) {
   fbb.finish_size_prefixed(root, Some(SCALAR_STUFF_IDENTIFIER));
 }

--- a/tests/private_annotation_test/annotations_generated.rs
+++ b/tests/private_annotation_test/annotations_generated.rs
@@ -36,8 +36,8 @@ impl<'a> Annotations<'a> {
     Annotations { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args AnnotationsArgs
   ) -> flatbuffers::WIPOffset<Annotations<'bldr>> {
     let mut builder = AnnotationsBuilder::new(_fbb);
@@ -85,17 +85,17 @@ impl<'a> Default for AnnotationsArgs {
   }
 }
 
-pub(crate) struct AnnotationsBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub(crate) struct AnnotationsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> AnnotationsBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> AnnotationsBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_value(&mut self, value: i32) {
     self.fbb_.push_slot::<i32>(Annotations::VT_VALUE, value, 0);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> AnnotationsBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> AnnotationsBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     AnnotationsBuilder {
       fbb_: _fbb,
@@ -129,9 +129,9 @@ impl Default for AnnotationsT {
   }
 }
 impl AnnotationsT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Annotations<'b>> {
     let value = self.value;
     Annotations::create(_fbb, &AnnotationsArgs{

--- a/tests/private_annotation_test/any_generated.rs
+++ b/tests/private_annotation_test/any_generated.rs
@@ -121,7 +121,7 @@ impl AnyT {
       Self::Annotations(_) => Any::Annotations,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::Game(v) => Some(v.pack(fbb).as_union_value()),

--- a/tests/private_annotation_test/game_generated.rs
+++ b/tests/private_annotation_test/game_generated.rs
@@ -36,8 +36,8 @@ impl<'a> Game<'a> {
     Game { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args GameArgs
   ) -> flatbuffers::WIPOffset<Game<'bldr>> {
     let mut builder = GameBuilder::new(_fbb);
@@ -85,17 +85,17 @@ impl<'a> Default for GameArgs {
   }
 }
 
-pub(crate) struct GameBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub(crate) struct GameBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> GameBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> GameBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_value(&mut self, value: i32) {
     self.fbb_.push_slot::<i32>(Game::VT_VALUE, value, 0);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> GameBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> GameBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     GameBuilder {
       fbb_: _fbb,
@@ -129,9 +129,9 @@ impl Default for GameT {
   }
 }
 impl GameT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<Game<'b>> {
     let value = self.value;
     Game::create(_fbb, &GameArgs{

--- a/tests/rust_namer_test/rust_namer_test/field_table_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/field_table_generated.rs
@@ -35,8 +35,8 @@ impl<'a> FieldTable<'a> {
     FieldTable { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     _args: &'args FieldTableArgs
   ) -> flatbuffers::WIPOffset<FieldTable<'bldr>> {
     let mut builder = FieldTableBuilder::new(_fbb);
@@ -70,13 +70,13 @@ impl<'a> Default for FieldTableArgs {
   }
 }
 
-pub struct FieldTableBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct FieldTableBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> FieldTableBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> FieldTableBuilder<'a, 'b, A> {
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> FieldTableBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> FieldTableBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     FieldTableBuilder {
       fbb_: _fbb,
@@ -107,9 +107,9 @@ impl Default for FieldTableT {
   }
 }
 impl FieldTableT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<FieldTable<'b>> {
     FieldTable::create(_fbb, &FieldTableArgs{
     })

--- a/tests/rust_namer_test/rust_namer_test/field_union_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/field_union_generated.rs
@@ -115,7 +115,7 @@ impl FieldUnionT {
       Self::F(_) => FieldUnion::f,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::F(v) => Some(v.pack(fbb).as_union_value()),

--- a/tests/rust_namer_test/rust_namer_test/game_message_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/game_message_generated.rs
@@ -127,7 +127,7 @@ impl GameMessageT {
       Self::PlayerInputChange(_) => GameMessage::PlayerInputChange,
     }
   }
-  pub fn pack(&self, fbb: &mut flatbuffers::FlatBufferBuilder) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
     match self {
       Self::NONE => None,
       Self::PlayerStatEvent(v) => Some(v.pack(fbb).as_union_value()),

--- a/tests/rust_namer_test/rust_namer_test/game_message_wrapper_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/game_message_wrapper_generated.rs
@@ -37,8 +37,8 @@ impl<'a> GameMessageWrapper<'a> {
     GameMessageWrapper { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args GameMessageWrapperArgs
   ) -> flatbuffers::WIPOffset<GameMessageWrapper<'bldr>> {
     let mut builder = GameMessageWrapperBuilder::new(_fbb);
@@ -166,11 +166,11 @@ impl<'a> Default for GameMessageWrapperArgs {
   }
 }
 
-pub struct GameMessageWrapperBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct GameMessageWrapperBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> GameMessageWrapperBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> GameMessageWrapperBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_Message_type(&mut self, Message_type: GameMessage) {
     self.fbb_.push_slot::<GameMessage>(GameMessageWrapper::VT_MESSAGE_TYPE, Message_type, GameMessage::NONE);
@@ -180,7 +180,7 @@ impl<'a: 'b, 'b> GameMessageWrapperBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(GameMessageWrapper::VT_MESSAGE, Message);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> GameMessageWrapperBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> GameMessageWrapperBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     GameMessageWrapperBuilder {
       fbb_: _fbb,
@@ -241,9 +241,9 @@ impl Default for GameMessageWrapperT {
   }
 }
 impl GameMessageWrapperT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<GameMessageWrapper<'b>> {
     let Message_type = self.Message.game_message_type();
     let Message = self.Message.pack(_fbb);

--- a/tests/rust_namer_test/rust_namer_test/player_input_change_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/player_input_change_generated.rs
@@ -35,8 +35,8 @@ impl<'a> PlayerInputChange<'a> {
     PlayerInputChange { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     _args: &'args PlayerInputChangeArgs
   ) -> flatbuffers::WIPOffset<PlayerInputChange<'bldr>> {
     let mut builder = PlayerInputChangeBuilder::new(_fbb);
@@ -70,13 +70,13 @@ impl<'a> Default for PlayerInputChangeArgs {
   }
 }
 
-pub struct PlayerInputChangeBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct PlayerInputChangeBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> PlayerInputChangeBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> PlayerInputChangeBuilder<'a, 'b, A> {
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> PlayerInputChangeBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> PlayerInputChangeBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     PlayerInputChangeBuilder {
       fbb_: _fbb,
@@ -107,9 +107,9 @@ impl Default for PlayerInputChangeT {
   }
 }
 impl PlayerInputChangeT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<PlayerInputChange<'b>> {
     PlayerInputChange::create(_fbb, &PlayerInputChangeArgs{
     })

--- a/tests/rust_namer_test/rust_namer_test/player_spectate_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/player_spectate_generated.rs
@@ -35,8 +35,8 @@ impl<'a> PlayerSpectate<'a> {
     PlayerSpectate { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     _args: &'args PlayerSpectateArgs
   ) -> flatbuffers::WIPOffset<PlayerSpectate<'bldr>> {
     let mut builder = PlayerSpectateBuilder::new(_fbb);
@@ -70,13 +70,13 @@ impl<'a> Default for PlayerSpectateArgs {
   }
 }
 
-pub struct PlayerSpectateBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct PlayerSpectateBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> PlayerSpectateBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> PlayerSpectateBuilder<'a, 'b, A> {
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> PlayerSpectateBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> PlayerSpectateBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     PlayerSpectateBuilder {
       fbb_: _fbb,
@@ -107,9 +107,9 @@ impl Default for PlayerSpectateT {
   }
 }
 impl PlayerSpectateT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<PlayerSpectate<'b>> {
     PlayerSpectate::create(_fbb, &PlayerSpectateArgs{
     })

--- a/tests/rust_namer_test/rust_namer_test/player_stat_event_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/player_stat_event_generated.rs
@@ -35,8 +35,8 @@ impl<'a> PlayerStatEvent<'a> {
     PlayerStatEvent { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     _args: &'args PlayerStatEventArgs
   ) -> flatbuffers::WIPOffset<PlayerStatEvent<'bldr>> {
     let mut builder = PlayerStatEventBuilder::new(_fbb);
@@ -70,13 +70,13 @@ impl<'a> Default for PlayerStatEventArgs {
   }
 }
 
-pub struct PlayerStatEventBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct PlayerStatEventBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> PlayerStatEventBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> PlayerStatEventBuilder<'a, 'b, A> {
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> PlayerStatEventBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> PlayerStatEventBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     PlayerStatEventBuilder {
       fbb_: _fbb,
@@ -107,9 +107,9 @@ impl Default for PlayerStatEventT {
   }
 }
 impl PlayerStatEventT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<PlayerStatEvent<'b>> {
     PlayerStatEvent::create(_fbb, &PlayerStatEventArgs{
     })

--- a/tests/rust_namer_test/rust_namer_test/root_table_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/root_table_generated.rs
@@ -37,8 +37,8 @@ impl<'a> RootTable<'a> {
     RootTable { _tab: table }
   }
   #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
     args: &'args RootTableArgs
   ) -> flatbuffers::WIPOffset<RootTable<'bldr>> {
     let mut builder = RootTableBuilder::new(_fbb);
@@ -124,11 +124,11 @@ impl<'a> Default for RootTableArgs {
   }
 }
 
-pub struct RootTableBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub struct RootTableBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> RootTableBuilder<'a, 'b> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> RootTableBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_field42_type(&mut self, field42_type: FieldUnion) {
     self.fbb_.push_slot::<FieldUnion>(RootTable::VT_FIELD42_TYPE, field42_type, FieldUnion::NONE);
@@ -138,7 +138,7 @@ impl<'a: 'b, 'b> RootTableBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(RootTable::VT_FIELD42, field42);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> RootTableBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> RootTableBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     RootTableBuilder {
       fbb_: _fbb,
@@ -185,9 +185,9 @@ impl Default for RootTableT {
   }
 }
 impl RootTableT {
-  pub fn pack<'b>(
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
     &self,
-    _fbb: &mut flatbuffers::FlatBufferBuilder<'b>
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
   ) -> flatbuffers::WIPOffset<RootTable<'b>> {
     let field42_type = self.field42.field_union_type();
     let field42 = self.field42.pack(_fbb);


### PR DESCRIPTION
This PR adds the Allocator trait that is now used in FlatBufferBuilder. Fixes https://github.com/google/flatbuffers/issues/7385