### PR TITLE
Go set []byte capacity on Table ByteVector

### DIFF
--- a/go/table.go
+++ b/go/table.go
@@ -35,7 +35,7 @@ func (t *Table) ByteVector(off UOffsetT) []byte {
 	off += GetUOffsetT(t.Bytes[off:])
 	start := off + UOffsetT(SizeUOffsetT)
 	length := GetUOffsetT(t.Bytes[off:])
-	return t.Bytes[start : start+length]
+	return t.Bytes[start : start+length : start+length]
 }
 
 // VectorLen retrieves the length of the vector whose offset is stored at


### PR DESCRIPTION
By setting the capacity==length on slices returned from Table.ByteVector the integrity of the Table is preserved if appends are made beyond the length of the returned slice. I.e. now it will force a reallocation rather than overwriting unrelated fields in the Table.

This is especially useful when using the Object API with a Table containing 2 or more []byte fields. Depending on the order of building appending to fields "earlier" in the table can modify other fields in the struct which is probably surprising as other types have been deep copied from the original serialised Table.
