### PR TITLE
Demonstrate broken C++ codegen with keywords

### DIFF
--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -392,6 +392,7 @@ flatc(
 
 # Generate the keywords tests
 flatc(BASE_OPTS + CS_OPTS, schema="keyword_test.fbs")
+flatc(CPP_OPTS, schema="keyword_test.fbs")
 flatc(RUST_OPTS, prefix="keyword_test", schema="keyword_test.fbs")
 flatc(
     BASE_OPTS + CS_OPTS + ["--cs-global-alias", "--gen-onefile"],

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -132,6 +132,7 @@ cc_test(
     deps = [
         ":alignment_test_cc_fbs",
         ":arrays_test_cc_fbs",
+        ":keyword_test_cc_fbs",
         ":monster_extra_cc_fbs",
         ":monster_test_cc_fbs",
         ":native_type_test_cc_fbs",
@@ -239,6 +240,11 @@ cc_library(
 flatbuffer_cc_library(
     name = "monster_extra_cc_fbs",
     srcs = ["monster_extra.fbs"],
+)
+
+flatbuffer_cc_library(
+    name = "keyword_test_cc_fbs",
+    srcs = ["keyword_test.fbs"],
 )
 
 flatbuffer_cc_library(

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -37,6 +37,7 @@
 #include "fuzz_test.h"
 #include "json_test.h"
 #include "key_field_test.h"
+#include "keyword_test_generated.h"
 #include "monster_test.h"
 #include "monster_test_generated.h"
 #include "native_inline_table_test_generated.h"


### PR DESCRIPTION
I was checking some robustness of the C++ codegen to keywords around Union types in particular and ran into some issues. Creating this commit to document the presence of issues; I may or may not get around to trying to address this myself. I don't have a strong need for support for this to be fixed myself.

I don't mind closing this PR to keep the backlog clean; I will create an issue once I have satisfied myself that this is indeed an issue and not just me doing something wrong.