### PR TITLE
[Swift] Fixes load from misaligned raw pointer

### DIFF
--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -303,7 +303,7 @@ public struct FlatBufferBuilder {
     var isAlreadyAdded: Int?
 
     let vt2 = _bb.memory.advanced(by: _bb.writerIndex)
-    let len2 = vt2.load(fromByteOffset: 0, as: Int16.self)
+    let len2 = _bb.read(def: Int16.self, position: _bb.writerIndex)
 
     for index in stride(from: 0, to: _vtables.count, by: 1) {
       let position = _bb.capacity &- Int(_vtables[index])


### PR DESCRIPTION
The following PR fixes a bug where we store a memory pointer to the underlying buffer memory and try to load it as an aligned value. However it seems that there was an issue with that in swift 6.1. This is fixed by using the `_bb.read()` method that assumes the type and loads it instead.

Closes #8648