### PR TITLE
[Rust] use core:error:Error unconditionally

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://google.github.io/flatbuffers/"
 repository = "https://github.com/google/flatbuffers"
 keywords = ["flatbuffers", "serialization", "zero-copy"]
 categories = ["encoding", "data-structures", "memory-management"]
-rust = "1.51"
+rust-version = "1.81"
 
 [features]
 default = ["std"]

--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use core::cmp::max;
 use core::convert::Infallible;

--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -28,10 +28,6 @@
 //! At this time, to generate Rust code, you will need the latest `master` version of `flatc`, available from here: <https://github.com/google/flatbuffers>
 //! (On OSX, you can install FlatBuffers from `HEAD` with the Homebrew package manager.)
 
-#![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(all(nightly, not(feature = "std")), feature(error_in_core))]
-
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 mod array;
@@ -56,8 +52,8 @@ pub use crate::push::{Push, PushAlignment};
 pub use crate::table::{buffer_has_identifier, Table};
 pub use crate::vector::{follow_cast_ref, Vector, VectorIter};
 pub use crate::verifier::{
-    ErrorTraceDetail, InvalidFlatbuffer, SimpleToVerifyInSlice, TableVerifier, Verifiable, Verifier,
-    VerifierOptions,
+    ErrorTraceDetail, InvalidFlatbuffer, SimpleToVerifyInSlice, TableVerifier, Verifiable,
+    Verifier, VerifierOptions,
 };
 pub use crate::vtable::field_index_to_field_offset;
 pub use bitflags;

--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -1,19 +1,10 @@
 use crate::follow::Follow;
 use crate::{ForwardsUOffset, SOffsetT, SkipSizePrefix, UOffsetT, VOffsetT, Vector, SIZE_UOFFSET};
-#[cfg(not(feature = "std"))]
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
+use core::error::Error;
 use core::ops::Range;
 use core::option::Option;
-
-#[cfg(not(feature = "std"))]
-use alloc::borrow::Cow;
-#[cfg(feature = "std")]
-use std::borrow::Cow;
-
-#[cfg(all(nightly, not(feature = "std")))]
-use core::error::Error;
-#[cfg(feature = "std")]
-use std::error::Error;
 
 /// Traces the location of data errors. Not populated for Dos detecting errors.
 /// Useful for MissingRequiredField and Utf8Error in particular, though
@@ -86,7 +77,6 @@ pub enum InvalidFlatbuffer {
     DepthLimitReached,
 }
 
-#[cfg(any(nightly, feature = "std"))]
 impl Error for InvalidFlatbuffer {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         if let InvalidFlatbuffer::Utf8Error { error: source, .. } = self {
@@ -560,7 +550,7 @@ impl<'ver, 'opts, 'buf> TableVerifier<'ver, 'opts, 'buf> {
                 )?;
                 Ok(self)
             }
-            _ => InvalidFlatbuffer::new_inconsistent_union(key_field_name.into(), val_field_name.into()),
+            _ => InvalidFlatbuffer::new_inconsistent_union(key_field_name.into(),val_field_name.into()),
         }
     }
     pub fn finish(self) -> &'ver mut Verifier<'opts, 'buf> {


### PR DESCRIPTION
Since Error is now part of core, this PR enables the previously gated std features to now work on no_std targets.
The "std" feature still exists in Cargo.toml, but it doesn't do anything.

A downside of this PR is that this raises the minimum supported rust version to 1.81 for future releases. Please let me know your opinion on this PR.  
