### PR TITLE
Fix dereference operator of VectorIterator to structures

### DIFF
--- a/include/flatbuffers/array.h
+++ b/include/flatbuffers/array.h
@@ -31,13 +31,10 @@ template<typename T, uint16_t length> class Array {
   // Array<T> can carry only POD data types (scalars or structs).
   typedef typename flatbuffers::bool_constant<flatbuffers::is_scalar<T>::value>
       scalar_tag;
-  typedef
-      typename flatbuffers::conditional<scalar_tag::value, T, const T *>::type
-          IndirectHelperType;
 
  public:
   typedef uint16_t size_type;
-  typedef typename IndirectHelper<IndirectHelperType>::return_type return_type;
+  typedef typename IndirectHelper<T>::return_type return_type;
   typedef VectorConstIterator<T, return_type, uoffset_t> const_iterator;
   typedef VectorReverseIterator<const_iterator> const_reverse_iterator;
 
@@ -50,7 +47,7 @@ template<typename T, uint16_t length> class Array {
 
   return_type Get(uoffset_t i) const {
     FLATBUFFERS_ASSERT(i < size());
-    return IndirectHelper<IndirectHelperType>::Read(Data(), i);
+    return IndirectHelper<T>::Read(Data(), i);
   }
 
   return_type operator[](uoffset_t i) const { return Get(i); }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -834,6 +834,24 @@ void FixedLengthArrayConstructorTest() {
   TEST_EQ(arr_struct.e(), 10);
   TEST_EQ(arr_struct.f()->Get(0), -2);
   TEST_EQ(arr_struct.f()->Get(1), -1);
+
+  // Test for each loop over NestedStruct entries
+  for (auto i : *arr_struct.d()) {
+    for (auto a : *i->a()) {
+      TEST_EQ(a, 1);
+      break;  // one iteration is enough, just testing compilation
+    }
+    TEST_EQ(i->b(), MyGame::Example::TestEnum::B);
+    for (auto c : *i->c()) {
+      TEST_EQ(c, MyGame::Example::TestEnum::A);
+      break;  // one iteration is enough, just testing compilation
+    }
+    for (auto d : *i->d()) {
+      TEST_EQ(d, -2);
+      break;  // one iteration is enough, just testing compilation
+    }
+    break;  // one iteration is enough, just testing compilation
+  }
 }
 #else
 void FixedLengthArrayConstructorTest() {}


### PR DESCRIPTION
It fixes issue #8093. This is an alternative #8164 and #8166.  Details in commit message.