### PR TITLE
Update libs.versions.toml

### DIFF
--- a/kotlin/gradle/libs.versions.toml
+++ b/kotlin/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ plugin-kotlin = "1.6.10"
 plugin-gver = "0.42.0"
 kotlinx-benchmark = "0.4.8"
 junit = "4.12"
-gson = "2.8.5"
+gson = "2.8.9"
 moshi-kotlin = "1.11.0"
 
 [libraries]


### PR DESCRIPTION
Fix CVE-2022-25647

The package com.google.code.gson:gson before 2.8.9 is vulnerable to Deserialization of Untrusted Data via the writeReplace() method in internal classes, which may lead to denial of service attacks.

Bump up version of the gson package.

https://github.com/advisories/GHSA-4jrv-ppp4-jm57