### PR TITLE
feat: library definition for PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,28 @@
+{
+    "name": "flatbuffers",
+    "version": "24.3.7",
+    "description": "FlatBuffers is a cross platform serialization library architected for maximum memory efficiency",
+    "keywords": "FlatBuffers, serialization",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/google/flatbuffers"
+    },
+    "authors": [
+      {
+        "name": "FPL",
+        "maintainer": true
+      }
+    ],
+    "license": "Apache-2.0",
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "platforms": "espressif32",
+    "build": {
+      "includeDir": "include",
+      "srcFilter": "-<*>"
+    }
+  }
+
+


### PR DESCRIPTION
Many embedded projects are using PlatfomIO as a development environment, in particular in the ESP32 world.

It is possible to use third party libraries via such a definition in the project platform.io file:

```
lib_deps = 
    https://github.com/boblemaire/asyncHTTPrequest
```

For this to work, the referenced project must include a `library.json` file describing the library and its folder layout.

This PR provides the file so that flatbuffers is usable as a dependency in PlatformIO, as requested by #7189 