### PR TITLE
[Swift] Fixes inlining & module importing

### DIFF
--- a/grpc/examples/swift/Greeter/Sources/Model/greeter_generated.swift
+++ b/grpc/examples/swift/Greeter/Sources/Model/greeter_generated.swift
@@ -2,6 +2,10 @@
 // swiftlint:disable all
 // swiftformat:disable all
 
+#if canImport(Common)
+import Common
+#endif
+
 import FlatBuffers
 
 public struct models_HelloReply: FlatBufferObject, Verifiable {

--- a/samples/monster_generated.swift
+++ b/samples/monster_generated.swift
@@ -2,6 +2,10 @@
 // swiftlint:disable all
 // swiftformat:disable all
 
+#if canImport(Common)
+import Common
+#endif
+
 import FlatBuffers
 
 public enum MyGame_Sample_Color: Int8, Enum, Verifiable {

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -174,10 +174,12 @@ class SwiftGenerator : public BaseGenerator {
     code_ += "// swiftlint:disable all";
     code_ += "// swiftformat:disable all\n";
     if (parser_.opts.include_dependence_headers || parser_.opts.generate_all) {
-      if (parser_.opts.swift_implementation_only)
-        code_ += "@_implementationOnly \\";
-
-      code_ += "import FlatBuffers\n";
+      code_.SetValue("IMPLEMENTONLY", parser_.opts.swift_implementation_only ? "@_implementationOnly " : "");
+      code_ += "#if canImport(Common)";
+      code_ += "{{IMPLEMENTONLY}}import Common";
+      code_ += "#endif";
+      code_ += "";
+      code_ += "{{IMPLEMENTONLY}}import FlatBuffers\n";
     }
 
     // Generate code for all the enum declarations.

--- a/swift/Sources/FlatBuffers/Constants.swift
+++ b/swift/Sources/FlatBuffers/Constants.swift
@@ -15,7 +15,7 @@
  */
 
 #if canImport(Common)
-@_exported import Common
+import Common
 #endif
 import Foundation
 

--- a/swift/Sources/FlatBuffers/Enum.swift
+++ b/swift/Sources/FlatBuffers/Enum.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(Common)
+import Common
+#endif
 
 import Foundation
 

--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(Common)
+import Common
+#endif
 
 import Foundation
 

--- a/swift/Sources/FlatBuffers/Mutable.swift
+++ b/swift/Sources/FlatBuffers/Mutable.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(Common)
+import Common
+#endif
 
 import Foundation
 

--- a/swift/Sources/FlatBuffers/Struct.swift
+++ b/swift/Sources/FlatBuffers/Struct.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(Common)
+import Common
+#endif
 
 import Foundation
 

--- a/swift/Sources/FlatBuffers/Table.swift
+++ b/swift/Sources/FlatBuffers/Table.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(Common)
+import Common
+#endif
 
 import Foundation
 

--- a/swift/Sources/FlatBuffers/Verifiable.swift
+++ b/swift/Sources/FlatBuffers/Verifiable.swift
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#if canImport(Common)
+import Common
+#endif
+
 import Foundation
 
 /// Verifiable is a protocol all swift flatbuffers object should conform to,

--- a/swift/Sources/FlatBuffers/_InternalByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/_InternalByteBuffer.swift
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#if canImport(Common)
+import Common
+#endif
+
 import Foundation
 
 /// `ByteBuffer` is the interface that stores the data for a `Flatbuffers` object

--- a/swift/Sources/FlexBuffers/Utils/Constants.swift
+++ b/swift/Sources/FlexBuffers/Utils/Constants.swift
@@ -15,7 +15,7 @@
  */
 
 #if canImport(Common)
-@_exported import Common
+import Common
 #endif
 import Foundation
 

--- a/swift/Sources/FlexBuffers/Utils/Value.swift
+++ b/swift/Sources/FlexBuffers/Utils/Value.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(Common)
+import Common
+#endif
 
 import Foundation
 

--- a/swift/Sources/FlexBuffers/Utils/functions.swift
+++ b/swift/Sources/FlexBuffers/Utils/functions.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(Common)
+import Common
+#endif
 
 import Foundation
 

--- a/swift/Sources/FlexBuffers/Writer/FlexBuffersWriter.swift
+++ b/swift/Sources/FlexBuffers/Writer/FlexBuffersWriter.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(Common)
+import Common
+#endif
 
 import Foundation
 
@@ -80,7 +83,6 @@ public struct FlexBuffersWriter {
   }
 
   // MARK: - Storing root
-  @inline(__always)
   public mutating func finish() {
     assert(stack.count == 1)
 
@@ -115,7 +117,6 @@ public struct FlexBuffersWriter {
   }
 
   @discardableResult
-  @inline(__always)
   public mutating func endVector(
     start: Int,
     typed: Bool = false,
@@ -181,7 +182,6 @@ public struct FlexBuffersWriter {
   }
 
   @discardableResult
-  @inline(__always)
   public mutating func endMap(start: Int) -> UInt64 {
     let len = sortMapByKeys(start: start)
 
@@ -507,8 +507,8 @@ public struct FlexBuffersWriter {
 
   // MARK: Writing to buffer
 
-  @inline(__always)
-  private mutating func write(value: Value, byteWidth: Int) {
+  @usableFromInline
+  mutating func write(value: Value, byteWidth: Int) {
     switch value.type {
     case .null, .int: write(value: value.i, byteWidth: byteWidth)
     case .bool, .uint: write(value: value.u, byteWidth: byteWidth)
@@ -518,8 +518,8 @@ public struct FlexBuffersWriter {
     }
   }
 
-  @inline(__always)
-  private mutating func pushIndirect<T>(
+  @usableFromInline
+  mutating func pushIndirect<T>(
     value: T,
     type: FlexBufferType,
     bitWidth: BitWidth)
@@ -542,8 +542,8 @@ public struct FlexBuffersWriter {
   /// - Parameter str: String that will be added to the buffer
   /// - Parameter len: length of the string
   @discardableResult
-  @inline(__always)
-  private mutating func write(str: borrowing String, len: Int) -> UInt {
+  @usableFromInline
+  mutating func write(str: borrowing String, len: Int) -> UInt {
     let resetTo = writerIndex
     var sloc = str.withCString {
       storeBlob(pointer: $0, len: len, trailing: 1, type: .string)
@@ -573,8 +573,8 @@ public struct FlexBuffersWriter {
   }
 
   @discardableResult
-  @inline(__always)
-  private mutating func add(key: borrowing String, len: Int) -> UInt {
+  @usableFromInline
+  mutating func add(key: borrowing String, len: Int) -> UInt {
     _bb.ensureSpace(size: len)
 
     var sloc: UInt = numericCast(writerIndex)
@@ -596,8 +596,8 @@ public struct FlexBuffersWriter {
   }
 
   // MARK: - Storing Blobs
-  @inline(__always)
-  private mutating func storeBlob<T>(
+  @usableFromInline
+  mutating func storeBlob<T>(
     _ bytes: T,
     len: Int,
     type: FlexBufferType) -> UInt where T: ContiguousBytes
@@ -609,7 +609,6 @@ public struct FlexBuffersWriter {
 
   @discardableResult
   @usableFromInline
-  @inline(__always)
   mutating func storeBlob(
     pointer: borrowing UnsafeRawPointer,
     len: Int,
@@ -636,8 +635,8 @@ public struct FlexBuffersWriter {
 
   // MARK: Write Vectors
   @discardableResult
-  @inline(__always)
-  private mutating func create<T>(vector: [T], fixed: Bool) -> Int
+  @usableFromInline
+  mutating func create<T>(vector: [T], fixed: Bool) -> Int
     where T: Scalar
   {
     let length: UInt64 = numericCast(vector.count)
@@ -668,8 +667,8 @@ public struct FlexBuffersWriter {
     return vloc
   }
 
-  @inline(__always)
-  private mutating func createVector(
+  @usableFromInline
+  mutating func createVector(
     start: Int,
     count: Int,
     step: Int,
@@ -800,8 +799,8 @@ public struct FlexBuffersWriter {
     return bytes
   }
 
-  @inline(__always)
-  private mutating func sortMapByKeys(start: Int) -> Int {
+  @usableFromInline
+  mutating func sortMapByKeys(start: Int) -> Int {
     let len = mapElementCount(start: start)
     for index in stride(from: start, to: stack.count, by: 2) {
       assert(stack[index].type == .key)
@@ -838,10 +837,9 @@ public struct FlexBuffersWriter {
 // MARK: - Vectors helper functions
 extension FlexBuffersWriter {
   @discardableResult
-  @inline(__always)
   public mutating func vector(
     key: String,
-    _ closure: @escaping FlexBuffersWriterBuilder) -> UInt64
+    _ closure: FlexBuffersWriterBuilder) -> UInt64
   {
     let start = startVector(key: key)
     closure(&self)
@@ -849,8 +847,7 @@ extension FlexBuffersWriter {
   }
 
   @discardableResult
-  @inline(__always)
-  public mutating func vector(_ closure: @escaping FlexBuffersWriterBuilder)
+  public mutating func vector(_ closure: FlexBuffersWriterBuilder)
     -> UInt64
   {
     let start = startVector()
@@ -862,10 +859,9 @@ extension FlexBuffersWriter {
 // MARK: - Maps helper functions
 extension FlexBuffersWriter {
   @discardableResult
-  @inline(__always)
   public mutating func map(
     key: String,
-    _ closure: @escaping FlexBuffersWriterBuilder) -> UInt64
+    _ closure: FlexBuffersWriterBuilder) -> UInt64
   {
     let start = startMap(key: key)
     closure(&self)
@@ -873,8 +869,7 @@ extension FlexBuffersWriter {
   }
 
   @discardableResult
-  @inline(__always)
-  public mutating func map(_ closure: @escaping FlexBuffersWriterBuilder)
+  public mutating func map(_ closure: FlexBuffersWriterBuilder)
     -> UInt64
   {
     let start = startMap()

--- a/swift/Sources/FlexBuffers/_InternalByteBuffer.swift
+++ b/swift/Sources/FlexBuffers/_InternalByteBuffer.swift
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#if canImport(Common)
+import Common
+#endif
+
 import Foundation
 
 /// `ByteBuffer` is the interface that stores the data for a `Flatbuffers` object
@@ -152,6 +156,7 @@ struct _InternalByteBuffer {
     ensureSpace(size: writerIndex)
   }
 
+  @inline(__always)
   mutating func writeBytes(_ ptr: UnsafeRawPointer, len: Int) {
     memcpy(
       _storage.memory.advanced(by: writerIndex),
@@ -160,6 +165,7 @@ struct _InternalByteBuffer {
     writerIndex = writerIndex &+ len
   }
 
+  @inline(__always)
   mutating func write<T>(_ v: T, len: Int) {
     withUnsafePointer(to: v) {
       memcpy(

--- a/tests/swift/Tests/Flatbuffers/MutatingBool_generated.swift
+++ b/tests/swift/Tests/Flatbuffers/MutatingBool_generated.swift
@@ -2,6 +2,10 @@
 // swiftlint:disable all
 // swiftformat:disable all
 
+#if canImport(Common)
+import Common
+#endif
+
 import FlatBuffers
 
 public struct Property: NativeStruct, Verifiable, FlatbuffersInitializable, NativeObject {

--- a/tests/swift/Tests/Flatbuffers/monster_test_generated.swift
+++ b/tests/swift/Tests/Flatbuffers/monster_test_generated.swift
@@ -2,6 +2,10 @@
 // swiftlint:disable all
 // swiftformat:disable all
 
+#if canImport(Common)
+import Common
+#endif
+
 import FlatBuffers
 
 ///  Composite components of Monster color.

--- a/tests/swift/Tests/Flatbuffers/more_defaults_generated.swift
+++ b/tests/swift/Tests/Flatbuffers/more_defaults_generated.swift
@@ -2,6 +2,10 @@
 // swiftlint:disable all
 // swiftformat:disable all
 
+#if canImport(Common)
+import Common
+#endif
+
 import FlatBuffers
 
 public enum ABC: Int32, Enum, Verifiable {

--- a/tests/swift/Tests/Flatbuffers/nan_inf_test_generated.swift
+++ b/tests/swift/Tests/Flatbuffers/nan_inf_test_generated.swift
@@ -2,6 +2,10 @@
 // swiftlint:disable all
 // swiftformat:disable all
 
+#if canImport(Common)
+import Common
+#endif
+
 import FlatBuffers
 
 public struct Swift_Tests_NanInfTable: FlatBufferObject, Verifiable {

--- a/tests/swift/Tests/Flatbuffers/optional_scalars_generated.swift
+++ b/tests/swift/Tests/Flatbuffers/optional_scalars_generated.swift
@@ -2,6 +2,10 @@
 // swiftlint:disable all
 // swiftformat:disable all
 
+#if canImport(Common)
+import Common
+#endif
+
 import FlatBuffers
 
 public enum optional_scalars_OptionalByte: Int8, Enum, Verifiable {

--- a/tests/swift/Tests/Flatbuffers/union_vector_generated.swift
+++ b/tests/swift/Tests/Flatbuffers/union_vector_generated.swift
@@ -2,6 +2,10 @@
 // swiftlint:disable all
 // swiftformat:disable all
 
+#if canImport(Common)
+import Common
+#endif
+
 import FlatBuffers
 
 public enum Character: UInt8, UnionEnum {

--- a/tests/swift/Tests/Flatbuffers/vector_has_test_generated.swift
+++ b/tests/swift/Tests/Flatbuffers/vector_has_test_generated.swift
@@ -2,6 +2,10 @@
 // swiftlint:disable all
 // swiftformat:disable all
 
+#if canImport(Common)
+import Common
+#endif
+
 import FlatBuffers
 
 public struct Swift_Tests_Vectors: FlatBufferObject, Verifiable {

--- a/tests/swift/Wasm.tests/Tests/FlatBuffers.Test.Swift.WasmTests/monster_test_generated.swift
+++ b/tests/swift/Wasm.tests/Tests/FlatBuffers.Test.Swift.WasmTests/monster_test_generated.swift
@@ -2,6 +2,10 @@
 // swiftlint:disable all
 // swiftformat:disable all
 
+#if canImport(Common)
+import Common
+#endif
+
 import FlatBuffers
 
 ///  Composite components of Monster color.

--- a/tests/swift/fuzzer/CodeGenerationTests/test_import_generated.swift
+++ b/tests/swift/fuzzer/CodeGenerationTests/test_import_generated.swift
@@ -2,6 +2,10 @@
 // swiftlint:disable all
 // swiftformat:disable all
 
+#if canImport(Common)
+@_implementationOnly import Common
+#endif
+
 @_implementationOnly import FlatBuffers
 
 internal struct Message: FlatBufferObject, Verifiable, ObjectAPIPacker {


### PR DESCRIPTION
- The following PR removed `@_exported import` in favor of using the default import
- Fixes a couple of inline functions to only be usable from inline