### PR TITLE
Add support for Bazel 7 and 8 in Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,6 +4,7 @@ matrix:
   bazel:
     - 6.x
     - 7.x
+    - 8.x
 tasks:
   verify_ubuntu2004:
     platform: ubuntu2004

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -39,7 +39,7 @@ tasks:
   verify_macos:
     platform: macos
     bazel: ${{ bazel }}
-    xcode_version: "14.3"
+    xcode_version: "15.2"
     build_targets:
     - "//:flatbuffers"
     - "//:flatc"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,6 +3,7 @@ buildifier: latest
 matrix:
   bazel:
     - 6.x
+    - 7.x
 tasks:
   verify_ubuntu2004:
     platform: ubuntu2004

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,8 +41,8 @@ apple_rules_dependencies()
 
 http_archive(
     name = "build_bazel_rules_swift",
-    sha256 = "a2fd565e527f83fb3f9eb07eb9737240e668c9242d3bc318712efa54a7deda97",
-    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.27.0/rules_swift.0.27.0.tar.gz",
+    sha256 = "b1de723ff0dc433ac4ddfc6a7e8635bd4fb10c44d42d20a433de854196777f3d",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.10.1/rules_swift.1.10.1.tar.gz",
 )
 
 load(

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,3 @@
+# This file is needed during the transition to Bzlmod
+# Remove this file if we only support Bazel 8+ which 
+# defaults to --enable_workspace=false.

--- a/tests/ts/bazel_repository_test_dir/WORKSPACE
+++ b/tests/ts/bazel_repository_test_dir/WORKSPACE
@@ -9,9 +9,9 @@ local_repository(
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "124ed29fb0b3d0cba5b44f8f8e07897cf61b34e35e33b1f83d1a943dfd91b193",
-    strip_prefix = "rules_js-1.24.0",
-    url = "https://github.com/aspect-build/rules_js/releases/download/v1.24.0/rules_js-v1.24.0.tar.gz",
+    sha256 = "76a04ef2120ee00231d85d1ff012ede23963733339ad8db81f590791a031f643",
+    strip_prefix = "rules_js-1.34.1",
+    url = "https://github.com/aspect-build/rules_js/releases/download/v1.34.1/rules_js-v1.34.1.tar.gz",
 )
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
@@ -24,17 +24,17 @@ pnpm_repository(name = "pnpm")
 
 http_archive(
     name = "aspect_rules_ts",
-    sha256 = "8eb25d1fdafc0836f5778d33fb8eaac37c64176481d67872b54b0a05de5be5c0",
-    strip_prefix = "rules_ts-1.3.3",
-    url = "https://github.com/aspect-build/rules_ts/releases/download/v1.3.3/rules_ts-v1.3.3.tar.gz",
+    sha256 = "4c3f34fff9f96ffc9c26635d8235a32a23a6797324486c7d23c1dfa477e8b451",
+    strip_prefix = "rules_ts-1.4.5",
+    url = "https://github.com/aspect-build/rules_ts/releases/download/v1.4.5/rules_ts-v1.4.5.tar.gz",
 )
 
 load("@aspect_rules_ts//ts:repositories.bzl", "rules_ts_dependencies")
 
 rules_ts_dependencies(
     # curl --silent https://registry.npmjs.org/typescript/5.0.3 | jq ._integrity
-    ts_integrity = "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
-    ts_version = "5.0.3",
+    ts_integrity = "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+    ts_version = "5.3.3",
 )
 
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
@@ -61,17 +61,17 @@ npm_repositories()
 
 http_archive(
     name = "aspect_rules_esbuild",
-    sha256 = "2ea31bd97181a315e048be693ddc2815fddda0f3a12ca7b7cc6e91e80f31bac7",
-    strip_prefix = "rules_esbuild-0.14.4",
-    url = "https://github.com/aspect-build/rules_esbuild/releases/download/v0.14.4/rules_esbuild-v0.14.4.tar.gz",
+    sha256 = "098e38e5ee868c14a6484ba263b79e57d48afacfc361ba30137c757a9c4716d6",
+    strip_prefix = "rules_esbuild-0.15.0",
+    url = "https://github.com/aspect-build/rules_esbuild/releases/download/v0.15.0/rules_esbuild-v0.15.0.tar.gz",
 )
 
 # Register a toolchain containing esbuild npm package and native bindings
-load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_VERSION", "esbuild_register_toolchains")
+load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_ESBUILD_VERSION", "esbuild_register_toolchains")
 
 esbuild_register_toolchains(
     name = "esbuild",
-    esbuild_version = LATEST_VERSION,
+    esbuild_version = LATEST_ESBUILD_VERSION,
 )
 
 load("@com_github_google_flatbuffers//ts:repositories.bzl", "flatbuffers_npm")

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -7,6 +7,7 @@ filegroup(
     srcs = [
         "BUILD.bazel",
         "compile_flat_file.sh",
+        "pnpm-lock.yaml",
         "repositories.bzl",
     ] + glob([
         "*.ts",


### PR DESCRIPTION
Both default to Bzlmod, so this is now tested as well.