### PR TITLE
Update build.yml to ubuntu-24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       digests-gcc: ${{ steps.hash-gcc.outputs.hashes }}
       digests-clang: ${{ steps.hash-clang.outputs.hashes }}
     name: Build Linux
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         cxx: [g++-13, clang++-15]
@@ -63,7 +63,7 @@ jobs:
 
   build-linux-no-file-tests:
     name: Build Linux with -DFLATBUFFERS_NO_FILE_TESTS
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: cmake
@@ -75,7 +75,7 @@ jobs:
 
   build-linux-out-of-source:
     name: Build Linux with out-of-source build location
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: make build directory
@@ -97,7 +97,7 @@ jobs:
 
   build-linux-cpp-std:
     name: Build Linux C++
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -302,7 +302,7 @@ jobs:
 
   build-android:
    name: Build Android (on Linux)
-   runs-on: ubuntu-22.04-64core
+   runs-on: ubuntu-24.04
    steps:
    - uses: actions/checkout@v3
    - name: set up Java
@@ -321,7 +321,7 @@ jobs:
 
   build-generator:
     name: Check Generated Code
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         cxx: [g++-13, clang++-15]
@@ -352,7 +352,7 @@ jobs:
 
   build-benchmarks:
     name: Build Benchmarks (on Linux)
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         cxx: [g++-13]
@@ -370,7 +370,7 @@ jobs:
 
   build-java:
     name: Build Java
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: test
@@ -399,7 +399,7 @@ jobs:
 
   build-kotlin-linux:
     name: Build Kotlin Linux
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -422,7 +422,7 @@ jobs:
 
   build-rust-linux:
     name: Build Rust Linux
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: test
@@ -440,7 +440,7 @@ jobs:
 
   build-python:
     name: Build Python
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -452,7 +452,7 @@ jobs:
 
   build-go:
     name: Build Go
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -464,7 +464,7 @@ jobs:
 
   build-php:
    name: Build PHP
-   runs-on: ubuntu-22.04-64core
+   runs-on: ubuntu-24.04
    steps:
    - uses: actions/checkout@v3
    - name: flatc
@@ -478,7 +478,7 @@ jobs:
 
   build-swift:
     name: Build Swift
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: test
@@ -489,7 +489,7 @@ jobs:
 
   build-swift-wasm:
     name: Build Swift Wasm
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/swiftwasm/carton:0.15.3
     steps:
@@ -502,7 +502,7 @@ jobs:
 
   build-ts:
     name: Build TS
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -520,7 +520,7 @@ jobs:
 
   build-dart:
     name: Build Dart
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
@@ -535,7 +535,7 @@ jobs:
 
   build-nim:
     name: Build Nim
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -554,7 +554,7 @@ jobs:
     needs: [build-linux, build-windows, build-mac-intel, build-mac-universal]
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
       - name: Merge results
         id: hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
       digests-gcc: ${{ steps.hash-gcc.outputs.hashes }}
       digests-clang: ${{ steps.hash-clang.outputs.hashes }}
     name: Build Linux
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        cxx: [g++-12, clang++-15]
+        cxx: [g++-14, clang++-18]
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -53,21 +53,21 @@ jobs:
       with:
         files: Linux.flatc.binary.${{ matrix.cxx }}.zip
     - name: Generate SLSA subjects - clang
-      if: matrix.cxx == 'clang++-15' && startsWith(github.ref, 'refs/tags/')
+      if: matrix.cxx == 'clang++-18' && startsWith(github.ref, 'refs/tags/')
       id: hash-clang
       run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
     - name: Generate SLSA subjects - gcc
