### PR TITLE
[Swift] Adds swift 6 to the build matrix & bumps swift to 5.9

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -10,7 +10,7 @@ tasks:
     bazel: ${{ bazel }}
     environment:
       CC: clang
-      SWIFT_VERSION: "5.8"
+      SWIFT_VERSION: "5.9"
       SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
       PATH: "$PATH:$SWIFT_HOME/usr/bin"
     shell_commands:
@@ -26,7 +26,7 @@ tasks:
     bazel: ${{ bazel }}
     environment:
       CC: clang
-      SWIFT_VERSION: "5.8"
+      SWIFT_VERSION: "5.9"
       SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
       PATH: "$PATH:$SWIFT_HOME/usr/bin"
     shell_commands:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -495,7 +495,7 @@ jobs:
     name: Build Swift
     strategy:
       matrix:
-        swift: ["5.8", "5.9", "5.10"]
+        swift: ["5.9", "5.10", "6.0"]
     # Only 22.04 has swift at the moment https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md?plain=1#L30
     runs-on: ubuntu-22.04
     steps:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 /*
  * Copyright 2020 Google Inc. All rights reserved.
  *

--- a/benchmarks/swift/Package.swift
+++ b/benchmarks/swift/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 /*
  * Copyright 2020 Google Inc. All rights reserved.
  *

--- a/grpc/examples/swift/Greeter/Package.swift
+++ b/grpc/examples/swift/Greeter/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.9
 /*
  * Copyright 2020 Google Inc. All rights reserved.
  *

--- a/tests/swift/tests/Package.swift
+++ b/tests/swift/tests/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 /*
  * Copyright 2020 Google Inc. All rights reserved.
  *


### PR DESCRIPTION
Adds swift 6 to the matrix to insure that all the new features and current implementations are compatible with safe concurrency and the new swift features, and dropping support for 5.8 on the CI.