### PR TITLE
Visual Studio 2013 support and related fixes

### DIFF
--- a/android/app/src/main/cpp/generated/animal_generated.h
+++ b/android/app/src/main/cpp/generated/animal_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 24 &&
-              FLATBUFFERS_VERSION_MINOR == 12 &&
-              FLATBUFFERS_VERSION_REVISION == 23,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 2 &&
+              FLATBUFFERS_VERSION_REVISION == 10,
              "Non-compatible flatbuffers version included");
 
 namespace com {

--- a/benchmarks/cpp/flatbuffers/bench_generated.h
+++ b/benchmarks/cpp/flatbuffers/bench_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 24 &&
-              FLATBUFFERS_VERSION_MINOR == 12 &&
-              FLATBUFFERS_VERSION_REVISION == 23,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 2 &&
+              FLATBUFFERS_VERSION_REVISION == 10,
              "Non-compatible flatbuffers version included");
 
 namespace benchmarks_flatbuffers {
@@ -53,7 +53,7 @@ inline const char * const *EnumNamesEnum() {
 }
 
 inline const char *EnumNameEnum(Enum e) {
-  if (flatbuffers::IsOutRange(e, Enum_Apples, Enum_Bananas)) return "";
+  if (::flatbuffers::IsOutRange(e, Enum_Apples, Enum_Bananas)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesEnum()[index];
 }
@@ -76,24 +76,24 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Foo FLATBUFFERS_FINAL_CLASS {
     (void)padding0__;
   }
   Foo(uint64_t _id, int16_t _count, int8_t _prefix, uint32_t _length)
-      : id_(flatbuffers::EndianScalar(_id)),
-        count_(flatbuffers::EndianScalar(_count)),
-        prefix_(flatbuffers::EndianScalar(_prefix)),
+      : id_(::flatbuffers::EndianScalar(_id)),
+        count_(::flatbuffers::EndianScalar(_count)),
+        prefix_(::flatbuffers::EndianScalar(_prefix)),
         padding0__(0),
-        length_(flatbuffers::EndianScalar(_length)) {
+        length_(::flatbuffers::EndianScalar(_length)) {
     (void)padding0__;
   }
   uint64_t id() const {
-    return flatbuffers::EndianScalar(id_);
+    return ::flatbuffers::EndianScalar(id_);
   }
   int16_t count() const {
-    return flatbuffers::EndianScalar(count_);
+    return ::flatbuffers::EndianScalar(count_);
   }
   int8_t prefix() const {
-    return flatbuffers::EndianScalar(prefix_);
+    return ::flatbuffers::EndianScalar(prefix_);
   }
   uint32_t length() const {
-    return flatbuffers::EndianScalar(length_);
+    return ::flatbuffers::EndianScalar(length_);
   }
 };
 FLATBUFFERS_STRUCT_END(Foo, 16);
@@ -119,9 +119,9 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Bar FLATBUFFERS_FINAL_CLASS {
   }
   Bar(const benchmarks_flatbuffers::Foo &_parent, int32_t _time, float _ratio, uint16_t _size)
       : parent_(_parent),
-        time_(flatbuffers::EndianScalar(_time)),
-        ratio_(flatbuffers::EndianScalar(_ratio)),
-        size_(flatbuffers::EndianScalar(_size)),
+        time_(::flatbuffers::EndianScalar(_time)),
+        ratio_(::flatbuffers::EndianScalar(_ratio)),
+        size_(::flatbuffers::EndianScalar(_size)),
         padding0__(0),
         padding1__(0) {
     (void)padding0__;
@@ -131,18 +131,18 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Bar FLATBUFFERS_FINAL_CLASS {
     return parent_;
   }
   int32_t time() const {
-    return flatbuffers::EndianScalar(time_);
+    return ::flatbuffers::EndianScalar(time_);
   }
   float ratio() const {
-    return flatbuffers::EndianScalar(ratio_);
+    return ::flatbuffers::EndianScalar(ratio_);
   }
   uint16_t size() const {
-    return flatbuffers::EndianScalar(size_);
+    return ::flatbuffers::EndianScalar(size_);
   }
 };
 FLATBUFFERS_STRUCT_END(Bar, 32);
 
-struct FooBar FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+struct FooBar FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef FooBarBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_SIBLING = 4,
@@ -153,8 +153,8 @@ struct FooBar FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const benchmarks_flatbuffers::Bar *sibling() const {
     return GetStruct<const benchmarks_flatbuffers::Bar *>(VT_SIBLING);
   }
-  const flatbuffers::String *name() const {
-    return GetPointer<const flatbuffers::String *>(VT_NAME);
+  const ::flatbuffers::String *name() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_NAME);
   }
   double rating() const {
     return GetField<double>(VT_RATING, 0.0);
@@ -162,7 +162,7 @@ struct FooBar FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   uint8_t postfix() const {
     return GetField<uint8_t>(VT_POSTFIX, 0);
   }
-  bool Verify(flatbuffers::Verifier &verifier) const {
+  bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<benchmarks_flatbuffers::Bar>(verifier, VT_SIBLING, 8) &&
            VerifyOffset(verifier, VT_NAME) &&
@@ -175,12 +175,12 @@ struct FooBar FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 
 struct FooBarBuilder {
   typedef FooBar Table;
-  flatbuffers::FlatBufferBuilder &fbb_;
-  flatbuffers::uoffset_t start_;
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
   void add_sibling(const benchmarks_flatbuffers::Bar *sibling) {
     fbb_.AddStruct(FooBar::VT_SIBLING, sibling);
   }
-  void add_name(flatbuffers::Offset<flatbuffers::String> name) {
+  void add_name(::flatbuffers::Offset<::flatbuffers::String> name) {
     fbb_.AddOffset(FooBar::VT_NAME, name);
   }
   void add_rating(double rating) {
@@ -189,21 +189,21 @@ struct FooBarBuilder {
   void add_postfix(uint8_t postfix) {
     fbb_.AddElement<uint8_t>(FooBar::VT_POSTFIX, postfix, 0);
   }
-  explicit FooBarBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit FooBarBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<FooBar> Finish() {
+  ::flatbuffers::Offset<FooBar> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<FooBar>(end);
+    auto o = ::flatbuffers::Offset<FooBar>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<FooBar> CreateFooBar(
-    flatbuffers::FlatBufferBuilder &_fbb,
+inline ::flatbuffers::Offset<FooBar> CreateFooBar(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
     const benchmarks_flatbuffers::Bar *sibling = nullptr,
-    flatbuffers::Offset<flatbuffers::String> name = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> name = 0,
     double rating = 0.0,
     uint8_t postfix = 0) {
   FooBarBuilder builder_(_fbb);
@@ -214,8 +214,8 @@ inline flatbuffers::Offset<FooBar> CreateFooBar(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<FooBar> CreateFooBarDirect(
-    flatbuffers::FlatBufferBuilder &_fbb,
+inline ::flatbuffers::Offset<FooBar> CreateFooBarDirect(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
     const benchmarks_flatbuffers::Bar *sibling = nullptr,
     const char *name = nullptr,
     double rating = 0.0,
@@ -229,7 +229,7 @@ inline flatbuffers::Offset<FooBar> CreateFooBarDirect(
       postfix);
 }
 
-struct FooBarContainer FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+struct FooBarContainer FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef FooBarContainerBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_LIST = 4,
@@ -237,8 +237,8 @@ struct FooBarContainer FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_FRUIT = 8,
     VT_LOCATION = 10
   };
-  const flatbuffers::Vector<flatbuffers::Offset<benchmarks_flatbuffers::FooBar>> *list() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<benchmarks_flatbuffers::FooBar>> *>(VT_LIST);
+  const ::flatbuffers::Vector<::flatbuffers::Offset<benchmarks_flatbuffers::FooBar>> *list() const {
+    return GetPointer<const ::flatbuffers::Vector<::flatbuffers::Offset<benchmarks_flatbuffers::FooBar>> *>(VT_LIST);
   }
   bool initialized() const {
     return GetField<uint8_t>(VT_INITIALIZED, 0) != 0;
@@ -246,10 +246,10 @@ struct FooBarContainer FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   benchmarks_flatbuffers::Enum fruit() const {
     return static_cast<benchmarks_flatbuffers::Enum>(GetField<int16_t>(VT_FRUIT, 0));
   }
-  const flatbuffers::String *location() const {
-    return GetPointer<const flatbuffers::String *>(VT_LOCATION);
+  const ::flatbuffers::String *location() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_LOCATION);
   }
-  bool Verify(flatbuffers::Verifier &verifier) const {
+  bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_LIST) &&
            verifier.VerifyVector(list()) &&
@@ -264,9 +264,9 @@ struct FooBarContainer FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 
 struct FooBarContainerBuilder {
   typedef FooBarContainer Table;
-  flatbuffers::FlatBufferBuilder &fbb_;
-  flatbuffers::uoffset_t start_;
-  void add_list(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<benchmarks_flatbuffers::FooBar>>> list) {
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
+  void add_list(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<benchmarks_flatbuffers::FooBar>>> list) {
     fbb_.AddOffset(FooBarContainer::VT_LIST, list);
   }
   void add_initialized(bool initialized) {
@@ -275,26 +275,26 @@ struct FooBarContainerBuilder {
   void add_fruit(benchmarks_flatbuffers::Enum fruit) {
     fbb_.AddElement<int16_t>(FooBarContainer::VT_FRUIT, static_cast<int16_t>(fruit), 0);
   }
-  void add_location(flatbuffers::Offset<flatbuffers::String> location) {
+  void add_location(::flatbuffers::Offset<::flatbuffers::String> location) {
     fbb_.AddOffset(FooBarContainer::VT_LOCATION, location);
   }
-  explicit FooBarContainerBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit FooBarContainerBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<FooBarContainer> Finish() {
+  ::flatbuffers::Offset<FooBarContainer> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<FooBarContainer>(end);
+    auto o = ::flatbuffers::Offset<FooBarContainer>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<FooBarContainer> CreateFooBarContainer(
-    flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<benchmarks_flatbuffers::FooBar>>> list = 0,
+inline ::flatbuffers::Offset<FooBarContainer> CreateFooBarContainer(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<benchmarks_flatbuffers::FooBar>>> list = 0,
     bool initialized = false,
     benchmarks_flatbuffers::Enum fruit = benchmarks_flatbuffers::Enum_Apples,
-    flatbuffers::Offset<flatbuffers::String> location = 0) {
+    ::flatbuffers::Offset<::flatbuffers::String> location = 0) {
   FooBarContainerBuilder builder_(_fbb);
   builder_.add_location(location);
   builder_.add_list(list);
@@ -303,13 +303,13 @@ inline flatbuffers::Offset<FooBarContainer> CreateFooBarContainer(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<FooBarContainer> CreateFooBarContainerDirect(
-    flatbuffers::FlatBufferBuilder &_fbb,
-    const std::vector<flatbuffers::Offset<benchmarks_flatbuffers::FooBar>> *list = nullptr,
+inline ::flatbuffers::Offset<FooBarContainer> CreateFooBarContainerDirect(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    const std::vector<::flatbuffers::Offset<benchmarks_flatbuffers::FooBar>> *list = nullptr,
     bool initialized = false,
     benchmarks_flatbuffers::Enum fruit = benchmarks_flatbuffers::Enum_Apples,
     const char *location = nullptr) {
-  auto list__ = list ? _fbb.CreateVector<flatbuffers::Offset<benchmarks_flatbuffers::FooBar>>(*list) : 0;
+  auto list__ = list ? _fbb.CreateVector<::flatbuffers::Offset<benchmarks_flatbuffers::FooBar>>(*list) : 0;
   auto location__ = location ? _fbb.CreateString(location) : 0;
   return benchmarks_flatbuffers::CreateFooBarContainer(
       _fbb,
@@ -320,32 +320,32 @@ inline flatbuffers::Offset<FooBarContainer> CreateFooBarContainerDirect(
 }
 
 inline const benchmarks_flatbuffers::FooBarContainer *GetFooBarContainer(const void *buf) {
-  return flatbuffers::GetRoot<benchmarks_flatbuffers::FooBarContainer>(buf);
+  return ::flatbuffers::GetRoot<benchmarks_flatbuffers::FooBarContainer>(buf);
 }
 
 inline const benchmarks_flatbuffers::FooBarContainer *GetSizePrefixedFooBarContainer(const void *buf) {
-  return flatbuffers::GetSizePrefixedRoot<benchmarks_flatbuffers::FooBarContainer>(buf);
+  return ::flatbuffers::GetSizePrefixedRoot<benchmarks_flatbuffers::FooBarContainer>(buf);
 }
 
 inline bool VerifyFooBarContainerBuffer(
-    flatbuffers::Verifier &verifier) {
+    ::flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<benchmarks_flatbuffers::FooBarContainer>(nullptr);
 }
 
 inline bool VerifySizePrefixedFooBarContainerBuffer(
-    flatbuffers::Verifier &verifier) {
+    ::flatbuffers::Verifier &verifier) {
   return verifier.VerifySizePrefixedBuffer<benchmarks_flatbuffers::FooBarContainer>(nullptr);
 }
 
 inline void FinishFooBarContainerBuffer(
-    flatbuffers::FlatBufferBuilder &fbb,
-    flatbuffers::Offset<benchmarks_flatbuffers::FooBarContainer> root) {
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    ::flatbuffers::Offset<benchmarks_flatbuffers::FooBarContainer> root) {
   fbb.Finish(root);
 }
 
 inline void FinishSizePrefixedFooBarContainerBuffer(
-    flatbuffers::FlatBufferBuilder &fbb,
-    flatbuffers::Offset<benchmarks_flatbuffers::FooBarContainer> root) {
+    ::flatbuffers::FlatBufferBuilder &fbb,
+    ::flatbuffers::Offset<benchmarks_flatbuffers::FooBarContainer> root) {
   fbb.FinishSizePrefixed(root);
 }
 

--- a/include/flatbuffers/array.h
+++ b/include/flatbuffers/array.h
@@ -245,7 +245,7 @@ const Array<E, length> &CastToArrayOfEnum(const T (&arr)[length]) {
 
 template<typename T, uint16_t length>
 bool operator==(const Array<T, length> &lhs,
-                const Array<T, length> &rhs) noexcept {
+                const Array<T, length> &rhs) FLATBUFFERS_NOEXCEPT {
   return std::addressof(lhs) == std::addressof(rhs) ||
          (lhs.size() == rhs.size() &&
           std::memcmp(lhs.Data(), rhs.Data(), rhs.size() * sizeof(T)) == 0);

--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -172,6 +172,15 @@ namespace flatbuffers {
 #else
   #define FLATBUFFERS_CONSTEXPR const
   #define FLATBUFFERS_CONSTEXPR_CPP11
+  #if defined _MSC_VER && _MSC_VER == 1800
+    // disable VS2013 warning when if() condition is a constant expression
+    #pragma warning (disable: 4127)
+  #endif
+#endif
+
+#if defined _MSC_VER && _MSC_VER == 1800
+  // disabled the warning about behavior change that now conforms to the standard
+  #pragma warning (disable: 4351)
 #endif
 
 #if (defined(__cplusplus) && __cplusplus >= 201402L) || \

--- a/include/flatbuffers/detached_buffer.h
+++ b/include/flatbuffers/detached_buffer.h
@@ -45,7 +45,7 @@ class DetachedBuffer {
         cur_(cur),
         size_(sz) {}
 
-  DetachedBuffer(DetachedBuffer &&other) noexcept
+  DetachedBuffer(DetachedBuffer &&other) FLATBUFFERS_NOEXCEPT
       : allocator_(other.allocator_),
         own_allocator_(other.own_allocator_),
         buf_(other.buf_),
@@ -55,7 +55,7 @@ class DetachedBuffer {
     other.reset();
   }
 
-  DetachedBuffer &operator=(DetachedBuffer &&other) noexcept {
+  DetachedBuffer &operator=(DetachedBuffer &&other) FLATBUFFERS_NOEXCEPT {
     if (this == &other) return *this;
 
     destroy();

--- a/include/flatbuffers/flatbuffer_builder.h
+++ b/include/flatbuffers/flatbuffer_builder.h
@@ -112,7 +112,7 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
   }
 
   /// @brief Move constructor for FlatBufferBuilder.
-  FlatBufferBuilderImpl(FlatBufferBuilderImpl &&other) noexcept
+  FlatBufferBuilderImpl(FlatBufferBuilderImpl &&other) FLATBUFFERS_NOEXCEPT
       : buf_(1024, nullptr, false, AlignOf<largest_scalar_t>(),
              static_cast<SizeT>(Is64Aware ? FLATBUFFERS_MAX_64_BUFFER_SIZE
                                           : FLATBUFFERS_MAX_BUFFER_SIZE)),
@@ -133,7 +133,7 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
   }
 
   /// @brief Move assignment operator for FlatBufferBuilder.
-  FlatBufferBuilderImpl &operator=(FlatBufferBuilderImpl &&other) noexcept {
+  FlatBufferBuilderImpl &operator=(FlatBufferBuilderImpl &&other) FLATBUFFERS_NOEXCEPT {
     // Move construct a temporary and swap idiom
     FlatBufferBuilderImpl temp(std::move(other));
     Swap(temp);

--- a/include/flatbuffers/flatc.h
+++ b/include/flatbuffers/flatc.h
@@ -116,7 +116,7 @@ class FlatCompiler {
 
   void ValidateOptions(const FlatCOptions &options);
 
-  Parser GetConformParser(const FlatCOptions &options);
+  void GetConformParser(const FlatCOptions &options, Parser &conform_parser);
 
   std::unique_ptr<Parser> GenerateCode(const FlatCOptions &options,
                                        Parser &conform_parser);

--- a/include/flatbuffers/flatc.h
+++ b/include/flatbuffers/flatc.h
@@ -34,6 +34,15 @@ extern void LogCompilerWarn(const std::string &warn);
 extern void LogCompilerError(const std::string &err);
 
 struct FlatCOptions {
+  FlatCOptions() = default;
+  FlatCOptions(const FlatCOptions&) = delete;
+  FlatCOptions(FlatCOptions&&) = delete;
+
+  ~FlatCOptions() = default;
+
+  FlatCOptions& operator=(const FlatCOptions&) = delete;
+  FlatCOptions& operator=(FlatCOptions&&) = delete;
+
   IDLOptions opts;
 
   std::string program_name;
@@ -95,7 +104,7 @@ class FlatCompiler {
   std::string GetUsageString(const std::string &program_name) const;
 
   // Parse the FlatC options from command line arguments.
-  FlatCOptions ParseFromCommandLineArguments(int argc, const char **argv);
+  void ParseFromCommandLineArguments(int argc, const char **argv, FlatCOptions& options);
 
  private:
   void ParseFile(flatbuffers::Parser &parser, const std::string &filename,

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -1009,8 +1009,10 @@ class Parser : public ParserState {
   Parser(const Parser &) = delete;
   Parser &operator=(const Parser &) = delete;
 
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   Parser(Parser &&) = default;
   Parser &operator=(Parser &&) = default;
+#endif
 
   ~Parser() {
     for (auto it = namespaces_.begin(); it != namespaces_.end(); ++it) {

--- a/include/flatbuffers/vector_downward.h
+++ b/include/flatbuffers/vector_downward.h
@@ -48,7 +48,7 @@ template<typename SizeT = uoffset_t> class vector_downward {
         cur_(nullptr),
         scratch_(nullptr) {}
 
-  vector_downward(vector_downward &&other) noexcept
+  vector_downward(vector_downward &&other) FLATBUFFERS_NOEXCEPT
       // clang-format on
       : allocator_(other.allocator_),
         own_allocator_(other.own_allocator_),
@@ -70,7 +70,7 @@ template<typename SizeT = uoffset_t> class vector_downward {
     other.scratch_ = nullptr;
   }
 
-  vector_downward &operator=(vector_downward &&other) noexcept {
+  vector_downward &operator=(vector_downward &&other) FLATBUFFERS_NOEXCEPT {
     // Move construct a temporary and swap idiom
     vector_downward temp(std::move(other));
     swap(temp);

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -248,7 +248,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   std::vector<MyGame::Sample::Vec3> path{};
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/src/annotated_binary_text_gen.cpp
+++ b/src/annotated_binary_text_gen.cpp
@@ -53,6 +53,9 @@ static bool IsOffset(const BinaryRegionType type) {
 
 template<typename T> std::string ToString(T value) {
   if (std::is_floating_point<T>::value) {
+    std::string res;
+    if (ExplicitlyConvertSpecialValues(value, res))
+        return res;
     std::stringstream ss;
     ss << value;
     return ss.str();

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -778,9 +778,8 @@ void FlatCompiler::ValidateOptions(const FlatCOptions &options) {
   }
 }
 
-flatbuffers::Parser FlatCompiler::GetConformParser(
-    const FlatCOptions &options) {
-  flatbuffers::Parser conform_parser;
+void FlatCompiler::GetConformParser(
+    const FlatCOptions &options, flatbuffers::Parser &conform_parser) {
 
   // conform parser should check advanced options,
   // so, it have to have knowledge about languages:
@@ -801,7 +800,6 @@ flatbuffers::Parser FlatCompiler::GetConformParser(
                 options.conform_include_directories);
     }
   }
-  return conform_parser;
 }
 
 std::unique_ptr<Parser> FlatCompiler::GenerateCode(const FlatCOptions &options,
@@ -985,7 +983,8 @@ std::unique_ptr<Parser> FlatCompiler::GenerateCode(const FlatCOptions &options,
 
 int FlatCompiler::Compile(const FlatCOptions &options) {
   // TODO(derekbailey): change to std::optional<Parser>
-  Parser conform_parser = GetConformParser(options);
+  Parser conform_parser;
+  GetConformParser(options, conform_parser);
 
   // TODO(derekbailey): split to own method.
   if (!options.annotate_schema.empty()) {

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -272,8 +272,11 @@ const static FlatCOption flatc_options[] = {
     "The handlers will use the generated classes rather than raw bytes." },
 };
 
-auto cmp = [](FlatCOption a, FlatCOption b) { return a.long_opt < b.long_opt; };
-static std::set<FlatCOption, decltype(cmp)> language_options(cmp);
+struct cmp {
+  bool operator()(FlatCOption a, FlatCOption b) { return a.long_opt < b.long_opt; }
+};
+
+static std::set<FlatCOption, cmp> language_options((cmp()));
 
 static void AppendTextWrappedString(std::stringstream &ss, std::string &text,
                                     size_t max_col, size_t start_col) {

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -431,11 +431,10 @@ void FlatCompiler::AnnotateBinaries(const uint8_t *binary_schema,
   }
 }
 
-FlatCOptions FlatCompiler::ParseFromCommandLineArguments(int argc,
-                                                         const char **argv) {
+void FlatCompiler::ParseFromCommandLineArguments(int argc,
+                                                         const char **argv,
+                                                         FlatCOptions& options) {
   if (argc <= 1) { Error("Need to provide at least one argument."); }
-
-  FlatCOptions options;
 
   options.program_name = std::string(argv[0]);
 
@@ -734,7 +733,7 @@ FlatCOptions FlatCompiler::ParseFromCommandLineArguments(int argc,
         auto code_generator_it = code_generators_.find(arg);
         if (code_generator_it == code_generators_.end()) {
           Error("unknown commandline argument: " + arg, true);
-          return options;
+          return;
         }
 
         std::shared_ptr<CodeGenerator> code_generator =
@@ -754,8 +753,6 @@ FlatCOptions FlatCompiler::ParseFromCommandLineArguments(int argc,
       options.filenames.push_back(flatbuffers::PosixPath(argv[argi]));
     }
   }
-
-  return options;
 }
 
 void FlatCompiler::ValidateOptions(const FlatCOptions &options) {

--- a/src/flatc_main.cpp
+++ b/src/flatc_main.cpp
@@ -176,8 +176,8 @@ int main(int argc, const char *argv[]) {
       flatbuffers::NewTsCodeGenerator());
 
   // Create the FlatC options by parsing the command line arguments.
-  const flatbuffers::FlatCOptions &options =
-      flatc.ParseFromCommandLineArguments(argc, argv);
+  flatbuffers::FlatCOptions options;
+  flatc.ParseFromCommandLineArguments(argc, argv, options);
 
   // Compile with the extracted FlatC options.
   return flatc.Compile(options);

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -3147,7 +3147,7 @@ class CppGenerator : public BaseGenerator {
                 code_ += "_fbb.CreateVectorOfStructs\\";
                 if (field->offset64) {
                   // This is normal 32-bit vector, with 64-bit addressing.
-                  code_ += "64<::flatbuffers::Vector>\\";
+                  code_ += "64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>\\";
                 } else {
                   code_ += "<" + type + ">\\";
                 }
@@ -3166,7 +3166,7 @@ class CppGenerator : public BaseGenerator {
               // If the field uses 64-bit addressing, create a 64-bit vector.
               code_.SetValue("64OFFSET", field->offset64 ? "64" : "");
               code_.SetValue("TYPE",
-                             field->offset64 ? "::flatbuffers::Vector" : type);
+                             field->offset64 ? "::flatbuffers::Vector, ::flatbuffers::uoffset_t" : type);
 
               code_ += "_fbb.CreateVector{{64OFFSET}}<{{TYPE}}>\\";
             }
@@ -3499,7 +3499,7 @@ class CppGenerator : public BaseGenerator {
                   code += "_fbb.CreateVectorOfStructs";
                   if (field.offset64) {
                     // This is normal 32-bit vector, with 64-bit addressing.
-                    code += "64<::flatbuffers::Vector>";
+                    code += "64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>";
                   }
                 }
                 code += "(" + value + ")";
@@ -3576,7 +3576,7 @@ class CppGenerator : public BaseGenerator {
                 code += "_fbb.CreateVector";
                 if (field.offset64) {
                   // This is normal 32-bit vector, with 64-bit addressing.
-                  code += "64<::flatbuffers::Vector>";
+                  code += "64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>";
                 }
                 code += "(" + value + ")";
               }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2018,9 +2018,11 @@ class CppGenerator : public BaseGenerator {
     code_.SetValue("NATIVE_NAME",
                    NativeName(Name(struct_def), &struct_def, opts_));
     code_ += "  {{NATIVE_NAME}}(const {{NATIVE_NAME}} &o);";
+    code_ += "#ifdef FLATBUFFERS_DEFAULT_DECLARATION";
     code_ +=
         "  {{NATIVE_NAME}}({{NATIVE_NAME}}&&) FLATBUFFERS_NOEXCEPT = "
         "default;";
+    code_ += "#endif";
     code_ +=
         "  {{NATIVE_NAME}} &operator=({{NATIVE_NAME}} o) FLATBUFFERS_NOEXCEPT;";
   }

--- a/src/idl_gen_fbs.cpp
+++ b/src/idl_gen_fbs.cpp
@@ -196,7 +196,7 @@ static ProtobufToFbsIdMap MapProtoIdsToFieldsId(
 
   if (!ProtobufIdSanityCheck(struct_def, gap_action, no_log)) { return {}; }
 
-  static constexpr int UNION_ID = -1;
+  static FLATBUFFERS_CONSTEXPR int UNION_ID = -1;
   using ProtoIdFieldNamePair = std::pair<int, std::string>;
   std::vector<ProtoIdFieldNamePair> proto_ids;
 

--- a/tests/64bit/offset64_test.cpp
+++ b/tests/64bit/offset64_test.cpp
@@ -41,7 +41,7 @@ void Offset64Test() {
     // Then serialize all the fields that have 64-bit offsets, as these must be
     // serialized before any 32-bit fields are added to the buffer.
     const Offset64<Vector<uint8_t>> far_vector_offset =
-        builder.CreateVector64<Vector>(far_data);
+        builder.CreateVector64<Vector, uoffset_t>(far_data);
 
     const Offset64<String> far_string_offset =
         builder.CreateString<Offset64>("some far string");
@@ -136,7 +136,7 @@ void Offset64NestedFlatBuffer() {
     fbb.Clear();
 
     const Offset64<Vector64<uint8_t>> nested_flatbuffer_offset =
-        fbb.CreateVector64<Vector64>(nested_data);
+        fbb.CreateVector64(nested_data);
 
     // Now that we are done with the 64-bit fields, we can create and add the
     // normal fields.
@@ -387,7 +387,7 @@ void Offset64ManyVectors() {
   // of putting all 64-bit things at the tail of the buffer.
   std::array<Offset64<Vector<int8_t>>, kNumVectors> offsets_64bit;
   for (size_t i = 0; i < kNumVectors; ++i) {
-    offsets_64bit[i] = builder.CreateVector64<Vector>(data);
+    offsets_64bit[i] = builder.CreateVector64<Vector, uoffset_t>(data);
   }
 
   // Create some unrelated, 64-bit offset value for later testing.

--- a/tests/64bit/test_64bit_generated.h
+++ b/tests/64bit/test_64bit_generated.h
@@ -148,7 +148,7 @@ inline ::flatbuffers::Offset<WrapperTable> CreateWrapperTable(
 inline ::flatbuffers::Offset<WrapperTable> CreateWrapperTableDirect(
     ::flatbuffers::FlatBufferBuilder64 &_fbb,
     const std::vector<int8_t> *vector = nullptr) {
-  auto vector__ = vector ? _fbb.CreateVector64<::flatbuffers::Vector>(*vector) : 0;
+  auto vector__ = vector ? _fbb.CreateVector64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(*vector) : 0;
   return CreateWrapperTable(
       _fbb,
       vector__);
@@ -373,11 +373,11 @@ inline ::flatbuffers::Offset<RootTable> CreateRootTableDirect(
     const std::vector<LeafStruct> *big_struct_vector = nullptr,
     const std::vector<::flatbuffers::Offset<WrapperTable>> *many_vectors = nullptr,
     const std::vector<uint8_t> *forced_aligned_vector = nullptr) {
-  auto far_vector__ = far_vector ? _fbb.CreateVector64<::flatbuffers::Vector>(*far_vector) : 0;
+  auto far_vector__ = far_vector ? _fbb.CreateVector64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(*far_vector) : 0;
   auto far_string__ = far_string ? _fbb.CreateString<::flatbuffers::Offset64>(far_string) : 0;
   auto big_vector__ = big_vector ? _fbb.CreateVector64(*big_vector) : 0;
   auto nested_root__ = nested_root ? _fbb.CreateVector64(*nested_root) : 0;
-  auto far_struct_vector__ = far_struct_vector ? _fbb.CreateVectorOfStructs64<::flatbuffers::Vector>(*far_struct_vector) : 0;
+  auto far_struct_vector__ = far_struct_vector ? _fbb.CreateVectorOfStructs64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(*far_struct_vector) : 0;
   auto big_struct_vector__ = big_struct_vector ? _fbb.CreateVectorOfStructs64(*big_struct_vector) : 0;
   if (forced_aligned_vector) { _fbb.ForceVectorAlignment64(forced_aligned_vector->size(), sizeof(uint8_t), 32); }
   auto forced_aligned_vector__ = forced_aligned_vector ? _fbb.CreateVector64(*forced_aligned_vector) : 0;
@@ -430,7 +430,7 @@ inline ::flatbuffers::Offset<WrapperTable> CreateWrapperTable(::flatbuffers::Fla
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder64 *__fbb; const WrapperTableT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _vector = _o->vector.size() ? _fbb.CreateVector64<::flatbuffers::Vector>(_o->vector) : 0;
+  auto _vector = _o->vector.size() ? _fbb.CreateVector64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(_o->vector) : 0;
   return CreateWrapperTable(
       _fbb,
       _vector);
@@ -513,13 +513,13 @@ inline ::flatbuffers::Offset<RootTable> CreateRootTable(::flatbuffers::FlatBuffe
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder64 *__fbb; const RootTableT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _far_vector = _o->far_vector.size() ? _fbb.CreateVector64<::flatbuffers::Vector>(_o->far_vector) : 0;
+  auto _far_vector = _o->far_vector.size() ? _fbb.CreateVector64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(_o->far_vector) : 0;
   auto _a = _o->a;
   auto _far_string = _o->far_string.empty() ? 0 : _fbb.CreateString<::flatbuffers::Offset64>(_o->far_string);
   auto _big_vector = _o->big_vector.size() ? _fbb.CreateVector64(_o->big_vector) : 0;
   auto _near_string = _o->near_string.empty() ? 0 : _fbb.CreateString(_o->near_string);
   auto _nested_root = _o->nested_root.size() ? _fbb.CreateVector64(_o->nested_root) : 0;
-  auto _far_struct_vector = _o->far_struct_vector.size() ? _fbb.CreateVectorOfStructs64<::flatbuffers::Vector>(_o->far_struct_vector) : 0;
+  auto _far_struct_vector = _o->far_struct_vector.size() ? _fbb.CreateVectorOfStructs64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(_o->far_struct_vector) : 0;
   auto _big_struct_vector = _o->big_struct_vector.size() ? _fbb.CreateVectorOfStructs64(_o->big_struct_vector) : 0;
   auto _many_vectors = _o->many_vectors.size() ? _fbb.CreateVector<::flatbuffers::Offset<WrapperTable>> (_o->many_vectors.size(), [](size_t i, _VectorArgs *__va) { return CreateWrapperTable(*__va->__fbb, __va->__o->many_vectors[i].get(), __va->__rehasher); }, &_va ) : 0;
   _fbb.ForceVectorAlignment64(_o->forced_aligned_vector.size(), sizeof(uint8_t), 32);

--- a/tests/64bit/test_64bit_generated.h
+++ b/tests/64bit/test_64bit_generated.h
@@ -170,7 +170,9 @@ struct RootTableT : public ::flatbuffers::NativeTable {
   std::vector<uint8_t> forced_aligned_vector{};
   RootTableT() = default;
   RootTableT(const RootTableT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   RootTableT(RootTableT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   RootTableT &operator=(RootTableT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -1331,7 +1331,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   double double_inf_default = std::numeric_limits<double>::infinity();
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/minified_enums/enums_generated.h
+++ b/tests/minified_enums/enums_generated.h
@@ -16,11 +16,60 @@ static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
 enum Color : int32_t {
   Color_Red = 1,
   Color_Blue = 2,
-  Color_Orange = 3
+  Color_Orange = 3,
+  Color_MIN = Color_Red,
+  Color_MAX = Color_Orange
 };
+
+inline const Color (&EnumValuesColor())[3] {
+  static const Color values[] = {
+    Color_Red,
+    Color_Blue,
+    Color_Orange
+  };
+  return values;
+}
+
+inline const char * const *EnumNamesColor() {
+  static const char * const names[4] = {
+    "Red",
+    "Blue",
+    "Orange",
+    nullptr
+  };
+  return names;
+}
+
+inline const char *EnumNameColor(Color e) {
+  if (::flatbuffers::IsOutRange(e, Color_Red, Color_Orange)) return "";
+  const size_t index = static_cast<size_t>(e) - static_cast<size_t>(Color_Red);
+  return EnumNamesColor()[index];
+}
+
 enum Size : int32_t {
   Size_Small = 10,
   Size_Large = 100,
-  Size_Medium = 1000
+  Size_Medium = 1000,
+  Size_MIN = Size_Small,
+  Size_MAX = Size_Medium
 };
+
+inline const Size (&EnumValuesSize())[3] {
+  static const Size values[] = {
+    Size_Small,
+    Size_Large,
+    Size_Medium
+  };
+  return values;
+}
+
+inline const char *EnumNameSize(Size e) {
+  switch (e) {
+    case Size_Small: return "Small";
+    case Size_Large: return "Large";
+    case Size_Medium: return "Medium";
+    default: return "";
+  }
+}
+
 #endif  // FLATBUFFERS_GENERATED_ENUMS_H_

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -96,7 +96,7 @@ flatbuffers::DetachedBuffer CreateFlatBufferTest(std::string &buffer) {
 #endif
 
   // Make sure the template deduces an initializer as std::vector<std::string>
-  builder.CreateVectorOfStrings({ "hello", "world" });
+  builder.CreateVectorOfStrings(std::vector<std::string>{ "hello", "world" });
 
   // Create many vectors of strings
   std::vector<std::string> manyNames;

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -1327,7 +1327,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   double double_inf_default = std::numeric_limits<double>::infinity();
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/monster_test_suffix/ext_only/monster_test_generated.hpp
+++ b/tests/monster_test_suffix/ext_only/monster_test_generated.hpp
@@ -1319,7 +1319,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   double double_inf_default = std::numeric_limits<double>::infinity();
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/monster_test_suffix/filesuffix_only/monster_test_suffix.h
+++ b/tests/monster_test_suffix/filesuffix_only/monster_test_suffix.h
@@ -1319,7 +1319,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   double double_inf_default = std::numeric_limits<double>::infinity();
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/monster_test_suffix/monster_test_suffix.hpp
+++ b/tests/monster_test_suffix/monster_test_suffix.hpp
@@ -1319,7 +1319,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   double double_inf_default = std::numeric_limits<double>::infinity();
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -75,7 +75,9 @@ struct TableInFirstNST : public ::flatbuffers::NativeTable {
   std::unique_ptr<NamespaceA::NamespaceB::StructInNestedNS> foo_struct{};
   TableInFirstNST() = default;
   TableInFirstNST(const TableInFirstNST &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   TableInFirstNST(TableInFirstNST&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   TableInFirstNST &operator=(TableInFirstNST o) FLATBUFFERS_NOEXCEPT;
 };
 
@@ -207,7 +209,9 @@ struct TableInCT : public ::flatbuffers::NativeTable {
   std::unique_ptr<NamespaceA::SecondTableInAT> refer_to_a2{};
   TableInCT() = default;
   TableInCT(const TableInCT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   TableInCT(TableInCT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   TableInCT &operator=(TableInCT o) FLATBUFFERS_NOEXCEPT;
 };
 
@@ -294,7 +298,9 @@ struct SecondTableInAT : public ::flatbuffers::NativeTable {
   std::unique_ptr<NamespaceC::TableInCT> refer_to_c{};
   SecondTableInAT() = default;
   SecondTableInAT(const SecondTableInAT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   SecondTableInAT(SecondTableInAT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   SecondTableInAT &operator=(SecondTableInAT o) FLATBUFFERS_NOEXCEPT;
 };
 


### PR DESCRIPTION
The goal of this changeset is to make flatbuffers compile on VS2013, which _mostly_ supports C++11.
This includes:
1. Fixing C++11 keywords being used directly instead of already existing FLATBUFFERS_* defines that were created exactly for older compiler support.
2. Fixing VS2013 not supporting defaulting move constructors using existing FLATBUFFERS_DEFAULT_DECLARATION.
3. Fixed actual bug that was crashing on VS2013 - taking reference to a value returned from function.
4. More significant change: VS2013 has buggy handling of template template packs, which is the case for Vector<T, SizeT>: see the https://godbolt.org/z/Trfrsja46 for valid code that fails in VS2013. I tried to work around it without changing API.