### PR TITLE
Improve error handling on Object API name collision.

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -467,6 +467,20 @@ class CppGenerator : public BaseGenerator {
         }
         if (opts_.generate_object_based_api) {
           auto nativeName = NativeName(Name(*struct_def), struct_def, opts_);
+
+          // Check that nativeName doesn't collide the name of another struct.
+          for (const auto &other_struct_def : parser_.structs_.vec) {
+            if (other_struct_def == struct_def) { continue; }
+
+            auto other_name = Name(*other_struct_def);
+            if (nativeName == other_name) {
+              LogCompilerError("Generated Object API type for " +
+                               Name(*struct_def) + " collides with " +
+                               other_name);
+              FLATBUFFERS_ASSERT(true);
+            }
+          }
+
           if (!struct_def->fixed) { code_ += "struct " + nativeName + ";"; }
         }
         code_ += "";


### PR DESCRIPTION
If a schema contains a message named e.g. FooT and a message named Foo while the Object API suffix is T, then two classes with colliding names will be generated. This scenario will produce a C++ compiler error, but it's confusing.

This patch moves the error to the compiler, allowing the user to more readily act to correct the issue.
