### PR TITLE
Fix small typo in word JavaScript (JavasScript -> JavaScript)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -139,7 +139,7 @@ nav:
     - Dart: "languages/dart.md"
     - Go: "languages/go.md"
     - Java: "languages/java.md"
-    - JavasScript: "languages/javascript.md"
+    - JavaScript: "languages/javascript.md"
     - Kotlin: "languages/kotlin.md"
     - Lobster: "languages/lobster.md"
     - Lua: "languages/lua.md"


### PR DESCRIPTION
Noticed this on the site. I'm not sure if you have to change it anywhere else, but this looks like the only place the typo occurs

This is only a change in the documentation YAML definition (no code changes). If it needs to be updated in other places, let me know and I can look into those as well.
