### PR TITLE
Fix Enum type definition

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -549,6 +549,8 @@ class PythonStubGenerator {
     stub << "class " << namer_.Type(*enum_def);
     imports->Export(ModuleFor(enum_def), namer_.Type(*enum_def));
 
+    imports->Import("typing", "cast");
+
     if (version_.major == 3){
       imports->Import("enum", "IntEnum");
       stub << "(IntEnum)";
@@ -559,8 +561,8 @@ class PythonStubGenerator {
 
     stub << ":\n";
     for (const EnumVal *val : enum_def->Vals()) {
-      stub << "  " << namer_.Variant(*val) << ": "
-           << ScalarType(enum_def->underlying_type.base_type) << "\n";
+      stub << "  " << namer_.Variant(*val) << " = cast("
+           << ScalarType(enum_def->underlying_type.base_type) << ", ...)\n";
     }
 
     if (parser_.opts.generate_object_based_api & enum_def->is_union) {

--- a/tests/MyGame/Example/NestedUnion/Any.pyi
+++ b/tests/MyGame/Example/NestedUnion/Any.pyi
@@ -8,12 +8,13 @@ import typing
 from MyGame.Example.NestedUnion.TestSimpleTableWithEnum import TestSimpleTableWithEnum
 from MyGame.Example.NestedUnion.Vec3 import Vec3
 from flatbuffers import table
+from typing import cast
 
 uoffset: typing.TypeAlias = flatbuffers.number_types.UOffsetTFlags.py_type
 
 class Any(object):
-  NONE: int
-  Vec3: int
-  TestSimpleTableWithEnum: int
+  NONE = cast(int, ...)
+  Vec3 = cast(int, ...)
+  TestSimpleTableWithEnum = cast(int, ...)
 def AnyCreator(union_type: typing.Literal[Any.NONE, Any.Vec3, Any.TestSimpleTableWithEnum], table: table.Table) -> typing.Union[None, Vec3, TestSimpleTableWithEnum]: ...
 

--- a/tests/MyGame/Example/NestedUnion/Color.pyi
+++ b/tests/MyGame/Example/NestedUnion/Color.pyi
@@ -5,11 +5,12 @@ import numpy as np
 
 import flatbuffers
 import typing
+from typing import cast
 
 uoffset: typing.TypeAlias = flatbuffers.number_types.UOffsetTFlags.py_type
 
 class Color(object):
-  Red: int
-  Green: int
-  Blue: int
+  Red = cast(int, ...)
+  Green = cast(int, ...)
+  Blue = cast(int, ...)
 

--- a/tests/MyGame/Example/TestEnum.pyi
+++ b/tests/MyGame/Example/TestEnum.pyi
@@ -5,11 +5,12 @@ import numpy as np
 
 import flatbuffers
 import typing
+from typing import cast
 
 uoffset: typing.TypeAlias = flatbuffers.number_types.UOffsetTFlags.py_type
 
 class TestEnum(object):
-  A: int
-  B: int
-  C: int
+  A = cast(int, ...)
+  B = cast(int, ...)
+  C = cast(int, ...)
 


### PR DESCRIPTION
Using the : syntax leads to non member attributes.

> If an attribute is defined in the class body with a type annotation
> but with no assigned value, a type checker should assume this is a non-member attribute

```
class Pet(Enum):
    genus: str  # Non-member attribute
    species: str  # Non-member attribute

    CAT = 1  # Member attribute
    DOG = 2  # Member attribute
```

https://typing.python.org/en/latest/spec/enums.html#defining-members