### PR TITLE
Add constant primitives

### DIFF
--- a/docs/source/Schemas.md
+++ b/docs/source/Schemas.md
@@ -12,6 +12,8 @@ first:
 
     attribute "priority";
 
+    const MAX_MANA:short = 150;
+
     enum Color : byte { Red = 1, Green, Blue }
 
     union Any { Monster, Weapon, Pickup }
@@ -24,7 +26,7 @@ first:
 
     table Monster {
       pos:Vec3;
-      mana:short = 150;
+      mana:short = MAX_MANA;
       hp:short = 100;
       name:string;
       friendly:bool = false (deprecated, priority: 1);
@@ -216,6 +218,15 @@ types). In the example IDL file above, use [Any] to add a vector of Any to
 Monster table. There is also experimental support for other types besides
 tables in unions, in particular structs and strings. There's no direct support
 for scalars in unions, but they can be wrapped in a struct at no space cost.
+
+### Constant primitives
+
+Defines a (scalar) constant that can be used within the schema itself. It is declared using the
+keyword `const` followed by the `NAME`, the (mandatory) `:type`, and the `= value`.
+Recomendation is to use `UPPER_CASE` with underscores.
+
+They can be used to set fields default values, fixed-size arrays, or other constants.
+(Generating constants in code is supported only for C++ so far.)
 
 ### Namespaces
 

--- a/docs/source/Tutorial.md
+++ b/docs/source/Tutorial.md
@@ -169,6 +169,8 @@ the `schema` that defines the template for our monsters:
 
   namespace MyGame.Sample;
 
+  const MAX_MANA:short = 150;
+
   enum Color:byte { Red = 0, Green, Blue = 2 }
 
   union Equipment { Weapon } // Optionally add more tables.
