### PR TITLE
ci: fix g++13 build on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,77 +27,77 @@ jobs:
         cxx: [g++-13, clang++-15]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
-    - name: cmake
-      run: CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON -DFLATBUFFERS_STATIC_FLATC=ON .
-    - name: build
-      run: make -j
-    - name: test
-      run: ./flattests
-    - name: make flatc executable
-      run: |
-        chmod +x flatc
-        ./flatc --version
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: Linux flatc binary ${{ matrix.cxx }}
-        path: flatc
-    # Below if only for release.
-    - name: Zip file
-      if: startsWith(github.ref, 'refs/tags/')
-      run: zip Linux.flatc.binary.${{ matrix.cxx }}.zip flatc
-    - name: Release zip file
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: Linux.flatc.binary.${{ matrix.cxx }}.zip
-    - name: Generate SLSA subjects - clang
-      if: matrix.cxx == 'clang++-15' && startsWith(github.ref, 'refs/tags/')
-      id: hash-clang
-      run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
-    - name: Generate SLSA subjects - gcc
-      if: matrix.cxx == 'g++-13' && startsWith(github.ref, 'refs/tags/')
-      id: hash-gcc
-      run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+      - name: cmake
+        run: CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON -DFLATBUFFERS_STATIC_FLATC=ON .
+      - name: build
+        run: make -j
+      - name: test
+        run: ./flattests
+      - name: make flatc executable
+        run: |
+          chmod +x flatc
+          ./flatc --version
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: Linux flatc binary ${{ matrix.cxx }}
+          path: flatc
+      # Below if only for release.
+      - name: Zip file
+        if: startsWith(github.ref, 'refs/tags/')
+        run: zip Linux.flatc.binary.${{ matrix.cxx }}.zip flatc
+      - name: Release zip file
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: Linux.flatc.binary.${{ matrix.cxx }}.zip
+      - name: Generate SLSA subjects - clang
+        if: matrix.cxx == 'clang++-15' && startsWith(github.ref, 'refs/tags/')
+        id: hash-clang
+        run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
+      - name: Generate SLSA subjects - gcc
+        if: matrix.cxx == 'g++-13' && startsWith(github.ref, 'refs/tags/')
+        id: hash-gcc
+        run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
 
   build-linux-no-file-tests:
     name: Build Linux with -DFLATBUFFERS_NO_FILE_TESTS
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
-    - uses: actions/checkout@v3
-    - name: cmake
-      run: CXX=clang++-15 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON -DFLATBUFFERS_CXX_FLAGS="-DFLATBUFFERS_NO_FILE_TESTS" .
-    - name: build
-      run: make -j
-    - name: test
-      run: ./flattests
+      - uses: actions/checkout@v3
+      - name: cmake
+        run: CXX=clang++-15 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON -DFLATBUFFERS_CXX_FLAGS="-DFLATBUFFERS_NO_FILE_TESTS" .
+      - name: build
+        run: make -j
+      - name: test
+        run: ./flattests
 
   build-linux-out-of-source:
     name: Build Linux with out-of-source build location
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
-    - uses: actions/checkout@v3
-    - name: make build directory
-      run: mkdir build
-    - name: cmake
-      working-directory: build
-      run: >
-        CXX=clang++-15 cmake .. -G "Unix Makefiles" -DFLATBUFFERS_STRICT_MODE=ON
-        -DFLATBUFFERS_BUILD_CPP17=ON -DFLATBUFFERS_CPP_STD=17
-    - name: build
-      working-directory: build
-      run: make -j
-    - name: test
-      working-directory: build
-      run: pwd && ./flattests
-    - name: test C++17
-      working-directory: build
-      run: ./flattests_cpp17
+      - uses: actions/checkout@v3
+      - name: make build directory
+        run: mkdir build
+      - name: cmake
+        working-directory: build
+        run: >
+          CXX=clang++-15 cmake .. -G "Unix Makefiles" -DFLATBUFFERS_STRICT_MODE=ON
+          -DFLATBUFFERS_BUILD_CPP17=ON -DFLATBUFFERS_CPP_STD=17
+      - name: build
+        working-directory: build
+        run: make -j
+      - name: test
+        working-directory: build
+        run: pwd && ./flattests
+      - name: test C++17
+        working-directory: build
+        run: ./flattests_cpp17
 
   build-linux-cpp-std:
     name: Build Linux C++
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     strategy:
       fail-fast: false
       matrix:
