### PR TITLE
Fix start page: Backwards and Forwards Compatibility

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -21,14 +21,16 @@ It is available as Open Source on
 - :material-memory:{ .lg .middle } **Memory Efficiency and Speed**
 
     ---
-    The only memory needed to access your data is that of the buffer. No heap is
-  required.
+    The only memory needed to access your data is that of the buffer.
+  No heap is required.
 
 - :material-compare-horizontal:{ .lg .middle } **Backwards and Forwards
   Compatibility**
 
     ---
-    The only memory needed to access your data is that of the buffer. No heap is
+    FlatBuffers enables the schema to evolve over time while still maintaining
+  forwards and backwards compatibility with old flatbuffers.
+
   required.
 
 - :material-scale-off:{ .lg .middle } **Small Footprint**


### PR DESCRIPTION
Small docs update for the front page fixing a copy paste mistake.

fixes: #8586 fixes: #8562 fixes: #8605