### PR TITLE
Fix build on musl

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -270,7 +270,8 @@ namespace flatbuffers {
   // strtoull_l}.
   #if (defined(_MSC_VER) && _MSC_VER >= 1800) || \
       (defined(__ANDROID_API__) && __ANDROID_API__>= 21) || \
-      (defined(_XOPEN_VERSION) && (_XOPEN_VERSION >= 700)) && \
+      (defined(_XOPEN_VERSION) && (_XOPEN_VERSION >= 700) && \
+        defined(__GLIBC__) && !defined(__UCLIBC__)) && \
         (!defined(__Fuchsia__) && !defined(__ANDROID_API__))
     #define FLATBUFFERS_LOCALE_INDEPENDENT 1
   #else


### PR DESCRIPTION
Build of applications using flatbuffers such as mediasoup (see related issue https://github.com/versatica/mediasoup/issues/1223) are broken on musl (such as in Alpine Linux) since version 1.11.0 and google@5f32f94 because `strtoll_l` (and `strtoull_l`) are not available on musl.

flatbuffers checks for the availability of `strtoull_l` in `CMakeLists.txt` so flatbuffers builds successfully, but for applications using flatbuffers the result of this check is not available and `FLATBUFFERS_LOCALE_INDEPENDENT` is set to 1 resulting in the following build failure:

```
In file included from ../../../subprojects/flatbuffers-23.3.3/include/flatbuffers/minireflect.h:21,
  from ../../../include/Channel/ChannelRequest.hpp:8,
  from ../../../include/Settings.hpp:6,
  from ../../../include/Logger.hpp:91,
  from ../../../src/RTC/RTCP/XrReceiverReferenceTime.cpp:5:
  ../../../subprojects/flatbuffers-23.3.3/include/flatbuffers/util.h: In function 'void flatbuffers::strtoval_impl(int64_t, const char*, char**, int)':
  ../../../subprojects/flatbuffers-23.3.3/include/flatbuffers/util.h:229:38: error: 'strtoll_l' was not declared in this scope; did you mean 'strtold_l'?
  229 | #define __strtoll_impl(s, pe, b) strtoll_l(s, pe, b, ClassicLocale::Get())
      |         ^~~~~~~~~~~~~~
```

This issue was reported in https://github.com/google/flatbuffers/pull/6773 but was closed without a solution. Then a flatbuffers fork made this exact commit:
https://github.com/sartura/flatbuffers/commit/92bd62407329caacd66e92e5bfd2949f2f137bfe

Due to rationale given in the closed issue, I'm not sure this PR will be accepted. If not, I strongly think that flatbuffers documentation should say that applications using it in musl environments must define `FLATBUFFERS_LOCALE_INDEPENDENT=0` in their main project.
