### PR TITLE
[C++] Comparing floats safely

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -47,6 +47,10 @@
 #include <iterator>
 #include <memory>
 
+#if !defined(FLATBUFFERS_NAN_DEFAULTS)
+  #include <cmath>
+#endif
+
 #if defined(__unix__) && !defined(FLATBUFFERS_LOCALE_INDEPENDENT)
   #include <unistd.h>
 #endif
@@ -475,6 +479,13 @@ template<> inline bool IsTheSameAs<float>(float e, float def) {
 }
 template<> inline bool IsTheSameAs<double>(double e, double def) {
   return IsFloatTheSameAs(e, def);
+}
+#else
+template<> inline bool IsTheSameAs<float>(float e, float def) {
+  return std::fabs(e - def) < std::numeric_limits<float>::epsilon() || ((std::signbit(e) == std::signbit(def)) && std::isinf(e) && std::isinf(def));
+}
+template<> inline bool IsTheSameAs<double>(double e, double def) {
+  return std::fabs(e - def) < std::numeric_limits<double>::epsilon() || ((std::signbit(e) == std::signbit(def)) && std::isinf(e) && std::isinf(def));
 }
 #endif
 


### PR DESCRIPTION
This will allow the code to be compiled with `-Wfloat-equal` 

```
vendor/flatbuffers/include/flatbuffers/base.h:465:69:
  error: comparing floating point with == or != is unsafe [-Werror,-Wfloat-equal]
template<typename T> inline bool IsTheSameAs(T e, T def) { return e == def; }
```

Im not 100% happy because it will still break when `FLATBUFFERS_NAN_DEFAULTS` is defined.