### PR TITLE
Fix --gen-compare to not generate comparators for native types.

### DIFF
--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -334,7 +334,7 @@ flatc(
 )
 
 flatc(
-    ["--cpp", "--gen-mutable", "--gen-object-api", "--reflect-names"],
+    ["--cpp", "--gen-compare", "--gen-mutable", "--gen-object-api", "--reflect-names"],
     schema="native_type_test.fbs",
 )
 

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -494,7 +494,8 @@ class CppGenerator : public BaseGenerator {
     // Generate forward declarations for all equal operators
     if (opts_.generate_object_based_api && opts_.gen_compare) {
       for (const auto &struct_def : parser_.structs_.vec) {
-        if (!struct_def->generated) {
+        const auto native_type = struct_def->attributes.Lookup("native_type");
+        if (!struct_def->generated && !native_type) {
           SetNameSpace(struct_def->defined_namespace);
           auto nativeName = NativeName(Name(*struct_def), struct_def, opts_);
           code_ += "bool operator==(const " + nativeName + " &lhs, const " +
@@ -2128,6 +2129,10 @@ class CppGenerator : public BaseGenerator {
 
   void GenCompareOperator(const StructDef &struct_def,
                           const std::string &accessSuffix = "") {
+    // Do not generate compare operators for native types.
+    const auto native_type = struct_def.attributes.Lookup("native_type");
+    if (native_type) { return; }
+
     std::string compare_op;
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {

--- a/tests/native_type_test_generated.h
+++ b/tests/native_type_test_generated.h
@@ -25,6 +25,9 @@ struct ApplicationData;
 struct ApplicationDataBuilder;
 struct ApplicationDataT;
 
+bool operator==(const ApplicationDataT &lhs, const ApplicationDataT &rhs);
+bool operator!=(const ApplicationDataT &lhs, const ApplicationDataT &rhs);
+
 inline const ::flatbuffers::TypeTable *Vector3DTypeTable();
 
 inline const ::flatbuffers::TypeTable *Vector3DAltTypeTable();
@@ -234,6 +237,20 @@ inline ::flatbuffers::Offset<ApplicationData> CreateApplicationDataDirect(
 }
 
 ::flatbuffers::Offset<ApplicationData> CreateApplicationData(::flatbuffers::FlatBufferBuilder &_fbb, const ApplicationDataT *_o, const ::flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
+
+inline bool operator==(const ApplicationDataT &lhs, const ApplicationDataT &rhs) {
+  return
+      (lhs.vectors == rhs.vectors) &&
+      (lhs.vectors_alt == rhs.vectors_alt) &&
+      ((lhs.position == rhs.position) || (lhs.position && rhs.position && *lhs.position == *rhs.position)) &&
+      (lhs.position_inline == rhs.position_inline);
+}
+
+inline bool operator!=(const ApplicationDataT &lhs, const ApplicationDataT &rhs) {
+    return !(lhs == rhs);
+}
+
 
 inline ApplicationDataT::ApplicationDataT(const ApplicationDataT &o)
       : vectors(o.vectors),

--- a/tests/native_type_test_impl.h
+++ b/tests/native_type_test_impl.h
@@ -17,6 +17,10 @@ struct Vector3D {
     this->y = _y;
     this->z = _z;
   }
+
+  bool operator==(const Vector3D &other) const {
+    return (x == other.x) && (y == other.y) && (z == other.z);
+  }
 };
 }  // namespace Native
 


### PR DESCRIPTION
Per the definition of --gen-compare: only generate comparators for object API generated structs. Types annoated with native_type must define their own comparators if `--gen-compare` is enabled.

Also enables --gen-compare for native_type_test and fixes the test by adding a comparator for the Native::Vector3D type.