### PR TITLE
dart: Ensure fields are only written once

### DIFF
--- a/dart/lib/flat_buffers.dart
+++ b/dart/lib/flat_buffers.dart
@@ -208,7 +208,6 @@ class Builder {
 
   void addStruct(int field, int offset) {
     assert(_inVTable);
-    _trackField(field);
     _currentVTable!.addField(field, offset);
   }
 
@@ -1393,6 +1392,7 @@ class _VTable {
     assert(!offsetsComputed);
     assert(offset > 0); // it's impossible for field to start at the buffer end
     assert(offset <= 4294967295); // uint32 max
+    assert(fieldOffsets[field] == 0); // only write each field once
     fieldOffsets[field] = offset;
   }
 


### PR DESCRIPTION
Someone with a protobuf background might assume that vector object fields are
written by calling `.addFoo()` in a loop. However this results in a silently
corrupted message since the vector isn't serialized as expected.

This patch adds a debug assertion to ensure fields are only written once to
catch this type of error.

The assertion uncovered a bug in the library where struct fields are needlessly
added twice, which we also fix.
