### PR TITLE
Fix typo in quick_start.md

### DIFF
--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -30,7 +30,7 @@ See the [Tutorial](tutorial.md) for a more in depth guide.
     code:
 
     ```sh
-    ./flatc --cpp --rust mosnter.fbs
+    ./flatc --cpp --rust monster.fbs
     ```
 
     Which generates `monster_generated.h` and `monster_generated.rs` files.


### PR DESCRIPTION
Fixes a typo in the quick start guide.