### PR TITLE
Change JSON Handling of inf and nan (#8527)

### DIFF
--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -96,7 +96,16 @@ struct JsonPrinter {
       // print as numeric value
     }
 
-    text += NumToString(val);
+    auto val_str = NumToString(val);
+    if (StringIsFlatbufferNan(val_str)) {
+      val_str = "NaN";
+    } else if (StringIsFlatbufferPositiveInfinity(val_str)) {
+      val_str = "Infinity";
+    } else if (StringIsFlatbufferNegativeInfinity(val_str)) {
+      val_str = "-Infinity";
+    }
+
+    text += val_str;
     return;
   }
 

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -676,14 +676,14 @@ void TestMonsterExtraFloats(const std::string &tests_data_path) {
   auto result = GenText(parser, def_obj, &jsongen);
   TEST_NULL(result);
   // Check expected default values.
-  TEST_EQ(std::string::npos != jsongen.find("f0: nan"), true);
-  TEST_EQ(std::string::npos != jsongen.find("f1: nan"), true);
-  TEST_EQ(std::string::npos != jsongen.find("f2: inf"), true);
-  TEST_EQ(std::string::npos != jsongen.find("f3: -inf"), true);
-  TEST_EQ(std::string::npos != jsongen.find("d0: nan"), true);
-  TEST_EQ(std::string::npos != jsongen.find("d1: nan"), true);
-  TEST_EQ(std::string::npos != jsongen.find("d2: inf"), true);
-  TEST_EQ(std::string::npos != jsongen.find("d3: -inf"), true);
+  TEST_EQ(std::string::npos != jsongen.find("f0: NaN"), true);
+  TEST_EQ(std::string::npos != jsongen.find("f1: NaN"), true);
+  TEST_EQ(std::string::npos != jsongen.find("f2: Infinity"), true);
+  TEST_EQ(std::string::npos != jsongen.find("f3: -Infinity"), true);
+  TEST_EQ(std::string::npos != jsongen.find("d0: NaN"), true);
+  TEST_EQ(std::string::npos != jsongen.find("d1: NaN"), true);
+  TEST_EQ(std::string::npos != jsongen.find("d2: Infinity"), true);
+  TEST_EQ(std::string::npos != jsongen.find("d3: -Infinity"), true);
   // Parse 'mosterdata_extra.json'.
   const auto extra_base = tests_data_path + "monsterdata_extra";
   jsongen = "";


### PR DESCRIPTION
JSON doesn't spec how to handle inf and nan, but there are some unofficial ways of encoding these values that are implemented in javascript and python. Specifically, they use:

- `Infinity`
- `-Infinity`
- `NaN`

This changes the default emitting of these values by the idl json printer.