### PR TITLE
[Swift] Moves capacity from storage to struct

### DIFF
--- a/swift/Sources/FlatBuffers/ByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/ByteBuffer.swift
@@ -40,11 +40,11 @@ public struct ByteBuffer {
 
     /// This storage doesn't own the memory, therefore, we won't deallocate on deinit.
     private let isOwned: Bool
+    /// Capacity of UInt8 the buffer can hold
+    private let capacity: Int
     /// Retained blob of data that requires the storage to retain a pointer to.
     @usableFromInline
     var retainedBlob: Blob
-    /// Capacity of UInt8 the buffer can hold
-    var capacity: Int
 
     @usableFromInline
     init(count: Int) {
@@ -179,11 +179,11 @@ public struct ByteBuffer {
   /// The size of the elements written to the buffer + their paddings
   private var _readerIndex: Int = 0
   /// Reader is the position of the current Writer Index (capacity - size)
-  public var reader: Int { _storage.capacity &- _readerIndex }
+  public var reader: Int { capacity &- _readerIndex }
   /// Current size of the buffer
   public var size: UOffset { UOffset(_readerIndex) }
   /// Current capacity for the buffer
-  public var capacity: Int { _storage.capacity }
+  public let capacity: Int
 
   /// Constructor that creates a Flatbuffer object from an InternalByteBuffer
   /// - Parameter
@@ -194,6 +194,7 @@ public struct ByteBuffer {
       blob: .byteBuffer(byteBuffer),
       capacity: byteBuffer.capacity)
     _readerIndex = Int(byteBuffer.size)
+    self.capacity = byteBuffer.capacity
   }
 
   /// Constructor that creates a Flatbuffer from unsafe memory region by copying
@@ -209,7 +210,8 @@ public struct ByteBuffer {
   {
     _storage = Storage(count: capacity)
     _storage.copy(from: memory, count: capacity)
-    _readerIndex = _storage.capacity
+    _readerIndex = capacity
+    self.capacity = capacity
   }
 
   /// Constructor that creates a Flatbuffer object from a UInt8
@@ -218,7 +220,8 @@ public struct ByteBuffer {
   @inline(__always)
   public init(bytes: [UInt8]) {
     _storage = Storage(blob: .array(bytes), capacity: bytes.count)
-    _readerIndex = _storage.capacity
+    _readerIndex = bytes.count
+    capacity = bytes.count
   }
 
   #if !os(WASI)
@@ -228,7 +231,8 @@ public struct ByteBuffer {
   @inline(__always)
   public init(data: Data) {
     _storage = Storage(blob: .data(data), capacity: data.count)
-    _readerIndex = _storage.capacity
+    _readerIndex = data.count
+    capacity = data.count
   }
 
   /// Constructor that creates a Flatbuffer object from a ContiguousBytes
@@ -241,7 +245,8 @@ public struct ByteBuffer {
     count: Int)
   {
     _storage = Storage(blob: .bytes(contiguousBytes), capacity: count)
-    _readerIndex = _storage.capacity
+    _readerIndex = count
+    self.capacity = count
   }
   #endif
 
@@ -259,7 +264,8 @@ public struct ByteBuffer {
     _storage = Storage(
       blob: .pointer(memory),
       capacity: capacity)
-    _readerIndex = _storage.capacity
+    _readerIndex = capacity
+    self.capacity = capacity
   }
 
   /// Creates a copy of the existing flatbuffer, by copying it to a different memory.
@@ -275,6 +281,7 @@ public struct ByteBuffer {
   {
     _storage = Storage(blob: blob, capacity: count)
     _readerIndex = removeBytes
+    capacity = count
   }
 
   /// Write stores an object into the buffer directly or indirectly.
@@ -289,11 +296,11 @@ public struct ByteBuffer {
   func write<T>(value: T, index: Int, direct: Bool = false) {
     var index = index
     if !direct {
-      index = _storage.capacity &- index
+      index = capacity &- index
     }
-    assert(index < _storage.capacity, "Write index is out of writing bound")
+    assert(index < capacity, "Write index is out of writing bound")
     assert(index >= 0, "Writer index should be above zero")
-    withUnsafePointer(to: value) { ptr in
+    _ = withUnsafePointer(to: value) { ptr in
       _storage.withUnsafeRawPointer {
         memcpy(
           $0.advanced(by: index),
@@ -325,7 +332,7 @@ public struct ByteBuffer {
     count: Int) -> [T]
   {
     assert(
-      index + count <= _storage.capacity,
+      index + count <= capacity,
       "Reading out of bounds is illegal")
 
     return _storage.readWithUnsafeRawPointer(position: index) {
@@ -348,7 +355,7 @@ public struct ByteBuffer {
     body: (UnsafeRawBufferPointer) throws -> T) rethrows -> T
   {
     assert(
-      index + count <= _storage.capacity,
+      index + count <= capacity,
       "Reading out of bounds is illegal")
     return try _storage.readWithUnsafeRawPointer(position: index) {
       try body(UnsafeRawBufferPointer(start: $0, count: count))
@@ -368,7 +375,7 @@ public struct ByteBuffer {
     type: String.Encoding = .utf8) -> String?
   {
     assert(
-      index + count <= _storage.capacity,
+      index + count <= capacity,
       "Reading out of bounds is illegal")
     return _storage.readWithUnsafeRawPointer(position: index) {
       let buf = UnsafeBufferPointer(
@@ -390,7 +397,7 @@ public struct ByteBuffer {
     count: Int) -> String?
   {
     assert(
-      index + count <= _storage.capacity,
+      index + count <= capacity,
       "Reading out of bounds is illegal")
     return _storage.readWithUnsafeRawPointer(position: index) {
       String(cString: $0.bindMemory(to: UInt8.self, capacity: count))
@@ -404,11 +411,11 @@ public struct ByteBuffer {
   public func duplicate(removing removeBytes: Int = 0) -> ByteBuffer {
     assert(removeBytes > 0, "Can NOT remove negative bytes")
     assert(
-      removeBytes < _storage.capacity,
+      removeBytes < capacity,
       "Can NOT remove more bytes than the ones allocated")
     return ByteBuffer(
       blob: _storage.retainedBlob,
-      count: _storage.capacity,
+      count: capacity,
       removing: _readerIndex &- removeBytes)
   }
 
@@ -456,7 +463,7 @@ extension ByteBuffer: CustomDebugStringConvertible {
   public var debugDescription: String {
     """
     buffer located at: \(_storage.retainedBlob), 
-    with capacity of \(_storage.capacity),
+    with capacity of \(capacity),
     { writtenSize: \(_readerIndex), readerSize: \(reader), 
     size: \(size) }
     """

--- a/swift/Sources/FlatBuffers/Mutable.swift
+++ b/swift/Sources/FlatBuffers/Mutable.swift
@@ -49,7 +49,7 @@ extension Mutable where Self == Table {
   ///   - index: index of the Element
   public func mutate<T: Scalar>(_ value: T, index: Int32) -> Bool {
     guard index != 0 else { return false }
-    return mutate(value: value, o: index + position)
+    return mutate(value: value, o: index &+ position)
   }
 
   /// Directly mutates the element by calling mutate
@@ -70,7 +70,7 @@ extension Mutable where Self == Struct {
   ///   - value: New value to be inserted to the buffer
   ///   - index: index of the Element
   public func mutate<T: Scalar>(_ value: T, index: Int32) -> Bool {
-    mutate(value: value, o: index + position)
+    mutate(value: value, o: index &+ position)
   }
 
   /// Directly mutates the element by calling mutate

--- a/swift/Sources/FlatBuffers/Struct.swift
+++ b/swift/Sources/FlatBuffers/Struct.swift
@@ -45,7 +45,7 @@ public struct Struct {
   ///   - o: Current offset of the data
   /// - Returns: Data of Type T that conforms to type Scalar
   public func readBuffer<T: Scalar>(of type: T.Type, at o: Int32) -> T {
-    let r = bb.read(def: T.self, position: Int(o + position))
+    let r = bb.read(def: T.self, position: Int(o &+ position))
     return r
   }
 }

--- a/swift/Sources/FlatBuffers/Table.swift
+++ b/swift/Sources/FlatBuffers/Table.swift
@@ -167,7 +167,7 @@ public struct Table {
   public func vector(at o: Int32) -> Int32 {
     var o = o
     o &+= position
-    return o &+ bb.read(def: Int32.self, position: Int(o)) + 4
+    return o &+ bb.read(def: Int32.self, position: Int(o)) &+ 4
   }
 
   /// Reading an indirect offset of a table.
@@ -176,7 +176,7 @@ public struct Table {
   ///   - fbb: ByteBuffer
   /// - Returns: table offset
   static public func indirect(_ o: Int32, _ fbb: ByteBuffer) -> Int32 {
-    o + fbb.read(def: Int32.self, position: Int(o))
+    o &+ fbb.read(def: Int32.self, position: Int(o))
   }
 
   /// Gets a vtable value according to an table Offset and a field offset

--- a/swift/Sources/FlexBuffers/Reader/FlexBufferVector.swift
+++ b/swift/Sources/FlexBuffers/Reader/FlexBufferVector.swift
@@ -25,7 +25,7 @@ extension FlexBufferVector {
     json += "["
     for i in 0..<count {
       if let val = self[i]?.jsonString() {
-        let comma = i == count - 1 ? "" : ", "
+        let comma = i == count &- 1 ? "" : ", "
         json += "\(val)\(comma)"
       }
     }

--- a/swift/Sources/FlexBuffers/Reader/Map.swift
+++ b/swift/Sources/FlexBuffers/Reader/Map.swift
@@ -52,7 +52,7 @@ extension Map {
     json += "{"
     for i in 0..<count {
       if let key = keys[i]?.cString {
-        let comma = i == count - 1 ? "" : ", "
+        let comma = i == count &- 1 ? "" : ", "
         let value = values[i]?.jsonString() ?? StaticJSON.null
         json += "\"\(key)\": \(value)\(comma)"
       }

--- a/swift/Sources/FlexBuffers/Utils/functions.swift
+++ b/swift/Sources/FlexBuffers/Utils/functions.swift
@@ -117,9 +117,9 @@ func toFixedTypedVectorElementType(type: FlexBufferType)
   let fixedType: UInt64 = numericCast(
     type.rawValue &- FlexBufferType.vectorInt2
       .rawValue)
-  let len: Int = numericCast((fixedType / 3) + 2)
+  let len: Int = numericCast(fixedType.dividedReportingOverflow(by: 3).partialValue &+ 2)
   return (
-    FlexBufferType(rawValue: (fixedType % 3) + FlexBufferType.int.rawValue),
+    FlexBufferType(rawValue: (fixedType.quotientAndRemainder(dividingBy: 3).remainder) &+ FlexBufferType.int.rawValue),
     len)
 }
 

--- a/swift/Sources/FlexBuffers/Writer/FlexBuffersWriter.swift
+++ b/swift/Sources/FlexBuffers/Writer/FlexBuffersWriter.swift
@@ -143,7 +143,7 @@ public struct FlexBuffersWriter {
   {
     let vec = createVector(
       start: start,
-      count: stack.count - start,
+      count: stack.count &- start,
       step: 1,
       typed: typed,
       fixed: fixed,
@@ -211,7 +211,7 @@ public struct FlexBuffersWriter {
       typed: true,
       fixed: false)
     let vec = createVector(
-      start: start + 1,
+      start: start &+ 1,
       count: len,
       step: 2,
       typed: false,
@@ -598,7 +598,7 @@ public struct FlexBuffersWriter {
 
     var sloc: UInt = numericCast(writerIndex)
     key.withCString {
-      _bb.writeBytes($0, len: len + 1)
+      _bb.writeBytes($0, len: len &+ 1)
     }
 
     if flags > .shareKeys {
@@ -705,7 +705,7 @@ public struct FlexBuffersWriter {
       /// If this vector is part of a map, we will pre-fix an offset to the keys
       /// to this vector.
       bitWidth = max(bitWidth, keys!.elementWidth(size: writerIndex, index: 0))
-      prefixElements += 2
+      prefixElements = prefixElements &+ 2
     }
     var vectorType: FlexBufferType = .key
 

--- a/tests/swift/Tests/Flatbuffers/ByteBufferTests.swift
+++ b/tests/swift/Tests/Flatbuffers/ByteBufferTests.swift
@@ -42,7 +42,7 @@ final class ByteBufferTests: XCTestCase {
     let byteBuffer = ByteBuffer(data: ptr)
     byteBuffer.withUnsafeBytes { memory in
       ptr.withUnsafeBytes { ptr in
-        XCTAssertEqual(memory.baseAddress!, ptr)
+        XCTAssertEqual(memory.baseAddress!, ptr.baseAddress!)
       }
     }
   }

--- a/tests/swift/Tests/Flatbuffers/FlatbuffersVerifierTests.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatbuffersVerifierTests.swift
@@ -19,13 +19,7 @@ import XCTest
 
 final class FlatbuffersVerifierTests: XCTestCase {
 
-  lazy var validStorage: ByteBuffer.Storage = ByteBuffer.Storage(
-    count: Int(FlatBufferMaxSize) - 1)
-  lazy var errorStorage: ByteBuffer.Storage = ByteBuffer.Storage(
-    count: Int(FlatBufferMaxSize) + 1)
-
   var buffer: ByteBuffer!
-
   var validFlatbuffersObject: ByteBuffer!
   var invalidFlatbuffersObject: ByteBuffer!
   var invalidFlatbuffersObject2: ByteBuffer!
@@ -52,15 +46,13 @@ final class FlatbuffersVerifierTests: XCTestCase {
 
   func testVeriferInitPassing() {
     let memory = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 1)
-    var buffer = ByteBuffer(assumingMemoryBound: memory, capacity: 8)
-    buffer._storage = validStorage
+    var buffer = ByteBuffer(assumingMemoryBound: memory, capacity: Int(FlatBufferMaxSize) - 1)
     XCTAssertNoThrow(try Verifier(buffer: &buffer))
   }
 
   func testVeriferInitFailing() {
     let memory = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 1)
-    var buffer = ByteBuffer(assumingMemoryBound: memory, capacity: 8)
-    buffer._storage = errorStorage
+    var buffer = ByteBuffer(assumingMemoryBound: memory, capacity: Int(FlatBufferMaxSize) + 1)
     XCTAssertThrowsError(try Verifier(buffer: &buffer))
   }
 


### PR DESCRIPTION
- Moves `capacity` from storage to `_internalbuffer` and `buffer` implementations in both `Flexbuffers` and `Flatbuffers` to avoid extra unexpected reference counts.
- Uses overflow operators in places that missed using them.