### PR TITLE
Improve performance of CreateSharedString by using std::unordered_set instead of std::set

### DIFF
--- a/include/flatbuffers/base.h
+++ b/include/flatbuffers/base.h
@@ -42,6 +42,7 @@
 #include <type_traits>
 #include <vector>
 #include <set>
+#include <unordered_set>
 #include <algorithm>
 #include <limits>
 #include <iterator>


### PR DESCRIPTION
The current implementation of CreateSharedString uses `std::set`, which has logarithmic `find` runtime. In practice, this is very slow and infeasible if used for many strings. In contrast, `std::unordered_set` has an amortized constant lookup time which we found to be much faster. 

I chose FNV1a because it is fast and has good collision behaviour in general. The downside is that when serializing large quantities of user-supplied strings, the map is now vulnerable to HashDoS attacks. But up until now, the map was so imperformant that supplying any large amount of strings caused a denial of service anyway, so this is clearly an upgrade. If this poses an issue nevertheless, I suggest implementing something like BLAKE3.