@@ -109,20 +109,20 @@ jobs:
             std: 23
 
     steps:
-    - uses: actions/checkout@v3
-    - name: cmake
-      run: >
-        CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles"
-        -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON
-        -DFLATBUFFERS_CPP_STD=${{ matrix.std }}
-        -DFLATBUFFERS_BUILD_CPP17=${{ matrix.std >= 17 && 'On' || 'Off'}}
-    - name: build
-      run: make -j
-    - name: test
-      run: ./flattests
-    - name: test C++17
-      if: matrix.std >= 17
-      run: ./flattests_cpp17
+      - uses: actions/checkout@v3
+      - name: cmake
+        run: >
+          CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles"
+          -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON
+          -DFLATBUFFERS_CPP_STD=${{ matrix.std }}
+          -DFLATBUFFERS_BUILD_CPP17=${{ matrix.std >= 17 && 'On' || 'Off'}}
+      - name: build
+        run: make -j
+      - name: test
+        run: ./flattests
+      - name: test C++17
+        if: matrix.std >= 17
+        run: ./flattests_cpp17
 
   build-cpp-std:
     name: Build Windows C++
@@ -132,22 +132,22 @@ jobs:
         std: [11, 14, 17, 20, 23]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
-    - name: cmake
-      run: >
-        cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release
-        -DFLATBUFFERS_STRICT_MODE=ON
-        -DFLATBUFFERS_CPP_STD=${{ matrix.std }}
-        -DFLATBUFFERS_BUILD_CPP17=${{ matrix.std >= 17 && 'On' || 'Off'}}
-    - name: build
-      run: msbuild.exe FlatBuffers.sln /p:Configuration=Release /p:Platform=x64
-    - name: test
-      run: Release\flattests.exe
-    - name: test C++17
-      if: matrix.std >= 17
-      run: Release\flattests_cpp17.exe
+      - uses: actions/checkout@v3
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+      - name: cmake
+        run: >
+          cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release
+          -DFLATBUFFERS_STRICT_MODE=ON
+          -DFLATBUFFERS_CPP_STD=${{ matrix.std }}
+          -DFLATBUFFERS_BUILD_CPP17=${{ matrix.std >= 17 && 'On' || 'Off'}}
+      - name: build
+        run: msbuild.exe FlatBuffers.sln /p:Configuration=Release /p:Platform=x64
+      - name: test
+        run: Release\flattests.exe
+      - name: test C++17
+        if: matrix.std >= 17
+        run: Release\flattests_cpp17.exe
 
   build-windows:
     permissions:
