### PR TITLE
[Swift] Allows keepingCapacity for the underlying memory

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,13 +47,11 @@ let package = Package(
     .testTarget(
       name: "FlatbuffersTests",
       dependencies: .dependencies,
-      path: "tests/swift/Tests/Flatbuffers"
-    ),
+      path: "tests/swift/Tests/Flatbuffers"),
     .testTarget(
       name: "FlexbuffersTests",
       dependencies: ["FlexBuffers"],
-      path: "tests/swift/Tests/Flexbuffers"
-    )
+      path: "tests/swift/Tests/Flexbuffers"),
   ])
 
 extension Array where Element == Package.Dependency {
@@ -75,7 +73,7 @@ extension Array where Element == PackageDescription.Target.Dependency {
     // Test only Dependency
     [
       .product(name: "GRPC", package: "grpc-swift"),
-      "FlatBuffers"
+      "FlatBuffers",
     ]
     #endif
   }

--- a/swift/Sources/FlatBuffers/Enum.swift
+++ b/swift/Sources/FlatBuffers/Enum.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #if canImport(Common)
 import Common
 #endif

--- a/swift/Sources/FlatBuffers/Mutable.swift
+++ b/swift/Sources/FlatBuffers/Mutable.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #if canImport(Common)
 import Common
 #endif

--- a/swift/Sources/FlatBuffers/Struct.swift
+++ b/swift/Sources/FlatBuffers/Struct.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #if canImport(Common)
 import Common
 #endif

--- a/swift/Sources/FlatBuffers/Table.swift
+++ b/swift/Sources/FlatBuffers/Table.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #if canImport(Common)
 import Common
 #endif

--- a/swift/Sources/FlatBuffers/_InternalByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/_InternalByteBuffer.swift
@@ -29,12 +29,10 @@ struct _InternalByteBuffer {
   /// deallocating the memory that was held by (memory: UnsafeMutableRawPointer)
   @usableFromInline
   final class Storage {
-    // This storage doesn't own the memory, therefore, we won't deallocate on deinit.
-    private let unowned: Bool
     /// pointer to the start of the buffer object in memory
-    var memory: UnsafeMutableRawPointer
+    private(set) var memory: UnsafeMutableRawPointer
     /// Capacity of UInt8 the buffer can hold
-    var capacity: Int
+    private(set) var capacity: Int
 
     @usableFromInline
     init(count: Int, alignment: Int) {
@@ -42,20 +40,14 @@ struct _InternalByteBuffer {
         byteCount: count,
         alignment: alignment)
       capacity = count
-      unowned = false
     }
 
     deinit {
-      if !unowned {
-        memory.deallocate()
-      }
+      memory.deallocate()
     }
 
     @usableFromInline
     func initialize(for size: Int) {
-      assert(
-        !unowned,
-        "initalize should NOT be called on a buffer that is built by assumingMemoryBound")
       memset(memory, 0, size)
     }
 
@@ -86,6 +78,7 @@ struct _InternalByteBuffer {
 
   @usableFromInline var _storage: Storage
 
+  private let initialSize: Int
   /// The size of the elements written to the buffer + their paddings
   private var _writerSize: Int = 0
   /// Alignment of the current  memory being written to the buffer
@@ -108,9 +101,9 @@ struct _InternalByteBuffer {
   ///   - size: Length of the buffer
   ///   - allowReadingUnalignedBuffers: allow reading from unaligned buffer
   init(initialSize size: Int) {
-    let size = size.convertToPowerofTwo
-    _storage = Storage(count: size, alignment: alignment)
-    _storage.initialize(for: size)
+    initialSize = size.convertToPowerofTwo
+    _storage = Storage(count: initialSize, alignment: alignment)
+    _storage.initialize(for: initialSize)
   }
 
   /// Fills the buffer with padding by adding to the writersize
@@ -298,10 +291,14 @@ struct _InternalByteBuffer {
 
   /// Clears the current instance of the buffer, replacing it with new memory
   @inline(__always)
-  mutating public func clear() {
+  mutating public func clear(keepingCapacity: Bool = false) {
     _writerSize = 0
     alignment = 1
-    _storage.initialize(for: _storage.capacity)
+    if keepingCapacity {
+      _storage.initialize(for: _storage.capacity)
+    } else {
+      _storage = Storage(count: initialSize, alignment: alignment)
+    }
   }
 
   /// Reads an object from the buffer

--- a/swift/Sources/FlexBuffers/Utils/Value.swift
+++ b/swift/Sources/FlexBuffers/Utils/Value.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #if canImport(Common)
 import Common
 #endif

--- a/swift/Sources/FlexBuffers/Utils/functions.swift
+++ b/swift/Sources/FlexBuffers/Utils/functions.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #if canImport(Common)
 import Common
 #endif

--- a/tests/swift/Tests/Flexbuffers/FlexBuffersReaderTests.swift
+++ b/tests/swift/Tests/Flexbuffers/FlexBuffersReaderTests.swift
@@ -15,8 +15,9 @@
  */
 
 import Common
-import FlexBuffers
 import XCTest
+
+@testable import FlexBuffers
 
 final class FlexBuffersReaderTests: XCTestCase {
 
@@ -28,6 +29,29 @@ final class FlexBuffersReaderTests: XCTestCase {
   func testReadingSizedBuffer() throws {
     let buf: ByteBuffer = createSizedBuffer()
     try validate(buffer: buf)
+  }
+
+  func testReset() throws {
+    var fbx = FlexBuffersWriter(
+      initialSize: 8,
+      flags: .shareKeysAndStrings)
+    write(fbx: &fbx)
+
+    try validate(buffer: ByteBuffer(data: fbx.data))
+    XCTAssertEqual(fbx.capacity, 512)
+    fbx.reset()
+    XCTAssertEqual(fbx.writerIndex, 0)
+    XCTAssertEqual(fbx.capacity, 8)
+
+    write(fbx: &fbx)
+    try validate(buffer: ByteBuffer(data: fbx.data))
+    fbx.reset(keepingCapacity: true)
+    XCTAssertEqual(fbx.writerIndex, 0)
+    XCTAssertEqual(fbx.capacity, 512)
+
+    write(fbx: &fbx)
+    try validate(buffer: ByteBuffer(data: fbx.data))
+    XCTAssertEqual(fbx.capacity, 512)
   }
 
   private func validate(buffer buf: ByteBuffer) throws {

--- a/tests/swift/Tests/Flexbuffers/Mocks.swift
+++ b/tests/swift/Tests/Flexbuffers/Mocks.swift
@@ -32,7 +32,11 @@ func createProperBuffer() -> FlexBuffersWriter {
   var fbx = FlexBuffersWriter(
     initialSize: 8,
     flags: .shareKeysAndStrings)
+  write(fbx: &fbx)
+  return fbx
+}
 
+func write(fbx: inout FlexBuffersWriter) {
   fbx.map { map in
     map.vector(key: "vec") { v in
       v.add(int64: -100)
@@ -57,5 +61,4 @@ func createProperBuffer() -> FlexBuffersWriter {
   }
 
   fbx.finish()
-  return fbx
 }


### PR DESCRIPTION
The following PR addresses #8642 where it seems that the memory is kept alive although the user has deallocated it.

This would allow the users to by default to reset the Builders for Flexbuffers and Flatbuffers to their initial starting sizes example:

```
let fbx = FlexBuffersWriter(initialSize:8)
fbx.reset()
XCTAssertEqual(fbx.writerIndex, 0)
XCTAssertEqual(fbx.capacity, 8)
```

However when needed developers can use the api `fbx.reset(keepingCapacity: true)` which will retain all the internal sizes and builds within that already existing memory.
