### PR TITLE
TypeScript: read vtable entries as uint16

### DIFF
--- a/ts/byte-buffer.ts
+++ b/ts/byte-buffer.ts
@@ -172,7 +172,7 @@ export class ByteBuffer {
      */
     __offset(bb_pos: number, vtable_offset: number): Offset {
       const vtable = bb_pos - this.readInt32(bb_pos);
-      return vtable_offset < this.readInt16(vtable) ? this.readInt16(vtable + vtable_offset) : 0;
+      return vtable_offset < this.readUint16(vtable) ? this.readUint16(vtable + vtable_offset) : 0;
     }
   
     /**


### PR DESCRIPTION
According to the [internals docs](https://flatbuffers.dev/flatbuffers_internals.html), vtable entries are uint16 rather than int16.

This change allows reading to work when vtable entries are larger than 2^15-1 (which already works in C++). For example, the following schema is now readable:

```
struct FixedArray {
  // This array is large enough that it pushes the offset of another_double above INT16_MAX
  fixed_array:[double:5555];
}

table LargeOffset {
  another_double:double;
  fixed_array:FixedArray;
}

root_type LargeOffset;
```