### PR TITLE
[TS] BUFIX: Generated typescript imports parent directory

### DIFF
--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -271,6 +271,12 @@ class TsGenerator : public BaseGenerator {
           std::copy(it.second.ns->components.begin(),
                     it.second.ns->components.end(),
                     std::back_inserter(rel_components));
+
+        // Remove leading relative components from the path until the first matching directory is found.
+        while (!rel_components.empty() && it.second.symbolic_name != rel_components.front()) {
+          rel_components.erase(rel_components.begin());
+        }
+
         auto base_file_name =
             namer_.File(*(def.second), SkipFile::SuffixAndExtension);
         auto base_name =


### PR DESCRIPTION
This fixes something that seems to be an edgecase where the entry file for a directory will include its own parent directory in the childrens relative paths.

Example:
```
namespace A.B.C;

table MyTable {
  test:string;
}
```

Output:

**a\b\c.ts**
```
// automatically generated by the FlatBuffers compiler, do not modify

/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */

export { MyTable } from './b/c/my-table';
```

this should be ``export { MyTable } from './c/my-table';``

I'm not quite sure if my fix is the way to go about it but it works for now for my use case.