### PR TITLE
[C++] Use C++17 inline variables for enum_value

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -1355,7 +1355,12 @@ class CppGenerator : public BaseGenerator {
         }
 
         auto value = GetEnumValUse(enum_def, ev);
-        code_ += "  static const {{ENUM_NAME}} enum_value = " + value + ";";
+        if (opts_.g_cpp_std >= cpp::CPP_STD_17) {
+          code_ +=
+              "  static inline const {{ENUM_NAME}} enum_value = " + value + ";";
+        } else {
+          code_ += "  static const {{ENUM_NAME}} enum_value = " + value + ";";
+        }
         code_ += "};";
         code_ += "";
       }
@@ -1390,7 +1395,12 @@ class CppGenerator : public BaseGenerator {
         }
 
         auto value = GetEnumValUse(enum_def, ev);
-        code_ += "  static const {{ENUM_NAME}} enum_value = " + value + ";";
+        if (opts_.g_cpp_std >= cpp::CPP_STD_17) {
+          code_ +=
+              "  static inline const {{ENUM_NAME}} enum_value = " + value + ";";
+        } else {
+          code_ += "  static const {{ENUM_NAME}} enum_value = " + value + ";";
+        }
         code_ += "};";
         code_ += "";
       }

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -236,35 +236,35 @@ inline const char *EnumNameAny(Any e) {
 }
 
 template<typename T> struct AnyTraits {
-  static const Any enum_value = Any::NONE;
+  static inline const Any enum_value = Any::NONE;
 };
 
 template<> struct AnyTraits<MyGame::Example::Monster> {
-  static const Any enum_value = Any::Monster;
+  static inline const Any enum_value = Any::Monster;
 };
 
 template<> struct AnyTraits<MyGame::Example::TestSimpleTableWithEnum> {
-  static const Any enum_value = Any::TestSimpleTableWithEnum;
+  static inline const Any enum_value = Any::TestSimpleTableWithEnum;
 };
 
 template<> struct AnyTraits<MyGame::Example2::Monster> {
-  static const Any enum_value = Any::MyGame_Example2_Monster;
+  static inline const Any enum_value = Any::MyGame_Example2_Monster;
 };
 
 template<typename T> struct AnyUnionTraits {
-  static const Any enum_value = Any::NONE;
+  static inline const Any enum_value = Any::NONE;
 };
 
 template<> struct AnyUnionTraits<MyGame::Example::MonsterT> {
-  static const Any enum_value = Any::Monster;
+  static inline const Any enum_value = Any::Monster;
 };
 
 template<> struct AnyUnionTraits<MyGame::Example::TestSimpleTableWithEnumT> {
-  static const Any enum_value = Any::TestSimpleTableWithEnum;
+  static inline const Any enum_value = Any::TestSimpleTableWithEnum;
 };
 
 template<> struct AnyUnionTraits<MyGame::Example2::MonsterT> {
-  static const Any enum_value = Any::MyGame_Example2_Monster;
+  static inline const Any enum_value = Any::MyGame_Example2_Monster;
 };
 
 struct AnyUnion {
@@ -363,35 +363,35 @@ inline const char *EnumNameAnyUniqueAliases(AnyUniqueAliases e) {
 }
 
 template<typename T> struct AnyUniqueAliasesTraits {
-  static const AnyUniqueAliases enum_value = AnyUniqueAliases::NONE;
+  static inline const AnyUniqueAliases enum_value = AnyUniqueAliases::NONE;
 };
 
 template<> struct AnyUniqueAliasesTraits<MyGame::Example::Monster> {
-  static const AnyUniqueAliases enum_value = AnyUniqueAliases::M;
+  static inline const AnyUniqueAliases enum_value = AnyUniqueAliases::M;
 };
 
 template<> struct AnyUniqueAliasesTraits<MyGame::Example::TestSimpleTableWithEnum> {
-  static const AnyUniqueAliases enum_value = AnyUniqueAliases::TS;
+  static inline const AnyUniqueAliases enum_value = AnyUniqueAliases::TS;
 };
 
 template<> struct AnyUniqueAliasesTraits<MyGame::Example2::Monster> {
-  static const AnyUniqueAliases enum_value = AnyUniqueAliases::M2;
+  static inline const AnyUniqueAliases enum_value = AnyUniqueAliases::M2;
 };
 
 template<typename T> struct AnyUniqueAliasesUnionTraits {
-  static const AnyUniqueAliases enum_value = AnyUniqueAliases::NONE;
+  static inline const AnyUniqueAliases enum_value = AnyUniqueAliases::NONE;
 };
 
 template<> struct AnyUniqueAliasesUnionTraits<MyGame::Example::MonsterT> {
-  static const AnyUniqueAliases enum_value = AnyUniqueAliases::M;
+  static inline const AnyUniqueAliases enum_value = AnyUniqueAliases::M;
 };
 
 template<> struct AnyUniqueAliasesUnionTraits<MyGame::Example::TestSimpleTableWithEnumT> {
-  static const AnyUniqueAliases enum_value = AnyUniqueAliases::TS;
+  static inline const AnyUniqueAliases enum_value = AnyUniqueAliases::TS;
 };
 
 template<> struct AnyUniqueAliasesUnionTraits<MyGame::Example2::MonsterT> {
-  static const AnyUniqueAliases enum_value = AnyUniqueAliases::M2;
+  static inline const AnyUniqueAliases enum_value = AnyUniqueAliases::M2;
 };
 
 struct AnyUniqueAliasesUnion {

--- a/tests/cpp17/generated_cpp17/union_vector_generated.h
+++ b/tests/cpp17/generated_cpp17/union_vector_generated.h
@@ -195,27 +195,27 @@ inline const char *EnumNameGadget(Gadget e) {
 }
 
 template<typename T> struct GadgetTraits {
-  static const Gadget enum_value = Gadget::NONE;
+  static inline const Gadget enum_value = Gadget::NONE;
 };
 
 template<> struct GadgetTraits<FallingTub> {
-  static const Gadget enum_value = Gadget::FallingTub;
+  static inline const Gadget enum_value = Gadget::FallingTub;
 };
 
 template<> struct GadgetTraits<HandFan> {
-  static const Gadget enum_value = Gadget::HandFan;
+  static inline const Gadget enum_value = Gadget::HandFan;
 };
 
 template<typename T> struct GadgetUnionTraits {
-  static const Gadget enum_value = Gadget::NONE;
+  static inline const Gadget enum_value = Gadget::NONE;
 };
 
 template<> struct GadgetUnionTraits<FallingTub> {
-  static const Gadget enum_value = Gadget::FallingTub;
+  static inline const Gadget enum_value = Gadget::FallingTub;
 };
 
 template<> struct GadgetUnionTraits<HandFanT> {
-  static const Gadget enum_value = Gadget::HandFan;
+  static inline const Gadget enum_value = Gadget::HandFan;
 };
 
 struct GadgetUnion {


### PR DESCRIPTION
Trait structs have declarations of `enum_value`, which are static variables, but these structs don't have the instance definition of the variables. That causes link errors if a user takes the address of such variables, explicitly or implicitly. (ref: https://wandbox.org/permlink/oIB71xEbLzU5QIH6 )

We can easily solve it by converting them to inline variables in C++17.
(ref: https://wandbox.org/permlink/GqrQKdIDETQiS1v4 )
WDYT?