### PR TITLE
Improve Rust flatbuffers crate

### DIFF
--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -56,8 +56,8 @@ pub use crate::push::{Push, PushAlignment};
 pub use crate::table::{buffer_has_identifier, Table};
 pub use crate::vector::{follow_cast_ref, Vector, VectorIter};
 pub use crate::verifier::{
-    ErrorTraceDetail, InvalidFlatbuffer, SimpleToVerifyInSlice, TableVerifier, Verifiable, Verifier,
-    VerifierOptions,
+    ErrorTraceDetail, InvalidFlatbuffer, SimpleToVerifyInSlice, TableVerifier, Verifiable,
+    Verifier, VerifierOptions,
 };
 pub use crate::vtable::field_index_to_field_offset;
 pub use bitflags;

--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -92,7 +92,7 @@ impl<'a, T: 'a> Vector<'a, T> {
     }
 
     /// # Safety
-    /// 
+    ///
     /// The underlying bytes must be interpretable as a vector of the *same number* of `U`'s.
     #[inline(always)]
     pub unsafe fn cast<U: 'a>(&self) -> Vector<'a, U> {
@@ -131,11 +131,11 @@ impl<'a, T: Follow<'a> + 'a> Vector<'a, T> {
                 Ordering::Equal => return Some(value),
                 Ordering::Less => left = mid + 1,
                 Ordering::Greater => {
-                  if mid == 0 {
-                    return None;
-                  }
-                  right = mid - 1;
-                },
+                    if mid == 0 {
+                        return None;
+                    }
+                    right = mid - 1;
+                }
             }
         }
 

--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -90,6 +90,14 @@ impl<'a, T: 'a> Vector<'a, T> {
         let len = self.len();
         &self.0[self.1 + SIZE_UOFFSET..self.1 + SIZE_UOFFSET + sz * len]
     }
