### PR TITLE
Fix license details

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "flatbuffers"
   ],
   "author": "The FlatBuffers project",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/google/flatbuffers/issues"
   },


### PR DESCRIPTION
We updated to the latest release of the flatbuffers javascript library from npm, and Arnica threw up a warning that flatbuffers was using a non-standard license. However you're actually using a completely standard Apache 2.0 license, it was just mislabeled. (I diffed it against https://www.apache.org/licenses/LICENSE-2.0.txt to be sure and noticed that it didn't even have the copyright info filled in!) 

So, this PR fixes two things:

1. `package.json` now uses the correct SPDX license identifier. 
    * This is useful for automated tools that scan for license requirements, and will also allow https://www.npmjs.com/package/flatbuffers to show the correct license info.
    * See https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license for more info
2. ~~The copyright year and owner in the `LICENSE` file is now filled in~~
    * See https://www.apache.org/licenses/LICENSE-2.0.html#apply 
    * Now removed from this PR


Feel free to edit that as appropriate. I can also split this into two PRs if preferred.


