### PR TITLE
[PHP] Use IDL namer in generator and add prefixed size, clear, and createBytesVector in builder

### DIFF
--- a/php/FlatbufferBuilder.php
+++ b/php/FlatbufferBuilder.php
@@ -188,11 +188,7 @@ final class FlatbufferBuilder
 
         $nbb->setPosition($new_buf_size - $old_buf_size);
 
-        // TODO(chobie): is this little bit faster?
-        //$nbb->_buffer = substr_replace($nbb->_buffer, $bb->_buffer, $new_buf_size - $old_buf_size, strlen($bb->_buffer));
-        for ($i = $new_buf_size - $old_buf_size, $j = 0; $j < strlen($bb->_buffer); $i++, $j++) {
-            $nbb->_buffer[$i] = $bb->_buffer[$j];
-        }
+        $nbb->_buffer = substr_replace($nbb->_buffer, $bb->_buffer, $new_buf_size - $old_buf_size, strlen($bb->_buffer));
 
         return $nbb;
     }

--- a/src/bfbs_gen_lua.cpp
+++ b/src/bfbs_gen_lua.cpp
@@ -59,6 +59,7 @@ Namer::Config LuaDefaultConfig() {
            /*namespace_seperator=*/"__",
            /*object_prefix=*/"",
            /*object_suffix=*/"",
+           /*keywords_case_sensitive=*/true,
            /*keyword_prefix=*/"",
            /*keyword_suffix=*/"_",
            /*filenames=*/Case::kKeep,

--- a/src/bfbs_gen_nim.cpp
+++ b/src/bfbs_gen_nim.cpp
@@ -68,6 +68,7 @@ Namer::Config NimDefaultConfig() {
            /*namespace_seperator=*/"/",
            /*object_prefix=*/"",
            /*object_suffix=*/"T",
+           /*keywords_case_sensitive=*/true,
            /*keyword_prefix=*/"",
            /*keyword_suffix=*/"_",
            /*filenames=*/Case::kKeep,

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -46,6 +46,7 @@ static Namer::Config DartDefaultConfig() {
            /*namespace_seperator=*/".",
            /*object_prefix=*/"",
            /*object_suffix=*/"T",
+           /*keywords_case_sensitive=*/true,
            /*keyword_prefix=*/"$",
            /*keyword_suffix=*/"",
            /*filenames=*/Case::kKeep,

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -73,6 +73,7 @@ static Namer::Config GoDefaultConfig() {
            /*namespace_seperator=*/"__",
            /*object_prefix=*/"",
            /*object_suffix=*/"T",
+           /*keywords_case_sensitive=*/true,
            /*keyword_prefix=*/"",
            /*keyword_suffix=*/"_",
            /*filenames=*/Case::kKeep,

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -44,6 +44,7 @@ static Namer::Config JavaDefaultConfig() {
     /*namespace_seperator=*/".",
     /*object_prefix=*/"",
     /*object_suffix=*/"T",
+    /*keywords_case_sensitive=*/true,
     /*keyword_prefix=*/"",
     /*keyword_suffix=*/"_",
     /*filenames=*/Case::kKeep,

--- a/src/idl_gen_kotlin.cpp
+++ b/src/idl_gen_kotlin.cpp
@@ -62,6 +62,7 @@ static Namer::Config KotlinDefaultConfig() {
            /*namespace_seperator=*/"__",
            /*object_prefix=*/"",
            /*object_suffix=*/"T",
+           /*keywords_case_sensitive=*/true,
            /*keyword_prefix=*/"",
            /*keyword_suffix=*/"_",
            /*filenames=*/Case::kKeep,

--- a/src/idl_gen_kotlin_kmp.cpp
+++ b/src/idl_gen_kotlin_kmp.cpp
@@ -60,6 +60,7 @@ static Namer::Config KotlinDefaultConfig() {
            /*namespace_seperator=*/".",
            /*object_prefix=*/"",
            /*object_suffix=*/"T",
+           /*keywords_case_sensitive=*/true,
            /*keyword_prefix=*/"",
            /*keyword_suffix=*/"E",
            /*filenames=*/Case::kUpperCamel,

--- a/src/idl_gen_php.cpp
+++ b/src/idl_gen_php.cpp
@@ -24,8 +24,62 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
+#include "idl_namer.h"
 
 namespace flatbuffers {
+
+static Namer::Config PhpDefaultConfig() {
+  return { /*types=*/Case::kKeep,
+           /*constants=*/Case::kKeep,
+           /*methods=*/Case::kLowerCamel,
+           /*functions=*/Case::kUpperCamel,
+           /*fields=*/Case::kKeep,
+           /*variables=*/Case::kLowerCamel,
+           /*variants=*/Case::kKeep,
+           /*enum_variant_seperator=*/"::",
+           /*escape_keywords=*/Namer::Config::Escape::BeforeConvertingCase,
+           /*namespaces=*/Case::kUnknown,
+           /*namespace_seperator=*/"_",
+           /*object_prefix=*/"",
+           /*object_suffix=*/"T",
+           /*keywords_case_sensitive=*/false,
+           /*keyword_prefix=*/"",
+           /*keyword_suffix=*/"_",
+           /*filenames=*/Case::kKeep,
+           /*directories=*/Case::kKeep,
+           /*output_path=*/"",
+           /*filename_suffix=*/"_generated",
+           /*filename_extension=*/".php" };
+}
+
+static std::set<std::string> PhpKeywords() {
+  // List of keywords retrieved from here:
+  // https://www.php.net/manual/en/reserved.keywords.php
+  //
+  // List of reserved words retrieved from here:
+  // https://www.php.net/manual/en/reserved.other-reserved-words.php
+  return { "__halt_compiler", "abstract",     "and",       "array",
+           "as",              "break",        "callable",  "case",
+           "catch",           "class",        "clone",     "const",
+           "continue",        "declare",      "default",   "die",
+           "do",              "echo",         "else",      "elseif",
+           "empty",           "enddeclare",   "endfor",    "endforeach",
+           "endif",           "endswitch",    "endwhile",  "eval",
+           "exit",            "extends",      "final",     "for",
+           "foreach",         "function",     "global",    "goto",
+           "if",              "implements",   "include",   "include_once",
+           "instanceof",      "insteadof",    "interface", "isset",
+           "list",            "namespace",    "new",       "or",
+           "print",           "private",      "protected", "public",
+           "require",         "require_once", "return",    "static",
+           "switch",          "throw",        "trait",     "try",
+           "unset",           "use",          "var",       "while",
+           "xor",             "int",          "float",     "bool",
+           "string",          "true",         "false",     "null",
+           "void",            "iterable",     "object",    "mixed",
+           "never",           "enum",         "resource",  "numeric" };
+}
+
 namespace php {
 // Hardcode spaces per indentation.
 const std::string Indent = "    ";
@@ -33,7 +87,9 @@ class PhpGenerator : public BaseGenerator {
  public:
   PhpGenerator(const Parser &parser, const std::string &path,
                const std::string &file_name)
-      : BaseGenerator(parser, path, file_name, "\\", "\\", "php") {}
+      : BaseGenerator(parser, path, file_name, "\\", "\\", "php"),
+        namer_(WithFlagOptions(PhpDefaultConfig(), parser.opts, path),
+               PhpKeywords()) {}
   bool generate() {
     if (!GenerateEnums()) return false;
     if (!GenerateStructs()) return false;
@@ -100,61 +156,60 @@ class PhpGenerator : public BaseGenerator {
   }
 
   // Begin a class declaration.
-  static void BeginClass(const StructDef &struct_def, std::string *code_ptr) {
+  void BeginClass(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
     if (struct_def.fixed) {
-      code += "class " + struct_def.name + " extends Struct\n";
+      code += "class " + namer_.Type(struct_def) + " extends Struct\n";
     } else {
-      code += "class " + struct_def.name + " extends Table\n";
+      code += "class " + namer_.Type(struct_def) + " extends Table\n";
     }
     code += "{\n";
   }
 
-  static void EndClass(std::string *code_ptr) {
+  void EndClass(std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "}\n";
   }
 
   // Begin enum code with a class declaration.
-  static void BeginEnum(const std::string &class_name, std::string *code_ptr) {
+  void BeginEnum(const std::string &class_name, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += "class " + class_name + "\n{\n";
+    code += "class " + namer_.Type(class_name) + "\n{\n";
   }
 
   // A single enum member.
-  static void EnumMember(const EnumDef &enum_def, const EnumVal &ev,
-                         std::string *code_ptr) {
+  void EnumMember(const EnumDef &enum_def, const EnumVal &ev,
+                  std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += Indent + "const ";
-    code += ev.name;
+    code += namer_.Variant(ev);
     code += " = ";
     code += enum_def.ToString(ev) + ";\n";
   }
 
   // End enum code.
-  static void EndEnum(std::string *code_ptr) {
+  void EndEnum(std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "}\n";
   }
 
   // Initialize a new struct or table from existing data.
-  static void NewRootTypeFromBuffer(const StructDef &struct_def,
-                                    std::string *code_ptr,
-                                    bool size_prefixed) {
+  void NewRootTypeFromBuffer(const StructDef &struct_def, std::string *code_ptr,
+                             bool size_prefixed) {
     std::string &code = *code_ptr;
-    std::string sizePrefixed("SizePrefixed");
+    const std::string sizePrefixed(size_prefixed ? "SizePrefixed" : "");
+    const std::string struct_type = namer_.Type(struct_def);
 
     code += Indent + "/**\n";
     code += Indent + " * @param ByteBuffer $bb\n";
-    code += Indent + " * @return " + struct_def.name + "\n";
+    code += Indent + " * @return " + struct_type + "\n";
     code += Indent + " */\n";
-    code += Indent + "public static function get" + 
-            (size_prefixed ? sizePrefixed : "") + "RootAs";
-    code += struct_def.name;
+    code += Indent + "public static function " +
+            namer_.Method("get" + sizePrefixed + "RootAs", struct_type);
     code += "(ByteBuffer $bb)\n";
     code += Indent + "{\n";
 
-    code += Indent + Indent + "$obj = new " + struct_def.name + "();\n";
+    code += Indent + Indent + "$obj = new " + struct_type + "();\n";
     if (size_prefixed) {
       code += Indent + Indent;
       code += "$bb->setPosition($bb->getPosition() + Constants::SIZEOF_INT);\n";
@@ -166,14 +221,13 @@ class PhpGenerator : public BaseGenerator {
   }
 
   // Initialize an existing object with other data, to avoid an allocation.
-  static void InitializeExisting(const StructDef &struct_def,
-                                 std::string *code_ptr) {
+  void InitializeExisting(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
     code += Indent + "/**\n";
     code += Indent + " * @param int $_i offset\n";
     code += Indent + " * @param ByteBuffer $_bb\n";
-    code += Indent + " * @return " + struct_def.name + "\n";
+    code += Indent + " * @return " + namer_.Type(struct_def) + "\n";
     code += Indent + " **/\n";
     code += Indent + "public function init($_i, ByteBuffer $_bb)\n";
     code += Indent + "{\n";
@@ -184,14 +238,14 @@ class PhpGenerator : public BaseGenerator {
   }
 
   // Get the length of a vector.
-  static void GetVectorLen(const FieldDef &field, std::string *code_ptr) {
+  void GetVectorLen(const FieldDef &field, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
     code += Indent + "/**\n";
     code += Indent + " * @return int\n";
     code += Indent + " */\n";
-    code += Indent + "public function get";
-    code += ConvertCase(field.name, Case::kUpperCamel) + "Length()\n";
+    code += Indent + "public function " +
+            namer_.Method("get", field, "Length") + "()\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$o = $this->__offset(";
     code += NumToString(field.value.offset) + ");\n";
@@ -201,14 +255,14 @@ class PhpGenerator : public BaseGenerator {
   }
 
   // Get a [ubyte] vector as a byte array.
-  static void GetUByte(const FieldDef &field, std::string *code_ptr) {
+  void GetUByte(const FieldDef &field, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
     code += Indent + "/**\n";
     code += Indent + " * @return string\n";
     code += Indent + " */\n";
-    code += Indent + "public function get";
-    code += ConvertCase(field.name, Case::kUpperCamel) + "Bytes()\n";
+    code += Indent + "public function " +
+            namer_.Method("get", field.name, "Bytes") + "()\n";
     code += Indent + "{\n";
     code += Indent + Indent + "return $this->__vector_as_bytes(";
     code += NumToString(field.value.offset) + ");\n";
@@ -216,22 +270,19 @@ class PhpGenerator : public BaseGenerator {
   }
 
   // Get the value of a struct's scalar.
-  static void GetScalarFieldOfStruct(const FieldDef &field,
-                                     std::string *code_ptr) {
+  void GetScalarFieldOfStruct(const FieldDef &field, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    std::string getter = GenGetter(field.value.type);
 
     code += Indent + "/**\n";
-    code += Indent + " * @return ";
-    code += GenTypeGet(field.value.type) + "\n";
+    code += Indent + " * @return " + GenTypeGet(field.value.type) + "\n";
     code += Indent + " */\n";
-    code += Indent + "public function " + getter;
-    code += ConvertCase(field.name, Case::kUpperCamel) + "()\n";
+    code += Indent + "public function " +
+            namer_.LegacyPhpField(GenGetter(field.value.type), field) + "()\n";
     code += Indent + "{\n";
-    code += Indent + Indent + "return ";
 
-    code += "$this->bb->get";
-    code += ConvertCase(GenTypeGet(field.value.type), Case::kUpperCamel);
+    code += Indent + Indent + "return ";
+    code += "$this->bb->";
+    code += namer_.Method("get", GenTypeGet(field.value.type));
     code += "($this->bb_pos + ";
     code += NumToString(field.value.offset) + ")";
     code += ";\n";
@@ -246,15 +297,13 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + "/**\n";
     code += Indent + " * @return " + GenTypeGet(field.value.type) + "\n";
     code += Indent + " */\n";
-    code += Indent + "public function get";
-    code += ConvertCase(field.name, Case::kUpperCamel);
-    code += "()\n";
+    code += Indent + "public function " + namer_.Method("get", field) + "()\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$o = $this->__offset(" +
             NumToString(field.value.offset) + ");\n" + Indent + Indent +
             "return $o != 0 ? ";
-    code += "$this->bb->get";
-    code += ConvertCase(GenTypeGet(field.value.type), Case::kUpperCamel) +
+    code += "$this->bb->";
+    code += namer_.Method("get", GenTypeGet(field.value.type)) +
             "($o + $this->bb_pos)";
     code += " : " + GenDefaultValue(field.value) + ";\n";
     code += Indent + "}\n\n";
@@ -268,14 +317,13 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + "/**\n";
     code += Indent + " * @return " + GenTypeGet(field.value.type) + "\n";
     code += Indent + " */\n";
-    code += Indent + "public function get";
-    code += ConvertCase(field.name, Case::kUpperCamel) + "()\n";
+    code += Indent + "public function " + namer_.Method("get", field) + "()\n";
     code += Indent + "{\n";
-    code += Indent + Indent + "$obj = new ";
-    code += GenTypeGet(field.value.type) + "();\n";
-    code += Indent + Indent + "$obj->init($this->bb_pos + ";
-    code += NumToString(field.value.offset) + ", $this->bb);";
-    code += "\n" + Indent + Indent + "return $obj;\n";
+    code += Indent + Indent + "$obj = new " +
+            GenTypeGet(field.value.type) + "();\n";
+    code += Indent + Indent + "$obj->init($this->bb_pos + " +
+            NumToString(field.value.offset) + ", $this->bb);\n";
+    code += Indent + Indent + "return $obj;\n";
     code += Indent + "}\n\n";
   }
 
@@ -284,13 +332,10 @@ class PhpGenerator : public BaseGenerator {
   void GetStructFieldOfTable(const FieldDef &field, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
-    code += Indent + "public function get";
-    code += ConvertCase(field.name, Case::kUpperCamel);
+    code += Indent + "public function " + namer_.Method("get", field.name);
     code += "()\n";
     code += Indent + "{\n";
-    code += Indent + Indent + "$obj = new ";
-    code +=
-        ConvertCase(GenTypeGet(field.value.type), Case::kUpperCamel) + "();\n";
+    code += Indent + Indent + "$obj = new " + ScalarType(field) + "();\n";
     code += Indent + Indent + "$o = $this->__offset(" +
             NumToString(field.value.offset) + ");\n";
     code += Indent + Indent;
@@ -307,9 +352,8 @@ class PhpGenerator : public BaseGenerator {
   // Get the value of a string.
   void GetStringField(const FieldDef &field, std::string *code_ptr) {
     std::string &code = *code_ptr;
-    code += Indent + "public function get";
-    code += ConvertCase(field.name, Case::kUpperCamel);
-    code += "()\n";
+
+    code += Indent + "public function " + namer_.Method("get", field) + "()\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$o = $this->__offset(" +
             NumToString(field.value.offset) + ");\n";
@@ -326,8 +370,8 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + "/**\n";
     code += Indent + " * @return" + GenTypeBasic(field.value.type) + "\n";
     code += Indent + " */\n";
-    code += Indent + "public function get";
-    code += ConvertCase(field.name, Case::kUpperCamel) + "($obj)\n";
+    code +=
+        Indent + "public function " + namer_.Method("get", field) + "($obj)\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$o = $this->__offset(" +
             NumToString(field.value.offset) + ");\n";
@@ -345,15 +389,12 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + "/**\n";
     code += Indent + " * @return" + GenTypeBasic(field.value.type) + "\n";
     code += Indent + " */\n";
-    code += Indent + "public function get";
-    code += ConvertCase(field.name, Case::kUpperCamel);
-    code += "($j)\n";
+    code +=
+        Indent + "public function " + namer_.Method("get", field) + "($j)\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$o = $this->__offset(" +
             NumToString(field.value.offset) + ");\n";
-    code += Indent + Indent + "$obj = new ";
-    code +=
-        ConvertCase(GenTypeGet(field.value.type), Case::kUpperCamel) + "();\n";
+    code += Indent + Indent + "$obj = new " + ScalarType(field) + "();\n";
 
     switch (field.value.type.base_type) {
       case BASE_TYPE_STRUCT:
@@ -407,9 +448,8 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + " * @param int offset\n";
     code += Indent + " * @return " + GenTypeGet(field.value.type) + "\n";
     code += Indent + " */\n";
-    code += Indent + "public function get";
-    code += ConvertCase(field.name, Case::kUpperCamel);
-    code += "($j)\n";
+    code += Indent + "public function " + namer_.Method("get", field) +
+            "($j)\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$o = $this->__offset(" +
             NumToString(field.value.offset) + ");\n";
@@ -420,8 +460,8 @@ class PhpGenerator : public BaseGenerator {
       code += NumToString(InlineSize(vectortype)) + ") : ";
       code += GenDefaultValue(field.value) + ";\n";
     } else {
-      code += Indent + Indent + "return $o != 0 ? $this->bb->get";
-      code += ConvertCase(GenTypeGet(field.value.type), Case::kUpperCamel);
+      code += Indent + Indent + "return $o != 0 ? $this->bb->";
+      code += namer_.Method("get", GenTypeGet(field.value.type));
       code += "($this->__vector($o) + $j * ";
       code += NumToString(InlineSize(vectortype)) + ") : ";
       code += GenDefaultValue(field.value) + ";\n";
@@ -439,9 +479,8 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + " * @param int offset\n";
     code += Indent + " * @return " + GenTypeGet(field.value.type) + "\n";
     code += Indent + " */\n";
-    code += Indent + "public function get";
-    code += ConvertCase(field.name, Case::kUpperCamel);
-    code += "($j, $obj)\n";
+    code += Indent + "public function " + namer_.Method("get", field) +
+            "($j, $obj)\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$o = $this->__offset(" +
             NumToString(field.value.offset) + ");\n";
@@ -453,8 +492,8 @@ class PhpGenerator : public BaseGenerator {
 
   // Recursively generate arguments for a constructor, to deal with nested
   // structs.
-  static void StructBuilderArgs(const StructDef &struct_def,
-                                const char *nameprefix, std::string *code_ptr) {
+  void StructBuilderArgs(const StructDef &struct_def, const char *nameprefix,
+                         std::string *code_ptr) {
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
       auto &field = **it;
@@ -468,16 +507,17 @@ class PhpGenerator : public BaseGenerator {
       } else {
         std::string &code = *code_ptr;
         code += std::string(", $") + nameprefix;
-        code += ConvertCase(field.name, Case::kLowerCamel);
+        code += namer_.Variable(field);
       }
     }
   }
 
   // Recursively generate struct construction statements and instert manual
   // padding.
-  static void StructBuilderBody(const StructDef &struct_def,
-                                const char *nameprefix, std::string *code_ptr) {
+  void StructBuilderBody(const StructDef &struct_def, const char *nameprefix,
+                         std::string *code_ptr) {
     std::string &code = *code_ptr;
+
     code += Indent + Indent + "$builder->prep(";
     code += NumToString(struct_def.minalign) + ", ";
     code += NumToString(struct_def.bytesize) + ");\n";
@@ -493,23 +533,22 @@ class PhpGenerator : public BaseGenerator {
                           (nameprefix + (field.name + "_")).c_str(), code_ptr);
       } else {
         code += Indent + Indent + "$builder->put" + GenMethod(field) + "($";
-        code +=
-            nameprefix + ConvertCase(field.name, Case::kLowerCamel) + ");\n";
+        code += nameprefix + namer_.Variable(field) + ");\n";
       }
     }
   }
 
   // Get the value of a table's starting offset.
-  static void GetStartOfTable(const StructDef &struct_def,
-                              std::string *code_ptr) {
+  void GetStartOfTable(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
 
     code += Indent + "/**\n";
     code += Indent + " * @param FlatBufferBuilder $builder\n";
     code += Indent + " * @return void\n";
     code += Indent + " */\n";
-    code += Indent + "public static function start" + struct_def.name;
-    code += "(FlatBufferBuilder $builder)\n";
+    code += Indent + "public static function " +
+            namer_.Method("start", struct_def) +
+            "(FlatBufferBuilder $builder)\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$builder->StartObject(";
     code += NumToString(struct_def.fields.vec.size());
@@ -518,9 +557,10 @@ class PhpGenerator : public BaseGenerator {
 
     code += Indent + "/**\n";
     code += Indent + " * @param FlatBufferBuilder $builder\n";
-    code += Indent + " * @return " + struct_def.name + "\n";
+    code += Indent + " * @return " + namer_.Type(struct_def) + "\n";
     code += Indent + " */\n";
-    code += Indent + "public static function create" + struct_def.name;
+    code += Indent + "public static function " +
+            namer_.Method("create", struct_def);
     code += "(FlatBufferBuilder $builder, ";
 
     for (auto it = struct_def.fields.vec.begin();
@@ -541,9 +581,8 @@ class PhpGenerator : public BaseGenerator {
       auto &field = **it;
       if (field.deprecated) continue;
 
-      code += Indent + Indent + "self::add";
-      code += ConvertCase(field.name, Case::kUpperCamel) + "($builder, $" +
-              field.name + ");\n";
+      code += Indent + Indent + "self::" + namer_.Method("add", field);
+      code += "($builder, $" + field.name + ");\n";
     }
 
     code += Indent + Indent + "$o = $builder->endObject();\n";
@@ -562,7 +601,7 @@ class PhpGenerator : public BaseGenerator {
   }
 
   // Set the value of a table's field.
-  static void BuildFieldOfTable(const FieldDef &field, const size_t offset,
+  void BuildFieldOfTable(const FieldDef &field, const size_t offset,
                                 std::string *code_ptr) {
     std::string &code = *code_ptr;
 
@@ -571,17 +610,14 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + " * @param " + GenTypeBasic(field.value.type) + "\n";
     code += Indent + " * @return void\n";
     code += Indent + " */\n";
-    code += Indent + "public static function ";
-    code += "add" + ConvertCase(field.name, Case::kUpperCamel);
-    code += "(FlatBufferBuilder $builder, ";
-    code += "$" + ConvertCase(field.name, Case::kLowerCamel);
-    code += ")\n";
+    code += Indent + "public static function " + namer_.Method("add", field) +
+            "(FlatBufferBuilder $builder, $" + namer_.Variable(field) + ")\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$builder->add";
     code += GenMethod(field) + "X(";
     code += NumToString(offset) + ", ";
 
-    code += "$" + ConvertCase(field.name, Case::kLowerCamel);
+    code += "$" + namer_.Variable(field);
     code += ", ";
 
     if (field.value.type.base_type == BASE_TYPE_BOOL) {
@@ -594,20 +630,20 @@ class PhpGenerator : public BaseGenerator {
   }
 
   // Set the value of one of the members of a table's vector.
-  static void BuildVectorOfTable(const FieldDef &field, std::string *code_ptr) {
+  void BuildVectorOfTable(const FieldDef &field, std::string *code_ptr) {
     std::string &code = *code_ptr;
-
     auto vector_type = field.value.type.VectorType();
     auto alignment = InlineAlignment(vector_type);
     auto elem_size = InlineSize(vector_type);
+
     code += Indent + "/**\n";
     code += Indent + " * @param FlatBufferBuilder $builder\n";
     code += Indent + " * @param array offset array\n";
     code += Indent + " * @return int vector offset\n";
     code += Indent + " */\n";
-    code += Indent + "public static function create";
-    code += ConvertCase(field.name, Case::kUpperCamel);
-    code += "Vector(FlatBufferBuilder $builder, array $data)\n";
+    code += Indent + "public static function ";
+    code += namer_.Method("create", field, "Vector");
+    code += "(FlatBufferBuilder $builder, array $data)\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$builder->startVector(";
     code += NumToString(elem_size);
@@ -617,9 +653,8 @@ class PhpGenerator : public BaseGenerator {
     code += "for ($i = count($data) - 1; $i >= 0; $i--) {\n";
     if (IsScalar(field.value.type.VectorType().base_type)) {
       code += Indent + Indent + Indent;
-      code += "$builder->put";
-      code += ConvertCase(GenTypeBasic(field.value.type.VectorType()),
-                          Case::kUpperCamel);
+      code += "$builder->";
+      code += namer_.Method("put", GenTypeBasic(field.value.type.VectorType()));
       code += "($data[$i]);\n";
     } else {
       code += Indent + Indent + Indent;
@@ -634,9 +669,9 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + " * @param int $numElems\n";
     code += Indent + " * @return void\n";
     code += Indent + " */\n";
-    code += Indent + "public static function start";
-    code += ConvertCase(field.name, Case::kUpperCamel);
-    code += "Vector(FlatBufferBuilder $builder, $numElems)\n";
+    code += Indent + "public static function ";
+    code += namer_.Method("start", field, "Vector");
+    code += "(FlatBufferBuilder $builder, $numElems)\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$builder->startVector(";
     code += NumToString(elem_size);
@@ -648,12 +683,11 @@ class PhpGenerator : public BaseGenerator {
   void GenerateFinisher(const StructDef &struct_def, std::string &code,
                         bool size_prefixed) {
     if (parser_.root_struct_def_ == &struct_def) {
-      std::string sizePrefixed("SizePrefixed");
+      std::string sizePrefixed(size_prefixed ? "SizePrefixed" : "");
 
       code += "\n";
-      code += Indent + "public static function finish";
-      code += size_prefixed ? sizePrefixed : "";
-      code += struct_def.name;
+      code += Indent + "public static function " +
+              namer_.Method("finish" + sizePrefixed, struct_def);
       code += "Buffer(FlatBufferBuilder $builder, $offset)\n";
       code += Indent + "{\n";
       code += Indent + Indent + "$builder->finish($offset";
@@ -678,7 +712,8 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + " * @param FlatBufferBuilder $builder\n";
     code += Indent + " * @return int table offset\n";
     code += Indent + " */\n";
-    code += Indent + "public static function end" + struct_def.name;
+    code += Indent + "public static function " +
+            namer_.Method("end", struct_def);
     code += "(FlatBufferBuilder $builder)\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$o = $builder->endObject();\n";
@@ -755,8 +790,8 @@ class PhpGenerator : public BaseGenerator {
       auto offset = it - struct_def.fields.vec.begin();
       if (field.value.type.base_type == BASE_TYPE_UNION) {
         std::string &code = *code_ptr;
-        code += Indent + "public static function add";
-        code += ConvertCase(field.name, Case::kUpperCamel);
+        code += Indent + "public static function ";
+        code += namer_.Method("add", field);
         code += "(FlatBufferBuilder $builder, $offset)\n";
         code += Indent + "{\n";
         code += Indent + Indent + "$builder->addOffsetX(";
@@ -789,27 +824,28 @@ class PhpGenerator : public BaseGenerator {
     if (!struct_def.fixed) {
       if (parser_.file_identifier_.length()) {
         // Return the identifier
-        code += Indent + "public static function " + struct_def.name;
-        code += "Identifier()\n";
+        code += Indent + "public static function " +
+                namer_.LegacyPhpMethod(struct_def, "Identifier") + "()\n";
         code += Indent + "{\n";
         code += Indent + Indent + "return \"";
         code += parser_.file_identifier_ + "\";\n";
         code += Indent + "}\n\n";
 
         // Check if a buffer has the identifier.
-        code += Indent + "public static function " + struct_def.name;
-        code += "BufferHasIdentifier(ByteBuffer $buf)\n";
+        code += Indent + "public static function " +
+                namer_.LegacyPhpMethod(struct_def, "BufferHasIdentifier") +
+                "(ByteBuffer $buf)\n";
         code += Indent + "{\n";
         code += Indent + Indent + "return self::";
         code += "__has_identifier($buf, self::";
-        code += struct_def.name + "Identifier());\n";
+        code += namer_.Type(struct_def) + "Identifier());\n";
         code += Indent + "}\n\n";
       }
 
       if (parser_.file_extension_.length()) {
         // Return the extension
-        code += Indent + "public static function " + struct_def.name;
-        code += "Extension()\n";
+        code += Indent + "public static function " +
+                namer_.LegacyPhpMethod(struct_def, "Extension") + "()\n";
         code += Indent + "{\n";
         code += Indent + Indent + "return \"" + parser_.file_extension_;
         code += "\";\n";
@@ -839,7 +875,7 @@ class PhpGenerator : public BaseGenerator {
   }
 
   // Generate enum declarations.
-  static void GenEnum(const EnumDef &enum_def, std::string *code_ptr) {
+  void GenEnum(const EnumDef &enum_def, std::string *code_ptr) {
     if (enum_def.generated) return;
 
     GenComment(enum_def.doc_comment, code_ptr, nullptr);
@@ -871,7 +907,7 @@ class PhpGenerator : public BaseGenerator {
   }
 
   // Returns the function name that is able to read a value of the given type.
-  static std::string GenGetter(const Type &type) {
+  std::string GenGetter(const Type &type) {
     switch (type.base_type) {
       case BASE_TYPE_STRING: return "__string";
       case BASE_TYPE_STRUCT: return "__struct";
@@ -882,13 +918,13 @@ class PhpGenerator : public BaseGenerator {
   }
 
   // Returns the method name for use with add/put calls.
-  static std::string GenMethod(const FieldDef &field) {
+  std::string GenMethod(const FieldDef &field) {
     return IsScalar(field.value.type.base_type)
                ? ConvertCase(GenTypeBasic(field.value.type), Case::kUpperCamel)
                : (IsStruct(field.value.type) ? "Struct" : "Offset");
   }
 
-  static std::string GenTypeBasic(const Type &type) {
+  std::string GenTypeBasic(const Type &type) {
     // clang-format off
     static const char *ctypename[] = {
       #define FLATBUFFERS_TD(ENUM, IDLTYPE, \
@@ -925,30 +961,30 @@ class PhpGenerator : public BaseGenerator {
     }
   }
 
-  static std::string GenTypePointer(const Type &type) {
+  std::string GenTypePointer(const Type &type) {
     switch (type.base_type) {
       case BASE_TYPE_STRING: return "string";
       case BASE_TYPE_VECTOR: return GenTypeGet(type.VectorType());
-      case BASE_TYPE_STRUCT: return type.struct_def->name;
+      case BASE_TYPE_STRUCT: return namer_.Type(*type.struct_def);
       case BASE_TYPE_UNION:
         // fall through
       default: return "Table";
     }
   }
 
-  static std::string GenTypeGet(const Type &type) {
+  std::string GenTypeGet(const Type &type) {
     return IsScalar(type.base_type) ? GenTypeBasic(type) : GenTypePointer(type);
   }
 
   // Create a struct with a builder and the struct's arguments.
-  static void GenStructBuilder(const StructDef &struct_def,
-                               std::string *code_ptr) {
+  void GenStructBuilder(const StructDef &struct_def, std::string *code_ptr) {
     std::string &code = *code_ptr;
     code += "\n";
     code += Indent + "/**\n";
     code += Indent + " * @return int offset\n";
     code += Indent + " */\n";
-    code += Indent + "public static function create" + struct_def.name;
+    code += Indent + "public static function " +
+            namer_.Method("create", struct_def);
     code += "(FlatBufferBuilder $builder";
     StructBuilderArgs(struct_def, "", code_ptr);
     code += ")\n";
@@ -959,6 +995,12 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + Indent + "return $builder->offset();\n";
     code += Indent + "}\n";
   }
+
+  std::string ScalarType(const FieldDef &field) {
+    return ConvertCase(GenTypeGet(field.value.type), Case::kUpperCamel);
+  }
+
+  IdlNamer namer_;
 };
 }  // namespace php
 

--- a/src/idl_gen_php.cpp
+++ b/src/idl_gen_php.cpp
@@ -547,7 +547,7 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + " * @return void\n";
     code += Indent + " */\n";
     code += Indent + "public static function " +
-            namer_.Method("start", struct_def) +
+            namer_.LegacyPhpMethod("start", struct_def) +
             "(FlatBufferBuilder $builder)\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$builder->StartObject(";
@@ -560,7 +560,7 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + " * @return " + namer_.Type(struct_def) + "\n";
     code += Indent + " */\n";
     code += Indent + "public static function " +
-            namer_.Method("create", struct_def);
+            namer_.LegacyPhpMethod("create", struct_def);
     code += "(FlatBufferBuilder $builder, ";
 
     for (auto it = struct_def.fields.vec.begin();
@@ -687,7 +687,7 @@ class PhpGenerator : public BaseGenerator {
 
       code += "\n";
       code += Indent + "public static function " +
-              namer_.Method("finish" + sizePrefixed, struct_def);
+              namer_.LegacyPhpMethod("finish" + sizePrefixed, struct_def);
       code += "Buffer(FlatBufferBuilder $builder, $offset)\n";
       code += Indent + "{\n";
       code += Indent + Indent + "$builder->finish($offset";
@@ -713,7 +713,7 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + " * @return int table offset\n";
     code += Indent + " */\n";
     code += Indent + "public static function " +
-            namer_.Method("end", struct_def);
+            namer_.LegacyPhpMethod("end", struct_def);
     code += "(FlatBufferBuilder $builder)\n";
     code += Indent + "{\n";
     code += Indent + Indent + "$o = $builder->endObject();\n";
@@ -838,7 +838,7 @@ class PhpGenerator : public BaseGenerator {
         code += Indent + "{\n";
         code += Indent + Indent + "return self::";
         code += "__has_identifier($buf, self::";
-        code += namer_.Type(struct_def) + "Identifier());\n";
+        code += namer_.LegacyPhpMethod(struct_def, "Identifier") + "());\n";
         code += Indent + "}\n\n";
       }
 
@@ -984,7 +984,7 @@ class PhpGenerator : public BaseGenerator {
     code += Indent + " * @return int offset\n";
     code += Indent + " */\n";
     code += Indent + "public static function " +
-            namer_.Method("create", struct_def);
+            namer_.LegacyPhpMethod("create", struct_def);
     code += "(FlatBufferBuilder $builder";
     StructBuilderArgs(struct_def, "", code_ptr);
     code += ")\n";

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -61,6 +61,7 @@ static Namer::Config PythonDefaultConfig() {
            /*namespace_seperator=*/".",
            /*object_prefix=*/"",
            /*object_suffix=*/"T",
+           /*keywords_case_sensitive=*/true,
            /*keyword_prefix=*/"",
            /*keyword_suffix=*/"_",
            /*filenames=*/Case::kKeep,

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -47,6 +47,7 @@ static Namer::Config RustDefaultConfig() {
            /*namespace_seperator=*/"::",
            /*object_prefix=*/"",
            /*object_suffix=*/"T",
+           /*keywords_case_sensitive=*/true,
            /*keyword_prefix=*/"",
            /*keyword_suffix=*/"_",
            /*filenames=*/Case::kSnake,

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -45,6 +45,7 @@ static Namer::Config SwiftDefaultConfig() {
            /*namespace_seperator=*/"_",
            /*object_prefix=*/"",
            /*object_suffix=*/"T",
+           /*keywords_case_sensitive=*/true,
            /*keyword_prefix=*/"",
            /*keyword_suffix=*/"_",
            /*filenames=*/Case::kKeep,

--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -65,6 +65,7 @@ Namer::Config TypeScriptDefaultConfig() {
            /*namespace_seperator=*/"_",
            /*object_prefix=*/"",
            /*object_suffix=*/"T",
+           /*keywords_case_sensitive=*/true,
            /*keyword_prefix=*/"",
            /*keyword_suffix=*/"_",
            /*filenames=*/Case::kDasher,

--- a/src/idl_namer.h
+++ b/src/idl_namer.h
@@ -154,7 +154,11 @@ class IdlNamer : public Namer {
   // Php method for structs are a mix of keep case and lower camel case.
   std::string LegacyPhpMethod(const StructDef &d,
                               const std::string &suffix) const {
-    return d.name + suffix;
+    return Type(d.name) + suffix;
+  }
+  std::string LegacyPhpMethod(const std::string &prefix,
+                              const StructDef &d) const {
+    return prefix + Type(d.name);
   }
   std::string LegacyPhpField(const std::string &prefix,
                              const FieldDef &field) const {

--- a/src/idl_namer.h
+++ b/src/idl_namer.h
@@ -151,6 +151,16 @@ class IdlNamer : public Namer {
     return ConvertCase(d.name, config_.fields, Case::kLowerCamel) + "_type";
   }
 
+  // Php method for structs are a mix of keep case and lower camel case.
+  std::string LegacyPhpMethod(const StructDef &d,
+                              const std::string &suffix) const {
+    return d.name + suffix;
+  }
+  std::string LegacyPhpField(const std::string &prefix,
+                             const FieldDef &field) const {
+    return prefix + ConvertCase(field.name, Case::kUpperCamel);
+  }
+
  private:
   std::string NamespacedString(const struct Namespace *ns,
                                const std::string &str) const {

--- a/src/namer.h
+++ b/src/namer.h
@@ -213,7 +213,7 @@ class Namer {
       // Standard languages *usually* don't use non-ASCII characters for
       // keywords, therefore this operations should be safe.
       for (auto chr = name_cased.begin(); chr != name_cased.end(); chr++) {
-        *chr = std::tolower(*chr);
+        *chr = static_cast<char>(std::tolower(*chr));
       }
     }
     if (keywords_.find(name_cased) == keywords_.end()) {

--- a/src/namer.h
+++ b/src/namer.h
@@ -87,6 +87,8 @@ class Namer {
     std::string object_suffix;
 
     // Keywords.
+    // If the keywords list is case sensitive. It is usually true.
+    bool keywords_case_sensitive;
     // Prefix used to escape keywords. It is usually empty string.
     std::string keyword_prefix;
     // Suffix used to escape keywords. It is usually "_".
@@ -205,7 +207,16 @@ class Namer {
   }
 
   virtual std::string EscapeKeyword(const std::string &name) const {
-    if (keywords_.find(name) == keywords_.end()) {
+    std::string name_cased(name);
+
+    if (!config_.keywords_case_sensitive) {
+      // Standard languages *usually* don't use non-ASCII characters for
+      // keywords, therefore this operations should be safe.
+      for (auto chr = name_cased.begin(); chr != name_cased.end(); chr++) {
+        *chr = std::tolower(*chr);
+      }
+    }
+    if (keywords_.find(name_cased) == keywords_.end()) {
       return name;
     } else {
       return config_.keyword_prefix + name + config_.keyword_suffix;

--- a/tests/MyGame/Example/Ability.php
+++ b/tests/MyGame/Example/Ability.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class Ability extends Struct
 {

--- a/tests/MyGame/Example/Monster.php
+++ b/tests/MyGame/Example/Monster.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 /// an example documentation comment: "monster object"
 class Monster extends Table
@@ -18,6 +19,17 @@ class Monster extends Table
     public static function getRootAsMonster(ByteBuffer $bb)
     {
         $obj = new Monster();
+        return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
+    }
+
+    /**
+     * @param ByteBuffer $bb
+     * @return Monster
+     */
+    public static function getSizePrefixedRootAsMonster(ByteBuffer $bb)
+    {
+        $obj = new Monster();
+        $bb->setPosition($bb->getPosition() + Constants::SIZEOF_INT);
         return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
     }
 
@@ -1997,5 +2009,10 @@ class Monster extends Table
     public static function finishMonsterBuffer(FlatBufferBuilder $builder, $offset)
     {
         $builder->finish($offset, "MONS");
+    }
+
+    public static function finishSizePrefixedMonsterBuffer(FlatBufferBuilder $builder, $offset)
+    {
+        $builder->finish($offset, "MONS", true);
     }
 }

--- a/tests/MyGame/Example/Referrable.php
+++ b/tests/MyGame/Example/Referrable.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class Referrable extends Table
 {
@@ -17,6 +18,17 @@ class Referrable extends Table
     public static function getRootAsReferrable(ByteBuffer $bb)
     {
         $obj = new Referrable();
+        return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
+    }
+
+    /**
+     * @param ByteBuffer $bb
+     * @return Referrable
+     */
+    public static function getSizePrefixedRootAsReferrable(ByteBuffer $bb)
+    {
+        $obj = new Referrable();
+        $bb->setPosition($bb->getPosition() + Constants::SIZEOF_INT);
         return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
     }
 

--- a/tests/MyGame/Example/Stat.php
+++ b/tests/MyGame/Example/Stat.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class Stat extends Table
 {
@@ -17,6 +18,17 @@ class Stat extends Table
     public static function getRootAsStat(ByteBuffer $bb)
     {
         $obj = new Stat();
+        return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
+    }
+
+    /**
+     * @param ByteBuffer $bb
+     * @return Stat
+     */
+    public static function getSizePrefixedRootAsStat(ByteBuffer $bb)
+    {
+        $obj = new Stat();
+        $bb->setPosition($bb->getPosition() + Constants::SIZEOF_INT);
         return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
     }
 

--- a/tests/MyGame/Example/StructOfStructs.php
+++ b/tests/MyGame/Example/StructOfStructs.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class StructOfStructs extends Struct
 {

--- a/tests/MyGame/Example/StructOfStructsOfStructs.php
+++ b/tests/MyGame/Example/StructOfStructsOfStructs.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class StructOfStructsOfStructs extends Struct
 {

--- a/tests/MyGame/Example/Test.php
+++ b/tests/MyGame/Example/Test.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class Test extends Struct
 {

--- a/tests/MyGame/Example/TestSimpleTableWithEnum.php
+++ b/tests/MyGame/Example/TestSimpleTableWithEnum.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class TestSimpleTableWithEnum extends Table
 {
@@ -17,6 +18,17 @@ class TestSimpleTableWithEnum extends Table
     public static function getRootAsTestSimpleTableWithEnum(ByteBuffer $bb)
     {
         $obj = new TestSimpleTableWithEnum();
+        return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
+    }
+
+    /**
+     * @param ByteBuffer $bb
+     * @return TestSimpleTableWithEnum
+     */
+    public static function getSizePrefixedRootAsTestSimpleTableWithEnum(ByteBuffer $bb)
+    {
+        $obj = new TestSimpleTableWithEnum();
+        $bb->setPosition($bb->getPosition() + Constants::SIZEOF_INT);
         return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
     }
 

--- a/tests/MyGame/Example/TypeAliases.php
+++ b/tests/MyGame/Example/TypeAliases.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class TypeAliases extends Table
 {
@@ -17,6 +18,17 @@ class TypeAliases extends Table
     public static function getRootAsTypeAliases(ByteBuffer $bb)
     {
         $obj = new TypeAliases();
+        return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
+    }
+
+    /**
+     * @param ByteBuffer $bb
+     * @return TypeAliases
+     */
+    public static function getSizePrefixedRootAsTypeAliases(ByteBuffer $bb)
+    {
+        $obj = new TypeAliases();
+        $bb->setPosition($bb->getPosition() + Constants::SIZEOF_INT);
         return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
     }
 

--- a/tests/MyGame/Example/Vec3.php
+++ b/tests/MyGame/Example/Vec3.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class Vec3 extends Struct
 {

--- a/tests/MyGame/Example2/Monster.php
+++ b/tests/MyGame/Example2/Monster.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class Monster extends Table
 {
@@ -17,6 +18,17 @@ class Monster extends Table
     public static function getRootAsMonster(ByteBuffer $bb)
     {
         $obj = new Monster();
+        return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
+    }
+
+    /**
+     * @param ByteBuffer $bb
+     * @return Monster
+     */
+    public static function getSizePrefixedRootAsMonster(ByteBuffer $bb)
+    {
+        $obj = new Monster();
+        $bb->setPosition($bb->getPosition() + Constants::SIZEOF_INT);
         return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
     }
 

--- a/tests/MyGame/InParentNamespace.php
+++ b/tests/MyGame/InParentNamespace.php
@@ -7,6 +7,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class InParentNamespace extends Table
 {
@@ -17,6 +18,17 @@ class InParentNamespace extends Table
     public static function getRootAsInParentNamespace(ByteBuffer $bb)
     {
         $obj = new InParentNamespace();
+        return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
+    }
+
+    /**
+     * @param ByteBuffer $bb
+     * @return InParentNamespace
+     */
+    public static function getSizePrefixedRootAsInParentNamespace(ByteBuffer $bb)
+    {
+        $obj = new InParentNamespace();
+        $bb->setPosition($bb->getPosition() + Constants::SIZEOF_INT);
         return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
     }
 

--- a/tests/union_vector/Attacker.php
+++ b/tests/union_vector/Attacker.php
@@ -5,6 +5,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class Attacker extends Table
 {
@@ -15,6 +16,17 @@ class Attacker extends Table
     public static function getRootAsAttacker(ByteBuffer $bb)
     {
         $obj = new Attacker();
+        return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
+    }
+
+    /**
+     * @param ByteBuffer $bb
+     * @return Attacker
+     */
+    public static function getSizePrefixedRootAsAttacker(ByteBuffer $bb)
+    {
+        $obj = new Attacker();
+        $bb->setPosition($bb->getPosition() + Constants::SIZEOF_INT);
         return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
     }
 

--- a/tests/union_vector/BookReader.php
+++ b/tests/union_vector/BookReader.php
@@ -5,6 +5,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class BookReader extends Struct
 {

--- a/tests/union_vector/FallingTub.php
+++ b/tests/union_vector/FallingTub.php
@@ -5,6 +5,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class FallingTub extends Struct
 {

--- a/tests/union_vector/HandFan.php
+++ b/tests/union_vector/HandFan.php
@@ -5,6 +5,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class HandFan extends Table
 {
@@ -15,6 +16,17 @@ class HandFan extends Table
     public static function getRootAsHandFan(ByteBuffer $bb)
     {
         $obj = new HandFan();
+        return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
+    }
+
+    /**
+     * @param ByteBuffer $bb
+     * @return HandFan
+     */
+    public static function getSizePrefixedRootAsHandFan(ByteBuffer $bb)
+    {
+        $obj = new HandFan();
+        $bb->setPosition($bb->getPosition() + Constants::SIZEOF_INT);
         return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
     }
 

--- a/tests/union_vector/Movie.php
+++ b/tests/union_vector/Movie.php
@@ -5,6 +5,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class Movie extends Table
 {
@@ -15,6 +16,17 @@ class Movie extends Table
     public static function getRootAsMovie(ByteBuffer $bb)
     {
         $obj = new Movie();
+        return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
+    }
+
+    /**
+     * @param ByteBuffer $bb
+     * @return Movie
+     */
+    public static function getSizePrefixedRootAsMovie(ByteBuffer $bb)
+    {
+        $obj = new Movie();
+        $bb->setPosition($bb->getPosition() + Constants::SIZEOF_INT);
         return ($obj->init($bb->getInt($bb->getPosition()) + $bb->getPosition(), $bb));
     }
 
@@ -216,5 +228,10 @@ class Movie extends Table
     public static function finishMovieBuffer(FlatBufferBuilder $builder, $offset)
     {
         $builder->finish($offset, "MOVI");
+    }
+
+    public static function finishSizePrefixedMovieBuffer(FlatBufferBuilder $builder, $offset)
+    {
+        $builder->finish($offset, "MOVI", true);
     }
 }

--- a/tests/union_vector/Rapunzel.php
+++ b/tests/union_vector/Rapunzel.php
@@ -5,6 +5,7 @@ use \Google\FlatBuffers\Struct;
 use \Google\FlatBuffers\Table;
 use \Google\FlatBuffers\ByteBuffer;
 use \Google\FlatBuffers\FlatBufferBuilder;
+use \Google\FlatBuffers\Constants;
 
 class Rapunzel extends Struct
 {


### PR DESCRIPTION
This PR adds some missing functionality and improved performance to PHP flatbuffers:
 - in PHP builder: finish with prefixed size, clear, and createBytesVector methods. I drew inspiration from [TS](https://github.com/google/flatbuffers/blob/master/ts/builder.ts#L425-L453).
 - added PHP IDL generator namer; partially addressed in #7491, and I continued that work.
 - for-loops replaced with substr_replace in createString and growByteBuffer. createBytesVector also uses this.

During internal testing, I noticed that tables using PHP keywords as names (e.g., bytes, string) would yield errors in the generated code because keywords cannot be used as class names despite their casing (also mentioned in [PHP docs](https://www.php.net/manual/en/reserved.keywords.php)). Therefore, I added a check (see commit [a58f40c](https://github.com/google/flatbuffers/commit/a58f40c7a8e064b94a35d7df4d01963581480ccf)) when escaping keywords, which generally is disabled, except for IDL PHP generator.

Also, when I replaced for-loops with substr_replace  in createString and growByteBuffer, the performance improved, especially for longer strings. Below is a benchmark ([here](https://gist.github.com/razvanalex/ad32f83360be92039074dc99c2ee69fd) is the code).

Before the change:
``` txt
BenchmarkCreateString/1 0.0019979476928711 ms
BenchmarkCreateString/10        0.0022983551025391 ms
BenchmarkCreateString/100       0.010838508605957 ms
BenchmarkCreateString/1000      0.083937644958496 ms
BenchmarkCreateString/10000     0.96836090087891 ms
BenchmarkCreateString/100000    8.6467790603638 ms
BenchmarkCreateString/1000000   82.010021209717 ms
BenchmarkCreateString/10000000  936.62708282471 ms
```

After the change:
``` txt
BenchmarkCreateString/1 0.0019216537475586 ms
BenchmarkCreateString/10        0.0020408630371094 ms
BenchmarkCreateString/100       0.0075387954711914 ms
BenchmarkCreateString/1000      0.053601264953613 ms
BenchmarkCreateString/10000     0.52011966705322 ms
BenchmarkCreateString/100000    4.9904012680054 ms
BenchmarkCreateString/1000000   50.608458518982 ms
BenchmarkCreateString/10000000  506.61317825317 ms
```
