### PR TITLE
Use libc++ not libstdc++ for clang++-14 + C++23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,8 +113,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: cmake
+      # Need to use libc++ not libstdc++ for std 23 because libstdc++
+      # 10.3.0 doesn't support std 23
       run: >
-        CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles"
+        CXX=${{ matrix.cxx }}
+        CXXFLAGS=${{ (matrix.cxx == 'clang++-14' && matrix.std >= 23) && '-stdlib=libc++' || '' }}
+        cmake -G "Unix Makefiles"
         -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON
         -DFLATBUFFERS_CPP_STD=${{ matrix.std }}
         -DFLATBUFFERS_BUILD_CPP17=${{ matrix.std >= 17 && 'On' || 'Off'}}


### PR DESCRIPTION
Because libstdc++ 10.3.0 doesn't support C++23.

This fixes the following build error:

    In file included from /home/runner/work/flatbuffers/flatbuffers/src/idl_parser.cpp:17:
    In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/algorithm:60:
    In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_algobase.h:67:
    /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_iterator.h:2618:35: error: missing 'typename' prior to dependent type name 'iterator_traits<_It>::iterator_category'
          { using iterator_category = iterator_traits<_It>::iterator_category; };
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
