### PR TITLE
[TS/JS] Create byte vectors

### DIFF
--- a/tests/ts/JavaScriptTest.js
+++ b/tests/ts/JavaScriptTest.js
@@ -48,6 +48,7 @@ function main() {
   testNullStrings();
   testSharedStrings();
   testVectorOfStructs();
+  testCreateByteVector();
 
   console.log('FlatBuffers test: completed successfully');
 }
@@ -475,6 +476,22 @@ function testVectorOfStructs() {
   assert.strictEqual(decodedMonster.test4[0].b, 2);
   assert.strictEqual(decodedMonster.test4[1].a, 3);
   assert.strictEqual(decodedMonster.test4[1].b, 4);
+}
+
+function testCreateByteVector() {
+  const data = Uint8Array.from([1, 2, 3, 4, 5]);
+
+  const builder = new flatbuffers.Builder();
+  const required = builder.createString("required");
+  const offset = builder.createByteVector(data);
+  
+  Monster.startMonster(builder);
+  Monster.addName(builder, required);
+  Monster.addInventory(builder, offset)
+  builder.finish(Monster.endMonster(builder));
+
+  let decodedMonster = Monster.getRootAsMonster(builder.dataBuffer());
+  assert.deepEqual(decodedMonster.inventoryArray(), data);
 }
 
 main();

--- a/ts/builder.ts
+++ b/ts/builder.ts
@@ -539,9 +539,24 @@ export class Builder {
       this.addInt8(0);
       this.startVector(1, utf8.length, 1);
       this.bb.setPosition(this.space -= utf8.length);
-      for (let i = 0, offset = this.space, bytes = this.bb.bytes(); i < utf8.length; i++) {
-        bytes[offset++] = utf8[i];
+      this.bb.bytes().set(utf8, this.space);
+      return this.endVector();
+    }
+  
+    /**
+     * Create a byte vector.
+     *
+     * @param v The bytes to add
+     * @returns The offset in the buffer where the byte vector starts
+     */
+    createByteVector(v: Uint8Array | null | undefined): Offset {
+      if (v === null || v === undefined) {
+        return 0;
       }
+
+      this.startVector(1, v.length, 1);
+      this.bb.setPosition(this.space -= v.length);
+      this.bb.bytes().set(v, this.space);
       return this.endVector();
     }
   


### PR DESCRIPTION
Flatbuffers supports creating byte vectors from native byte objects in some languages (e.g., [Go](https://github.com/google/flatbuffers/blob/master/go/builder.go#L385-L398), [Python](https://github.com/google/flatbuffers/blob/master/python/flatbuffers/builder.py#L451-L471), [Swift](https://github.com/google/flatbuffers/blob/master/swift/Sources/FlatBuffers/FlatBufferBuilder.swift#L476-L490), [Java](https://github.com/google/flatbuffers/blob/master/java/src/main/java/com/google/flatbuffers/FlatBufferBuilder.java#L625-L637)).
This PR brings `createByteVector` to TypeScript, which is similar to `createString` except it does not add the null terminator and does not require UTF-8 encoded data.

Also, the performance for `createString` method could be improved (see below) if instead of using for loop we use [`set`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set), since the buffer is a Uint8Array. Larger gains can be seen when creating large byte vectors. Set is used also [here](https://github.com/google/flatbuffers/blob/master/ts/builder.ts#L323), so the change would not break any previous compatibility requirements.

[Here](https://gist.github.com/razvanalex/8d44653929e805a8f9f13d37534aab17) is a gist with the benchmarking code. I used node v18.16.1.

Results before the change:
``` text
BenchmarkCreateString/1 0.016412479999999997 ms
BenchmarkCreateString/10        0.00312446 ms
BenchmarkCreateString/100       0.0065587 ms
BenchmarkCreateString/1000      0.039675659999999995 ms
BenchmarkCreateString/10000     0.27408254 ms
BenchmarkCreateString/100000    0.19494983999999999 ms
BenchmarkCreateString/1000000   1.3230981599999998 ms
BenchmarkCreateString/10000000  11.25195066 ms
BenchmarkCreateString/100000000 148.96931926 ms
BenchmarkCreateString/1000000000        1361.0493652799998 ms

real    1m16.644s
user    0m55.069s
sys     0m22.605s
```

Results after the change:
``` text
BenchmarkCreateString/1 0.01656288 ms
BenchmarkCreateString/10        0.0027338599999999994 ms
BenchmarkCreateString/100       0.00389304 ms
BenchmarkCreateString/1000      0.00394246 ms
BenchmarkCreateString/10000     0.03633938 ms
BenchmarkCreateString/100000    0.1101002 ms
BenchmarkCreateString/1000000   0.4885558 ms
BenchmarkCreateString/10000000  2.8422376 ms
BenchmarkCreateString/100000000 57.1328341 ms
BenchmarkCreateString/1000000000        511.0220611 ms

real    0m29.061s
user    0m8.405s
sys     0m21.822s
```
