### PR TITLE
Bugfix: grpc supress incorrect warning

### DIFF
--- a/include/flatbuffers/grpc.h
+++ b/include/flatbuffers/grpc.h
@@ -121,7 +121,7 @@ class SliceAllocator : public Allocator {
     memcpy_downward(old_p, old_size, new_p, new_size, in_use_back,
                     in_use_front);
     slice_ = new_slice;
-    return new_p;
+    return const_cast<uint8_t *>(slice_.begin());
   }
 
  private:


### PR DESCRIPTION
new_p is a local addr but is owned now by slice_
thus the life time does not end at the end of the function

The newest compilers had opinions about returning `new_p` here.