@@ -157,34 +157,34 @@ jobs:
     name: Build Windows 2019
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v3
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
-    - name: cmake
-      run: cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_CPP17=ON -DFLATBUFFERS_STRICT_MODE=ON .
-    - name: build
-      run: msbuild.exe FlatBuffers.sln /p:Configuration=Release /p:Platform=x64
-    - name: test
-      run: Release\flattests.exe
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: Windows flatc binary
-        path: Release\flatc.exe
-    # Below if only for release.
-    - name: Zip file
-      if: startsWith(github.ref, 'refs/tags/')
-      run: move Release/flatc.exe . && Compress-Archive flatc.exe Windows.flatc.binary.zip
-    - name: Release binary
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: Windows.flatc.binary.zip
-    - name: Generate SLSA subjects
-      if: startsWith(github.ref, 'refs/tags/')
-      id: hash
-      shell: bash
-      run: echo "hashes=$(sha256sum Windows.flatc.binary.zip | base64 -w0)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+      - name: cmake
+        run: cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_CPP17=ON -DFLATBUFFERS_STRICT_MODE=ON .
+      - name: build
+        run: msbuild.exe FlatBuffers.sln /p:Configuration=Release /p:Platform=x64
+      - name: test
+        run: Release\flattests.exe
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: Windows flatc binary
+          path: Release\flatc.exe
+      # Below if only for release.
+      - name: Zip file
+        if: startsWith(github.ref, 'refs/tags/')
+        run: move Release/flatc.exe . && Compress-Archive flatc.exe Windows.flatc.binary.zip
+      - name: Release binary
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: Windows.flatc.binary.zip
+      - name: Generate SLSA subjects
+        if: startsWith(github.ref, 'refs/tags/')
+        id: hash
+        shell: bash
+        run: echo "hashes=$(sha256sum Windows.flatc.binary.zip | base64 -w0)" >> $GITHUB_OUTPUT
 
   build-dotnet-windows:
     name: Build .NET Windows
@@ -192,27 +192,27 @@ jobs:
     strategy:
       matrix:
         configuration: [
-          '',
-          '-p:UnsafeByteBuffer=true',
-          # Fails two tests currently.
-          #'-p:EnableSpanT=true,UnsafeByteBuffer=true'
+            "",
+            "-p:UnsafeByteBuffer=true",
+            # Fails two tests currently.
+            #'-p:EnableSpanT=true,UnsafeByteBuffer=true'
           ]
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '8.0.x'
-    - name: Build
-      run: |
-        cd tests\FlatBuffers.Test
-        dotnet new sln --force --name FlatBuffers.Test
-        dotnet sln FlatBuffers.Test.sln add FlatBuffers.Test.csproj
-        dotnet build -c Release ${{matrix.configuration}} -o out FlatBuffers.Test.sln
-    - name: Run
-      run: |
-        cd tests\FlatBuffers.Test
-        out\FlatBuffers.Test.exe
+      - uses: actions/checkout@v3
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "8.0.x"
+      - name: Build
+        run: |
+          cd tests\FlatBuffers.Test
+          dotnet new sln --force --name FlatBuffers.Test
+          dotnet sln FlatBuffers.Test.sln add FlatBuffers.Test.csproj
+          dotnet build -c Release ${{matrix.configuration}} -o out FlatBuffers.Test.sln
+      - name: Run
+        run: |
+          cd tests\FlatBuffers.Test
+          out\FlatBuffers.Test.exe
 
   build-mac-intel:
     permissions:
@@ -222,40 +222,40 @@ jobs:
     name: Build Mac (for Intel)
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: cmake
-      run: cmake -G "Xcode" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON .
-    - name: build
-      run: xcodebuild -toolchain clang -configuration Release -target flattests
-    - name: check that the binary is x86_64
-      run: |
-        info=$(file Release/flatc)
-        echo $info
-        echo $info | grep "Mach-O 64-bit executable x86_64"
-    - name: test
-      run: Release/flattests
-    - name: make flatc executable
-      run: |
-        chmod +x Release/flatc
-        Release/flatc --version
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: Mac flatc binary
-        path: Release/flatc
-    # Below if only for release.
-    - name: Zip file
-      if: startsWith(github.ref, 'refs/tags/')
-      run: mv Release/flatc . && zip MacIntel.flatc.binary.zip flatc
-    - name: Release binary
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: MacIntel.flatc.binary.zip
-    - name: Generate SLSA subjects
-      if: startsWith(github.ref, 'refs/tags/')
-      id: hash
-      run: echo "hashes=$(shasum -a 256 MacIntel.flatc.binary.zip | base64)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+      - name: cmake
+        run: cmake -G "Xcode" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON .
+      - name: build
+        run: xcodebuild -toolchain clang -configuration Release -target flattests
+      - name: check that the binary is x86_64
+        run: |
+          info=$(file Release/flatc)
+          echo $info
+          echo $info | grep "Mach-O 64-bit executable x86_64"
+      - name: test
+        run: Release/flattests
+      - name: make flatc executable
+        run: |
+          chmod +x Release/flatc
+          Release/flatc --version
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: Mac flatc binary
+          path: Release/flatc
+      # Below if only for release.
+      - name: Zip file
+        if: startsWith(github.ref, 'refs/tags/')
+        run: mv Release/flatc . && zip MacIntel.flatc.binary.zip flatc
+      - name: Release binary
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: MacIntel.flatc.binary.zip
+      - name: Generate SLSA subjects
+        if: startsWith(github.ref, 'refs/tags/')
+        id: hash
+        run: echo "hashes=$(shasum -a 256 MacIntel.flatc.binary.zip | base64)" >> $GITHUB_OUTPUT
 
   build-mac-universal:
     permissions:
@@ -265,231 +265,231 @@ jobs:
     name: Build Mac (universal build)
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: cmake
-      run: cmake -G "Xcode" -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON .
-    - name: build
-      run: xcodebuild -toolchain clang -configuration Release -target flattests
-    - name: check that the binary is "universal"
-      run: |
-        info=$(file Release/flatc)
-        echo $info
-        echo $info | grep "Mach-O universal binary with 2 architectures"
-    - name: test
-      run: Release/flattests
-    - name: make flatc executable
-      run: |
-        chmod +x Release/flatc
-        Release/flatc --version
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: Mac flatc binary
-        path: Release/flatc
-    # Below if only for release.
-    - name: Zip file
-      if: startsWith(github.ref, 'refs/tags/')
-      run: mv Release/flatc . && zip Mac.flatc.binary.zip flatc
-    - name: Release binary
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: Mac.flatc.binary.zip
-    - name: Generate SLSA subjects
-      if: startsWith(github.ref, 'refs/tags/')
-      id: hash
-      run: echo "hashes=$(shasum -a 256 Mac.flatc.binary.zip | base64)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+      - name: cmake
+        run: cmake -G "Xcode" -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON .
+      - name: build
+        run: xcodebuild -toolchain clang -configuration Release -target flattests
+      - name: check that the binary is "universal"
+        run: |
+          info=$(file Release/flatc)
+          echo $info
+          echo $info | grep "Mach-O universal binary with 2 architectures"
+      - name: test
+        run: Release/flattests
+      - name: make flatc executable
+        run: |
+          chmod +x Release/flatc
+          Release/flatc --version
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: Mac flatc binary
+          path: Release/flatc
+      # Below if only for release.
+      - name: Zip file
+        if: startsWith(github.ref, 'refs/tags/')
+        run: mv Release/flatc . && zip Mac.flatc.binary.zip flatc
+      - name: Release binary
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: Mac.flatc.binary.zip
+      - name: Generate SLSA subjects
+        if: startsWith(github.ref, 'refs/tags/')
+        id: hash
+        run: echo "hashes=$(shasum -a 256 Mac.flatc.binary.zip | base64)" >> $GITHUB_OUTPUT
 
   build-android:
-   name: Build Android (on Linux)
-   runs-on: ubuntu-22.04-64core
-   steps:
-   - uses: actions/checkout@v3
-   - name: set up Java
-     uses: actions/setup-java@v3
-     with:
-       distribution: 'temurin'
-       java-version: '11'
-   - name: set up flatc
-     run: |
-       cmake -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF -DFLATBUFFERS_STRICT_MODE=ON .
-       make -j
-       echo "${PWD}" >> $GITHUB_PATH
-   - name: build
-     working-directory: android
-     run: gradle clean build
+    name: Build Android (on Linux)
+    runs-on: ubuntu-24.04-64core
+    steps:
+      - uses: actions/checkout@v3
+      - name: set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11"
+      - name: set up flatc
+        run: |
+          cmake -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF -DFLATBUFFERS_STRICT_MODE=ON .
+          make -j
+          echo "${PWD}" >> $GITHUB_PATH
+      - name: build
+        working-directory: android
+        run: gradle clean build
 
   build-generator:
     name: Check Generated Code
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     strategy:
       matrix:
         cxx: [g++-13, clang++-15]
     steps:
-    - uses: actions/checkout@v3
-    - name: cmake
-      run: CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles" -DFLATBUFFERS_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON . && make -j
-    - name: Generate
-      run: scripts/check_generate_code.py
-    - name: Generate gRPC
-      run: scripts/check-grpc-generated-code.py
+      - uses: actions/checkout@v3
+      - name: cmake
+        run: CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles" -DFLATBUFFERS_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON . && make -j
+      - name: Generate
+        run: scripts/check_generate_code.py
+      - name: Generate gRPC
+        run: scripts/check-grpc-generated-code.py
 
   build-generator-windows:
     name: Check Generated Code on Windows
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v3
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
-    - name: cmake
-      run: cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_CPP17=ON -DFLATBUFFERS_STRICT_MODE=ON .
-    - name: build
-      run: msbuild.exe FlatBuffers.sln /p:Configuration=Release /p:Platform=x64
-    - name: Generate
-      run: python3 scripts/check_generate_code.py --flatc Release\flatc.exe
-    - name: Generate gRPC
-      run: python3 scripts/check-grpc-generated-code.py --flatc Release\flatc.exe
+      - uses: actions/checkout@v3
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+      - name: cmake
+        run: cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_CPP17=ON -DFLATBUFFERS_STRICT_MODE=ON .
+      - name: build
+        run: msbuild.exe FlatBuffers.sln /p:Configuration=Release /p:Platform=x64
+      - name: Generate
+        run: python3 scripts/check_generate_code.py --flatc Release\flatc.exe
+      - name: Generate gRPC
+        run: python3 scripts/check-grpc-generated-code.py --flatc Release\flatc.exe
 
   build-benchmarks:
     name: Build Benchmarks (on Linux)
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     strategy:
       matrix:
         cxx: [g++-13]
     steps:
-    - uses: actions/checkout@v3
-    - name: cmake
-      run: CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles" -DFLATBUFFERS_CXX_FLAGS="-Wno-unused-parameter -fno-aligned-new" -DFLATBUFFERS_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON . && make -j
-    - name: Run benchmarks
-      run: ./flatbenchmark --benchmark_repetitions=5 --benchmark_display_aggregates_only=true --benchmark_out_format=console --benchmark_out=benchmarks/results_${{matrix.cxx}}
-    - name: Upload benchmarks results
-      uses: actions/upload-artifact@v1
-      with:
-        name: Linux flatbenchmark results ${{matrix.cxx}}
-        path: benchmarks/results_${{matrix.cxx}}
+      - uses: actions/checkout@v3
+      - name: cmake
+        run: CXX=${{ matrix.cxx }} cmake -G "Unix Makefiles" -DFLATBUFFERS_CXX_FLAGS="-Wno-unused-parameter -fno-aligned-new" -DFLATBUFFERS_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON . && make -j
+      - name: Run benchmarks
+        run: ./flatbenchmark --benchmark_repetitions=5 --benchmark_display_aggregates_only=true --benchmark_out_format=console --benchmark_out=benchmarks/results_${{matrix.cxx}}
+      - name: Upload benchmarks results
+        uses: actions/upload-artifact@v1
+        with:
+          name: Linux flatbenchmark results ${{matrix.cxx}}
+          path: benchmarks/results_${{matrix.cxx}}
 
   build-java:
     name: Build Java
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
-    - uses: actions/checkout@v3
-    - name: test
-      working-directory: java
-      run: mvn test
+      - uses: actions/checkout@v3
+      - name: test
+        working-directory: java
+        run: mvn test
 
   build-kotlin-macos:
     name: Build Kotlin MacOS
     runs-on: macos-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - uses: gradle/wrapper-validation-action@v1.0.5
