### PR TITLE
ci: fix x86_64 macos build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: cmake
-      run: cmake -G "Xcode" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON .
+      run: cmake -G "Xcode" -DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON .
     - name: build
       run: xcodebuild -toolchain clang -configuration Release -target flattests
     - name: check that the binary is x86_64


### PR DESCRIPTION
Because of some runner update, the xcodebuild now defaults to arm64 when not specified. 

This PR fixes that by specifying the desired architecture. Although, I'd suggest removing the intel build altoghether - there's a universal build that works on both architectures. WDYT?
