### PR TITLE
[Python] Avoid double flatbuffers include in pyi files

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -587,6 +587,7 @@ class PythonStubGenerator {
     std::map<std::string, std::set<std::string>> names_by_module;
     for (const Import &import : imports.imports) {
       if (import.IsLocal()) continue;  // skip all local imports
+      if (import.module == "flatbuffers" && import.name == "") continue; // skip double include hardcoded flatbuffers
       if (import.name == "") {
         modules.insert(import.module);
       } else {

--- a/tests/MyGame/Example/ArrayStruct.pyi
+++ b/tests/MyGame/Example/ArrayStruct.pyi
@@ -3,7 +3,6 @@ from __future__ import annotations
 import flatbuffers
 import numpy as np
 
-import flatbuffers
 import typing
 from MyGame.Example.NestedStruct import NestedStruct, NestedStructT
 from MyGame.Example.TestEnum import TestEnum

--- a/tests/MyGame/Example/ArrayTable.pyi
+++ b/tests/MyGame/Example/ArrayTable.pyi
@@ -3,7 +3,6 @@ from __future__ import annotations
 import flatbuffers
 import numpy as np
 
-import flatbuffers
 import typing
 from MyGame.Example.ArrayStruct import ArrayStruct, ArrayStructT
 

--- a/tests/MyGame/Example/NestedStruct.pyi
+++ b/tests/MyGame/Example/NestedStruct.pyi
@@ -3,7 +3,6 @@ from __future__ import annotations
 import flatbuffers
 import numpy as np
 
-import flatbuffers
 import typing
 from MyGame.Example.TestEnum import TestEnum
 

--- a/tests/MyGame/Example/NestedUnion/Any.pyi
+++ b/tests/MyGame/Example/NestedUnion/Any.pyi
@@ -3,7 +3,6 @@ from __future__ import annotations
 import flatbuffers
 import numpy as np
 
-import flatbuffers
 import typing
 from MyGame.Example.NestedUnion.TestSimpleTableWithEnum import TestSimpleTableWithEnum
 from MyGame.Example.NestedUnion.Vec3 import Vec3

--- a/tests/MyGame/Example/NestedUnion/Color.pyi
+++ b/tests/MyGame/Example/NestedUnion/Color.pyi
@@ -3,7 +3,6 @@ from __future__ import annotations
 import flatbuffers
 import numpy as np
 
-import flatbuffers
 import typing
 from typing import cast
 

--- a/tests/MyGame/Example/NestedUnion/NestedUnionTest.pyi
+++ b/tests/MyGame/Example/NestedUnion/NestedUnionTest.pyi
@@ -3,7 +3,6 @@ from __future__ import annotations
 import flatbuffers
 import numpy as np
 
-import flatbuffers
 import typing
 from MyGame.Example.NestedUnion.Any import Any
 from MyGame.Example.NestedUnion.TestSimpleTableWithEnum import TestSimpleTableWithEnumT

--- a/tests/MyGame/Example/NestedUnion/Test.pyi
+++ b/tests/MyGame/Example/NestedUnion/Test.pyi
@@ -3,7 +3,6 @@ from __future__ import annotations
 import flatbuffers
 import numpy as np
 
-import flatbuffers
 import typing
 
 uoffset: typing.TypeAlias = flatbuffers.number_types.UOffsetTFlags.py_type

--- a/tests/MyGame/Example/NestedUnion/TestSimpleTableWithEnum.pyi
+++ b/tests/MyGame/Example/NestedUnion/TestSimpleTableWithEnum.pyi
@@ -3,7 +3,6 @@ from __future__ import annotations
 import flatbuffers
 import numpy as np
 
-import flatbuffers
 import typing
 from MyGame.Example.NestedUnion.Color import Color
 

--- a/tests/MyGame/Example/NestedUnion/Vec3.pyi
+++ b/tests/MyGame/Example/NestedUnion/Vec3.pyi
@@ -3,7 +3,6 @@ from __future__ import annotations
 import flatbuffers
 import numpy as np
 
-import flatbuffers
 import typing
 from MyGame.Example.NestedUnion.Color import Color
 from MyGame.Example.NestedUnion.Test import Test, TestT

--- a/tests/MyGame/Example/TestEnum.pyi
+++ b/tests/MyGame/Example/TestEnum.pyi
@@ -3,7 +3,6 @@ from __future__ import annotations
 import flatbuffers
 import numpy as np
 
-import flatbuffers
 import typing
 from typing import cast
 

--- a/tests/MyGame/MonsterExtra.pyi
+++ b/tests/MyGame/MonsterExtra.pyi
@@ -3,7 +3,6 @@ from __future__ import annotations
 import flatbuffers
 import numpy as np
 
-import flatbuffers
 import typing
 
 uoffset: typing.TypeAlias = flatbuffers.number_types.UOffsetTFlags.py_type


### PR DESCRIPTION
Unneeded flatbuffers removed as it is statically added in the beginning every time.
