### PR TITLE
[dart] fix toString() method generated for enum value

### DIFF
--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -281,7 +281,15 @@ class DartGenerator : public BaseGenerator {
             enum_type + "Reader();\n\n";
     code += "  @override\n";
     code += "  String toString() {\n";
-    code += "    return '" + enum_type + "{value: $value}';\n";
+    code += "    switch (value) {\n";
+    for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
+      auto &ev = **it;
+      const auto enum_var = namer_.Variant(ev);
+      code += "      case " + enum_def.ToString(ev) + ": return \"" + enum_var +
+              "\";\n";
+    }
+    code += "      default: return \"\";\n";
+    code += "    }\n";
     code += "  }\n";
     code += "}\n\n";
 


### PR DESCRIPTION
example fbs file:
```fb
enum Foo : ubyte {
  Bar0 = 0,
  Bar1,
  Bar2,
}
```

before change:
```dart
@override
String toString() {
  return 'Foo{value: $value}';
}
```

after change:
```dart
@override
String toString() {
  switch (value) {
    case 0: return "Bar0";
    case 1: return "Bar1";
    case 2: return "Bar2";
    default: "";
  }
}
```