### PR TITLE
Support for Numpy 2.0 in tests

### DIFF
--- a/tests/py_test.py
+++ b/tests/py_test.py
@@ -1095,7 +1095,7 @@ class TestByteLayout(unittest.TestCase):
 
       # Reverse endian:
       b = flatbuffers.Builder(0)
-      x_other_endian = x.byteswap().newbyteorder()
+      x_other_endian = x.byteswap().view(x.dtype.newbyteorder())
       b.CreateNumpyVector(x_other_endian)
       self.assertBuilderEquals(
           b,
@@ -1144,7 +1144,7 @@ class TestByteLayout(unittest.TestCase):
 
       # Reverse endian:
       b = flatbuffers.Builder(0)
-      x_other_endian = x.byteswap().newbyteorder()
+      x_other_endian = x.byteswap().view(x.dtype.newbyteorder())
       b.CreateNumpyVector(x_other_endian)
       self.assertBuilderEquals(
           b,
@@ -1213,7 +1213,7 @@ class TestByteLayout(unittest.TestCase):
 
       # Reverse endian:
       b = flatbuffers.Builder(0)
-      x_other_endian = x.byteswap().newbyteorder()
+      x_other_endian = x.byteswap().view(x.dtype.newbyteorder())
       b.CreateNumpyVector(x_other_endian)
       self.assertBuilderEquals(
           b,
@@ -1287,7 +1287,7 @@ class TestByteLayout(unittest.TestCase):
 
       # Reverse endian:
       b = flatbuffers.Builder(0)
-      x_other_endian = x.byteswap().newbyteorder()
+      x_other_endian = x.byteswap().view(x.dtype.newbyteorder())
       b.CreateNumpyVector(x_other_endian)
       self.assertBuilderEquals(
           b,
@@ -1361,7 +1361,7 @@ class TestByteLayout(unittest.TestCase):
 
       # Reverse endian:
       b = flatbuffers.Builder(0)
-      x_other_endian = x.byteswap().newbyteorder()
+      x_other_endian = x.byteswap().view(x.dtype.newbyteorder())
       b.CreateNumpyVector(x_other_endian)
       self.assertBuilderEquals(
           b,
@@ -1427,7 +1427,7 @@ class TestByteLayout(unittest.TestCase):
 
       # Reverse endian:
       b = flatbuffers.Builder(0)
-      x_other_endian = x.byteswap().newbyteorder()
+      x_other_endian = x.byteswap().view(x.dtype.newbyteorder())
       b.CreateNumpyVector(x_other_endian)
       self.assertBuilderEquals(
           b,


### PR DESCRIPTION
The newbyteorder has been removed in Numpy 2.0 [1]. Its usages are replaced with respect to migration guide.

[1] https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ndarray-and-scalar-methods

Fixes: #8332