### PR TITLE
Fix issue #8389: any nonzero byte is truthy

### DIFF
--- a/go/encode.go
+++ b/go/encode.go
@@ -25,7 +25,7 @@ func GetByte(buf []byte) byte {
 
 // GetBool decodes a little-endian bool from a byte slice.
 func GetBool(buf []byte) bool {
-	return buf[0] == 1
+	return buf[0] != 0
 }
 
 // GetUint8 decodes a little-endian uint8 from a byte slice.


### PR DESCRIPTION
This patch changes Go's `GetBool()` function to check whether a byte is nonzero rather than checking if a [byte is == 1](https://github.com/google/flatbuffers/blob/8db59321d9f02cdffa30126654059c7d02f70c32/go/encode.go#L28)

This is more consistent with other impls