### PR TITLE
Cmake: Also build nuget package with flatc.exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -682,6 +682,17 @@ if(FLATBUFFERS_INSTALL)
   endif()
 endif()
 
+add_custom_command(
+  OUTPUT $<CONFIG>/FlatBuffers.Tools.${PROJECT_VERSION}.nupkg
+  COMMAND nuget pack ${CMAKE_SOURCE_DIR}/net/FlatBuffers.Tools/FlatBuffers.Tools.nuspec -OutputDirectory $<CONFIG>
+  DEPENDS flatbuffers flatc
+  COMMENT "Creating NuGet package"
+)
+
+add_custom_target(create_nuget_package ALL
+  DEPENDS $<CONFIG>/FlatBuffers.Tools.${PROJECT_VERSION}.nupkg
+)
+
 if(FLATBUFFERS_BUILD_TESTS)
   enable_testing()
 

--- a/net/FlatBuffers.Tools/FlatBuffers.Tools.nuspec
+++ b/net/FlatBuffers.Tools/FlatBuffers.Tools.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>FlatBuffers.Tools</id>
+    
+    <!-- This will be replaced with the correct version by scripts/release.sh -->
+    <version>25.2.10</version>
+    
+    <authors>Google LLC</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>FlatBuffers compiler tools</description>
+    <tags>flatbuffers compiler tools</tags>
+  </metadata>
+  <files>
+    <file src="../../build/Release/flatc.exe" target="tools\flatc.exe" />
+  </files>
+</package>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -79,6 +79,11 @@ sed -i \
   -e "s/\(<PackageVersion>\).*\(<\/PackageVersion>\)/\1$version\2/" \
   net/FlatBuffers/Google.FlatBuffers.csproj
 
+echo "Updating net/FlatBuffers.Tools/FlatBuffers.Tools.nuspec..."
+sed -i \
+  -e "s/\(<version>\).*\(<\/version>\)/\1$version\2/" \
+  net/FlatBuffers.Tools/FlatBuffers.Tools.nuspec
+
 echo "Updating dart/pubspec.yaml..."
 sed -i \
   -e "s/\(version: \).*/\1$version/" \


### PR DESCRIPTION
This pr only fixes a part of https://github.com/google/flatbuffers/issues/8443 since only the windows flatc.exe executable is included. I thought it could be helpful for windows users and could be extended later.