### PR TITLE
Allow include directive in python generator with gen-onefile

### DIFF
--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -568,7 +568,6 @@ FlatCOptions FlatCompiler::ParseFromCommandLineArguments(int argc,
         opts.include_dependence_headers = false;
       } else if (arg == "--gen-onefile") {
         opts.one_file = true;
-        opts.include_dependence_headers = false;
       } else if (arg == "--raw-binary") {
         options.raw_binary = true;
       } else if (arg == "--size-prefixed") {


### PR DESCRIPTION
This PR fixes #8543, by generating import statements when a foreign definition (a definition that was not defined in the file currently being parsed) is encountered.
As well as using the `def->declaration_file`, instead of the `def->file`, when available, to create the import statement. This is done, since the `def->file` filename will have an absolute path in certain cases, whereas the `def->declaration_file` does not.

Please let me know if there is anything you'd like me to change or if there's anything wrong with my logic.