### PR TITLE
Make shared attribute working in Golang

### DIFF
--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -1113,8 +1113,13 @@ class GoGenerator : public BaseGenerator {
       if (IsString(field.value.type)) {
         code += "\t" + offset + " := flatbuffers.UOffsetT(0)\n";
         code += "\tif t." + field_field + " != \"\" {\n";
-        code += "\t\t" + offset + " = builder.CreateString(t." + field_field +
-                ")\n";
+        if (field.shared) {
+          code += "\t\t" + offset + " = builder.CreateSharedString(t." + field_field +
+                  ")\n";
+        } else {
+          code += "\t\t" + offset + " = builder.CreateString(t." + field_field +
+                  ")\n";
+        }
         code += "\t}\n";
       } else if (IsVector(field.value.type) &&
                  field.value.type.element == BASE_TYPE_UCHAR &&


### PR DESCRIPTION
The `shared` attribute is already recognized by schema parser.
I just add it handling for Golang code generator.
