### PR TITLE
Build flatc on release for ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -625,7 +625,7 @@ jobs:
           set -euo pipefail
           echo "$LINUXGCC_X86_64_DIGESTS" | base64 -d > checksums.txt
           echo "$LINUXCLANG_X86_64_DIGESTS" | base64 -d >> checksums.txt
-          echo "$LINUXGCC_AARCH64_DIGESTS" | base64 -d > checksums.txt
+          echo "$LINUXGCC_AARCH64_DIGESTS" | base64 -d >> checksums.txt
           echo "$LINUXCLANG_AARCH64_DIGESTS" | base64 -d >> checksums.txt
           echo "$MAC_DIGESTS" | base64 -d >> checksums.txt
           echo "$MACINTEL_DIGESTS" | base64 -d >> checksums.txt


### PR DESCRIPTION
This PR adds a build of flatc at release for `aarch64` via the [`ubuntu-24.04-arm` runner](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories). 