### PR TITLE
CNAME: add custom domain

### DIFF
--- a/docs/source/CNAME
+++ b/docs/source/CNAME
@@ -1,0 +1,1 @@
+flatbuffers.dev


### PR DESCRIPTION
This is needed to keep the custom domain from reverting.