### PR TITLE
Fixed license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "flatbuffers"
   ],
   "author": "The FlatBuffers project",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/google/flatbuffers/issues"
   },


### PR DESCRIPTION
The project is licensed under the Apache 2.0 license, but it isn't reflected in the package.json field, which is used for automatic license auditing.