### PR TITLE
update flatbuffers java to be Android API level 23 compatible 

### DIFF
--- a/java/src/main/java/com/google/flatbuffers/Utf8Old.java
+++ b/java/src/main/java/com/google/flatbuffers/Utf8Old.java
@@ -42,8 +42,15 @@ public class Utf8Old extends Utf8 {
     }
   }
 
+  // ThreadLocal.withInitial() is not used to make the following code compatible with Android API
+  // level 23.
   private static final ThreadLocal<Cache> CACHE =
-      ThreadLocal.withInitial(() -> new Cache());
+      new ThreadLocal<Cache>() {
+        @Override
+        protected Cache initialValue() {
+          return new Cache();
+        }
+      };
 
   // Play some games so that the old encoder doesn't pay twice for computing
   // the length of the encoded string.


### PR DESCRIPTION
Make flatbuffers java compatible with Android API level 23 , due to TfLite going back to Android Level 23 in this [CL](https://critique.corp.google.com/cl/581423598)

corresponding [google3 cl](https://critique.corp.google.com/cl/582433564) with these changes 