### PR TITLE
[Java] Add Automatic-Module-Name to Manifest file

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -59,6 +59,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.google.flatbuffers</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <includes>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,6 +61,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.4.2</version>
         <configuration>
           <archive>
             <manifestEntries>


### PR DESCRIPTION
This change explicitly defines the module name for flatbuffers for Java 9+. Without this configuration, the module name is auto-generated based on the filename `flatbuffers-java`.

This is the current warning during compile time for downstream projects:
```
Warning:  **********************************************************************************************************************************************************************
Warning:  * Required filename-based automodules detected: [flatbuffers-java-24.3.25.jar]. Please don't publish this project to a public artifact repository! *
Warning:  **********************************************************************************************************************************************************************
```

Fixes: https://github.com/google/flatbuffers/issues/8348