### PR TITLE
Also use rules_bazel_bazel_integration_test dependency with Bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,6 +31,11 @@ bazel_dep(
     version = "0.0.7",
 )
 bazel_dep(
+    name = "rules_bazel_integration_test",
+    version = "0.31.0",
+    dev_dependency = True,
+)
+bazel_dep(
     name = "rules_cc",
     version = "0.0.9",
 )
@@ -65,8 +70,10 @@ rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_d
 rules_ts_ext.deps()
 use_repo(rules_ts_ext, "npm_typescript")
 
-non_module_dependencies = use_extension("//:extensions.bzl", "non_module_dependencies", dev_dependency = True)
-use_repo(
-    non_module_dependencies,
-    "bazel_linux_x86_64",
+bazel_binaries = use_extension(
+    "@rules_bazel_integration_test//:extensions.bzl",
+    "bazel_binaries",
+    dev_dependency = True,
 )
+bazel_binaries.download(version = "6.3.2")
+use_repo(bazel_binaries, "bazel_binaries", "bazel_binaries_bazelisk", "build_bazel_bazel_6_3_2")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,25 +23,20 @@ bazel_dep(
 )
 bazel_dep(
     name = "grpc",
-    version = "1.48.1",
+    version = "1.69.0",
     repo_name = "com_github_grpc_grpc",
 )
 bazel_dep(
     name = "platforms",
-    version = "0.0.7",
-)
-bazel_dep(
-    name = "rules_bazel_integration_test",
-    version = "0.31.0",
-    dev_dependency = True,
+    version = "0.0.10",
 )
 bazel_dep(
     name = "rules_cc",
-    version = "0.0.9",
+    version = "0.0.16",
 )
 bazel_dep(
     name = "rules_go",
-    version = "0.41.0",
+    version = "0.50.1",
     repo_name = "io_bazel_rules_go",
 )
 bazel_dep(
@@ -50,7 +45,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_swift",
-    version = "1.2.0",
+    version = "1.18.0",
     repo_name = "build_bazel_rules_swift",
 )
 
@@ -69,6 +64,12 @@ use_repo(node, "nodejs_linux_amd64")
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)
 rules_ts_ext.deps()
 use_repo(rules_ts_ext, "npm_typescript")
+
+bazel_dep(
+    name = "rules_bazel_integration_test",
+    version = "0.31.0",
+    dev_dependency = True,
+)
 
 bazel_binaries = use_extension(
     "@rules_bazel_integration_test//:extensions.bzl",


### PR DESCRIPTION
Adapt MODULE.bazel to the changes in #8495.

This also bumps a few versions to the ones already used in the resolved dependency graph.