### PR TITLE
Use rules_bazel_integration_test to download Bazel binary

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 workspace(name = "com_github_google_flatbuffers")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "platforms",
@@ -191,12 +191,22 @@ esbuild_register_toolchains(
     esbuild_version = LATEST_ESBUILD_VERSION,
 )
 
-http_file(
-    name = "bazel_linux_x86_64",
-    downloaded_file_path = "bazel",
-    executable = True,
-    sha256 = "e78fc3394deae5408d6f49a15c7b1e615901969ecf6e50d55ef899996b0b8458",
+http_archive(
+    name = "rules_bazel_integration_test",
+    sha256 = "3e24bc0fba88177cd0ae87c1e37bf7de5d5af8e812f00817a58498b1a8368fca",
     urls = [
-        "https://github.com/bazelbuild/bazel/releases/download/6.3.2/bazel-6.3.2-linux-x86_64",
+        "https://github.com/bazel-contrib/rules_bazel_integration_test/releases/download/v0.31.0/rules_bazel_integration_test.v0.31.0.tar.gz",
     ],
 )
+
+load("@rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+
+bazel_integration_test_rules_dependencies()
+
+load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
+
+bazel_starlib_dependencies()
+
+load("@rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+
+bazel_binaries(versions = ["6.3.2"])

--- a/tests/bazel_repository_test_template.sh
+++ b/tests/bazel_repository_test_template.sh
@@ -14,7 +14,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v3 ---
 
-BAZEL_BIN="$(rlocation bazel_linux_x86_64/file/bazel)"
+BAZEL_BIN="$(rlocation {{BAZEL_PATH}})"
 readonly BAZEL_BIN
 
 if [[ ! -x "${BAZEL_BIN}" ]]; then

--- a/tests/defs.bzl
+++ b/tests/defs.bzl
@@ -1,7 +1,31 @@
 """Helper macros and rules for tests."""
 
+load("@bazel_binaries//:defs.bzl", "bazel_binaries")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+
+def repo_name(label):
+    if hasattr(label, "repo_name"):  # Added in Bazel 7.1
+        return label.repo_name
+    else:
+        return "build_bazel_bazel_6_3_2"
+
+def rlocationpath(label):
+    """Returns the rlocationpath for a label
+
+    Args:
+        label (Label): The label to determine the rlocationpath for
+
+    Returns:
+        str: The rlocationpath for label
+    """
+    path = ""
+    if repo_name(label):
+        path += repo_name(label) + "/"
+    if label.package:
+        path += label.package + "/"
+    path += label.name
+    return path
 
 def flatbuffers_as_external_repo_test(name, directory):
     """Run all tests in a bazel workspace that imports flatbuffers as an external repository.
@@ -11,11 +35,13 @@ def flatbuffers_as_external_repo_test(name, directory):
         directory: The directory in which the bazel workspace is located. This is the directory
             that imports flatbuffers as an external repository.
     """
+    bazel_binary_label = Label(bazel_binaries.label(bazel_binaries.versions.current))
     expand_template(
         name = name + "__template_expansion",
         out = name + ".sh",
         substitutions = {
             "{{REPOSITORY_DIR}}": paths.join(native.package_name(), directory),
+            "{{BAZEL_PATH}}": rlocationpath(bazel_binary_label),
         },
         template = "//tests:bazel_repository_test_template.sh",
     )
@@ -25,7 +51,7 @@ def flatbuffers_as_external_repo_test(name, directory):
         srcs = [":%s.sh" % name],
         data = [
             "//:distribution",
-            "@bazel_linux_x86_64//file",
+            bazel_binary_label,
         ] + native.glob(
             [
                 directory + "/**/*",


### PR DESCRIPTION
This improves compatibility with Bazel Central Registry (BCR).