### PR TITLE
Add support for Bzlmod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,7 +153,6 @@ cmake-build-debug/
 _deps/
 **/.gradle/**
 kotlin/**/generated
-MODULE.bazel
 MODULE.bazel.lock
 
 # Ignore the generated docs

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,6 +31,7 @@ filegroup(
         ".bazelignore",
         ".npmrc",
         "BUILD.bazel",
+        "MODULE.bazel",
         "WORKSPACE",
         "build_defs.bzl",
         "package.json",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,72 @@
-###############################################################################
-# Bazel now uses Bzlmod by default to manage external dependencies.
-# Please consider migrating your external dependencies from WORKSPACE to MODULE.bazel.
-#
-# For more details, please check https://github.com/bazelbuild/bazel/issues/18958
-###############################################################################
+module(
+    name = "flatbuffers",
+    version = "24.3.25",
+    compatibility_level = 1,
+    repo_name = "com_github_google_flatbuffers",
+)
+
+bazel_dep(
+    name = "aspect_bazel_lib",
+    version = "1.40.0",
+)
+bazel_dep(
+    name = "aspect_rules_esbuild",
+    version = "0.15.0",
+)
+bazel_dep(
+    name = "aspect_rules_js",
+    version = "1.34.1",
+)
+bazel_dep(
+    name = "aspect_rules_ts",
+    version = "1.4.5",
+)
+bazel_dep(
+    name = "grpc",
+    version = "1.48.1",
+    repo_name = "com_github_grpc_grpc",
+)
+bazel_dep(
+    name = "platforms",
+    version = "0.0.7",
+)
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.9",
+)
+bazel_dep(
+    name = "rules_go",
+    version = "0.41.0",
+    repo_name = "io_bazel_rules_go",
+)
+bazel_dep(
+    name = "rules_nodejs",
+    version = "5.8.3",
+)
+bazel_dep(
+    name = "rules_swift",
+    version = "1.2.0",
+    repo_name = "build_bazel_rules_swift",
+)
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
+npm.npm_translate_lock(
+    name = "npm",
+    npmrc = "//:.npmrc",
+    pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+use_repo(npm, "npm")
+
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+use_repo(node, "nodejs_linux_amd64")
+
+rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)
+rules_ts_ext.deps()
+use_repo(rules_ts_ext, "npm_typescript")
+
+non_module_dependencies = use_extension("//:extensions.bzl", "non_module_dependencies", dev_dependency = True)
+use_repo(
+    non_module_dependencies,
+    "bazel_linux_x86_64",
+)

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,0 +1,19 @@
+"""Bzlmod extensions"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+def _non_module_dependencies_impl(_ctx):
+    """Non module dependencies"""
+    http_file(
+        name = "bazel_linux_x86_64",
+        downloaded_file_path = "bazel",
+        executable = True,
+        sha256 = "e78fc3394deae5408d6f49a15c7b1e615901969ecf6e50d55ef899996b0b8458",
+        urls = [
+            "https://github.com/bazelbuild/bazel/releases/download/6.3.2/bazel-6.3.2-linux-x86_64",
+        ],
+    )
+
+non_module_dependencies = module_extension(
+    implementation = _non_module_dependencies_impl,
+)

--- a/tests/ts/bazel_repository_test_dir/MODULE.bazel
+++ b/tests/ts/bazel_repository_test_dir/MODULE.bazel
@@ -1,0 +1,24 @@
+module(name = "bazel_repository_test")
+
+bazel_dep(name = "flatbuffers", repo_name = "com_github_google_flatbuffers")
+
+local_path_override(
+    module_name = "com_github_google_flatbuffers",
+    path = "../../../",
+)
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
+npm.npm_translate_lock(
+    name = "npm",
+    npmrc = "//:.npmrc",
+    pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+use_repo(npm, "npm")
+
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+use_repo(node, "nodejs_linux_amd64")
+
+rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)
+rules_ts_ext.deps()
+use_repo(rules_ts_ext, "npm_typescript")


### PR DESCRIPTION
Support for Bzlmod has been introduced in Bazel 6, defaulted in Bazel 7, WORKSPACE support is disabled by default in Bazel 8 and will be removed in Bazel 9.