### PR TITLE
[Go] add ResetKeep() and ResetBuffer()

### DIFF
--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -131,6 +131,8 @@ func TestAll(t *testing.T) {
 	CheckByteStringIsNestedError(t.Fatalf)
 	CheckStructIsNotInlineError(t.Fatalf)
 	CheckFinishedBytesError(t.Fatalf)
+
+	CheckReset(t.Fatalf)
 	CheckSharedStrings(t.Fatalf)
 	CheckEmptiedBuilder(t.Fatalf)
 
@@ -1620,6 +1622,36 @@ func CheckEmptiedBuilder(fail func(string, ...interface{})) {
 	if err := quick.Check(f, nil); err != nil {
 		fail("expected different offset")
 	}
+}
+
+// Check Reset() functions and allocations
+func CheckReset(fail func(string, ...interface{})) {
+	checkHeadLenCap := func(b *flatbuffers.Builder, h flatbuffers.UOffsetT, l, c int) {
+		if b.Head() != h || len(b.Bytes) != l || cap(b.Bytes) != c {
+			fail("expected head=%d, len=%d, cap=%d got head=%d, len=%d, cap=%d", h, l, c, b.Head(), len(b.Bytes), cap(b.Bytes))
+		}
+	}
+
+	b := flatbuffers.NewBuilder(0)
+	checkHeadLenCap(b, 0, 0, 0)
+	b.PrependUint32(1)
+	checkHeadLenCap(b, 12, 16, 16)
+	b.PrependUint32(2)
+	b.PrependUint32(3)
+	checkHeadLenCap(b, 4, 16, 16)
+	b.PrependUint32(4)
+	b.PrependUint32(5)
+	checkHeadLenCap(b, 12, 32, 32)
+
+	b.ResetKeep()
+	checkHeadLenCap(b, 12, 12, 32)
+	b.Reset()
+	checkHeadLenCap(b, 32, 32, 32)
+
+	b.ResetBuffer(make([]byte, 1, 40))
+	checkHeadLenCap(b, 1, 1, 40)
+	b.PrependUint32(6)
+	checkHeadLenCap(b, 36, 40, 40)
 }
 
 func CheckSharedStrings(fail func(string, ...interface{})) {


### PR DESCRIPTION
Add a function `ResetKeep()` which is like `Reset()` except that it only re-uses the unused space left in the buffer: it keeps previous data which was in the buffer. This is useful if you want to allocate 1 large buffer and use it for a bunch of flatbuffer objects.

With this change, both `Reset()` and `ResetKeep()` are now implemented in terms of a general `ResetBuffer()` function which allows using an arbitrary given buffer.

This also changes the behaviour of `growBytesBuffer` to never re-use the existing buffer: that would go against the meaning of `ResetKeep()`. It was an unlikely code path anyway: it could happen only if `len(b.Bytes) < cap(b.Bytes)` which is only possible if the user manually set `b.Bytes`.

The code in `growBytesBuffer` was also simplified and optimized: the benchmark added in https://github.com/google/flatbuffers/pull/8287 went from
```
BenchmarkBuildAllocations-12             2186073              1595 ns/op          81.49 MB/s         824 B/op         13 allocs/op
```
to
```
BenchmarkBuildAllocations-12             2396973              1432 ns/op          90.79 MB/s         560 B/op          6 allocs/op
```
on my personal laptop.