### PR TITLE
[Python] Avoid include own type

### DIFF
--- a/include/codegen/python.cc
+++ b/include/codegen/python.cc
@@ -59,5 +59,21 @@ const python::Import &python::Imports::Import(const std::string &module,
   imports.push_back(std::move(import));
   return imports.back();
 }
+
+const python::Import &python::Imports::Export(const std::string &module) {
+  python::Import import;
+  import.module = module;
+  exports.push_back(std::move(import));
+  return exports.back();
+}
+
+const python::Import &python::Imports::Export(const std::string &module,
+                                              const std::string &name) {
+  python::Import import;
+  import.module = module;
+  import.name = name;
+  exports.push_back(std::move(import));
+  return exports.back();
+}
 }  // namespace python
 }  // namespace flatbuffers

--- a/include/codegen/python.h
+++ b/include/codegen/python.h
@@ -85,7 +85,12 @@ struct Imports {
   const python::Import &Import(const std::string &module,
                                const std::string &name);
 
+  const python::Import &Export(const std::string &module);
+  const python::Import &Export(const std::string &module,
+                               const std::string &name);
+
   std::vector<python::Import> imports;
+  std::vector<python::Import> exports;
 };
 }  // namespace python
 }  // namespace flatbuffers

--- a/tests/MyGame/Example/ArrayStruct.pyi
+++ b/tests/MyGame/Example/ArrayStruct.pyi
@@ -5,7 +5,6 @@ import numpy as np
 
 import flatbuffers
 import typing
-from MyGame.Example.ArrayStruct import ArrayStruct
 from MyGame.Example.NestedStruct import NestedStruct, NestedStructT
 from MyGame.Example.TestEnum import TestEnum
 

--- a/tests/MyGame/Example/ArrayTable.pyi
+++ b/tests/MyGame/Example/ArrayTable.pyi
@@ -6,7 +6,6 @@ import numpy as np
 import flatbuffers
 import typing
 from MyGame.Example.ArrayStruct import ArrayStruct, ArrayStructT
-from MyGame.Example.ArrayTable import ArrayTable
 
 uoffset: typing.TypeAlias = flatbuffers.number_types.UOffsetTFlags.py_type
 

--- a/tests/MyGame/Example/NestedStruct.pyi
+++ b/tests/MyGame/Example/NestedStruct.pyi
@@ -5,7 +5,6 @@ import numpy as np
 
 import flatbuffers
 import typing
-from MyGame.Example.NestedStruct import NestedStruct
 from MyGame.Example.TestEnum import TestEnum
 
 uoffset: typing.TypeAlias = flatbuffers.number_types.UOffsetTFlags.py_type

--- a/tests/MyGame/Example/NestedUnion/Any.pyi
+++ b/tests/MyGame/Example/NestedUnion/Any.pyi
@@ -5,7 +5,6 @@ import numpy as np
 
 import flatbuffers
 import typing
-from MyGame.Example.NestedUnion.Any import Any
 from MyGame.Example.NestedUnion.TestSimpleTableWithEnum import TestSimpleTableWithEnum
 from MyGame.Example.NestedUnion.Vec3 import Vec3
 from flatbuffers import table

--- a/tests/MyGame/Example/NestedUnion/NestedUnionTest.pyi
+++ b/tests/MyGame/Example/NestedUnion/NestedUnionTest.pyi
@@ -6,7 +6,6 @@ import numpy as np
 import flatbuffers
 import typing
 from MyGame.Example.NestedUnion.Any import Any
-from MyGame.Example.NestedUnion.NestedUnionTest import NestedUnionTest
 from MyGame.Example.NestedUnion.TestSimpleTableWithEnum import TestSimpleTableWithEnumT
 from MyGame.Example.NestedUnion.Vec3 import Vec3T
 from flatbuffers import table

--- a/tests/MyGame/Example/NestedUnion/Test.pyi
+++ b/tests/MyGame/Example/NestedUnion/Test.pyi
@@ -5,7 +5,6 @@ import numpy as np
 
 import flatbuffers
 import typing
-from MyGame.Example.NestedUnion.Test import Test
 
 uoffset: typing.TypeAlias = flatbuffers.number_types.UOffsetTFlags.py_type
 

--- a/tests/MyGame/Example/NestedUnion/TestSimpleTableWithEnum.pyi
+++ b/tests/MyGame/Example/NestedUnion/TestSimpleTableWithEnum.pyi
@@ -6,7 +6,6 @@ import numpy as np
 import flatbuffers
 import typing
 from MyGame.Example.NestedUnion.Color import Color
-from MyGame.Example.NestedUnion.TestSimpleTableWithEnum import TestSimpleTableWithEnum
 
 uoffset: typing.TypeAlias = flatbuffers.number_types.UOffsetTFlags.py_type
 

--- a/tests/MyGame/Example/NestedUnion/Vec3.pyi
+++ b/tests/MyGame/Example/NestedUnion/Vec3.pyi
@@ -7,7 +7,6 @@ import flatbuffers
 import typing
 from MyGame.Example.NestedUnion.Color import Color
 from MyGame.Example.NestedUnion.Test import Test, TestT
-from MyGame.Example.NestedUnion.Vec3 import Vec3
 
 uoffset: typing.TypeAlias = flatbuffers.number_types.UOffsetTFlags.py_type
 

--- a/tests/MyGame/MonsterExtra.pyi
+++ b/tests/MyGame/MonsterExtra.pyi
@@ -5,7 +5,6 @@ import numpy as np
 
 import flatbuffers
 import typing
-from MyGame.MonsterExtra import MonsterExtra
 
 uoffset: typing.TypeAlias = flatbuffers.number_types.UOffsetTFlags.py_type
 


### PR DESCRIPTION
This prevents the include of the type defined in the pyi, otherwise this leads to error message like this:
error: Name XYZ already defined (possibly by an import)  [no-redef]
