### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,10 @@ jobs:
       matrix:
         std: [11, 14, 17, 20, 23]
         cxx: [g++-13, clang++-15]
+        exclude:
+          # Clang++15 10.3.0 stdlibc++ doesn't fully support std 23
+          - cxx: clang++-15
+            std: 23        
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cxx: [g++-10, clang++-14]
+        cxx: [g++-13, clang++-15]
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -58,11 +58,11 @@ jobs:
       with:
         files: Linux.flatc.binary.${{ matrix.cxx }}.zip
     - name: Generate SLSA subjects - clang
-      if: matrix.cxx == 'clang++-14' && startsWith(github.ref, 'refs/tags/')
+      if: matrix.cxx == 'clang++-15' && startsWith(github.ref, 'refs/tags/')
       id: hash-clang
       run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
     - name: Generate SLSA subjects - gcc
-      if: matrix.cxx == 'g++-10' && startsWith(github.ref, 'refs/tags/')
+      if: matrix.cxx == 'g++-13' && startsWith(github.ref, 'refs/tags/')
       id: hash-gcc
       run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
 
@@ -72,7 +72,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: cmake
-      run: CXX=clang++-14 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON -DFLATBUFFERS_CXX_FLAGS="-DFLATBUFFERS_NO_FILE_TESTS" .
+      run: CXX=clang++-15 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON -DFLATBUFFERS_CXX_FLAGS="-DFLATBUFFERS_NO_FILE_TESTS" .
     - name: build
       run: make -j
 
@@ -86,7 +86,7 @@ jobs:
     - name: cmake
       working-directory: build
       run: >
-        CXX=clang++-14 cmake .. -G "Unix Makefiles" -DFLATBUFFERS_STRICT_MODE=ON
+        CXX=clang++-15 cmake .. -G "Unix Makefiles" -DFLATBUFFERS_STRICT_MODE=ON
         -DFLATBUFFERS_BUILD_CPP17=ON -DFLATBUFFERS_CPP_STD=17
     - name: build
       working-directory: build
@@ -105,11 +105,8 @@ jobs:
       fail-fast: false
       matrix:
         std: [11, 14, 17, 20, 23]
-        cxx: [g++-10, clang++-14]
-        exclude:
-          # GCC 10.3.0 doesn't support std 23
-          - cxx: g++-10
-            std: 23
+        cxx: [g++-13, clang++-15]
+
     steps:
     - uses: actions/checkout@v3
     - name: cmake
@@ -358,7 +355,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cxx: [g++-10, clang++-14]
+        cxx: [g++-13, clang++-15]
     steps:
     - uses: actions/checkout@v3
     - name: cmake
@@ -389,7 +386,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cxx: [g++-10]
+        cxx: [g++-13]
     steps:
     - uses: actions/checkout@v3
     - name: cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,7 +556,7 @@ if(FLATBUFFERS_BUILD_TESTS)
 
   # Add a library so there is a single target that the generated samples can 
   # link too.
-  add_library(flatsample INTERFACE)
+  add_library(flatsample STATIC)
 
   # Since flatsample has no sources, we have to explicitly set the linker lang.
   set_target_properties(flatsample PROPERTIES LINKER_LANGUAGE CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,12 +276,6 @@ set(FlatBuffers_GRPCTest_SRCS
   grpc/tests/message_builder_test.cpp
 )
 
-# Seems libstdc++ doesn't support all of C++23 yet, use libc++j for now.
-if(IS_CLANG AND FLATBUFFERS_CPP_STD GREATER_EQUAL 23)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
-endif()
-
 # TODO(dbaileychess): Figure out how this would now work. I posted a question on
 # https://stackoverflow.com/questions/71772330/override-target-compile-options-via-cmake-command-line.
 # Append FLATBUFFERS_CXX_FLAGS to CMAKE_CXX_FLAGS.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,11 @@ set(FlatBuffers_GRPCTest_SRCS
   grpc/tests/message_builder_test.cpp
 )
 
+# Seems libstdc++ doesn't support all of C++23 yet, use libc++j for now.
+if(IS_CLANG AND FLATBUFFERS_CPP_STD GREATER_EQUAL 23)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+endif()
+
 # TODO(dbaileychess): Figure out how this would now work. I posted a question on
 # https://stackoverflow.com/questions/71772330/override-target-compile-options-via-cmake-command-line.
 # Append FLATBUFFERS_CXX_FLAGS to CMAKE_CXX_FLAGS.
@@ -556,7 +561,11 @@ if(FLATBUFFERS_BUILD_TESTS)
 
   # Add a library so there is a single target that the generated samples can 
   # link too.
-  add_library(flatsample STATIC)
+  if(MSVC_LIKE)
+    add_library(flatsample INFTERFACE)
+  else()
+    add_library(flatsample STATIC)
+  endif()
 
   # Since flatsample has no sources, we have to explicitly set the linker lang.
   set_target_properties(flatsample PROPERTIES LINKER_LANGUAGE CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,7 @@ set(FlatBuffers_GRPCTest_SRCS
 # Seems libstdc++ doesn't support all of C++23 yet, use libc++j for now.
 if(IS_CLANG AND FLATBUFFERS_CPP_STD GREATER_EQUAL 23)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
 endif()
 
 # TODO(dbaileychess): Figure out how this would now work. I posted a question on
@@ -561,8 +562,8 @@ if(FLATBUFFERS_BUILD_TESTS)
 
   # Add a library so there is a single target that the generated samples can 
   # link too.
-  if(MSVC_LIKE)
-    add_library(flatsample INFTERFACE)
+  if(MSVC)
+    add_library(flatsample INTERFACE)
   else()
     add_library(flatsample STATIC)
   endif()

--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -1720,7 +1720,7 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
         max_vectors_(buf_len),
         check_alignment_(_check_alignment),
         reuse_tracker_(reuse_tracker) {
-    FLATBUFFERS_ASSERT(size_ < FLATBUFFERS_MAX_BUFFER_SIZE);
+    FLATBUFFERS_ASSERT(static_cast<int32_t>(size_) < FLATBUFFERS_MAX_BUFFER_SIZE);
     if (reuse_tracker_) {
       reuse_tracker_->clear();
       reuse_tracker_->resize(size_, PackedType(BIT_WIDTH_8, FBT_NULL));

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -86,7 +86,7 @@ void TriviallyCopyableTest() {
   // clang-format off
   #if __GNUG__ && __GNUC__ < 5 && \
       !(defined(__clang__) && __clang_major__ >= 16)
-    TEST_EQ(__has_trivial_copy(Vec3), true);
+    TEST_EQ(__is_trivially_copyable(Vec3), true);
   #else
     #if __cplusplus >= 201103L
       TEST_EQ(std::is_trivially_copyable<Vec3>::value, true);


### PR DESCRIPTION
Various fixes to get the CI working.

Upgrade to gcc 13 and clang 15.

Clang-15 and  C++23 don't seem to be working, so excluding it from CI for now.