### PR TITLE
Added ToSizedArrayPadded(int padLeft, int padRight) to ByteBuffers to avoid unnecessary copying.

### DIFF
--- a/net/FlatBuffers/ByteBuffer.cs
+++ b/net/FlatBuffers/ByteBuffer.cs
@@ -264,6 +264,22 @@ namespace Google.FlatBuffers
         }
 #endif
 
+        public T[] ToArrayPadded<T>(int pos, int len, int padLeft, int padRight)
+            where T : struct
+        {
+            AssertOffsetAndLength(pos, len);
+            int totalBytes = padLeft + len + padRight;
+            byte[] raw = _buffer.Buffer;
+            T[] arr = new T[totalBytes];
+            Buffer.BlockCopy(raw, pos, arr, padLeft, len);
+            return arr;
+        }
+		
+		public byte[] ToSizedArrayPadded(int padLeft, int padRight)
+        {
+            return ToArrayPadded<byte>(Position, Length - Position, padLeft, padRight);
+        }
+
         public byte[] ToSizedArray()
         {
             return ToArray<byte>(Position, Length - Position);


### PR DESCRIPTION
I've added 2 new functions to C#'s ByteBuffers:
`public byte[] ToSizedArrayPadded(int padLeft, int padRight)`
`public T[] ToArrayPadded<T>(int pos, int len, int padLeft, int padRight)`

I needed those to create byte buffers with room in front of them where i can hotwire a header containing the type info and/on package length for TCP Framing. 

Code that calls .ToSizedArray only to create new byte array and yet another copy to add some padding wasn't the best approach, so I decided to add the padding feature in the library itself. This is great for highly optimized networking. 
My old framing code was the bottleneck because of Buffer.BlockCopy that is after a Buffer.BlockCopy during the .ToSizedArray()

Consider adding something similar to other languages thay may need padding during their framing / similar use cases, where ToSizedArray is THE thing that creates the initial byte array. 