### PR TITLE
Upgrade dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,7 +23,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "grpc",
-    version = "1.69.0",
+    version = "1.70.1",
     repo_name = "com_github_grpc_grpc",
 )
 bazel_dep(
@@ -49,7 +49,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(


### PR DESCRIPTION
As rules_swift bumped the compatibility level, this is required if any dependent repo wants to use the newer version (this is also triggered when a dependent repo updates transitively dependent repos of rules_swift like grpc).

TODO requires https://github.com/bazelbuild/bazel-central-registry/pull/3671