-      if: matrix.cxx == 'g++-12' && startsWith(github.ref, 'refs/tags/')
+      if: matrix.cxx == 'g++-14' && startsWith(github.ref, 'refs/tags/')
       id: hash-gcc
       run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
 
   build-linux-no-file-tests:
     name: Build Linux with -DFLATBUFFERS_NO_FILE_TESTS
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: cmake
-      run: CXX=clang++-15 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON -DFLATBUFFERS_CXX_FLAGS="-DFLATBUFFERS_NO_FILE_TESTS" .
+      run: CXX=clang++-18 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_STRICT_MODE=ON -DFLATBUFFERS_CXX_FLAGS="-DFLATBUFFERS_NO_FILE_TESTS" .
     - name: build
       run: make -j
     - name: test
@@ -75,7 +75,7 @@ jobs:
 
   build-linux-out-of-source:
     name: Build Linux with out-of-source build location
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: make build directory
@@ -83,7 +83,7 @@ jobs:
     - name: cmake
       working-directory: build
       run: >
-        CXX=clang++-15 cmake .. -G "Unix Makefiles" -DFLATBUFFERS_STRICT_MODE=ON
+        CXX=clang++-18 cmake .. -G "Unix Makefiles" -DFLATBUFFERS_STRICT_MODE=ON
         -DFLATBUFFERS_BUILD_CPP17=ON -DFLATBUFFERS_CPP_STD=17
     - name: build
       working-directory: build
@@ -97,15 +97,15 @@ jobs:
 
   build-linux-cpp-std:
     name: Build Linux C++
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         std: [11, 14, 17, 20, 23]
-        cxx: [g++-12, clang++-15]
+        cxx: [g++-14, clang++-18]
         exclude:
           # Clang++15 10.3.0 stdlibc++ doesn't fully support std 23
-          - cxx: clang++-15
+          - cxx: clang++-18
             std: 23
 
     steps:
@@ -302,7 +302,7 @@ jobs:
 
   build-android:
    name: Build Android (on Linux)
-   runs-on: ubuntu-22.04-64core
+   runs-on: ubuntu-24.04
    steps:
    - uses: actions/checkout@v3
    - name: set up Java
@@ -321,10 +321,10 @@ jobs:
 
   build-generator:
     name: Check Generated Code
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        cxx: [g++-12, clang++-15]
+        cxx: [g++-14, clang++-18]
     steps:
     - uses: actions/checkout@v3
     - name: cmake
@@ -352,10 +352,10 @@ jobs:
 
   build-benchmarks:
     name: Build Benchmarks (on Linux)
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        cxx: [g++-12]
+        cxx: [g++-14]
     steps:
     - uses: actions/checkout@v3
     - name: cmake
@@ -370,7 +370,7 @@ jobs:
 
   build-java:
     name: Build Java
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: test
@@ -399,7 +399,7 @@ jobs:
 
   build-kotlin-linux:
     name: Build Kotlin Linux
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -422,7 +422,7 @@ jobs:
 
   build-rust-linux:
     name: Build Rust Linux
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: test
@@ -440,7 +440,7 @@ jobs:
 
   build-python:
     name: Build Python
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -452,7 +452,7 @@ jobs:
 
   build-go:
     name: Build Go
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -464,7 +464,7 @@ jobs:
 
   build-php:
    name: Build PHP
-   runs-on: ubuntu-22.04-64core
+   runs-on: ubuntu-24.04
    steps:
    - uses: actions/checkout@v3
    - name: flatc
@@ -478,7 +478,7 @@ jobs:
 
   build-swift:
     name: Build Swift
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: test
@@ -489,7 +489,7 @@ jobs:
 
   build-swift-wasm:
     name: Build Swift Wasm
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/swiftwasm/carton:0.15.3
     steps:
