### PR TITLE
Add Automatic-Module-Name directive

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -102,6 +102,11 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>5.1.2</version>
         <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Automatic-Module-Name>com.google.flatbuffers</Automatic-Module-Name>
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
Add `Automatic-Module-Name` directive with the value `com.google.flatbuffers` to flatbuffers-java artifact to enable Java projects leveraging JPMS to safely refer to this artifact.

Fixes google/flatbuffers#8348
