### PR TITLE
[Swift] Increase platform support to iOS 12 to avoid deprecated warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ import PackageDescription
 let package = Package(
   name: "FlatBuffers",
   platforms: [
-    .iOS(.v11),
+    .iOS(.v12),
     .macOS(.v10_14),
   ],
   products: [


### PR DESCRIPTION
Compiling with Swift 6.0 and newer creates a build warning:
```
flatbuffers/Package.swift:23:11: warning: 'v11' is deprecated: iOS 12.0 is the oldest supported version
21 |   name: "FlatBuffers",
22 |   platforms: [
23 |     .iOS(.v11),
   |           `- warning: 'v11' is deprecated: iOS 12.0 is the oldest supported version
24 |     .macOS(.v10_14),
25 |   ],
```

iOS was released in [2017](https://en.wikipedia.org/wiki/IOS_11).