### PR TITLE
fix CScript string.compare

### DIFF
--- a/tests/MyGame/Example/Monster.cs
+++ b/tests/MyGame/Example/Monster.cs
@@ -521,7 +521,7 @@ public struct Monster : IFlatbufferObject
   public static VectorOffset CreateSortedVectorOfMonster(FlatBufferBuilder builder, Offset<Monster>[] offsets) {
     Array.Sort(offsets,
       (Offset<Monster> o1, Offset<Monster> o2) =>
-        new Monster().__assign(builder.DataBuffer.Length - o1.Value, builder.DataBuffer).Name.CompareTo(new Monster().__assign(builder.DataBuffer.Length - o2.Value, builder.DataBuffer).Name));
+        string.CompareOrdinal(new Monster().__assign(builder.DataBuffer.Length - o1.Value, builder.DataBuffer).Name, new Monster().__assign(builder.DataBuffer.Length - o2.Value, builder.DataBuffer).Name));
     return builder.CreateVectorOfTables(offsets);
   }
 
@@ -533,7 +533,7 @@ public struct Monster : IFlatbufferObject
       int middle = span / 2;
       int tableOffset = Table.__indirect(vectorLocation + 4 * (start + middle), bb);
       obj_.__assign(tableOffset, bb);
-      int comp = obj_.Name.CompareTo(key);
+      int comp = string.CompareOrdinal(obj_.Name, key);
       if (comp > 0) {
         span = middle;
       } else if (comp < 0) {

--- a/tests/union_value_collsion/union_value_collision_generated.cs
+++ b/tests/union_value_collsion/union_value_collision_generated.cs
@@ -292,7 +292,7 @@ public struct Collide : IFlatbufferObject
   public static VectorOffset CreateSortedVectorOfCollide(FlatBufferBuilder builder, Offset<Collide>[] offsets) {
     Array.Sort(offsets,
       (Offset<Collide> o1, Offset<Collide> o2) =>
-        new Collide().__assign(builder.DataBuffer.Length - o1.Value, builder.DataBuffer).Collide_.CompareTo(new Collide().__assign(builder.DataBuffer.Length - o2.Value, builder.DataBuffer).Collide_));
+        string.CompareOrdinal(new Collide().__assign(builder.DataBuffer.Length - o1.Value, builder.DataBuffer).Collide_, new Collide().__assign(builder.DataBuffer.Length - o2.Value, builder.DataBuffer).Collide_));
     return builder.CreateVectorOfTables(offsets);
   }
 
@@ -304,7 +304,7 @@ public struct Collide : IFlatbufferObject
       int middle = span / 2;
       int tableOffset = Table.__indirect(vectorLocation + 4 * (start + middle), bb);
       obj_.__assign(tableOffset, bb);
-      int comp = obj_.Collide_.CompareTo(key);
+      int comp = string.CompareOrdinal(obj_.Collide_, key);
       if (comp > 0) {
         span = middle;
       } else if (comp < 0) {


### PR DESCRIPTION
Because the default compare sorting rules of c# string are different from those of cpp, the binary file exported by flatc -b cannot use LookupByKey.
Modify the code generator to unify the rules