### PR TITLE
Doc fix verifier example code for cpp

### DIFF
--- a/docs/source/languages/cpp.md
+++ b/docs/source/languages/cpp.md
@@ -419,7 +419,8 @@ Each root type will have a verification function generated for it,
 e.g. for `Monster`, you can call:
 
 ```cpp
-	bool ok = VerifyMonsterBuffer(Verifier(buf, len));
+	Verifier verifier(buf, len);
+	bool ok = VerifyMonsterBuffer(verifier);
 ```
 
 if `ok` is true, the buffer is safe to read.


### PR DESCRIPTION
An other small fix for the cpp docs. Fixes #8636

This is also supported by how it is used in the tests:

```
    // Verify the root monster, which includes verifing the nested monster
    flatbuffers::Verifier verifier(builder.GetBufferPointer(),
                                   builder.GetSize());
    TEST_EQ(true, VerifyMonsterBuffer(verifier));
```
