### PR TITLE
Fix License

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "flatbuffers"
   ],
   "author": "The FlatBuffers project",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/google/flatbuffers/issues"
   },


### PR DESCRIPTION
## 📖 Description
The previous license value was not suitable for most software license scanners. Listing the actual license string in the package.json fixes this