-    - uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '11'
-    - name: Build flatc
-      run: |
-       cmake -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF .
-       make -j
-       echo "${PWD}" >> $GITHUB_PATH
-    - name: Build
-      working-directory: kotlin
-      run: ./gradlew clean iosSimulatorArm64Test macosX64Test macosArm64Test
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1.0.5
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11"
+      - name: Build flatc
+        run: |
+          cmake -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF .
+          make -j
+          echo "${PWD}" >> $GITHUB_PATH
+      - name: Build
+        working-directory: kotlin
+        run: ./gradlew clean iosSimulatorArm64Test macosX64Test macosArm64Test
 
   build-kotlin-linux:
     name: Build Kotlin Linux
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '11'
-    - uses: gradle/wrapper-validation-action@v1.0.5
-    - name: Build flatc
-      run: |
-       cmake -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF .
-       make -j
-       echo "${PWD}" >> $GITHUB_PATH
-    - name: Build
-      working-directory: kotlin
-      # we are using docker's version of gradle
-      # so no need for wrapper validation or user
-      # gradlew
-      run: gradle jvmMainClasses jvmTest jsTest jsBrowserTest
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11"
+      - uses: gradle/wrapper-validation-action@v1.0.5
+      - name: Build flatc
+        run: |
+          cmake -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF .
+          make -j
+          echo "${PWD}" >> $GITHUB_PATH
+      - name: Build
+        working-directory: kotlin
+        # we are using docker's version of gradle
+        # so no need for wrapper validation or user
+        # gradlew
+        run: gradle jvmMainClasses jvmTest jsTest jsBrowserTest
 
   build-rust-linux:
     name: Build Rust Linux
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
-    - uses: actions/checkout@v3
-    - name: test
-      working-directory: tests
-      run: bash RustTest.sh
+      - uses: actions/checkout@v3
+      - name: test
+        working-directory: tests
+        run: bash RustTest.sh
 
   build-rust-windows:
     name: Build Rust Windows
     runs-on: windows-2022-64core
     steps:
-    - uses: actions/checkout@v3
-    - name: test
-      working-directory: tests
-      run: ./RustTest.bat
+      - uses: actions/checkout@v3
+      - name: test
+        working-directory: tests
+        run: ./RustTest.bat
 
   build-python:
     name: Build Python
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
-    - uses: actions/checkout@v3
-    - name: flatc
-      # FIXME: make test script not rely on flatc
-      run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF -DFLATBUFFERS_STRICT_MODE=ON . && make -j
-    - name: test
-      working-directory: tests
-      run: bash PythonTest.sh
+      - uses: actions/checkout@v3
+      - name: flatc
+        # FIXME: make test script not rely on flatc
+        run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF -DFLATBUFFERS_STRICT_MODE=ON . && make -j
+      - name: test
+        working-directory: tests
+        run: bash PythonTest.sh
 
   build-go:
     name: Build Go
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
-    - uses: actions/checkout@v3
-    - name: flatc
-      # FIXME: make test script not rely on flatc
-      run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF -DFLATBUFFERS_STRICT_MODE=ON . && make -j
-    - name: test
-      working-directory: tests
-      run: bash GoTest.sh
+      - uses: actions/checkout@v3
+      - name: flatc
+        # FIXME: make test script not rely on flatc
+        run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF -DFLATBUFFERS_STRICT_MODE=ON . && make -j
+      - name: test
+        working-directory: tests
+        run: bash GoTest.sh
 
   build-php:
