### PR TITLE
fix: complying with rust edition 2024 (unsafe_op_in_unsafe_fn)

### DIFF
--- a/goldens/rust/basic_generated.rs
+++ b/goldens/rust/basic_generated.rs
@@ -37,7 +37,7 @@ impl<'a> flatbuffers::Follow<'a> for Galaxy<'a> {
   type Inner = Galaxy<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 
@@ -134,7 +134,7 @@ impl<'a> flatbuffers::Follow<'a> for Universe<'a> {
   type Inner = Universe<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/rust/reflection/src/reflection_generated.rs
+++ b/rust/reflection/src/reflection_generated.rs
@@ -243,7 +243,7 @@ impl<'a> flatbuffers::Follow<'a> for Type<'a> {
   type Inner = Type<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 
@@ -427,7 +427,7 @@ impl<'a> flatbuffers::Follow<'a> for KeyValue<'a> {
   type Inner = KeyValue<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 
@@ -552,7 +552,7 @@ impl<'a> flatbuffers::Follow<'a> for EnumVal<'a> {
   type Inner = EnumVal<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 
@@ -728,7 +728,7 @@ impl<'a> flatbuffers::Follow<'a> for Enum<'a> {
   type Inner = Enum<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 
@@ -941,7 +941,7 @@ impl<'a> flatbuffers::Follow<'a> for Field<'a> {
   type Inner = Field<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 
@@ -1273,7 +1273,7 @@ impl<'a> flatbuffers::Follow<'a> for Object<'a> {
   type Inner = Object<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 
@@ -1502,7 +1502,7 @@ impl<'a> flatbuffers::Follow<'a> for RPCCall<'a> {
   type Inner = RPCCall<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 
@@ -1680,7 +1680,7 @@ impl<'a> flatbuffers::Follow<'a> for Service<'a> {
   type Inner = Service<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 
@@ -1860,7 +1860,7 @@ impl<'a> flatbuffers::Follow<'a> for SchemaFile<'a> {
   type Inner = SchemaFile<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 
@@ -1987,7 +1987,7 @@ impl<'a> flatbuffers::Follow<'a> for Schema<'a> {
   type Inner = Schema<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/samples/rust_generated/my_game/sample/monster_generated.rs
+++ b/samples/rust_generated/my_game/sample/monster_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
   type Inner = Monster<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/samples/rust_generated/my_game/sample/weapon_generated.rs
