### PR TITLE
Visual Studio 2013 support and related fixes

### DIFF
--- a/include/flatbuffers/array.h
+++ b/include/flatbuffers/array.h
@@ -245,7 +245,7 @@ const Array<E, length> &CastToArrayOfEnum(const T (&arr)[length]) {
 
 template<typename T, uint16_t length>
 bool operator==(const Array<T, length> &lhs,
-                const Array<T, length> &rhs) noexcept {
+                const Array<T, length> &rhs) FLATBUFFERS_NOEXCEPT {
   return std::addressof(lhs) == std::addressof(rhs) ||
          (lhs.size() == rhs.size() &&
           std::memcmp(lhs.Data(), rhs.Data(), rhs.size() * sizeof(T)) == 0);

--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -172,6 +172,15 @@ namespace flatbuffers {
 #else
   #define FLATBUFFERS_CONSTEXPR const
   #define FLATBUFFERS_CONSTEXPR_CPP11
+  #if defined _MSC_VER && _MSC_VER == 1800
+    // disable VS2013 warning when if() condition is a constant expression
+    #pragma warning (disable: 4127)
+  #endif
+#endif
+
+#if defined _MSC_VER && _MSC_VER == 1800
+  // disabled the warning about behavior change that now conforms to the standard
+  #pragma warning (disable: 4351)
 #endif
 
 #if (defined(__cplusplus) && __cplusplus >= 201402L) || \

--- a/include/flatbuffers/detached_buffer.h
+++ b/include/flatbuffers/detached_buffer.h
@@ -45,7 +45,7 @@ class DetachedBuffer {
         cur_(cur),
         size_(sz) {}
 
-  DetachedBuffer(DetachedBuffer &&other) noexcept
+  DetachedBuffer(DetachedBuffer &&other) FLATBUFFERS_NOEXCEPT
       : allocator_(other.allocator_),
         own_allocator_(other.own_allocator_),
         buf_(other.buf_),
@@ -55,7 +55,7 @@ class DetachedBuffer {
     other.reset();
   }
 
-  DetachedBuffer &operator=(DetachedBuffer &&other) noexcept {
+  DetachedBuffer &operator=(DetachedBuffer &&other) FLATBUFFERS_NOEXCEPT {
     if (this == &other) return *this;
 
     destroy();

--- a/include/flatbuffers/flatbuffer_builder.h
+++ b/include/flatbuffers/flatbuffer_builder.h
@@ -112,7 +112,7 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
   }
 
   /// @brief Move constructor for FlatBufferBuilder.
-  FlatBufferBuilderImpl(FlatBufferBuilderImpl &&other) noexcept
+  FlatBufferBuilderImpl(FlatBufferBuilderImpl &&other) FLATBUFFERS_NOEXCEPT
       : buf_(1024, nullptr, false, AlignOf<largest_scalar_t>(),
              static_cast<SizeT>(Is64Aware ? FLATBUFFERS_MAX_64_BUFFER_SIZE
                                           : FLATBUFFERS_MAX_BUFFER_SIZE)),
@@ -133,7 +133,7 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
   }
 
   /// @brief Move assignment operator for FlatBufferBuilder.
-  FlatBufferBuilderImpl &operator=(FlatBufferBuilderImpl &&other) noexcept {
+  FlatBufferBuilderImpl &operator=(FlatBufferBuilderImpl &&other) FLATBUFFERS_NOEXCEPT {
     // Move construct a temporary and swap idiom
     FlatBufferBuilderImpl temp(std::move(other));
     Swap(temp);

--- a/include/flatbuffers/flatc.h
+++ b/include/flatbuffers/flatc.h
@@ -116,7 +116,7 @@ class FlatCompiler {
 
   void ValidateOptions(const FlatCOptions &options);
 
-  Parser GetConformParser(const FlatCOptions &options);
+  void GetConformParser(const FlatCOptions &options, Parser &conform_parser);
 
   std::unique_ptr<Parser> GenerateCode(const FlatCOptions &options,
                                        Parser &conform_parser);

--- a/include/flatbuffers/flatc.h
+++ b/include/flatbuffers/flatc.h
@@ -34,6 +34,15 @@ extern void LogCompilerWarn(const std::string &warn);
 extern void LogCompilerError(const std::string &err);
 
 struct FlatCOptions {
+  FlatCOptions() = default;
+  FlatCOptions(const FlatCOptions&) = delete;
+  FlatCOptions(FlatCOptions&&) = delete;
+
+  ~FlatCOptions() = default;
+
+  FlatCOptions& operator=(const FlatCOptions&) = delete;
+  FlatCOptions& operator=(FlatCOptions&&) = delete;
+
   IDLOptions opts;
 
   std::string program_name;
@@ -95,7 +104,7 @@ class FlatCompiler {
   std::string GetUsageString(const std::string &program_name) const;
 
   // Parse the FlatC options from command line arguments.
-  FlatCOptions ParseFromCommandLineArguments(int argc, const char **argv);
+  void ParseFromCommandLineArguments(int argc, const char **argv, FlatCOptions& options);
 
  private:
   void ParseFile(flatbuffers::Parser &parser, const std::string &filename,

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -1009,8 +1009,10 @@ class Parser : public ParserState {
   Parser(const Parser &) = delete;
   Parser &operator=(const Parser &) = delete;
 
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   Parser(Parser &&) = default;
   Parser &operator=(Parser &&) = default;
+#endif
 
   ~Parser() {
     for (auto it = namespaces_.begin(); it != namespaces_.end(); ++it) {

--- a/include/flatbuffers/util.h
+++ b/include/flatbuffers/util.h
@@ -149,9 +149,45 @@ template<> inline std::string NumToString<char>(char t) {
   return NumToString(static_cast<int>(t));
 }
 
+#if defined _MSC_VER && _MSC_VER <= 1800
+#define FLATBUFFERS_EXPLICIT_INF_NAN_CONVERSION
+#endif
+
+template <typename T>
+bool ExplicitlyConvertSpecialValues(T value, std::string &result, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr) {
+#ifdef FLATBUFFERS_EXPLICIT_INF_NAN_CONVERSION
+  if (value == std::numeric_limits<T>::infinity()) {
+    result = "inf";
+    return true;
+  }
+  if (value == -std::numeric_limits<T>::infinity()) {
+    result = "-inf";
+    return true;
+  }
+  if (std::isnan(value)) {
+    result = std::signbit(value) ? "-nan" : "nan";
+    return true;
+  }
+#else
+  (void)value;
+  (void)result;
+#endif
+  return false;
+}
+
+template <typename T>
+bool ExplicitlyConvertSpecialValues(T value, std::string &result, typename std::enable_if<!std::is_floating_point<T>::value>::type* = nullptr) {
+  (void)value;
+  (void)result;
+  return false;
+}
 // Special versions for floats/doubles.
 template<typename T> std::string FloatToString(T t, int precision) {
   // clang-format off
+  std::string res;
+  if (ExplicitlyConvertSpecialValues(t, res)) {
+    return res;
+  }
 
   #ifndef FLATBUFFERS_PREFER_PRINTF
     // to_string() prints different numbers of digits for floats depending on
@@ -306,12 +342,39 @@ inline bool StringToIntegerImpl(T *val, const char *const str,
   }
 }
 
+inline bool MatchFloatToString(const char *const str, const char *const constant_str, const char *& end) {
+  if (strcmp(str, constant_str) == 0) {
+    end = const_cast<char*>(str + strlen(constant_str));
+    return true;
+  }
+  return false;
+}
+
 template<typename T>
 inline bool StringToFloatImpl(T *val, const char *const str) {
   // Type T must be either float or double.
   FLATBUFFERS_ASSERT(str && val);
   auto end = str;
+#ifdef FLATBUFFERS_EXPLICIT_INF_NAN_CONVERSION
+  if (MatchFloatToString(str, "inf", end) ||
+      MatchFloatToString(str, "+inf", end) ||
+      MatchFloatToString(str, "infinity", end) ||
+      MatchFloatToString(str, "+infinity", end)) {
+    *val = std::numeric_limits<T>::infinity();
+  } else if (MatchFloatToString(str, "-inf", end) ||
+             MatchFloatToString(str, "-infinity", end)) {
+    *val = -std::numeric_limits<T>::infinity();
+  } else if (MatchFloatToString(str, "nan", end) ||
+             MatchFloatToString(str, "+nan", end)) {
+    *val = std::numeric_limits<T>::quiet_NaN();
+  } else if (MatchFloatToString(str, "-nan", end)) {
+    *val = -std::numeric_limits<T>::quiet_NaN();
+  } else {
+    strtoval_impl(val, str, const_cast<char **>(&end));
+  }
+#else
   strtoval_impl(val, str, const_cast<char **>(&end));
+#endif
   auto done = (end != str) && (*end == '\0');
   if (!done) *val = 0;  // erase partial result
   if (done && std::isnan(*val)) { *val = std::numeric_limits<T>::quiet_NaN(); }

--- a/include/flatbuffers/vector_downward.h
+++ b/include/flatbuffers/vector_downward.h
@@ -48,7 +48,7 @@ template<typename SizeT = uoffset_t> class vector_downward {
         cur_(nullptr),
         scratch_(nullptr) {}
 
-  vector_downward(vector_downward &&other) noexcept
+  vector_downward(vector_downward &&other) FLATBUFFERS_NOEXCEPT
       // clang-format on
       : allocator_(other.allocator_),
         own_allocator_(other.own_allocator_),
@@ -70,7 +70,7 @@ template<typename SizeT = uoffset_t> class vector_downward {
     other.scratch_ = nullptr;
   }
 
-  vector_downward &operator=(vector_downward &&other) noexcept {
+  vector_downward &operator=(vector_downward &&other) FLATBUFFERS_NOEXCEPT {
     // Move construct a temporary and swap idiom
     vector_downward temp(std::move(other));
     swap(temp);

--- a/samples/monster_generated.h
+++ b/samples/monster_generated.h
@@ -248,7 +248,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   std::vector<MyGame::Sample::Vec3> path{};
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/src/annotated_binary_text_gen.cpp
+++ b/src/annotated_binary_text_gen.cpp
@@ -53,6 +53,9 @@ static bool IsOffset(const BinaryRegionType type) {
 
 template<typename T> std::string ToString(T value) {
   if (std::is_floating_point<T>::value) {
+    std::string res;
+    if (ExplicitlyConvertSpecialValues(value, res))
+        return res;
     std::stringstream ss;
     ss << value;
     return ss.str();

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -778,9 +778,8 @@ void FlatCompiler::ValidateOptions(const FlatCOptions &options) {
   }
 }
 
-flatbuffers::Parser FlatCompiler::GetConformParser(
-    const FlatCOptions &options) {
-  flatbuffers::Parser conform_parser;
+void FlatCompiler::GetConformParser(
+    const FlatCOptions &options, flatbuffers::Parser &conform_parser) {
 
   // conform parser should check advanced options,
   // so, it have to have knowledge about languages:
@@ -801,7 +800,6 @@ flatbuffers::Parser FlatCompiler::GetConformParser(
                 options.conform_include_directories);
     }
   }
-  return conform_parser;
 }
 
 std::unique_ptr<Parser> FlatCompiler::GenerateCode(const FlatCOptions &options,
@@ -985,7 +983,8 @@ std::unique_ptr<Parser> FlatCompiler::GenerateCode(const FlatCOptions &options,
 
 int FlatCompiler::Compile(const FlatCOptions &options) {
   // TODO(derekbailey): change to std::optional<Parser>
-  Parser conform_parser = GetConformParser(options);
+  Parser conform_parser;
+  GetConformParser(options, conform_parser);
 
   // TODO(derekbailey): split to own method.
   if (!options.annotate_schema.empty()) {

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -272,8 +272,11 @@ const static FlatCOption flatc_options[] = {
     "The handlers will use the generated classes rather than raw bytes." },
 };
 
-auto cmp = [](FlatCOption a, FlatCOption b) { return a.long_opt < b.long_opt; };
-static std::set<FlatCOption, decltype(cmp)> language_options(cmp);
+struct cmp {
+  bool operator()(const FlatCOption& a, const FlatCOption& b) const { return a.long_opt < b.long_opt; }
+};
+
+static std::set<FlatCOption, cmp> language_options((cmp()));
 
 static void AppendTextWrappedString(std::stringstream &ss, std::string &text,
                                     size_t max_col, size_t start_col) {

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -431,11 +431,10 @@ void FlatCompiler::AnnotateBinaries(const uint8_t *binary_schema,
   }
 }
 
-FlatCOptions FlatCompiler::ParseFromCommandLineArguments(int argc,
-                                                         const char **argv) {
+void FlatCompiler::ParseFromCommandLineArguments(int argc,
+                                                         const char **argv,
+                                                         FlatCOptions& options) {
   if (argc <= 1) { Error("Need to provide at least one argument."); }
-
-  FlatCOptions options;
 
   options.program_name = std::string(argv[0]);
 
@@ -734,7 +733,7 @@ FlatCOptions FlatCompiler::ParseFromCommandLineArguments(int argc,
         auto code_generator_it = code_generators_.find(arg);
         if (code_generator_it == code_generators_.end()) {
           Error("unknown commandline argument: " + arg, true);
-          return options;
+          return;
         }
 
         std::shared_ptr<CodeGenerator> code_generator =
@@ -754,8 +753,6 @@ FlatCOptions FlatCompiler::ParseFromCommandLineArguments(int argc,
       options.filenames.push_back(flatbuffers::PosixPath(argv[argi]));
     }
   }
-
-  return options;
 }
 
 void FlatCompiler::ValidateOptions(const FlatCOptions &options) {

--- a/src/flatc_main.cpp
+++ b/src/flatc_main.cpp
@@ -176,8 +176,8 @@ int main(int argc, const char *argv[]) {
       flatbuffers::NewTsCodeGenerator());
 
   // Create the FlatC options by parsing the command line arguments.
-  const flatbuffers::FlatCOptions &options =
-      flatc.ParseFromCommandLineArguments(argc, argv);
+  flatbuffers::FlatCOptions options;
+  flatc.ParseFromCommandLineArguments(argc, argv, options);
 
   // Compile with the extracted FlatC options.
   return flatc.Compile(options);

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -3147,7 +3147,7 @@ class CppGenerator : public BaseGenerator {
                 code_ += "_fbb.CreateVectorOfStructs\\";
                 if (field->offset64) {
                   // This is normal 32-bit vector, with 64-bit addressing.
-                  code_ += "64<::flatbuffers::Vector>\\";
+                  code_ += "64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>\\";
                 } else {
                   code_ += "<" + type + ">\\";
                 }
@@ -3166,7 +3166,7 @@ class CppGenerator : public BaseGenerator {
               // If the field uses 64-bit addressing, create a 64-bit vector.
               code_.SetValue("64OFFSET", field->offset64 ? "64" : "");
               code_.SetValue("TYPE",
-                             field->offset64 ? "::flatbuffers::Vector" : type);
+                             field->offset64 ? "::flatbuffers::Vector, ::flatbuffers::uoffset_t" : type);
 
               code_ += "_fbb.CreateVector{{64OFFSET}}<{{TYPE}}>\\";
             }
@@ -3499,7 +3499,7 @@ class CppGenerator : public BaseGenerator {
                   code += "_fbb.CreateVectorOfStructs";
                   if (field.offset64) {
                     // This is normal 32-bit vector, with 64-bit addressing.
-                    code += "64<::flatbuffers::Vector>";
+                    code += "64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>";
                   }
                 }
                 code += "(" + value + ")";
@@ -3576,7 +3576,7 @@ class CppGenerator : public BaseGenerator {
                 code += "_fbb.CreateVector";
                 if (field.offset64) {
                   // This is normal 32-bit vector, with 64-bit addressing.
-                  code += "64<::flatbuffers::Vector>";
+                  code += "64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>";
                 }
                 code += "(" + value + ")";
               }

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2018,9 +2018,11 @@ class CppGenerator : public BaseGenerator {
     code_.SetValue("NATIVE_NAME",
                    NativeName(Name(struct_def), &struct_def, opts_));
     code_ += "  {{NATIVE_NAME}}(const {{NATIVE_NAME}} &o);";
+    code_ += "#ifdef FLATBUFFERS_DEFAULT_DECLARATION";
     code_ +=
         "  {{NATIVE_NAME}}({{NATIVE_NAME}}&&) FLATBUFFERS_NOEXCEPT = "
         "default;";
+    code_ += "#endif";
     code_ +=
         "  {{NATIVE_NAME}} &operator=({{NATIVE_NAME}} o) FLATBUFFERS_NOEXCEPT;";
   }

--- a/src/idl_gen_fbs.cpp
+++ b/src/idl_gen_fbs.cpp
@@ -196,7 +196,7 @@ static ProtobufToFbsIdMap MapProtoIdsToFieldsId(
 
   if (!ProtobufIdSanityCheck(struct_def, gap_action, no_log)) { return {}; }
 
-  static constexpr int UNION_ID = -1;
+  static FLATBUFFERS_CONSTEXPR int UNION_ID = -1;
   using ProtoIdFieldNamePair = std::pair<int, std::string>;
   std::vector<ProtoIdFieldNamePair> proto_ids;
 

--- a/tests/64bit/offset64_test.cpp
+++ b/tests/64bit/offset64_test.cpp
@@ -41,7 +41,7 @@ void Offset64Test() {
     // Then serialize all the fields that have 64-bit offsets, as these must be
     // serialized before any 32-bit fields are added to the buffer.
     const Offset64<Vector<uint8_t>> far_vector_offset =
-        builder.CreateVector64<Vector>(far_data);
+        builder.CreateVector64<Vector, uoffset_t>(far_data);
 
     const Offset64<String> far_string_offset =
         builder.CreateString<Offset64>("some far string");
@@ -136,7 +136,7 @@ void Offset64NestedFlatBuffer() {
     fbb.Clear();
 
     const Offset64<Vector64<uint8_t>> nested_flatbuffer_offset =
-        fbb.CreateVector64<Vector64>(nested_data);
+        fbb.CreateVector64(nested_data);
 
     // Now that we are done with the 64-bit fields, we can create and add the
     // normal fields.
@@ -387,7 +387,7 @@ void Offset64ManyVectors() {
   // of putting all 64-bit things at the tail of the buffer.
   std::array<Offset64<Vector<int8_t>>, kNumVectors> offsets_64bit;
   for (size_t i = 0; i < kNumVectors; ++i) {
-    offsets_64bit[i] = builder.CreateVector64<Vector>(data);
+    offsets_64bit[i] = builder.CreateVector64<Vector, uoffset_t>(data);
   }
 
   // Create some unrelated, 64-bit offset value for later testing.

--- a/tests/64bit/test_64bit_generated.h
+++ b/tests/64bit/test_64bit_generated.h
@@ -148,7 +148,7 @@ inline ::flatbuffers::Offset<WrapperTable> CreateWrapperTable(
 inline ::flatbuffers::Offset<WrapperTable> CreateWrapperTableDirect(
     ::flatbuffers::FlatBufferBuilder64 &_fbb,
     const std::vector<int8_t> *vector = nullptr) {
-  auto vector__ = vector ? _fbb.CreateVector64<::flatbuffers::Vector>(*vector) : 0;
+  auto vector__ = vector ? _fbb.CreateVector64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(*vector) : 0;
   return CreateWrapperTable(
       _fbb,
       vector__);
@@ -373,11 +373,11 @@ inline ::flatbuffers::Offset<RootTable> CreateRootTableDirect(
     const std::vector<LeafStruct> *big_struct_vector = nullptr,
     const std::vector<::flatbuffers::Offset<WrapperTable>> *many_vectors = nullptr,
     const std::vector<uint8_t> *forced_aligned_vector = nullptr) {
-  auto far_vector__ = far_vector ? _fbb.CreateVector64<::flatbuffers::Vector>(*far_vector) : 0;
+  auto far_vector__ = far_vector ? _fbb.CreateVector64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(*far_vector) : 0;
   auto far_string__ = far_string ? _fbb.CreateString<::flatbuffers::Offset64>(far_string) : 0;
   auto big_vector__ = big_vector ? _fbb.CreateVector64(*big_vector) : 0;
   auto nested_root__ = nested_root ? _fbb.CreateVector64(*nested_root) : 0;
-  auto far_struct_vector__ = far_struct_vector ? _fbb.CreateVectorOfStructs64<::flatbuffers::Vector>(*far_struct_vector) : 0;
+  auto far_struct_vector__ = far_struct_vector ? _fbb.CreateVectorOfStructs64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(*far_struct_vector) : 0;
   auto big_struct_vector__ = big_struct_vector ? _fbb.CreateVectorOfStructs64(*big_struct_vector) : 0;
   if (forced_aligned_vector) { _fbb.ForceVectorAlignment64(forced_aligned_vector->size(), sizeof(uint8_t), 32); }
   auto forced_aligned_vector__ = forced_aligned_vector ? _fbb.CreateVector64(*forced_aligned_vector) : 0;
@@ -430,7 +430,7 @@ inline ::flatbuffers::Offset<WrapperTable> CreateWrapperTable(::flatbuffers::Fla
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder64 *__fbb; const WrapperTableT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _vector = _o->vector.size() ? _fbb.CreateVector64<::flatbuffers::Vector>(_o->vector) : 0;
+  auto _vector = _o->vector.size() ? _fbb.CreateVector64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(_o->vector) : 0;
   return CreateWrapperTable(
       _fbb,
       _vector);
@@ -513,13 +513,13 @@ inline ::flatbuffers::Offset<RootTable> CreateRootTable(::flatbuffers::FlatBuffe
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder64 *__fbb; const RootTableT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _far_vector = _o->far_vector.size() ? _fbb.CreateVector64<::flatbuffers::Vector>(_o->far_vector) : 0;
+  auto _far_vector = _o->far_vector.size() ? _fbb.CreateVector64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(_o->far_vector) : 0;
   auto _a = _o->a;
   auto _far_string = _o->far_string.empty() ? 0 : _fbb.CreateString<::flatbuffers::Offset64>(_o->far_string);
   auto _big_vector = _o->big_vector.size() ? _fbb.CreateVector64(_o->big_vector) : 0;
   auto _near_string = _o->near_string.empty() ? 0 : _fbb.CreateString(_o->near_string);
   auto _nested_root = _o->nested_root.size() ? _fbb.CreateVector64(_o->nested_root) : 0;
-  auto _far_struct_vector = _o->far_struct_vector.size() ? _fbb.CreateVectorOfStructs64<::flatbuffers::Vector>(_o->far_struct_vector) : 0;
+  auto _far_struct_vector = _o->far_struct_vector.size() ? _fbb.CreateVectorOfStructs64<::flatbuffers::Vector, ::flatbuffers::uoffset_t>(_o->far_struct_vector) : 0;
   auto _big_struct_vector = _o->big_struct_vector.size() ? _fbb.CreateVectorOfStructs64(_o->big_struct_vector) : 0;
   auto _many_vectors = _o->many_vectors.size() ? _fbb.CreateVector<::flatbuffers::Offset<WrapperTable>> (_o->many_vectors.size(), [](size_t i, _VectorArgs *__va) { return CreateWrapperTable(*__va->__fbb, __va->__o->many_vectors[i].get(), __va->__rehasher); }, &_va ) : 0;
   _fbb.ForceVectorAlignment64(_o->forced_aligned_vector.size(), sizeof(uint8_t), 32);

--- a/tests/64bit/test_64bit_generated.h
+++ b/tests/64bit/test_64bit_generated.h
@@ -170,7 +170,9 @@ struct RootTableT : public ::flatbuffers::NativeTable {
   std::vector<uint8_t> forced_aligned_vector{};
   RootTableT() = default;
   RootTableT(const RootTableT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   RootTableT(RootTableT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   RootTableT &operator=(RootTableT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -1331,7 +1331,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   double double_inf_default = std::numeric_limits<double>::infinity();
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -96,7 +96,7 @@ flatbuffers::DetachedBuffer CreateFlatBufferTest(std::string &buffer) {
 #endif
 
   // Make sure the template deduces an initializer as std::vector<std::string>
-  builder.CreateVectorOfStrings({ "hello", "world" });
+  builder.CreateVectorOfStrings(std::vector<std::string>{ "hello", "world" });
 
   // Create many vectors of strings
   std::vector<std::string> manyNames;

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -1327,7 +1327,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   double double_inf_default = std::numeric_limits<double>::infinity();
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/monster_test_suffix/ext_only/monster_test_generated.hpp
+++ b/tests/monster_test_suffix/ext_only/monster_test_generated.hpp
@@ -1319,7 +1319,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   double double_inf_default = std::numeric_limits<double>::infinity();
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/monster_test_suffix/filesuffix_only/monster_test_suffix.h
+++ b/tests/monster_test_suffix/filesuffix_only/monster_test_suffix.h
@@ -1319,7 +1319,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   double double_inf_default = std::numeric_limits<double>::infinity();
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/monster_test_suffix/monster_test_suffix.hpp
+++ b/tests/monster_test_suffix/monster_test_suffix.hpp
@@ -1319,7 +1319,9 @@ struct MonsterT : public ::flatbuffers::NativeTable {
   double double_inf_default = std::numeric_limits<double>::infinity();
   MonsterT() = default;
   MonsterT(const MonsterT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   MonsterT(MonsterT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   MonsterT &operator=(MonsterT o) FLATBUFFERS_NOEXCEPT;
 };
 

--- a/tests/namespace_test/namespace_test2_generated.h
+++ b/tests/namespace_test/namespace_test2_generated.h
@@ -75,7 +75,9 @@ struct TableInFirstNST : public ::flatbuffers::NativeTable {
   std::unique_ptr<NamespaceA::NamespaceB::StructInNestedNS> foo_struct{};
   TableInFirstNST() = default;
   TableInFirstNST(const TableInFirstNST &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   TableInFirstNST(TableInFirstNST&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   TableInFirstNST &operator=(TableInFirstNST o) FLATBUFFERS_NOEXCEPT;
 };
 
@@ -207,7 +209,9 @@ struct TableInCT : public ::flatbuffers::NativeTable {
   std::unique_ptr<NamespaceA::SecondTableInAT> refer_to_a2{};
   TableInCT() = default;
   TableInCT(const TableInCT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   TableInCT(TableInCT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   TableInCT &operator=(TableInCT o) FLATBUFFERS_NOEXCEPT;
 };
 
@@ -294,7 +298,9 @@ struct SecondTableInAT : public ::flatbuffers::NativeTable {
   std::unique_ptr<NamespaceC::TableInCT> refer_to_c{};
   SecondTableInAT() = default;
   SecondTableInAT(const SecondTableInAT &o);
+#ifdef FLATBUFFERS_DEFAULT_DECLARATION
   SecondTableInAT(SecondTableInAT&&) FLATBUFFERS_NOEXCEPT = default;
+#endif
   SecondTableInAT &operator=(SecondTableInAT o) FLATBUFFERS_NOEXCEPT;
 };
 


### PR DESCRIPTION
The goal of this changeset is to make flatbuffers compile on VS2013, which mostly supports C++11.
This includes:

1. Fixing C++11 keywords (noexcept, constexpr) being used directly instead of already existing FLATBUFFERS_* defines that were created exactly for such old compiler support.
2. Fixing VS2013 not supporting defaulting move constructors - by using the existing FLATBUFFERS_DEFAULT_DECLARATION define.
3. Fixed generic bug that was seen crashing flatc on VS2013 - taking reference to a value returned from function.
4. Added special handling for string to float and vice versa conversions because VS2013 runtime wasn't doing that according to standard (this was fixed in VS2015).
5. More significant change: VS2013 has buggy handling of template template parameter packs, which is the case for Vector<T, SizeT>: see the https://godbolt.org/z/Trfrsja46 for a completely valid code that fails to build in VS2013. I tried to work around it without breaking API.