@@ -502,7 +502,7 @@ jobs:
 
   build-ts:
     name: Build TS
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -520,7 +520,7 @@ jobs:
 
   build-dart:
     name: Build Dart
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
@@ -535,7 +535,7 @@ jobs:
 
   build-nim:
     name: Build Nim
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -554,7 +554,7 @@ jobs:
     needs: [build-linux, build-windows, build-mac-intel, build-mac-universal]
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
-    runs-on: ubuntu-22.04-64core
+    runs-on: ubuntu-24.04
     steps:
       - name: Merge results
         id: hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,7 @@ jobs:
     outputs:
       digests: ${{ steps.hash.outputs.hashes }}
     name: Build Mac (for Intel)
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
     - uses: actions/checkout@v3
     - name: cmake
@@ -379,7 +379,7 @@ jobs:
 
   build-kotlin-macos:
     name: Build Kotlin MacOS
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -478,7 +478,8 @@ jobs:
 
   build-swift:
     name: Build Swift
-    runs-on: ubuntu-24.04
+    # Only 22.04 has swift at the moment https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md?plain=1#L30
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -377,25 +377,26 @@ jobs:
       working-directory: java
       run: mvn test
 
-  build-kotlin-macos:
-    name: Build Kotlin MacOS
-    runs-on: macos-latest-large
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - uses: gradle/wrapper-validation-action@v1.0.5
-    - uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '11'
-    - name: Build flatc
-      run: |
-       cmake -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF .
-       make -j
-       echo "${PWD}" >> $GITHUB_PATH
-    - name: Build
-      working-directory: kotlin
-      run: ./gradlew clean iosSimulatorArm64Test macosX64Test macosArm64Test
+  # Renable
+  # build-kotlin-macos:
+  #   name: Build Kotlin MacOS
+  #   runs-on: macos-latest-large
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v3
+  #   - uses: gradle/wrapper-validation-action@v1.0.5
+  #   - uses: actions/setup-java@v3
+  #     with:
+  #       distribution: 'temurin'
+  #       java-version: '11'
+  #   - name: Build flatc
+  #     run: |
+  #      cmake -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF .
+  #      make -j
+  #      echo "${PWD}" >> $GITHUB_PATH
+  #   - name: Build
+  #     working-directory: kotlin
+  #     run: ./gradlew clean iosSimulatorArm64Test macosX64Test macosArm64Test
 
   build-kotlin-linux:
     name: Build Kotlin Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        cxx: [g++-14, clang++-18]
+        cxx: [g++-13, clang++-18]
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
       id: hash-clang
       run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
     - name: Generate SLSA subjects - gcc
-      if: matrix.cxx == 'g++-14' && startsWith(github.ref, 'refs/tags/')
+      if: matrix.cxx == 'g++-13' && startsWith(github.ref, 'refs/tags/')
       id: hash-gcc
       run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
 
@@ -102,7 +102,7 @@ jobs:
       fail-fast: false
       matrix:
         std: [11, 14, 17, 20, 23]
-        cxx: [g++-14, clang++-18]
+        cxx: [g++-13, clang++-18]
         exclude:
           # Clang++15 10.3.0 stdlibc++ doesn't fully support std 23
           - cxx: clang++-18
@@ -324,7 +324,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        cxx: [g++-14, clang++-18]
+        cxx: [g++-13, clang++-18]
     steps:
     - uses: actions/checkout@v3
     - name: cmake
@@ -355,7 +355,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        cxx: [g++-14]
+        cxx: [g++-13]
     steps:
     - uses: actions/checkout@v3
     - name: cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
       digests-gcc: ${{ steps.hash-gcc.outputs.hashes }}
       digests-clang: ${{ steps.hash-clang.outputs.hashes }}
     name: Build Linux
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     strategy:
       matrix:
-        cxx: [g++-13, clang++-15]
+        cxx: [g++-12, clang++-15]
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -57,13 +57,13 @@ jobs:
       id: hash-clang
       run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
     - name: Generate SLSA subjects - gcc
