### PR TITLE
Update README logo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![logo](http://google.github.io/flatbuffers/fpl_logo_small.png) FlatBuffers
+![logo](https://flatbuffers.dev/assets/flatbuffers_logo.svg) FlatBuffers
 ===========
 
 ![Build status](https://github.com/google/flatbuffers/actions/workflows/build.yml/badge.svg?branch=master)


### PR DESCRIPTION
Seems like the logo path in the README hasn't been updated after the docs were moved, this just updates the link
