### PR TITLE
Fix typo in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,7 +598,7 @@ if(FLATBUFFERS_BUILD_GRPCTEST)
   find_package(protobuf CONFIG REQUIRED)
   find_package(gRPC CONFIG REQUIRED)
   add_executable(grpctest ${FlatBuffers_GRPCTest_SRCS})
-  target_link_libraries(grpctext
+  target_link_libraries(grpctest
     PRIVATE
       $<BUILD_INTERFACE:ProjectConfig>
       gRPC::grpc++_unsecure


### PR DESCRIPTION
When building with make, it was failing for me because the target grpctext doesn't exist. I strongly assume this was meant to be "grpctest".