### PR TITLE
Add missing opertors to VectorIterator

### DIFF
--- a/include/flatbuffers/vector.h
+++ b/include/flatbuffers/vector.h
@@ -56,12 +56,24 @@ struct VectorIterator {
     return data_ == other.data_;
   }
 
+  bool operator!=(const VectorIterator &other) const {
+    return data_ != other.data_;
+  }
+
   bool operator<(const VectorIterator &other) const {
     return data_ < other.data_;
   }
 
-  bool operator!=(const VectorIterator &other) const {
-    return data_ != other.data_;
+  bool operator>(const VectorIterator &other) const {
+    return data_ > other.data_;
+  }
+
+  bool operator<=(const VectorIterator &other) const {
+    return !(data_ > other.data_);
+  }
+
+  bool operator>=(const VectorIterator &other) const {
+    return !(data_ < other.data_);
   }
 
   difference_type operator-(const VectorIterator &other) const {


### PR DESCRIPTION
VectorIterator is supposed to be a random access iterator (per https://github.com/google/flatbuffers/issues/4095) but it was missing some operators per: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator which I don't believe are defaulted. This creates some compatibility issues.
