### PR TITLE
Fix Bazel ts support

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -142,6 +142,8 @@ def flatbuffer_library_public(
         reflection_genrule_cmd = " ".join([
             "SRCS=($(SRCS));",
             "for f in $${SRCS[@]:0:%s}; do" % len(srcs),
+            # Move the .fbs file into the current package if it is not there already
+            'if [[ $$(dirname $$f) != "{0}" ]]; then s="$$f"; f="{0}/$$(basename "$$f")"; mkdir -p "{0}"; mv "$$s" "$$f"; fi;'.format(native.package_relative_label(":invalid").package),
             "$(location %s)" % (TRUE_FLATC_PATH),
             "-b --schema",
             " ".join(flatc_args),
@@ -152,9 +154,10 @@ def flatbuffer_library_public(
             "done",
         ])
         reflection_outs = [
-            (out_prefix + "%s.bfbs") % (s.replace(".fbs", "").split("/")[-1])
+            (out_prefix + "%s.bfbs") % (native.package_relative_label(s).name.removesuffix(".fbs"))
             for s in srcs
         ]
+
         native.genrule(
             name = "%s_srcs" % reflection_name,
             srcs = srcs + includes,

--- a/reflection/BUILD.bazel
+++ b/reflection/BUILD.bazel
@@ -7,6 +7,12 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+# flatbuffer_ts_library() only supports .fbs file but not filegroups
+exports_files(
+    srcs = ["reflection.fbs"],
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "reflection_fbs_schema",
     srcs = ["reflection.fbs"],

--- a/reflection/ts/BUILD.bazel
+++ b/reflection/ts/BUILD.bazel
@@ -1,15 +1,8 @@
 load("//:typescript.bzl", "flatbuffer_ts_library")
 
-genrule(
-    name = "copy_schema_to_folder",
-    srcs = ["//reflection:reflection_fbs_schema"],
-    outs = ["reflection.fbs"],
-    cmd = "cp $< $@",
-)
-
 flatbuffer_ts_library(
     name = "reflection_ts_fbs",
-    srcs = [":reflection.fbs"],
+    srcs = ["//reflection:reflection.fbs"],
     gen_reflections = True,
     visibility = ["//visibility:public"],
 )

--- a/tests/ts/BUILD.bazel
+++ b/tests/ts/BUILD.bazel
@@ -18,6 +18,7 @@ flatbuffer_ts_library(
     name = "typescript_ts_fbs",
     srcs = ["typescript_keywords.fbs"],
     deps = [
+        "//reflection/ts:reflection_ts_fbs",
         "//tests/ts/test_dir:include_ts_fbs",
         "//tests/ts/test_dir:typescript_transitive_ts_fbs",
     ],

--- a/typescript.bzl
+++ b/typescript.bzl
@@ -47,7 +47,7 @@ def flatbuffer_ts_library(
         reflection binaries for the schemas.
     """
     srcs_lib = "%s_srcs" % (name)
-    out_base = [s.replace(".fbs", "").split("/")[-1].split(":")[-1] for s in srcs]
+    out_base = [native.package_relative_label(s).name.removesuffix(".fbs") for s in srcs]
 
     if len(srcs) != 1:
         fail("flatbuffer_ts_library only supports one .fbs file per target currently.")


### PR DESCRIPTION
Fixes the following error:
```
LOC/flatbuffers/tests/ts/typescript_keywords.fbs:2: 36: error: unable to load include file: reflection/reflection.fbs
```