+++ b/samples/rust_generated/my_game/sample/weapon_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for Weapon<'a> {
   type Inner = Weapon<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -1658,7 +1658,7 @@ class RustGenerator : public BaseGenerator {
     code_ += "  type Inner = {{STRUCT_TY}}<'a>;";
     code_ += "  #[inline]";
     code_ += "  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {";
-    code_ += "    Self { _tab: flatbuffers::Table::new(buf, loc) }";
+    code_ += "    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }";
     code_ += "  }";
     code_ += "}";
     code_ += "";

--- a/tests/arrays_test/my_game/example/array_table_generated.rs
+++ b/tests/arrays_test/my_game/example/array_table_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for ArrayTable<'a> {
   type Inner = ArrayTable<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/include_test1/my_game/other_name_space/table_b_generated.rs
+++ b/tests/include_test1/my_game/other_name_space/table_b_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TableB<'a> {
   type Inner = TableB<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/include_test1/table_a_generated.rs
+++ b/tests/include_test1/table_a_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TableA<'a> {
   type Inner = TableA<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/include_test2/my_game/other_name_space/table_b_generated.rs
+++ b/tests/include_test2/my_game/other_name_space/table_b_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TableB<'a> {
   type Inner = TableB<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/include_test2/table_a_generated.rs
+++ b/tests/include_test2/table_a_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TableA<'a> {
   type Inner = TableA<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/keyword_test/keyword_test/keywords_in_table_generated.rs
+++ b/tests/keyword_test/keyword_test/keywords_in_table_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for KeywordsInTable<'a> {
   type Inner = KeywordsInTable<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/keyword_test/keyword_test/table_2_generated.rs
+++ b/tests/keyword_test/keyword_test/table_2_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for Table2<'a> {
   type Inner = Table2<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test/my_game/example/monster_generated.rs
+++ b/tests/monster_test/my_game/example/monster_generated.rs
@@ -21,7 +21,7 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
   type Inner = Monster<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test/my_game/example/referrable_generated.rs
+++ b/tests/monster_test/my_game/example/referrable_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for Referrable<'a> {
   type Inner = Referrable<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test/my_game/example/stat_generated.rs
+++ b/tests/monster_test/my_game/example/stat_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for Stat<'a> {
   type Inner = Stat<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test/my_game/example/test_simple_table_with_enum_generated.rs
+++ b/tests/monster_test/my_game/example/test_simple_table_with_enum_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TestSimpleTableWithEnum<'a> {
   type Inner = TestSimpleTableWithEnum<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test/my_game/example/type_aliases_generated.rs
+++ b/tests/monster_test/my_game/example/type_aliases_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TypeAliases<'a> {
   type Inner = TypeAliases<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test/my_game/example_2/monster_generated.rs
+++ b/tests/monster_test/my_game/example_2/monster_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
   type Inner = Monster<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test/my_game/in_parent_namespace_generated.rs
+++ b/tests/monster_test/my_game/in_parent_namespace_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for InParentNamespace<'a> {
   type Inner = InParentNamespace<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test/my_game/other_name_space/table_b_generated.rs
+++ b/tests/monster_test/my_game/other_name_space/table_b_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TableB<'a> {
   type Inner = TableB<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test/table_a_generated.rs
+++ b/tests/monster_test/table_a_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TableA<'a> {
   type Inner = TableA<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/monster_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/monster_generated.rs
@@ -23,7 +23,7 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
   type Inner = Monster<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/referrable_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/referrable_generated.rs
@@ -22,7 +22,7 @@ impl<'a> flatbuffers::Follow<'a> for Referrable<'a> {
   type Inner = Referrable<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/stat_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/stat_generated.rs
@@ -22,7 +22,7 @@ impl<'a> flatbuffers::Follow<'a> for Stat<'a> {
   type Inner = Stat<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/test_simple_table_with_enum_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/test_simple_table_with_enum_generated.rs
@@ -22,7 +22,7 @@ impl<'a> flatbuffers::Follow<'a> for TestSimpleTableWithEnum<'a> {
   type Inner = TestSimpleTableWithEnum<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example/type_aliases_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/type_aliases_generated.rs
@@ -22,7 +22,7 @@ impl<'a> flatbuffers::Follow<'a> for TypeAliases<'a> {
   type Inner = TypeAliases<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test_serialize/my_game/example_2/monster_generated.rs
+++ b/tests/monster_test_serialize/my_game/example_2/monster_generated.rs
@@ -22,7 +22,7 @@ impl<'a> flatbuffers::Follow<'a> for Monster<'a> {
   type Inner = Monster<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test_serialize/my_game/in_parent_namespace_generated.rs
+++ b/tests/monster_test_serialize/my_game/in_parent_namespace_generated.rs
@@ -22,7 +22,7 @@ impl<'a> flatbuffers::Follow<'a> for InParentNamespace<'a> {
   type Inner = InParentNamespace<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test_serialize/my_game/other_name_space/table_b_generated.rs
+++ b/tests/monster_test_serialize/my_game/other_name_space/table_b_generated.rs
@@ -22,7 +22,7 @@ impl<'a> flatbuffers::Follow<'a> for TableB<'a> {
   type Inner = TableB<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/monster_test_serialize/table_a_generated.rs
+++ b/tests/monster_test_serialize/table_a_generated.rs
@@ -22,7 +22,7 @@ impl<'a> flatbuffers::Follow<'a> for TableA<'a> {
   type Inner = TableA<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/more_defaults/more_defaults_generated.rs
+++ b/tests/more_defaults/more_defaults_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for MoreDefaults<'a> {
   type Inner = MoreDefaults<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/namespace_test/namespace_a/namespace_b/table_in_nested_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/namespace_b/table_in_nested_ns_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TableInNestedNS<'a> {
   type Inner = TableInNestedNS<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/namespace_test/namespace_a/second_table_in_a_generated.rs
+++ b/tests/namespace_test/namespace_a/second_table_in_a_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for SecondTableInA<'a> {
   type Inner = SecondTableInA<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/namespace_test/namespace_a/table_in_first_ns_generated.rs
+++ b/tests/namespace_test/namespace_a/table_in_first_ns_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TableInFirstNS<'a> {
   type Inner = TableInFirstNS<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/namespace_test/namespace_c/table_in_c_generated.rs
+++ b/tests/namespace_test/namespace_c/table_in_c_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for TableInC<'a> {
   type Inner = TableInC<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/optional_scalars/optional_scalars/scalar_stuff_generated.rs
+++ b/tests/optional_scalars/optional_scalars/scalar_stuff_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for ScalarStuff<'a> {
   type Inner = ScalarStuff<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/private_annotation_test/annotations_generated.rs
+++ b/tests/private_annotation_test/annotations_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for Annotations<'a> {
   type Inner = Annotations<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/private_annotation_test/game_generated.rs
+++ b/tests/private_annotation_test/game_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for Game<'a> {
   type Inner = Game<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/rust_namer_test/rust_namer_test/field_table_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/field_table_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for FieldTable<'a> {
   type Inner = FieldTable<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/rust_namer_test/rust_namer_test/game_message_wrapper_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/game_message_wrapper_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for GameMessageWrapper<'a> {
   type Inner = GameMessageWrapper<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/rust_namer_test/rust_namer_test/player_input_change_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/player_input_change_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for PlayerInputChange<'a> {
   type Inner = PlayerInputChange<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/rust_namer_test/rust_namer_test/player_spectate_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/player_spectate_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for PlayerSpectate<'a> {
   type Inner = PlayerSpectate<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/rust_namer_test/rust_namer_test/player_stat_event_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/player_stat_event_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for PlayerStatEvent<'a> {
   type Inner = PlayerStatEvent<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 

--- a/tests/rust_namer_test/rust_namer_test/root_table_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/root_table_generated.rs
@@ -20,7 +20,7 @@ impl<'a> flatbuffers::Follow<'a> for RootTable<'a> {
   type Inner = RootTable<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table::new(buf, loc) }
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
   }
 }
 


### PR DESCRIPTION
This PR fixes the Rust code generation to comply with Rust edition 2024 that requires indicating unsafe operations inside unsafe functions. 

For reference: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html