### PR TITLE
[Swift] Addresses a bug where verifier skips capacity when verifying ID on buffers

### DIFF
--- a/swift/Sources/FlatBuffers/FlatbuffersErrors.swift
+++ b/swift/Sources/FlatBuffers/FlatbuffersErrors.swift
@@ -19,6 +19,8 @@ import Foundation
 /// Collection of thrown from the Flatbuffer verifier
 public enum FlatbuffersErrors: Error, Equatable {
 
+  /// Thrown when trying to verify a buffer that doesnt have the length of an ID
+  case bufferDoesntContainID
   /// Thrown when verifying a file id that doesnt match buffer id
   case bufferIdDidntMatchPassedId
   /// Prefixed size doesnt match the current (readable) buffer size

--- a/swift/Sources/FlatBuffers/Verifier.swift
+++ b/swift/Sources/FlatBuffers/Verifier.swift
@@ -201,8 +201,12 @@ public struct Verifier {
     _depth -= 1
   }
 
+  @inline(__always)
   mutating func verify(id: String) throws {
     let size = MemoryLayout<Int32>.size
+    guard _capacity >= (size * 2) else {
+      throw FlatbuffersErrors.bufferDoesntContainID
+    }
     let str = _buffer.readString(at: size, count: size)
     if id == str {
       return

--- a/tests/swift/tests/Tests/FlatBuffers.Test.SwiftTests/FlatbuffersVerifierTests.swift
+++ b/tests/swift/tests/Tests/FlatBuffers.Test.SwiftTests/FlatbuffersVerifierTests.swift
@@ -63,6 +63,17 @@ final class FlatbuffersVerifierTests: XCTestCase {
     XCTAssertThrowsError(try Verifier(buffer: &buffer))
   }
 
+  func testFailingID() {
+    let dutData : [UInt8] = [1,2,3,4,5,6,7]
+    var buff  = ByteBuffer(bytes: dutData)
+    do {
+      let _: Monster = try getCheckedRoot(byteBuffer: &buff, fileId: "ABCD")
+      XCTFail("This should always fail")
+    } catch {
+      XCTAssertEqual(error as? FlatbuffersErrors, .bufferDoesntContainID)
+    }
+  }
+
   func testVerifierCheckAlignment() {
     var verifier = try! Verifier(buffer: &buffer)
     do {


### PR DESCRIPTION
The following PR fixes a bug where we skip capacity verification on the IDs and that leads to an assertion or a crash depending on the environment using the lib.

Closes: #8408