### PR TITLE
Fix inclusion of LICENSE file in built Python wheel

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -3,4 +3,4 @@ universal=1
 
 [metadata]
 license_files =
-   ../license
+   ../LICENSE

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,7 +18,6 @@ setup(
     name='flatbuffers',
     version='24.3.25',
     license='Apache 2.0',
-    license_files='../LICENSE',
     author='Derek Bailey',
     author_email='derekbailey@google.com',
     url='https://google.github.io/flatbuffers/',


### PR DESCRIPTION
Closes #8376

After these changes, I've confirmed that the `LICENSE` file is included in the built wheel. Tested using `setuptools` 72.2.0 and running

```
python setup.py bdist_wheel
```