-      if: matrix.cxx == 'g++-13' && startsWith(github.ref, 'refs/tags/')
+      if: matrix.cxx == 'g++-12' && startsWith(github.ref, 'refs/tags/')
       id: hash-gcc
       run: echo "hashes=$(sha256sum Linux.flatc.binary.${{ matrix.cxx }}.zip | base64 -w0)" >> $GITHUB_OUTPUT
 
   build-linux-no-file-tests:
     name: Build Linux with -DFLATBUFFERS_NO_FILE_TESTS
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
     - uses: actions/checkout@v3
     - name: cmake
@@ -75,7 +75,7 @@ jobs:
 
   build-linux-out-of-source:
     name: Build Linux with out-of-source build location
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
     - uses: actions/checkout@v3
     - name: make build directory
@@ -97,12 +97,12 @@ jobs:
 
   build-linux-cpp-std:
     name: Build Linux C++
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     strategy:
       fail-fast: false
       matrix:
         std: [11, 14, 17, 20, 23]
-        cxx: [g++-13, clang++-15]
+        cxx: [g++-12, clang++-15]
         exclude:
           # Clang++15 10.3.0 stdlibc++ doesn't fully support std 23
           - cxx: clang++-15
@@ -302,7 +302,7 @@ jobs:
 
   build-android:
    name: Build Android (on Linux)
-   runs-on: ubuntu-24.04
+   runs-on: ubuntu-22.04-64core
    steps:
    - uses: actions/checkout@v3
    - name: set up Java
@@ -321,10 +321,10 @@ jobs:
 
   build-generator:
     name: Check Generated Code
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     strategy:
       matrix:
-        cxx: [g++-13, clang++-15]
+        cxx: [g++-12, clang++-15]
     steps:
     - uses: actions/checkout@v3
     - name: cmake
@@ -352,10 +352,10 @@ jobs:
 
   build-benchmarks:
     name: Build Benchmarks (on Linux)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     strategy:
       matrix:
-        cxx: [g++-13]
+        cxx: [g++-12]
     steps:
     - uses: actions/checkout@v3
     - name: cmake
@@ -370,7 +370,7 @@ jobs:
 
   build-java:
     name: Build Java
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
     - uses: actions/checkout@v3
     - name: test
@@ -399,7 +399,7 @@ jobs:
 
   build-kotlin-linux:
     name: Build Kotlin Linux
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -422,7 +422,7 @@ jobs:
 
   build-rust-linux:
     name: Build Rust Linux
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
     - uses: actions/checkout@v3
     - name: test
@@ -440,7 +440,7 @@ jobs:
 
   build-python:
     name: Build Python
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -452,7 +452,7 @@ jobs:
 
   build-go:
     name: Build Go
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -464,7 +464,7 @@ jobs:
 
   build-php:
    name: Build PHP
-   runs-on: ubuntu-24.04
+   runs-on: ubuntu-22.04-64core
    steps:
    - uses: actions/checkout@v3
    - name: flatc
@@ -478,7 +478,7 @@ jobs:
 
   build-swift:
     name: Build Swift
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
     - uses: actions/checkout@v3
     - name: test
@@ -489,7 +489,7 @@ jobs:
 
   build-swift-wasm:
     name: Build Swift Wasm
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     container:
       image: ghcr.io/swiftwasm/carton:0.15.3
     steps:
@@ -502,7 +502,7 @@ jobs:
 
   build-ts:
     name: Build TS
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -520,7 +520,7 @@ jobs:
 
   build-dart:
     name: Build Dart
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
@@ -535,7 +535,7 @@ jobs:
 
   build-nim:
     name: Build Nim
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
     - uses: actions/checkout@v3
     - name: flatc
@@ -554,7 +554,7 @@ jobs:
     needs: [build-linux, build-windows, build-mac-intel, build-mac-universal]
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-64core
     steps:
       - name: Merge results
         id: hash


### PR DESCRIPTION
Apparently g++-13 was removed from the ubuntu-22.04 runners.

We also don't have enterprise runners at 24.04 yet, so just use the free ones for now until we get support for those. CI builds might take longer now.

