### PR TITLE
[Python]  Fix function name for Pack method for structs

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -2097,7 +2097,7 @@ class PythonGenerator : public BaseGenerator {
   void GenPackForStruct(const StructDef &struct_def,
                         std::string *code_ptr) const {
     auto &code = *code_ptr;
-    const auto struct_fn = namer_.Function(struct_def);
+    const auto struct_fn = namer_.Type(struct_def);
 
     GenReceiverForObjectAPI(struct_def, code_ptr);
     code += "Pack(self, builder):";


### PR DESCRIPTION
This PR fixes #8422 .

Before we get this:
```
class ABCWordT(object):
    # ABCWordT
    def Pack(self, builder):
        return CreateAbcword(builder, self.w)
```
Where the function `CreateAbcword` does not exist.

After we get this:
```
class ABCWordT(object):
    # ABCWordT
    def Pack(self, builder):
        return CreateABCWord(builder, self.w)
```
And the function `CreateABCWord` does exist.