### PR TITLE
Add missing headers to runtime_cc target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -121,15 +121,7 @@ filegroup(
 # Library used by flatbuffer_cc_library rules.
 cc_library(
     name = "runtime_cc",
-    hdrs = [
-        "include/flatbuffers/base.h",
-        "include/flatbuffers/flatbuffers.h",
-        "include/flatbuffers/flexbuffers.h",
-        "include/flatbuffers/stl_emulation.h",
-        "include/flatbuffers/util.h",
-        "include/flatbuffers/vector.h",
-        "include/flatbuffers/verifier.h",
-    ],
+    hdrs = ["//:public_headers"],
     linkstatic = 1,
     strip_include_prefix = "/include",
 )


### PR DESCRIPTION
Transitive headers of `flatbuffers/flatbuffers.h` like `flatbuffers/array.h` (split out in 6c8c291559053f90a35c138499053449a40e3b9a) have not been available in the `runtime_cc` target causing the build to fail. Adding all public headers to make sure transitive headers of flatbuffers.h are available.