### PR TITLE
Remove unused comment and fix typo.

### DIFF
--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -100,7 +100,7 @@ public struct ByteBuffer {
 
   /// The size of the elements written to the buffer + their paddings
   private var _writerSize: Int = 0
-  /// Aliginment of the current  memory being written to the buffer
+  /// Alignment of the current  memory being written to the buffer
   var alignment = 1
   /// Current Index which is being used to write to the buffer, it is written from the end to the start of the buffer
   var writerIndex: Int { _storage.capacity &- _writerSize }

--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -474,7 +474,6 @@ public struct ByteBuffer {
   /// - Parameters:
   ///   - index: index of the string in the buffer
   ///   - count: length of the string
-  ///   - type: Encoding of the string
   @inline(__always)
   public func readString(
     at index: Int,

--- a/swift/Sources/FlatBuffers/NativeObject.swift
+++ b/swift/Sources/FlatBuffers/NativeObject.swift
@@ -23,7 +23,7 @@ public protocol NativeObject {}
 
 extension NativeObject {
 
-  /// Serialize is a helper function that serailizes the data from the Object API to a bytebuffer directly th
+  /// Serialize is a helper function that serializes the data from the Object API to a bytebuffer directly th
   /// - Parameter type: Type of the Flatbuffer object
   /// - Returns: returns the encoded sized ByteBuffer
   public func serialize<T: ObjectAPIPacker>(type: T.Type) -> ByteBuffer
@@ -33,7 +33,7 @@ extension NativeObject {
     return serialize(builder: &builder, type: type.self)
   }
 
-  /// Serialize is a helper function that serailizes the data from the Object API to a bytebuffer directly.
+  /// Serialize is a helper function that serializes the data from the Object API to a bytebuffer directly.
   ///
   /// - Parameters:
   ///   - builder: A FlatBufferBuilder


### PR DESCRIPTION
### Summary:

Update wording and remove unused comment.

+ Remove type parameter comment for `readString` because it does not existing.
+ serailizes => serializes
+ Aliginment => Alignment


### Modifications:

+ swift/Sources/FlatBuffers/ByteBuffer.swift
+ swift/Sources/FlatBuffers/NativeObject.swift

### Result:

Correct comment wording and remove unused comment.
