### PR TITLE
fix(go/grpc): avoid panic on short FlatBuffers input

### DIFF
--- a/go/grpc.go
+++ b/go/grpc.go
@@ -25,7 +25,8 @@ func (FlatbuffersCodec) Marshal(v interface{}) ([]byte, error) {
 
 // Unmarshal parses the wire format into v.
 func (FlatbuffersCodec) Unmarshal(data []byte, v interface{}) error {
-	// Need at least 4 bytes to read the root UOffsetT
+	// Need at least 4 bytes to read the root table offset (UOffsetT).
+	// Vtable soffset_t and metadata are read later during field access.
 	if len(data) < SizeUOffsetT {
 		return ErrInsufficientData
 	}

--- a/go/grpc.go
+++ b/go/grpc.go
@@ -1,7 +1,17 @@
 package flatbuffers
 
-// Codec implements gRPC-go Codec which is used to encode and decode messages.
-var Codec = "flatbuffers"
+import "errors"
+
+var (
+	// Codec implements gRPC-go Codec which is used to encode and decode messages.
+	Codec = "flatbuffers"
+
+	// ErrInsufficientData is returned when the data is too short to read the root UOffsetT.
+	ErrInsufficientData = errors.New("insufficient data")
+
+	// ErrInvalidRootOffset is returned when the root UOffsetT is out of bounds.
+	ErrInvalidRootOffset = errors.New("invalid root offset")
+)
 
 // FlatbuffersCodec defines the interface gRPC uses to encode and decode messages.  Note
 // that implementations of this interface must be thread safe; a Codec's
@@ -15,7 +25,19 @@ func (FlatbuffersCodec) Marshal(v interface{}) ([]byte, error) {
 
 // Unmarshal parses the wire format into v.
 func (FlatbuffersCodec) Unmarshal(data []byte, v interface{}) error {
-	v.(flatbuffersInit).Init(data, GetUOffsetT(data))
+	// Need at least 4 bytes to read the root UOffsetT
+	if len(data) < SizeUOffsetT {
+		return ErrInsufficientData
+	}
+
+	off := GetUOffsetT(data)
+
+	// The root UOffsetT must be within the data buffer
+	if int(off) > len(data)-SizeUOffsetT {
+		return ErrInvalidRootOffset
+	}
+
+	v.(flatbuffersInit).Init(data, off)
 	return nil
 }
 

--- a/go/grpc.go
+++ b/go/grpc.go
@@ -33,7 +33,8 @@ func (FlatbuffersCodec) Unmarshal(data []byte, v interface{}) error {
 	off := GetUOffsetT(data)
 
 	// The root UOffsetT must be within the data buffer
-	if int(off) > len(data)-SizeUOffsetT {
+	// Compare in the unsigned domain to avoid signedness pitfalls
+	if off > UOffsetT(len(data)-SizeUOffsetT) {
 		return ErrInvalidRootOffset
 	}
 


### PR DESCRIPTION
## Motivation

The FlatBuffers Go gRPC codec `go/grpc.go` unconditionally reads the root offset (`UOffsetT`) from incoming message bytes. For inputs shorter than 4 bytes, `GetUint32()` indexes `data[3]`, causing a panic. This is applicable to servers using `FlatbuffersCodec` with gRPC. It is basically an unauthenticated DoS vector.

See panic from the Go greeter [grpc/examples/go/greeter](https://github.com/google/flatbuffers/tree/master/grpc/examples/go/greeter) below. Tested with the latest versions:

- Go 1.25.0 on macOS
- `github.com/google/flatbuffers@v25.2.10+incompatible`
- `google.golang.org/grpc@v1.75.0`

<details>
<summary>Panic output</summary>
<code>
panic: runtime error: index out of range [3] with length 0

goroutine 5 [running]:
github.com/google/flatbuffers/go.GetUint32(...)
        /git/flatbuffers/grpc/examples/go/greeter/server/vendor/github.com/google/flatbuffers/go/encode.go:47
github.com/google/flatbuffers/go.GetUOffsetT(...)
        /git/flatbuffers/grpc/examples/go/greeter/server/vendor/github.com/google/flatbuffers/go/encode.go:121
github.com/google/flatbuffers/go.FlatbuffersCodec.Unmarshal({}, {0x0?, 0x0?, 0x0?}, {0x1051fc500?, 0x1400009a000?})
        /git/flatbuffers/grpc/examples/go/greeter/server/vendor/github.com/google/flatbuffers/go/grpc.go:18 +0xe0
google.golang.org/grpc.codecV0Bridge.Unmarshal({{0x12c3d3e00?, 0x105631ba0?}}, {0x0?, 0x0?, 0x14000187748?}, {0x1051fc500, 0x1400009a000})
        /git/flatbuffers/grpc/examples/go/greeter/server/vendor/google.golang.org/grpc/codec.go:78 +0x78
google.golang.org/grpc.(*Server).processUnaryRPC.func3({0x1051fc500, 0x1400009a000})
        /git/flatbuffers/grpc/examples/go/greeter/server/vendor/google.golang.org/grpc/server.go:1404 +0xb4
github.com/google/flatbuffers/grpc/examples/go/greeter/models._Greeter_SayHello_Handler({0x1051fb900, 0x105631ba0}, {0x105287200, 0x14000090150}, 0x14000094100, 0x0)
        /git/flatbuffers/grpc/examples/go/greeter/server/vendor/github.com/google/flatbuffers/grpc/examples/go/greeter/models/Greeter_grpc.go:105 +0x60
google.golang.org/grpc.(*Server).processUnaryRPC(0x1400021a200, {0x105287200, 0x140000900c0}, 0x14000102240, 0x140002282d0, 0x1055f1bf0, 0x0)
        /git/flatbuffers/grpc/examples/go/greeter/server/vendor/google.golang.org/grpc/server.go:1431 +0xbd0
google.golang.org/grpc.(*Server).handleStream(0x1400021a200, {0x1052874b8, 0x140001aad00}, 0x14000102240)
        /git/flatbuffers/grpc/examples/go/greeter/server/vendor/google.golang.org/grpc/server.go:1842 +0x858
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /git/flatbuffers/grpc/examples/go/greeter/server/vendor/google.golang.org/grpc/server.go:1061 +0x74
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 24
        /git/flatbuffers/grpc/examples/go/greeter/server/vendor/google.golang.org/grpc/server.go:1072 +0x120
</code>
</details>

## Changes

Add a simple length check and validate the root offset stays within the buffer. Return clear errors (insufficient data / invalid root offset) instead of panicking. Errors are exported from the module.

## Alternatives considered

I considered adding the checks to `GetUint32()`. I think performing explicit bounds checks is more targeted in the codec, and probably better w.r.t performance. Open to feedback.

## Other notes

Originally reported to Google OSS VRP. Happy to provide a private PoC & help with CVE if maintainers prefer.