### PR TITLE
Fixing Parser corruption after move (#8660)

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -235,7 +235,12 @@ struct Value {
 // Helper class that retains the original order of a set of identifiers and
 // also provides quick lookup.
 template<typename T> class SymbolTable {
+  SymbolTable(const SymbolTable&) = delete;
+
  public:
+  SymbolTable() = default;
+  SymbolTable(SymbolTable&&) = default;
+
   ~SymbolTable() {
     for (auto it = vec.begin(); it != vec.end(); ++it) { delete *it; }
   }


### PR DESCRIPTION
Fixing SymboTable within Parser not being moved properly.
