### PR TITLE
Fix: detect c++ standard on MSVC for span

### DIFF
--- a/include/flatbuffers/stl_emulation.h
+++ b/include/flatbuffers/stl_emulation.h
@@ -45,7 +45,8 @@
   // Testing __cpp_lib_span requires including either <version> or <span>,
   // both of which were added in C++20.
   // See: https://en.cppreference.com/w/cpp/utility/feature_test
-  #if defined(__cplusplus) && __cplusplus >= 202002L
+  #if defined(__cplusplus) && __cplusplus >= 202002L \
+      || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     #define FLATBUFFERS_USE_STD_SPAN 1
   #endif
 #endif // FLATBUFFERS_USE_STD_SPAN


### PR DESCRIPTION
Fixed FLATBUFFERS_USE_STD_SPAN, similar to FLATBUFFERS_USE_STD_OPTIONAL above.