-   name: Build PHP
-   runs-on: ubuntu-22.04-64core
-   steps:
-   - uses: actions/checkout@v3
-   - name: flatc
-     # FIXME: make test script not rely on flatc
-     run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF -DFLATBUFFERS_STRICT_MODE=ON . && make -j
-   - name: test
-     working-directory: tests
-     run: |
-       php phpTest.php
-       sh phpUnionVectorTest.sh
+    name: Build PHP
+    runs-on: ubuntu-24.04-64core
+    steps:
+      - uses: actions/checkout@v3
+      - name: flatc
+        # FIXME: make test script not rely on flatc
+        run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF -DFLATBUFFERS_STRICT_MODE=ON . && make -j
+      - name: test
+        working-directory: tests
+        run: |
+          php phpTest.php
+          sh phpUnionVectorTest.sh
 
   build-swift:
     name: Build Swift
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
-    - uses: actions/checkout@v3
-    - name: test
-      working-directory: tests/swift/tests
-      run: |
-        swift build --build-tests
-        swift test
+      - uses: actions/checkout@v3
+      - name: test
+        working-directory: tests/swift/tests
+        run: |
+          swift build --build-tests
+          swift test
 
   build-swift-wasm:
     name: Build Swift Wasm
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     container:
       image: ghcr.io/swiftwasm/carton:0.15.3
     steps:
@@ -502,25 +502,25 @@ jobs:
 
   build-ts:
     name: Build TS
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
-    - uses: actions/checkout@v3
-    - name: flatc
-      # FIXME: make test script not rely on flatc
-      run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF . && make -j
-    - name: deps
-      run: yarn
-    - name: compile
-      run: yarn compile
-    - name: test
-      working-directory: tests/ts
-      run: |
-        yarn global add esbuild
-        python3 TypeScriptTest.py
+      - uses: actions/checkout@v3
+      - name: flatc
+        # FIXME: make test script not rely on flatc
+        run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF . && make -j
+      - name: deps
+        run: yarn
+      - name: compile
+        run: yarn compile
+      - name: test
+        working-directory: tests/ts
+        run: |
+          yarn global add esbuild
+          python3 TypeScriptTest.py
 
   build-dart:
     name: Build Dart
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
@@ -535,26 +535,26 @@ jobs:
 
   build-nim:
     name: Build Nim
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
-    - uses: actions/checkout@v3
-    - name: flatc
-      # FIXME: make test script not rely on flatc
-      run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF . && make -j
-    - uses: jiro4989/setup-nim-action@v1
-    - name: install library
-      working-directory: nim
-      run: nimble -y develop && nimble install
-    - name: test
-      working-directory: tests/nim
-      run: python3 testnim.py
+      - uses: actions/checkout@v3
+      - name: flatc
+        # FIXME: make test script not rely on flatc
+        run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF . && make -j
+      - uses: jiro4989/setup-nim-action@v1
+      - name: install library
+        working-directory: nim
+        run: nimble -y develop && nimble install
+      - name: test
+        working-directory: tests/nim
+        run: python3 testnim.py
 
   release-digests:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [build-linux, build-windows, build-mac-intel, build-mac-universal]
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     steps:
       - name: Merge results
         id: hash
@@ -577,7 +577,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [release-digests]
     permissions:
-      actions: read   # To read the workflow path.
+      actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       digests-gcc: ${{ steps.hash-gcc.outputs.hashes }}
       digests-clang: ${{ steps.hash-clang.outputs.hashes }}
     name: Build Linux
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04-64core
     strategy:
       matrix:
         cxx: [g++-13, clang++-15]


### PR DESCRIPTION
g++13 was removed from ubuntu-22.04 (https://github.com/actions/runner-images/issues/9679, https://github.com/actions/runner-images/issues/9866) breaking everyone in the process...

updating the CI to use ubuntu-24.04 instead. This is currently blocked by the large runner not being enabled for the project - needs input from maintainers

P. S. sorry about the whitespace changes, the file was auto-fixed during search&replace by my editor. Let me know if that's really an issue and I can roll the whitespace change back