### PR TITLE
[Swift] Bug fix for verifier where its being copied

### DIFF
--- a/swift/Sources/FlatBuffers/Verifier.swift
+++ b/swift/Sources/FlatBuffers/Verifier.swift
@@ -22,22 +22,17 @@ public struct Verifier {
 
   /// Flag to check for alignment if true
   fileprivate let _checkAlignment: Bool
-  /// Capacity of the current buffer
-  fileprivate var _capacity: Int
-  /// Current ApparentSize
-  fileprivate var _apparentSize: UOffset = 0
-  /// Amount of tables present within a buffer
-  fileprivate var _tableCount = 0
-
-  /// Capacity of the buffer
-  internal var capacity: Int { _capacity }
-  /// Current reached depth within the buffer
-  internal var _depth = 0
+  /// Storage for all changing values within the verifier
+  private let storage: Storage
   /// Current verifiable ByteBuffer
   internal var _buffer: ByteBuffer
   /// Options for verification
   internal let _options: VerifierOptions
 
+  /// Current stored capacity within the verifier
+  var capacity: Int {
+    storage.capacity
+  }
   /// Initializer for the verifier
   /// - Parameters:
   ///   - buffer: Bytebuffer that is required to be verified
@@ -54,15 +49,15 @@ public struct Verifier {
     }
 
     _buffer = buffer
-    _capacity = buffer.capacity
     _checkAlignment = checkAlignment
     _options = options
+    storage = Storage(capacity: buffer.capacity)
   }
 
   /// Resets the verifier to initial state
   public mutating func reset() {
-    _depth = 0
-    _tableCount = 0
+    storage.depth = 0
+    storage.tableCount = 0
   }
 
   /// Checks if the value of type `T` is aligned properly in the buffer
@@ -97,10 +92,10 @@ public struct Verifier {
   public mutating func rangeInBuffer(position: Int, size: Int) throws {
     let end = UInt(clamping: (position &+ size).magnitude)
     if end > _buffer.capacity {
-      throw FlatbuffersErrors.outOfBounds(position: end, end: capacity)
+      throw FlatbuffersErrors.outOfBounds(position: end, end: storage.capacity)
     }
-    _apparentSize = _apparentSize &+ UInt32(size)
-    if _apparentSize > _options._maxApparentSize {
+    storage.apparentSize = storage.apparentSize &+ UInt32(size)
+    if storage.apparentSize > _options._maxApparentSize {
       throw FlatbuffersErrors.apparentSizeTooLarge
     }
   }
@@ -131,15 +126,15 @@ public struct Verifier {
       type: VOffset.self)
     try rangeInBuffer(position: vtablePosition, size: length)
 
-    _tableCount += 1
+    storage.tableCount += 1
 
-    if _tableCount > _options._maxTableCount {
+    if storage.tableCount > _options._maxTableCount {
       throw FlatbuffersErrors.maximumTables
     }
 
-    _depth += 1
+    storage.depth += 1
 
-    if _depth > _options._maxDepth {
+    if storage.depth > _options._maxDepth {
       throw FlatbuffersErrors.maximumDepth
     }
 
@@ -198,13 +193,13 @@ public struct Verifier {
 
   /// finishes the current iteration of verification on an object
   internal mutating func finish() {
-    _depth -= 1
+    storage.depth -= 1
   }
 
   @inline(__always)
   mutating func verify(id: String) throws {
     let size = MemoryLayout<Int32>.size
-    guard _capacity >= (size * 2) else {
+    guard storage.capacity >= (size * 2) else {
       throw FlatbuffersErrors.bufferDoesntContainID
     }
     let str = _buffer.readString(at: size, count: size)
@@ -214,4 +209,18 @@ public struct Verifier {
     throw FlatbuffersErrors.bufferIdDidntMatchPassedId
   }
 
+  final private class Storage {
+    /// Current ApparentSize
+    fileprivate var apparentSize: UOffset = 0
+    /// Amount of tables present within a buffer
+    fileprivate var tableCount = 0
+    /// Capacity of the current buffer
+    fileprivate let capacity: Int
+    /// Current reached depth within the buffer
+    fileprivate var depth = 0
+
+    init(capacity: Int) {
+      self.capacity = capacity
+    }
+  }
 }

--- a/tests/swift/tests/Package.swift
+++ b/tests/swift/tests/Package.swift
@@ -38,5 +38,6 @@ let package = Package(
       dependencies: [
         .product(name: "FlatBuffers", package: "flatbuffers"),
         .product(name: "GRPC", package: "grpc-swift"),
-      ]),
+      ]
+    )
   ])

--- a/tests/swift/tests/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersVectorsTests.swift
+++ b/tests/swift/tests/Tests/FlatBuffers.Test.SwiftTests/FlatBuffersVectorsTests.swift
@@ -65,9 +65,6 @@ final class FlatBuffersVectors: XCTestCase {
     var b = FlatBufferBuilder(initialSize: 100)
     let o = b.createVector(ofStructs: vector)
     b.finish(offset: o)
-    vector.withUnsafeBytes { pointer in
-      print(Array(pointer))
-    }
     // swiftformat:disable all
     XCTAssertEqual(b.sizedByteArray, [4, 0, 0, 0, 3, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 128, 64, 0, 0, 160, 64, 0, 0, 192, 64, 0, 0, 224, 64, 0, 0, 0, 65, 0, 0, 16, 65])
     // swiftformat:enable all


### PR DESCRIPTION
The following PR fixes a bug with the verifier where a copy is being made of it instead of simply an `inout` of the verifier. This was fixed by making a `Storage` class on the verifier that should always have the same address even if the verifier is being copied.