### PR TITLE
lua: fix generated code for adding table

### DIFF
--- a/src/bfbs_gen_lua.cpp
+++ b/src/bfbs_gen_lua.cpp
@@ -506,9 +506,10 @@ class LuaBfbsGenerator : public BaseBfbsGenerator {
   }
 
   std::string GenerateMethod(const r::Field *field) const {
-    const r::BaseType base_type = field->type()->base_type();
+    const r::Type *type = field->type();
+    const r::BaseType base_type = type->base_type();
     if (IsScalar(base_type)) { return namer_.Type(GenerateType(base_type)); }
-    if (IsStructOrTable(base_type)) { return "Struct"; }
+    if (IsStruct(type)) { return "Struct"; }
     return "UOffsetTRelative";
   }
 

--- a/tests/MyGame/Example/Monster.lua
+++ b/tests/MyGame/Example/Monster.lua
@@ -832,7 +832,7 @@ function Monster.StartTestarrayoftablesVector(builder, numElems)
 end
 
 function Monster.AddEnemy(builder, enemy)
-  builder:PrependStructSlot(12, enemy, 0)
+  builder:PrependUOffsetTRelativeSlot(12, enemy, 0)
 end
 
 function Monster.AddTestnestedflatbuffer(builder, testnestedflatbuffer)
@@ -844,7 +844,7 @@ function Monster.StartTestnestedflatbufferVector(builder, numElems)
 end
 
 function Monster.AddTestempty(builder, testempty)
-  builder:PrependStructSlot(14, testempty, 0)
+  builder:PrependUOffsetTRelativeSlot(14, testempty, 0)
 end
 
 function Monster.AddTestbool(builder, testbool)
@@ -952,7 +952,7 @@ function Monster.StartVectorOfDoublesVector(builder, numElems)
 end
 
 function Monster.AddParentNamespaceTest(builder, parentNamespaceTest)
-  builder:PrependStructSlot(34, parentNamespaceTest, 0)
+  builder:PrependUOffsetTRelativeSlot(34, parentNamespaceTest, 0)
 end
 
 function Monster.AddVectorOfReferrables(builder, vectorOfReferrables)

--- a/tests/MyGame/OtherNameSpace/TableB.lua
+++ b/tests/MyGame/OtherNameSpace/TableB.lua
@@ -41,7 +41,7 @@ function TableB.Start(builder)
 end
 
 function TableB.AddA(builder, a)
-  builder:PrependStructSlot(0, a, 0)
+  builder:PrependUOffsetTRelativeSlot(0, a, 0)
 end
 
 function TableB.End(builder)

--- a/tests/TableA.lua
+++ b/tests/TableA.lua
@@ -41,7 +41,7 @@ function TableA.Start(builder)
 end
 
 function TableA.AddB(builder, b)
-  builder:PrependStructSlot(0, b, 0)
+  builder:PrependUOffsetTRelativeSlot(0, b, 0)
 end
 
 function TableA.End(builder)


### PR DESCRIPTION
Example with issue:
```
table Test { x: int; }
table TestContainer { a: Test; b: Test; }
```

Generated code has TestContainer.AddA calling PrependStructSlot. Looking at the sample_binary.lua it's using explicit builder:PrependUOffsetTRelative to setup weapon vector. Update generated code to use PrependUOffsetTRelativeSlot