### PR TITLE
ci: fix kotlin tests on macos-latest

### DIFF
--- a/kotlin/gradle/libs.versions.toml
+++ b/kotlin/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.8.21"
+kotlin = "1.9.10"
 plugin-kotlin = "1.6.10"
 plugin-gver = "0.42.0"
 kotlinx-benchmark = "0.4.8"


### PR DESCRIPTION
Tests broke because of an update to xcode 15. searching for the error indicates we should update kotlin to 1.9.10 and it works for me locally.