### PR TITLE
Add BUILD.bazel for python flatbuffers library.

### DIFF
--- a/python/flatbuffers/BUILD.bazel
+++ b/python/flatbuffers/BUILD.bazel
@@ -1,0 +1,10 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "flatbuffers",
+    srcs = glob([
+        "**/*.py",
+    ]),
+)


### PR DESCRIPTION
This makes it possible for Python code in bazel workspaces to refer to flatbuffer code.