### PR TITLE
Fix: Actually call ValidateOptions

### DIFF
--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -758,6 +758,8 @@ FlatCOptions FlatCompiler::ParseFromCommandLineArguments(int argc,
     }
   }
 
+  ValidateOptions(options);
+
   return options;
 }
 

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -768,9 +768,8 @@ void FlatCompiler::ValidateOptions(const FlatCOptions &options) {
 
   if (!options.filenames.size()) Error("missing input files", false, true);
 
-  if (opts.proto_mode) {
-    if (options.any_generator)
-      Error("cannot generate code directly from .proto files", true);
+  if (opts.proto_mode && options.any_generator) {
+    Warn("cannot generate code directly from .proto files", true);
   } else if (!options.any_generator && options.conform_to_schema.empty() &&
              options.annotate_schema.empty()) {
     Error("no options: specify at least one generator.", true);


### PR DESCRIPTION
Hello!

I was working on my wireshark dissector generator PR #8576 and noticed that a validation function was not being ran -- looking through the history, it seems that in commit 641fbe46583c04c56bf33284ceb7971102ea4583 the validation logic was moved to a function, but that function wasn't ever set to be called. This fixes this up and re-adds this dead function back into production.

Thanks,

Justin 
