### PR TITLE
Update grpc-core version

### DIFF
--- a/grpc/flatbuffers-java-grpc/pom.xml
+++ b/grpc/flatbuffers-java-grpc/pom.xml
@@ -24,7 +24,7 @@
         </developer>
     </developers>
     <properties>
-        <gRPC.version>1.68.0</gRPC.version>
+        <gRPC.version>1.67.1</gRPC.version>
     </properties>
     <dependencies>
         <dependency>

--- a/grpc/flatbuffers-java-grpc/pom.xml
+++ b/grpc/flatbuffers-java-grpc/pom.xml
@@ -24,7 +24,7 @@
         </developer>
     </developers>
     <properties>
-        <gRPC.version>1.36.0</gRPC.version>
+        <gRPC.version>1.68.0</gRPC.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
io.grpc:grpc-core package in version 1.36.0 contains multiple [CVE's](https://mvnrepository.com/artifact/io.grpc/grpc-core/1.36.0). Bump grpc-core version to latest 1.68.0 version to mitigate potential vulnerabilities.