### PR TITLE
[python] types - do not add recursive imports to the generated file

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -2104,7 +2104,7 @@ class PythonGenerator : public BaseGenerator {
           // have a type that contains arrays of itself -- of the type
           // "from .MyType import MyType", which Python can't resolve. So
           // if we are trying to import ourself, we skip.
-          if (import_entry.first != local_import) {
+          if (import_entry.first != mod) {
             code += "from " + import_entry.first + " import " +
                     import_entry.second + "\n";
           }


### PR DESCRIPTION
Closes https://github.com/google/flatbuffers/issues/8122
The issue was that the code checking if the needed import is in the same file was checked with the filename with a dot at the start that is added a few lines before it, causing it to never be true.

See line 2094 - `const std::string local_import = "." + mod;`

The variable `import_entry.first` is `filename` while the `local_import` equals to `.filename`.