@@ -181,7 +183,7 @@ the `schema` that defines the template for our monsters:
 
   table Monster {
     pos:Vec3; // Struct.
-    mana:short = 150;
+    mana:short = MAX_MANA;
     hp:short = 100;
     name:string;
     friendly:bool = false (deprecated);
@@ -209,6 +211,11 @@ The `schema` starts with a `namespace` declaration. This determines the
 corresponding package/namespace for the generated code. In our example, we have
 the `Sample` namespace inside of the `MyGame` namespace.
 
+After we have a `const` definition. The type of the constant primitive `MAX_MANA`
+is `short` and the value associated is `150`;
+Fields that use constants will be replaced by the value they represent during
+the parsing step. They also generate scoped definition in code (only C++ so far).
+
 Next, we have an `enum` definition. In this example, we have an `enum` of type
 `byte`, named `Color`. We have three values in this `enum`: `Red`, `Green`, and
 `Blue`. We specify `Red = 0` and `Blue = 2`, but we do not specify an explicit
@@ -227,7 +234,9 @@ less memory and have faster lookup.
 
 The `Monster` table is the main object in our FlatBuffer. This will be used as
 the template to store our `orc` monster. We specify some default values for
-fields, such as `mana:short = 150`. If unspecified, scalar fields (like `int`,
+fields, such as `mana:short = MAX_MANA;` using the `const` defined above and 
+`hp:short = 100;`.
+If unspecified, scalar fields (like `int`,
 `uint`, or `float`) will be given a default of `0` while strings and tables will
 be given a default of `null`. Another thing to note is the line `friendly:bool =
 false (deprecated);`. Since you cannot delete fields from a `table` (to support

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -186,6 +186,7 @@ inline const char* StringOf(const BaseType t) {
 // clang-format on
 
 struct StructDef;
+struct ConstPrimDef;
 struct EnumDef;
 class Parser;
 
@@ -346,7 +347,7 @@ struct FieldDef : public Definition {
     return IsScalar() && IsOptional();
   }
   bool IsScalar() const {
-      return ::flatbuffers::IsScalar(value.type.base_type);
+    return ::flatbuffers::IsScalar(value.type.base_type);
   }
   bool IsOptional() const { return presence == kOptional; }
   bool IsRequired() const { return presence == kRequired; }
@@ -423,6 +424,10 @@ struct StructDef : public Definition {
 
   flatbuffers::unique_ptr<std::string> original_location;
   std::vector<voffset_t> reserved_ids;
+};
+
+struct ConstPrimDef : public Definition {
+  Value value;
 };
 
 struct EnumDef;
@@ -1103,6 +1108,9 @@ class Parser : public ParserState {
   FLATBUFFERS_CHECKED_ERROR ParseNamespacing(std::string *id,
                                              std::string *last);
   FLATBUFFERS_CHECKED_ERROR ParseTypeIdent(Type &type);
+  FLATBUFFERS_CHECKED_ERROR ConstantPrimLookUp(
+      const std::string const_prim_name, Value *val);
+  bool IsConstantPrimLookUp(const std::string const_prim_name);
   FLATBUFFERS_CHECKED_ERROR ParseType(Type &type);
   FLATBUFFERS_CHECKED_ERROR AddField(StructDef &struct_def,
                                      const std::string &name, const Type &type,
@@ -1154,6 +1162,7 @@ class Parser : public ParserState {
   FLATBUFFERS_CHECKED_ERROR StartEnum(const std::string &name, bool is_union,
                                       EnumDef **dest);
   FLATBUFFERS_CHECKED_ERROR ParseDecl(const char *filename);
+  FLATBUFFERS_CHECKED_ERROR ParseConstPrim();
   FLATBUFFERS_CHECKED_ERROR ParseService(const char *filename);
   FLATBUFFERS_CHECKED_ERROR ParseProtoFields(StructDef *struct_def,
                                              bool isextend, bool inside_oneof);
@@ -1202,6 +1211,7 @@ class Parser : public ParserState {
  public:
   SymbolTable<Type> types_;
   SymbolTable<StructDef> structs_;
+  SymbolTable<ConstPrimDef> const_prims_;
   SymbolTable<EnumDef> enums_;
   SymbolTable<ServiceDef> services_;
   std::vector<Namespace *> namespaces_;
@@ -1256,8 +1266,8 @@ class Parser : public ParserState {
 // it contains non-UTF-8 byte arrays in String values).
 extern bool GenerateTextFromTable(const Parser &parser,
                                          const void *table,
-                                         const std::string &tablename,
-                                         std::string *text);
+                                  const std::string &tablename,
+                                  std::string *text);
 extern const char *GenerateText(const Parser &parser, const void *flatbuffer,
                                 std::string *text);
 extern const char *GenerateTextFile(const Parser &parser,

--- a/samples/monster.fbs
+++ b/samples/monster.fbs
@@ -2,6 +2,11 @@
 
 namespace MyGame.Sample;
 
+const DEFAULT_MANA:int32 = 150;
+const NUM_EYES:short = 3;
+const MAX_PERCENT:float = 100.0;
+const MAX_LIFE:float = MAX_PERCENT;
+
 enum Color:byte { Red = 0, Green, Blue = 2 }
 
 union Equipment { Weapon } // Optionally add more tables.
@@ -12,9 +17,17 @@ struct Vec3 {
   z:float;
 }
 
+struct Eye {
+  blind:bool;
+}
+
+struct Eyes {
+  eyes:[Eye:NUM_EYES];
+}
+
 table Monster {
   pos:Vec3;
-  mana:short = 150;
+  mana:int32 = DEFAULT_MANA;
   hp:short = 100;
   name:string;
   friendly:bool = false (deprecated);
@@ -23,11 +36,13 @@ table Monster {
   weapons:[Weapon];
   equipped:Equipment;
   path:[Vec3];
+  eyes:Eyes;
 }
 
 table Weapon {
   name:string;
   damage:short;
+  life:float = MAX_LIFE;
 }
 
 root_type Monster;

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -456,6 +456,19 @@ class CppGenerator : public BaseGenerator {
 
     FLATBUFFERS_ASSERT(!cur_name_space_);
 
+    // Generate definition for all constant primitives
+    for (const auto &const_prim_def : parser_.const_prims_.vec) {
+      if (!const_prim_def->generated) {
+        SetNameSpace(const_prim_def->defined_namespace);
+        code_ += "constexpr " + GenTypeBasic(const_prim_def->value.type, true) +
+                 " " + Name(*const_prim_def) + " = " +
+                 NumToStringCpp(const_prim_def->value.constant,
+                                const_prim_def->value.type.base_type) +
+                 ";";
+      }
+    }
+    if (parser_.const_prims_.vec.size() > 0) { code_ += ""; }
+
     // Generate forward declarations for all structs/tables, since they may
     // have circular references.
     for (const auto &struct_def : parser_.structs_.vec) {


### PR DESCRIPTION
### Add constant primitives within a schema.
e.g. `const SOME_CONSTANT_FLOAT: float = 1.0;`

#### Notes
* Constants in generated code is only supported for C++.
* Supports only scalar constants (no string).
* Can be used for default values, fixed-array size, and other constants.
* Description of the feature is added to the documentation.
* [Related discussion](https://github.com/google/flatbuffers/discussions/8018)