+
+    /// # Safety
+    /// 
+    /// The underlying bytes must be interpretable as a vector of the *same number* of `U`'s.
+    #[inline(always)]
+    pub unsafe fn cast<U: 'a>(&self) -> Vector<'a, U> {
+        Vector::new(self.0, self.1)
+    }
 }
 
 impl<'a, T: Follow<'a> + 'a> Vector<'a, T> {

--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -275,7 +275,7 @@ fn trace_elem<T>(res: Result<T>, index: usize, position: usize) -> Result<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VerifierOptions<'a> {
+pub struct VerifierOptions {
     /// Maximum depth of nested tables allowed in a valid flatbuffer.
     pub max_depth: usize,
     /// Maximum number of tables allowed in a valid flatbuffer.
@@ -289,12 +289,9 @@ pub struct VerifierOptions<'a> {
     // probably want an option to ignore utf8 errors since strings come from c++
     // options to error un-recognized enums and unions? possible footgun.
     // Ignore nested flatbuffers, etc?
-
-    /// The name of the table to use as the root table instead of the schema root.
-    pub root_table_name: Option<&'a str>,
 }
 
-impl Default for VerifierOptions<'_> {
+impl Default for VerifierOptions {
     fn default() -> Self {
         Self {
             max_depth: 64,
@@ -302,7 +299,6 @@ impl Default for VerifierOptions<'_> {
             // size_ might do something different.
             max_apparent_size: 1 << 31,
             ignore_missing_null_terminator: false,
-            root_table_name: None,
         }
     }
 }
@@ -311,7 +307,7 @@ impl Default for VerifierOptions<'_> {
 #[derive(Debug)]
 pub struct Verifier<'opts, 'buf> {
     buffer: &'buf [u8],
-    opts: &'opts VerifierOptions<'opts>,
+    opts: &'opts VerifierOptions,
     depth: usize,
     num_tables: usize,
     apparent_size: usize,

--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -345,7 +345,7 @@ impl<'opts, 'buf> Verifier<'opts, 'buf> {
         if pos % core::mem::align_of::<T>() == 0 {
             Ok(())
         } else {
-            panic!("{}",InvalidFlatbuffer::Unaligned {
+            Err(InvalidFlatbuffer::Unaligned {
                 unaligned_type: Cow::Borrowed(core::any::type_name::<T>()),
                 position: pos,
                 error_trace: Default::default(),

--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -275,7 +275,7 @@ fn trace_elem<T>(res: Result<T>, index: usize, position: usize) -> Result<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VerifierOptions {
+pub struct VerifierOptions<'a> {
     /// Maximum depth of nested tables allowed in a valid flatbuffer.
     pub max_depth: usize,
     /// Maximum number of tables allowed in a valid flatbuffer.
@@ -289,9 +289,12 @@ pub struct VerifierOptions {
     // probably want an option to ignore utf8 errors since strings come from c++
     // options to error un-recognized enums and unions? possible footgun.
     // Ignore nested flatbuffers, etc?
+
+    /// The name of the table to use as the root table instead of the schema root.
+    pub root_table_name: Option<&'a str>,
 }
 
-impl Default for VerifierOptions {
+impl Default for VerifierOptions<'_> {
     fn default() -> Self {
         Self {
             max_depth: 64,
@@ -299,6 +302,7 @@ impl Default for VerifierOptions {
             // size_ might do something different.
             max_apparent_size: 1 << 31,
             ignore_missing_null_terminator: false,
+            root_table_name: None,
         }
     }
 }
@@ -307,7 +311,7 @@ impl Default for VerifierOptions {
 #[derive(Debug)]
 pub struct Verifier<'opts, 'buf> {
     buffer: &'buf [u8],
-    opts: &'opts VerifierOptions,
+    opts: &'opts VerifierOptions<'opts>,
     depth: usize,
     num_tables: usize,
     apparent_size: usize,

--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -345,7 +345,7 @@ impl<'opts, 'buf> Verifier<'opts, 'buf> {
         if pos % core::mem::align_of::<T>() == 0 {
             Ok(())
         } else {
-            Err(InvalidFlatbuffer::Unaligned {
+            panic!("{}",InvalidFlatbuffer::Unaligned {
                 unaligned_type: Cow::Borrowed(core::any::type_name::<T>()),
                 position: pos,
                 error_trace: Default::default(),

--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -560,7 +560,10 @@ impl<'ver, 'opts, 'buf> TableVerifier<'ver, 'opts, 'buf> {
                 )?;
                 Ok(self)
             }
-            _ => InvalidFlatbuffer::new_inconsistent_union(key_field_name.into(), val_field_name.into()),
+            _ => InvalidFlatbuffer::new_inconsistent_union(
+                key_field_name.into(),
+                val_field_name.into(),
+            ),
         }
     }
     pub fn finish(self) -> &'ver mut Verifier<'opts, 'buf> {

--- a/rust/reflection/Cargo.toml
+++ b/rust/reflection/Cargo.toml
@@ -2,6 +2,7 @@
 name = "flatbuffers-reflection"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 flatbuffers = { path = "../flatbuffers"}

--- a/rust/reflection/src/lib.rs
+++ b/rust/reflection/src/lib.rs
@@ -616,7 +616,7 @@ pub unsafe fn set_string(
 }
 
 /// Returns the size of a scalar type in the `BaseType` enum. In the case of structs, returns the size of their offset (`UOffsetT`) in the buffer.
-fn get_type_size(base_type: BaseType) -> usize {
+pub fn get_type_size(base_type: BaseType) -> usize {
     match base_type {
         BaseType::UType | BaseType::Bool | BaseType::Byte | BaseType::UByte => 1,
         BaseType::Short | BaseType::UShort => 2,

--- a/rust/reflection/src/lib.rs
+++ b/rust/reflection/src/lib.rs
@@ -16,7 +16,7 @@
 
 mod reflection_generated;
 mod reflection_verifier;
-mod safe_buffer;
+pub mod safe_buffer;
 mod r#struct;
 pub use crate::r#struct::Struct;
 pub use crate::reflection_generated::reflection;

--- a/rust/reflection/src/lib.rs
+++ b/rust/reflection/src/lib.rs
@@ -127,7 +127,9 @@ pub unsafe fn get_field_float<T: for<'a> Follow<'a, Inner = T> + Float>(
 /// The value of the corresponding slot must have type String
 pub unsafe fn get_field_string<'a>(table: &Table<'a>, field: &Field) -> &'a str {
     debug_assert_eq!(field.type_().base_type(), BaseType::String);
-    table.get::<ForwardsUOffset<&'a str>>(field.offset(), Some("")).unwrap()
+    table
+        .get::<ForwardsUOffset<&'a str>>(field.offset(), Some(""))
+        .unwrap()
 }
 
 /// Gets a [Struct] table field given its exact type. Returns [None] if the field is not set.

--- a/rust/reflection/src/lib.rs
+++ b/rust/reflection/src/lib.rs
@@ -125,9 +125,9 @@ pub unsafe fn get_field_float<T: for<'a> Follow<'a, Inner = T> + Float>(
 /// # Safety
 ///
 /// The value of the corresponding slot must have type String
-pub unsafe fn get_field_string<'a>(table: &Table<'a>, field: &Field) -> Option<&'a str> {
+pub unsafe fn get_field_string<'a>(table: &Table<'a>, field: &Field) -> &'a str {
     debug_assert_eq!(field.type_().base_type(), BaseType::String);
-    table.get::<ForwardsUOffset<&'a str>>(field.offset(), Some(""))
+    table.get::<ForwardsUOffset<&'a str>>(field.offset(), Some("")).unwrap()
 }
 
 /// Gets a [Struct] table field given its exact type. Returns [None] if the field is not set.
@@ -168,11 +168,10 @@ pub unsafe fn get_field_vector<'a, T: Follow<'a>>(
             get_type_size(field.type_().element())
         );
     }
-    // SAFETY: get() always returns either Some or default, which is a Some in this case. Therefore
-    // it always returns a Some, so we can use unwrap_unchecked().
+
     table
         .get::<ForwardsUOffset<Vector<'a, T>>>(field.offset(), Some(Vector::<T>::default()))
-        .unwrap_unchecked()
+        .unwrap()
 }
 
 /// Get a vector table field, whose elements have unknown type.
@@ -184,11 +183,9 @@ pub unsafe fn get_field_vector<'a, T: Follow<'a>>(
 /// The value of the corresponding slot must be a vector of elements of type `T`.
 pub unsafe fn get_field_vector_of_any<'a>(table: &Table<'a>, field: &Field) -> VectorOfAny<'a> {
     debug_assert_eq!(field.type_().base_type(), BaseType::Vector);
-    // SAFETY: get() always returns either Some or default, which is a Some in this case. Therefore
-    // it always returns a Some, so we can use unwrap_unchecked().
     table
         .get::<ForwardsUOffset<VectorOfAny<'a>>>(field.offset(), Some(VectorOfAny::default()))
-        .unwrap_unchecked()
+        .unwrap()
 }
 
 /// Gets a Table table field given its exact type. Returns [None] if the field is not set.

--- a/rust/reflection/src/lib.rs
+++ b/rust/reflection/src/lib.rs
@@ -52,8 +52,12 @@ pub enum FlatbufferError {
     SetStringPolluted,
     #[error("Invalid schema: Polluted buffer or the schema doesn't match the buffer.")]
     InvalidSchema,
-    #[error("Type not supported: {0}")]
-    TypeNotSupported(String),
+    #[error("Unsupported table field type: {0:?}")]
+    UnsupportedTableFieldType(BaseType),
+    #[error("Unsupported vector element type: {0:?}")]
+    UnsupportedVectorElementType(BaseType),
+    #[error("Unsupported union element type: {0:?}")]
+    UnsupportedUnionElementType(BaseType),
     #[error("No type or invalid type found in union enum")]
     InvalidUnionEnum,
     #[error("Table or Struct doesn't belong to the buffer")]

--- a/rust/reflection/src/lib.rs
+++ b/rust/reflection/src/lib.rs
@@ -187,10 +187,10 @@ pub unsafe fn get_field_struct<'a>(
 /// # Safety
 ///
 /// The value of the corresponding slot must be a vector of elements of type `T`.
-pub unsafe fn get_field_vector<'a, T: Follow<'a, Inner = T>>(
+pub unsafe fn get_field_vector<'a, T: Follow<'a>>(
     table: &Table<'a>,
     field: &Field,
-) -> FlatbufferResult<Option<Vector<'a, T>>> {
+) -> FlatbufferResult<Vector<'a, T>> {
     if field.type_().base_type() != BaseType::Vector
         || core::mem::size_of::<T>() != get_type_size(field.type_().element())
     {
@@ -204,8 +204,9 @@ pub unsafe fn get_field_vector<'a, T: Follow<'a, Inner = T>>(
                 .to_string(),
         ));
     }
-
-    Ok(table.get::<ForwardsUOffset<Vector<'a, T>>>(field.offset(), Some(Vector::<T>::default())))
+    // SAFETY: get() always returns either Some or default, which is a Some in this case. Therefore
+    // it always returns a Some, so we can use unwrap_unchecked().
+    Ok(table.get::<ForwardsUOffset<Vector<'a, T>>>(field.offset(), Some(Vector::<T>::default())).unwrap_unchecked())
 }
 
 /// Get a vector table field, whose elements have unknown type.
@@ -220,7 +221,7 @@ pub unsafe fn get_field_vector<'a, T: Follow<'a, Inner = T>>(
 pub unsafe fn get_field_vector_of_any<'a>(
     table: &Table<'a>,
     field: &Field,
-) -> FlatbufferResult<Option<VectorOfAny<'a>>> {
+) -> FlatbufferResult<VectorOfAny<'a>> {
     if field.type_().base_type() != BaseType::Vector {
         return Err(FlatbufferError::FieldTypeMismatch(
             String::from("VectorOfAny"),
@@ -232,8 +233,9 @@ pub unsafe fn get_field_vector_of_any<'a>(
                 .to_string(),
         ));
     }
-
-    Ok(table.get::<ForwardsUOffset<VectorOfAny<'a>>>(field.offset(), Some(VectorOfAny::default())))
+    // SAFETY: get() always returns either Some or default, which is a Some in this case. Therefore
+    // it always returns a Some, so we can use unwrap_unchecked().
+    Ok(table.get::<ForwardsUOffset<VectorOfAny<'a>>>(field.offset(), Some(VectorOfAny::default())).unwrap_unchecked())
 }
 
 /// Gets a Table table field given its exact type. Returns [None] if the field is not set. Returns error if the type doesn't match.

--- a/rust/reflection/src/lib.rs
+++ b/rust/reflection/src/lib.rs
@@ -22,6 +22,7 @@ pub use vector_of_any::VectorOfAny;
 mod r#struct;
 pub use crate::r#struct::Struct;
 pub use crate::reflection_generated::reflection;
+pub use crate::reflection_verifier::verify_with_options;
 pub use crate::safe_buffer::SafeBuffer;
 
 use flatbuffers::{

--- a/rust/reflection/src/reflection_verifier.rs
+++ b/rust/reflection/src/reflection_verifier.rs
@@ -299,7 +299,7 @@ fn verify_vector_of_unions<'a, 'b, 'c>(
 
     // Assuming the schema is valid, the previous field must be the enum vector, which consists of
     // of 1-byte enums.
-    let enum_field_offset = field.offset() - u16::try_from(SIZE_VOFFSET)?;
+    let enum_field_offset = field.offset() - u16::try_from(SIZE_VOFFSET).unwrap();
 
     // Either both vectors must be present, or both must be absent.
     let (value_field_pos, enum_field_pos) = match (

--- a/rust/reflection/src/reflection_verifier.rs
+++ b/rust/reflection/src/reflection_verifier.rs
@@ -364,7 +364,9 @@ fn verify_vector_of_unions<'a, 'b, 'c>(
 
     let enum_values = child_enum.values();
 
-    for (enum_pos, union_offset_pos) in enum_vector_range.zip(value_vector_range.step_by(SIZE_UOFFSET)) {
+    for (enum_pos, union_offset_pos) in
+        enum_vector_range.zip(value_vector_range.step_by(SIZE_UOFFSET))
+    {
         let enum_value = verifier.get_u8(enum_pos)?;
         if enum_value == 0 {
             // Discriminator is NONE. This should never happen: the C++ implementation forbids it.
@@ -387,7 +389,8 @@ fn verify_vector_of_unions<'a, 'b, 'c>(
         } else {
             return Err(FlatbufferError::InvalidUnionEnum);
         };
-        let union_pos = union_offset_pos.saturating_add(verifier.get_uoffset(union_offset_pos)?.try_into()?);
+        let union_pos =
+            union_offset_pos.saturating_add(verifier.get_uoffset(union_offset_pos)?.try_into()?);
         verifier.in_buffer::<u8>(union_pos)?;
 
         match enum_type.base_type() {

--- a/rust/reflection/src/reflection_verifier.rs
+++ b/rust/reflection/src/reflection_verifier.rs
@@ -154,15 +154,8 @@ fn verify_table(
                     table_verifier
                 }
             }
-            _ => {
-                return Err(FlatbufferError::TypeNotSupported(
-                    field
-                        .type_()
-                        .base_type()
-                        .variant_name()
-                        .unwrap_or_default()
-                        .to_string(),
-                ));
+            other => {
+                return Err(FlatbufferError::UnsupportedTableFieldType(other));
             }
         };
     }
@@ -340,15 +333,8 @@ fn verify_vector<'a, 'b, 'c>(
             }
             Ok(table_verifier)
         }
-        _ => {
-            return Err(FlatbufferError::TypeNotSupported(
-                field
-                    .type_()
-                    .base_type()
-                    .variant_name()
-                    .unwrap_or_default()
-                    .to_string(),
-            ))
+        other => {
+            return Err(FlatbufferError::UnsupportedVectorElementType(other));
         }
     }
 }
@@ -399,14 +385,8 @@ fn verify_union<'a, 'b, 'c>(
                     )?;
                 }
             }
-            _ => {
-                return Err(FlatbufferError::TypeNotSupported(
-                    enum_type
-                        .base_type()
-                        .variant_name()
-                        .unwrap_or_default()
-                        .to_string(),
-                ))
+            other => {
+                return Err(FlatbufferError::UnsupportedUnionElementType(other));
             }
         }
     } else {

--- a/rust/reflection/src/reflection_verifier.rs
+++ b/rust/reflection/src/reflection_verifier.rs
@@ -62,7 +62,8 @@ fn verify_table(
 
     let mut table_verifier = verifier.visit_table(table_pos)?;
 
-    for field in &table_object.fields() {
+    let fields = table_object.fields();
+    for field in &fields {
         let field_name = field.name().to_owned();
         table_verifier = match field.type_().base_type() {
             BaseType::UType | BaseType::UByte => {
@@ -195,91 +196,30 @@ fn verify_vector<'a, 'b, 'c>(
     buf_loc_to_obj_idx: &mut HashMap<usize, i32>,
 ) -> FlatbufferResult<TableVerifier<'a, 'b, 'c>> {
     let field_name = field.name().to_owned();
+    macro_rules! visit_vec {
+        ($t:ty) => {
+            table_verifier
+                .visit_field::<ForwardsUOffset<Vector<$t>>>(
+                    field_name,
+                    field.offset(),
+                    field.required(),
+                )
+                .map_err(FlatbufferError::VerificationError)
+        };
+    }
     match field.type_().element() {
-        BaseType::UType | BaseType::UByte => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<u8>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
-        BaseType::Bool => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<bool>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
-        BaseType::Byte => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<i8>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
-        BaseType::Short => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<i16>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
-        BaseType::UShort => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<u16>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
-        BaseType::Int => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<i32>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
-        BaseType::UInt => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<u32>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
-        BaseType::Long => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<i64>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
-        BaseType::ULong => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<u64>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
-        BaseType::Float => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<f32>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
-        BaseType::Double => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<f64>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
-        BaseType::String => table_verifier
-            .visit_field::<ForwardsUOffset<Vector<ForwardsUOffset<&str>>>>(
-                field_name,
-                field.offset(),
-                field.required(),
-            )
-            .map_err(FlatbufferError::VerificationError),
+        BaseType::UType | BaseType::UByte => visit_vec!(u8),
+        BaseType::Bool => visit_vec!(bool),
+        BaseType::Byte => visit_vec!(i8),
+        BaseType::Short => visit_vec!(i16),
+        BaseType::UShort => visit_vec!(u16),
+        BaseType::Int => visit_vec!(i32),
+        BaseType::UInt => visit_vec!(u32),
+        BaseType::Long => visit_vec!(i64),
+        BaseType::ULong => visit_vec!(u64),
+        BaseType::Float => visit_vec!(f32),
+        BaseType::Double => visit_vec!(f64),
+        BaseType::String => visit_vec!(ForwardsUOffset<&str>),
         BaseType::Obj => {
             if let Some(field_pos) = table_verifier.deref(field.offset())? {
                 let verifier = table_verifier.verifier();
@@ -333,10 +273,148 @@ fn verify_vector<'a, 'b, 'c>(
             }
             Ok(table_verifier)
         }
+        BaseType::Union => {
+            verify_vector_of_unions(table_verifier, field, schema, verified, buf_loc_to_obj_idx)
+        }
         other => {
             return Err(FlatbufferError::UnsupportedVectorElementType(other));
         }
     }
+}
+
+fn verify_vector_of_unions<'a, 'b, 'c>(
+    mut table_verifier: TableVerifier<'a, 'b, 'c>,
+    field: &Field,
+    schema: &Schema,
+    verified: &mut [bool],
+    buf_loc_to_obj_idx: &mut HashMap<usize, i32>,
+) -> FlatbufferResult<TableVerifier<'a, 'b, 'c>> {
+    let field_type = field.type_();
+    // If the schema is valid, none of these asserts can fail.
+    debug_assert_eq!(field_type.base_type(), BaseType::Vector);
+    debug_assert_eq!(field_type.element(), BaseType::Union);
+    let child_enum_idx = field_type.index();
+    let child_enum = schema.enums().get(child_enum_idx.try_into()?);
+    debug_assert!(!child_enum.values().is_empty());
+
+    // Assuming the schema is valid, the previous field must be the enum vector, which consists of
+    // of 1-byte enums.
+    let enum_field_offset = field.offset() - u16::try_from(SIZE_VOFFSET)?;
+
+    // Either both vectors must be present, or both must be absent.
+    let (value_field_pos, enum_field_pos) = match (
+        table_verifier.deref(field.offset())?,
+        table_verifier.deref(enum_field_offset)?,
+    ) {
+        (Some(value_field_pos), Some(enum_field_pos)) => (value_field_pos, enum_field_pos),
+        (None, None) => {
+            if field.required() {
+                return InvalidFlatbuffer::new_missing_required(field.name().to_owned())?;
+            } else {
+                return Ok(table_verifier);
+            }
+        }
+        _ => {
+            return InvalidFlatbuffer::new_inconsistent_union(
+                format!("{}_type", field.name()),
+                field.name().to_owned(),
+            )?;
+        }
+    };
+
+    let verifier = table_verifier.verifier();
+    let enum_vector_offset = verifier.get_uoffset(enum_field_pos)?;
+    let enum_vector_pos = enum_field_pos.saturating_add(enum_vector_offset.try_into()?);
+    let enum_vector_len = verifier.get_uoffset(enum_vector_pos)?;
+    let enum_vector_start = enum_vector_pos.saturating_add(SIZE_UOFFSET);
+
+    let value_vector_offset = verifier.get_uoffset(value_field_pos)?;
+    let value_vector_pos = value_field_pos.saturating_add(value_vector_offset.try_into()?);
+    let value_vector_len = verifier.get_uoffset(value_vector_pos)?;
+    let value_vector_start = value_vector_pos.saturating_add(SIZE_UOFFSET);
+
+    // Both vectors should have the same length.
+    // The C++ verifier instead assumes that the length of the value vector is the length of the enum vector:
+    // https://github.com/google/flatbuffers/blob/bd1b2d0bafb8be6059a29487db9e5ace5c32914d/src/reflection.cpp#L147-L162
+    // This has been reported at https://github.com/google/flatbuffers/issues/8567
+    if enum_vector_len != value_vector_len {
+        return InvalidFlatbuffer::new_inconsistent_union(
+            format!("{}_type", field.name()),
+            field.name().to_owned(),
+        )?;
+    }
+
+    // Regardless of its contents, the value vector in a vector of unions must be a vector of
+    // offsets. Source: https://github.com/dvidelabs/flatcc/blob/master/doc/binary-format.md#unions
+    verifier.is_aligned::<UOffsetT>(value_vector_start)?;
+    let value_vector_size = value_vector_len.saturating_mul(SIZE_UOFFSET.try_into()?);
+    verifier.range_in_buffer(value_vector_start, value_vector_size.try_into()?)?;
+    let value_vector_range = core::ops::Range {
+        start: value_vector_start,
+        end: value_vector_start.saturating_add(value_vector_size.try_into()?),
+    };
+
+    // The enums must have a size of 1 byte, so we just use the length of the vector.
+    let enum_vector_size = enum_vector_len;
+    verifier.range_in_buffer(enum_vector_start, enum_vector_size.try_into()?)?;
+    let enum_vector_range = core::ops::Range {
+        start: enum_vector_start,
+        end: enum_vector_start.saturating_add(enum_vector_size.try_into()?),
+    };
+
+    let enum_values = child_enum.values();
+
+    for (enum_pos, union_offset_pos) in enum_vector_range.zip(value_vector_range.step_by(SIZE_UOFFSET)) {
+        let enum_value = verifier.get_u8(enum_pos)?;
+        if enum_value == 0 {
+            // Discriminator is NONE. This should never happen: the C++ implementation forbids it.
+            // For example, the C++ JSON parser forbids the type entry to be NONE for a vector of
+            // unions: in
+            // https://github.com/google/flatbuffers/blob/bd1b2d0bafb8be6059a29487db9e5ace5c32914d/src/idl_parser.cpp#L1383
+            // the second argument is 'true', meaning that the NONE entry is skipped for the reverse
+            // lookup.
+            //
+            // This should possibly be an error, but we can be forgiving and just ignore the
+            // corresponding union entry entirely.
+            continue;
+        }
+
+        let enum_value: usize = enum_value.into();
+        let enum_type = if enum_value < enum_values.len() {
+            enum_values.get(enum_value).union_type().expect(
+                "Schema verification should have checked that every union enum value has a type",
+            )
+        } else {
+            return Err(FlatbufferError::InvalidUnionEnum);
+        };
+        let union_pos = union_offset_pos.saturating_add(verifier.get_uoffset(union_offset_pos)?.try_into()?);
+        verifier.in_buffer::<u8>(union_pos)?;
+
+        match enum_type.base_type() {
+            BaseType::String => <&str>::run_verifier(verifier, union_pos)?,
+            BaseType::Obj => {
+                let child_obj = schema.objects().get(enum_type.index().try_into()?);
+                buf_loc_to_obj_idx.insert(union_pos, enum_type.index());
+                if child_obj.is_struct() {
+                    verify_struct(verifier, &child_obj, union_pos, schema, buf_loc_to_obj_idx)?
+                } else {
+                    verify_table(
+                        verifier,
+                        &child_obj,
+                        union_pos,
+                        schema,
+                        verified,
+                        buf_loc_to_obj_idx,
+                    )?;
+                }
+            }
+            other => {
+                return Err(FlatbufferError::UnsupportedUnionElementType(other));
+            }
+        }
+        verified[union_pos] = true;
+    }
+    Ok(table_verifier)
 }
 
 fn verify_union<'a, 'b, 'c>(

--- a/rust/reflection/src/reflection_verifier.rs
+++ b/rust/reflection/src/reflection_verifier.rs
@@ -30,8 +30,14 @@ pub fn verify_with_options(
     buf_loc_to_obj_idx: &mut HashMap<usize, i32>,
 ) -> FlatbufferResult<()> {
     let mut verifier = Verifier::new(opts, buffer);
-    if let Some(table_object) = schema.root_table() {
-        if let core::result::Result::Ok(table_pos) = verifier.get_uoffset(0) {
+    let root_table = match opts.root_table_name {
+        Some(root_table_name) => schema
+            .objects()
+            .lookup_by_key(root_table_name, |o, k| o.key_compare_with_value(k)),
+        None => schema.root_table(),
+    };
+    if let Some(table_object) = root_table {
+        if let Ok(table_pos) = verifier.get_uoffset(0) {
             // Inserts -1 as object index for root table
             buf_loc_to_obj_idx.insert(table_pos.try_into()?, -1);
             let mut verified = vec![false; buffer.len()];

--- a/rust/reflection/src/reflection_verifier.rs
+++ b/rust/reflection/src/reflection_verifier.rs
@@ -28,12 +28,13 @@ pub fn verify_with_options(
     schema: &Schema,
     opts: &VerifierOptions,
     buf_loc_to_obj_idx: &mut HashMap<usize, i32>,
+    root_table_name: Option<&str>,
 ) -> FlatbufferResult<()> {
     let mut verifier = Verifier::new(opts, buffer);
-    let root_table = match opts.root_table_name {
-        Some(root_table_name) => schema
+    let root_table = match root_table_name {
+        Some(name) => schema
             .objects()
-            .lookup_by_key(root_table_name, |o, k| o.key_compare_with_value(k)),
+            .lookup_by_key(name, |o, k| o.key_compare_with_value(k)),
         None => schema.root_table(),
     };
     if let Some(table_object) = root_table {

--- a/rust/reflection/src/reflection_verifier.rs
+++ b/rust/reflection/src/reflection_verifier.rs
@@ -299,7 +299,10 @@ fn verify_vector_of_unions<'a, 'b, 'c>(
 
     // Assuming the schema is valid, the previous field must be the enum vector, which consists of
     // of 1-byte enums.
-    let enum_field_offset = field.offset() - u16::try_from(SIZE_VOFFSET).unwrap();
+    let enum_field_offset = field
+        .offset()
+        .checked_sub(u16::try_from(SIZE_VOFFSET).unwrap())
+        .ok_or(FlatbufferError::InvalidUnionEnum)?;
 
     // Either both vectors must be present, or both must be absent.
     let (value_field_pos, enum_field_pos) = match (

--- a/rust/reflection/src/safe_buffer.rs
+++ b/rust/reflection/src/safe_buffer.rs
@@ -141,7 +141,7 @@ impl<'a> SafeTable<'a> {
     pub fn get_field_string(&self, field_name: &str) -> FlatbufferResult<Option<&str>> {
         if let Some(field) = self.safe_buf.find_field_by_name(self.loc, field_name)? {
             // SAFETY: the buffer was verified during construction.
-            Ok(unsafe { get_field_string(&Table::new(&self.safe_buf.buf, self.loc), &field) })
+            Ok(Some(unsafe { get_field_string(&Table::new(&self.safe_buf.buf, self.loc), &field) }))
         } else {
             Err(FlatbufferError::FieldNotFound)
         }

--- a/rust/reflection/src/safe_buffer.rs
+++ b/rust/reflection/src/safe_buffer.rs
@@ -49,7 +49,7 @@ impl<'a> SafeBuffer<'a> {
         opts: &VerifierOptions,
     ) -> FlatbufferResult<Self> {
         let mut buf_loc_to_obj_idx = HashMap::new();
-        verify_with_options(&buf, schema, opts, &mut buf_loc_to_obj_idx)?;
+        verify_with_options(&buf, schema, opts, &mut buf_loc_to_obj_idx, None)?;
         Ok(SafeBuffer {
             buf,
             schema,
@@ -141,7 +141,9 @@ impl<'a> SafeTable<'a> {
     pub fn get_field_string(&self, field_name: &str) -> FlatbufferResult<Option<&str>> {
         if let Some(field) = self.safe_buf.find_field_by_name(self.loc, field_name)? {
             // SAFETY: the buffer was verified during construction.
-            Ok(Some(unsafe { get_field_string(&Table::new(&self.safe_buf.buf, self.loc), &field) }))
+            Ok(Some(unsafe {
+                get_field_string(&Table::new(&self.safe_buf.buf, self.loc), &field)
+            }))
         } else {
             Err(FlatbufferError::FieldNotFound)
         }

--- a/rust/reflection/src/safe_buffer.rs
+++ b/rust/reflection/src/safe_buffer.rs
@@ -170,7 +170,7 @@ impl<'a> SafeTable<'a> {
     pub fn get_field_vector<T: Follow<'a, Inner = T>>(
         &self,
         field_name: &str,
-    ) -> FlatbufferResult<Option<Vector<'a, T>>> {
+    ) -> FlatbufferResult<Vector<'a, T>> {
         if let Some(field) = self.safe_buf.find_field_by_name(self.loc, field_name)? {
             // SAFETY: the buffer was verified during construction.
             unsafe { get_field_vector(&Table::new(&self.safe_buf.buf, self.loc), &field) }

--- a/rust/reflection/src/struct.rs
+++ b/rust/reflection/src/struct.rs
@@ -33,6 +33,11 @@ impl<'a> Struct<'a> {
         self.loc
     }
 
+    #[inline]
+    pub fn bytes(&self) -> &'a [u8] {
+        &self.buf[self.loc..]
+    }
+    
     /// # Safety
     ///
     /// [buf] must contain a valid struct at [loc]

--- a/rust/reflection/src/struct.rs
+++ b/rust/reflection/src/struct.rs
@@ -37,7 +37,7 @@ impl<'a> Struct<'a> {
     pub fn bytes(&self) -> &'a [u8] {
         &self.buf[self.loc..]
     }
-    
+
     /// # Safety
     ///
     /// [buf] must contain a valid struct at [loc]

--- a/rust/reflection/src/vector_of_any.rs
+++ b/rust/reflection/src/vector_of_any.rs
@@ -1,0 +1,74 @@
+use flatbuffers::{read_scalar_at, Follow, UOffsetT, Vector, SIZE_UOFFSET};
+
+use crate::reflection::Object;
+
+pub struct VectorOfAny<'a> {
+    buf: &'a [u8],
+    loc: usize,
+}
+
+impl<'a> VectorOfAny<'a> {
+    /// # Safety
+    ///
+    /// [buf] must contain a valid vector at [loc]
+    #[inline]
+    pub unsafe fn new(buf: &'a [u8], loc: usize) -> Self {
+        Self { buf, loc }
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        // Safety:
+        // Valid vector at time of construction starting with UOffsetT element count
+        unsafe { read_scalar_at::<UOffsetT>(self.buf, self.loc) as usize }
+    }
+
+    /// Get a slice of all the bytes from the start of the vector to the *end of the buffer*.
+    /// 
+    /// We don't know the size of the elements in the vector, so we can't return just its contents.
+    #[inline(always)]
+    pub fn bytes(&self) -> &'a [u8] {
+        &self.buf[self.loc + SIZE_UOFFSET..]
+    }
+
+    /// Get a slice of bytes corresponding to the struct at [index], assuming this is a vector of
+    /// structs of type [obj].
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if [index] is out of bounds or if [obj] is not a struct.
+    #[inline(always)]
+    pub fn get_struct(&self, index: usize, obj: Object<'_>) -> &'a [u8] {
+        assert!(obj.is_struct());
+        assert!(index < self.len());
+        let bytesize = obj.bytesize() as usize;
+        let start = self.loc + SIZE_UOFFSET + index * bytesize;
+        let end = start + bytesize;
+        assert!(end <= self.buf.len());
+        &self.buf[start..end]
+    }
+
+    /// # Safety
+    ///
+    /// [buf] must contain a valid vector at [loc]
+    pub unsafe fn as_vector<T: Follow<'a>>(&self) -> Vector<T> {
+        Vector::new(self.buf, self.loc)
+    }
+}
+
+impl<'a> Follow<'a> for VectorOfAny<'a> {
+    type Inner = VectorOfAny<'a>;
+
+    #[inline(always)]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self { buf, loc }
+    }
+}
+
+impl Default for VectorOfAny<'_> {
+    fn default() -> Self {
+        Self { buf: &[], loc: 0 }
+    }
+}
+
+

--- a/rust/reflection/src/vector_of_any.rs
+++ b/rust/reflection/src/vector_of_any.rs
@@ -67,6 +67,7 @@ impl<'a> Follow<'a> for VectorOfAny<'a> {
 
 impl Default for VectorOfAny<'_> {
     fn default() -> Self {
-        Self { buf: &[], loc: 0 }
+        // Need to include length prefix, even if it is just zero.
+        Self { buf: &[0; core::mem::size_of::<UOffsetT>()], loc: 0 }
     }
 }

--- a/rust/reflection/src/vector_of_any.rs
+++ b/rust/reflection/src/vector_of_any.rs
@@ -24,7 +24,7 @@ impl<'a> VectorOfAny<'a> {
     }
 
     /// Get a slice of all the bytes from the start of the vector to the *end of the buffer*.
-    /// 
+    ///
     /// We don't know the size of the elements in the vector, so we can't return just its contents.
     #[inline(always)]
     pub fn bytes(&self) -> &'a [u8] {
@@ -33,9 +33,9 @@ impl<'a> VectorOfAny<'a> {
 
     /// Get a slice of bytes corresponding to the struct at [index], assuming this is a vector of
     /// structs of type [obj].
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if [index] is out of bounds or if [obj] is not a struct.
     #[inline(always)]
     pub fn get_struct(&self, index: usize, obj: Object<'_>) -> &'a [u8] {
@@ -70,5 +70,3 @@ impl Default for VectorOfAny<'_> {
         Self { buf: &[], loc: 0 }
     }
 }
-
-

--- a/rust/reflection/src/vector_of_any.rs
+++ b/rust/reflection/src/vector_of_any.rs
@@ -68,6 +68,9 @@ impl<'a> Follow<'a> for VectorOfAny<'a> {
 impl Default for VectorOfAny<'_> {
     fn default() -> Self {
         // Need to include length prefix, even if it is just zero.
-        Self { buf: &[0; core::mem::size_of::<UOffsetT>()], loc: 0 }
+        Self {
+            buf: &[0; core::mem::size_of::<UOffsetT>()],
+            loc: 0,
+        }
     }
 }


### PR DESCRIPTION
This PR fixes several bugs and adds support for missing features to the `flatbuffers` and `flatbuffers_reflection` crates.

* fixes https://github.com/google/flatbuffers/issues/8550
* fixes https://github.com/google/flatbuffers/issues/8548
* adds reflection support for vectors of values of unknown type
* adds verification support for vectors of unions
* makes the unsafe `get_field_*` functions infallible as their success is implied by the unsafe precondition
* adds the unsafe function `Vector::cast()` for casting between vector types
* exposes `get_type_size()`
* adds `Struct::bytes()` to get a slice to a byte buffer which starts with the struct value 
