### PR TITLE
Push contiguous bytes

### DIFF
--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -240,8 +240,8 @@ public struct ByteBuffer {
   #if swift(>=5.0) && !os(WASI)
   @inline(__always)
   @usableFromInline
-  mutating func push<T: ContiguousBytes>(value: T) {
-    value.withUnsafeBytes { ptr in
+  mutating func push<T: ContiguousBytes>(bytes: T) {
+    bytes.withUnsafeBytes { ptr in
       ensureSpace(size: ptr.count)
       _storage.memory
         .advanced(by: writerIndex &- ptr.count)

--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -235,6 +235,22 @@ public struct ByteBuffer {
     }
   }
 
+  /// Adds a `ContiguousBytes` to buffer memory
+  /// - Parameter value: bytes to copy
+  #if swift(>=5.0) && !os(WASI)
+  @inline(__always)
+  @usableFromInline
+  mutating func push<T: ContiguousBytes>(value: T) {
+    value.withUnsafeBytes { ptr in
+      ensureSpace(size: ptr.count)
+      _storage.memory
+        .advanced(by: writerIndex &- ptr.count)
+        .copyMemory(from: ptr.baseAddress!, byteCount: ptr.count)
+      self._writerSize = self._writerSize &+ ptr.count
+    }
+  }
+  #endif
+
   /// Adds an object of type NativeStruct into the buffer
   /// - Parameters:
   ///   - value: Object  that will be written to the buffer

--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -473,6 +473,14 @@ public struct FlatBufferBuilder {
     return endVector(len: size)
   }
 
+  @inline(__always)
+  mutating public func createVector(bytes: ContiguousBytes) -> Offset {
+    let size = bytes.withUnsafeBytes { ptr in ptr.count }
+    startVector(size, elementSize: MemoryLayout<UInt8>.size)
+    _bb.push(bytes: bytes)
+    return endVector(len: size)
+  }
+
   /// Creates a vector of type ``Enum`` into the ``ByteBuffer``
   ///
   /// ``createVector(_:)-9h189`` writes a vector of type ``Enum`` into


### PR DESCRIPTION
I noticed that saving in my app was quite slow as each individual byte of a byte buffer was treated generically as a `Scalar`:

![image](https://github.com/google/flatbuffers/assets/841144/3253b66c-d6ea-481c-9967-2b594557c684)

This change uses `ContiguousArray` to optimize that. Runtime went from 1s to 2ms. I'm not sure what the exact API should be.