### PR TITLE
Cleanup All clippy warnings and upgrade bitflags and num_enum

### DIFF
--- a/rust/flatbuffers/Cargo.toml
+++ b/rust/flatbuffers/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://google.github.io/flatbuffers/"
 repository = "https://github.com/google/flatbuffers"
 keywords = ["flatbuffers", "serialization", "zero-copy"]
 categories = ["encoding", "data-structures", "memory-management"]
-rust = "1.51"
+rust-version = "1.51"
 
 [features]
 default = ["std"]
@@ -17,8 +17,11 @@ std = []
 serialize = ["serde"]
 
 [dependencies]
-bitflags = "2.8.0"
+bitflags = "2.9.0"
 serde = { version = "1.0", optional = true }
 
 [build-dependencies]
 rustc_version = "0.4.0"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }

--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -42,6 +42,7 @@ use crate::vtable_writer::VTableWriter;
 ///
 /// The implementation of the allocator must match the defined behavior as described by the
 /// comments.
+#[allow(clippy::len_without_is_empty)]
 pub unsafe trait Allocator: DerefMut<Target = [u8]> {
     /// A type describing allocation failures
     type Error: Display + Debug;
@@ -738,7 +739,7 @@ impl<'fbb, A: Allocator> FlatBufferBuilder<'fbb, A> {
     #[inline]
     fn align(&mut self, len: usize, alignment: PushAlignment) {
         self.track_min_align(alignment.value());
-        let s = self.used_space() as usize;
+        let s = self.used_space();
         self.make_space(padding_bytes(s + len, alignment.value()));
     }
 
@@ -875,6 +876,7 @@ impl ReverseIndex {
     }
 }
 
+#[allow(clippy::suspicious_arithmetic_impl)]
 impl Sub<usize> for ReverseIndex {
     type Output = Self;
 
@@ -883,12 +885,14 @@ impl Sub<usize> for ReverseIndex {
     }
 }
 
+#[allow(clippy::suspicious_arithmetic_impl)]
 impl SubAssign<usize> for ReverseIndex {
     fn sub_assign(&mut self, rhs: usize) {
         *self = *self - rhs;
     }
 }
 
+#[allow(clippy::suspicious_arithmetic_impl)]
 impl Add<usize> for ReverseIndex {
     type Output = Self;
 

--- a/rust/flatbuffers/src/endian_scalar.rs
+++ b/rust/flatbuffers/src/endian_scalar.rs
@@ -147,11 +147,7 @@ pub unsafe fn emplace_scalar<T: EndianScalar>(s: &mut [u8], x: T) {
     );
 
     let x_le = x.to_little_endian();
-    core::ptr::copy_nonoverlapping(
-        &x_le as *const T::Scalar as *const u8,
-        s.as_mut_ptr() as *mut u8,
-        size,
-    );
+    core::ptr::copy_nonoverlapping(&x_le as *const T::Scalar as *const u8, s.as_mut_ptr(), size);
 }
 
 /// Read an EndianScalar from the provided byte slice at the specified location.

--- a/rust/flatbuffers/src/primitives.rs
+++ b/rust/flatbuffers/src/primitives.rs
@@ -108,7 +108,7 @@ impl<T> Deref for WIPOffset<T> {
         &self.0
     }
 }
-impl<'a, T: 'a> WIPOffset<T> {
+impl<T> WIPOffset<T> {
     /// Create a new WIPOffset.
     #[inline]
     pub fn new(o: UOffsetT) -> WIPOffset<T> {

--- a/rust/flatbuffers/src/push.rs
+++ b/rust/flatbuffers/src/push.rs
@@ -39,7 +39,7 @@ pub trait Push: Sized {
     }
 }
 
-impl<'a, T: Push> Push for &'a T {
+impl<T: Push> Push for &T {
     type Output = T::Output;
 
     unsafe fn push(&self, dst: &mut [u8], written_len: usize) {

--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -100,7 +100,7 @@ impl<'a, T: Follow<'a> + 'a> Vector<'a, T> {
         debug_assert!(sz > 0);
         // Safety:
         // Valid vector at time of construction, verified that idx < element count
-        unsafe { T::follow(self.0, self.1 as usize + SIZE_UOFFSET + sz * idx) }
+        unsafe { T::follow(self.0, self.1 + SIZE_UOFFSET + sz * idx) }
     }
 
     #[inline(always)]
@@ -123,11 +123,11 @@ impl<'a, T: Follow<'a> + 'a> Vector<'a, T> {
                 Ordering::Equal => return Some(value),
                 Ordering::Less => left = mid + 1,
                 Ordering::Greater => {
-                  if mid == 0 {
-                    return None;
-                  }
-                  right = mid - 1;
-                },
+                    if mid == 0 {
+                        return None;
+                    }
+                    right = mid - 1;
+                }
             }
         }
 
@@ -313,7 +313,7 @@ impl<'a, T: Follow<'a> + 'a> IntoIterator for Vector<'a, T> {
     }
 }
 
-impl<'a, 'b, T: Follow<'a> + 'a> IntoIterator for &'b Vector<'a, T> {
+impl<'a, T: Follow<'a> + 'a> IntoIterator for &Vector<'a, T> {
     type Item = T::Inner;
     type IntoIter = VectorIter<'a, T>;
     fn into_iter(self) -> Self::IntoIter {

--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -164,13 +164,13 @@ impl core::fmt::Display for InvalidFlatbuffer {
                     position, soffset, error_trace
                 )?;
             }
-            InvalidFlatbuffer::TooManyTables {} => {
+            InvalidFlatbuffer::TooManyTables => {
                 writeln!(f, "Too many tables.")?;
             }
-            InvalidFlatbuffer::ApparentSizeTooLarge {} => {
+            InvalidFlatbuffer::ApparentSizeTooLarge => {
                 writeln!(f, "Apparent size too large.")?;
             }
-            InvalidFlatbuffer::DepthLimitReached {} => {
+            InvalidFlatbuffer::DepthLimitReached => {
                 writeln!(f, "Nested table depth limit reached.")?;
             }
         }
@@ -560,7 +560,10 @@ impl<'ver, 'opts, 'buf> TableVerifier<'ver, 'opts, 'buf> {
                 )?;
                 Ok(self)
             }
-            _ => InvalidFlatbuffer::new_inconsistent_union(key_field_name.into(), val_field_name.into()),
+            _ => InvalidFlatbuffer::new_inconsistent_union(
+                key_field_name.into(),
+                val_field_name.into(),
+            ),
         }
     }
     pub fn finish(self) -> &'ver mut Verifier<'opts, 'buf> {
@@ -652,7 +655,7 @@ impl<T: Verifiable> Verifiable for Vector<'_, ForwardsUOffset<T>> {
     }
 }
 
-impl<'a> Verifiable for &'a str {
+impl Verifiable for &str {
     #[inline]
     fn run_verifier(v: &mut Verifier, pos: usize) -> Result<()> {
         let range = verify_vector_range::<u8>(v, pos)?;

--- a/rust/flatbuffers/src/vtable_writer.rs
+++ b/rust/flatbuffers/src/vtable_writer.rs
@@ -81,7 +81,7 @@ impl<'a> VTableWriter<'a> {
     pub fn clear(&mut self) {
         // This is the closest thing to memset in Rust right now.
         let len = self.buf.len();
-        let p = self.buf.as_mut_ptr() as *mut u8;
+        let p = self.buf.as_mut_ptr();
 
         // Safety:
         // p is byte aligned and of length `len`

--- a/rust/flexbuffers/Cargo.toml
+++ b/rust/flexbuffers/Cargo.toml
@@ -24,5 +24,5 @@ deserialize_human_readable = []
 serde = "1.0.119"
 serde_derive = "1.0.119"
 byteorder = "1.4.2"
-num_enum = "0.5.1"
-bitflags = "1.2.1"
+num_enum = "0.7.4"
+bitflags = "2.9.0"

--- a/rust/flexbuffers/src/bitwidth.rs
+++ b/rust/flexbuffers/src/bitwidth.rs
@@ -32,7 +32,9 @@ use std::slice::Iter;
     num_enum::TryFromPrimitive,
 )]
 #[repr(u8)]
+#[derive(Default)]
 pub enum BitWidth {
+    #[default]
     W8 = 0,
     W16 = 1,
     W32 = 2,
@@ -56,25 +58,19 @@ impl BitWidth {
     }
 }
 
-impl Default for BitWidth {
-    fn default() -> Self {
-        W8
-    }
-}
-
 // TODO(cneo): Overloading with `from` is probably not the most readable idea in hindsight.
 macro_rules! impl_bitwidth_from {
     ($from: ident, $w64: ident, $w32: ident, $w16: ident, $w8: ident) => {
         impl From<$from> for BitWidth {
             fn from(x: $from) -> BitWidth {
                 let x = x as $w64;
-                if x >= $w8::min_value() as $w64 && x <= $w8::max_value() as $w64 {
+                if x >= $w8::MIN as $w64 && x <= $w8::MAX as $w64 {
                     return W8;
                 }
-                if x >= $w16::min_value() as $w64 && x <= $w16::max_value() as $w64 {
+                if x >= $w16::MIN as $w64 && x <= $w16::MAX as $w64 {
                     return W16;
                 }
-                if x >= $w32::min_value() as $w64 && x <= $w32::max_value() as $w64 {
+                if x >= $w32::MIN as $w64 && x <= $w32::MAX as $w64 {
                     return W32;
                 }
                 W64
@@ -107,7 +103,7 @@ pub fn align(buffer: &mut Vec<u8>, width: BitWidth) {
     let bytes = 1 << width as u8;
     let alignment = (bytes - buffer.len() % bytes) % bytes;
     // Profiling reveals the loop is faster than Vec::resize.
-    for _ in 0..alignment as usize {
+    for _ in 0..alignment {
         buffer.push(0);
     }
 }

--- a/rust/flexbuffers/src/builder/map.rs
+++ b/rust/flexbuffers/src/builder/map.rs
@@ -43,7 +43,7 @@ impl<'a> MapBuilder<'a> {
     ///
     /// This will panic (in debug mode) if `key` contains internal nulls.
     #[inline]
-    pub fn start_vector(&mut self, key: &str) -> VectorBuilder {
+    pub fn start_vector(&mut self, key: &str) -> VectorBuilder<'_> {
         // Push the key that refers to this nested vector.
         self.builder.push_key(key);
         // Nested vector.
@@ -58,7 +58,7 @@ impl<'a> MapBuilder<'a> {
     ///
     /// This will panic (in debug mode) if `key` contains internal nulls.
     #[inline]
-    pub fn start_map(&mut self, key: &str) -> MapBuilder {
+    pub fn start_map(&mut self, key: &str) -> MapBuilder<'_> {
         // Push the key that refers to this nested vector.
         self.builder.push_key(key);
         // Nested map.

--- a/rust/flexbuffers/src/builder/mod.rs
+++ b/rust/flexbuffers/src/builder/mod.rs
@@ -111,11 +111,11 @@ struct CachedKey(usize);
 /// with  one of the following functions.
 /// * `build_singleton` will push 1 value to the buffer and serialize it as the root.
 /// * `start_vector` returns a `VectorBuilder`, into which many (potentially
-/// heterogenous) values can be pushed. The vector itself is the root and is serialized
-/// when the `VectorBuilder` is dropped (or `end` is called).
+///   heterogenous) values can be pushed. The vector itself is the root and is serialized
+///   when the `VectorBuilder` is dropped (or `end` is called).
 /// * `start_map` returns a `MapBuilder`, which is similar to a `VectorBuilder` except
-/// every value must be pushed with an associated key. The map is serialized when the
-/// `MapBuilder` is dropped (or `end` is called).
+///   every value must be pushed with an associated key. The map is serialized when the
+///   `MapBuilder` is dropped (or `end` is called).
 ///
 /// These functions reset and overwrite the Builder which means, while there are no
 /// active `MapBuilder` or `VectorBuilder`, the internal buffer is empty or contains a

--- a/rust/flexbuffers/src/builder/push.rs
+++ b/rust/flexbuffers/src/builder/push.rs
@@ -31,8 +31,8 @@ impl Sealed for () {}
 /// with both a length and null terminator.
 ///
 /// * For convenience and speed push typed vectors using rust arrays and slices.
-/// Doing so will immediately serialize the data, skipping the `Builder`'s
-/// internal cache.
+///   Doing so will immediately serialize the data, skipping the `Builder`'s
+///   internal cache.
 ///
 /// * Pushable cannot not be implemented by any downstream crates.
 pub trait Pushable: Sealed + Sized {

--- a/rust/flexbuffers/src/builder/ser.rs
+++ b/rust/flexbuffers/src/builder/ser.rs
@@ -101,9 +101,9 @@ impl ser::Error for Error {
 impl ser::SerializeSeq for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         value.serialize(&mut **self)
     }
@@ -116,15 +116,15 @@ impl ser::SerializeSeq for &mut FlexbufferSerializer {
 impl ser::SerializeMap for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         key.serialize(MapKeySerializer(self))
     }
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         value.serialize(&mut **self)
     }
@@ -135,9 +135,9 @@ impl ser::SerializeMap for &mut FlexbufferSerializer {
 impl ser::SerializeTuple for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         value.serialize(&mut **self)
     }
@@ -148,9 +148,9 @@ impl ser::SerializeTuple for &mut FlexbufferSerializer {
 impl ser::SerializeTupleStruct for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         value.serialize(&mut **self)
     }
@@ -161,13 +161,9 @@ impl ser::SerializeTupleStruct for &mut FlexbufferSerializer {
 impl ser::SerializeStruct for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.builder.push_key(key);
         value.serialize(&mut **self)
@@ -179,9 +175,9 @@ impl ser::SerializeStruct for &mut FlexbufferSerializer {
 impl ser::SerializeTupleVariant for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         value.serialize(&mut **self)
     }
@@ -193,13 +189,9 @@ impl ser::SerializeTupleVariant for &mut FlexbufferSerializer {
 impl ser::SerializeStructVariant for &mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.builder.push_key(key);
         value.serialize(&mut **self)
@@ -222,7 +214,7 @@ impl<'a> ser::Serializer for &'a mut FlexbufferSerializer {
     type Ok = ();
     type Error = Error;
     fn is_human_readable(&self) -> bool {
-        cfg!(serialize_human_readable)
+        cfg!(feature = "serialize_human_readable")
     }
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
         self.builder.push(v);
@@ -284,9 +276,9 @@ impl<'a> ser::Serializer for &'a mut FlexbufferSerializer {
         self.builder.push(());
         self.finish_if_not_nested()
     }
-    fn serialize_some<T: ?Sized>(self, t: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, t: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         t.serialize(self)
     }
@@ -307,17 +299,17 @@ impl<'a> ser::Serializer for &'a mut FlexbufferSerializer {
         self.builder.push(variant);
         self.finish_if_not_nested()
     }
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         value.serialize(self)
     }
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -325,7 +317,7 @@ impl<'a> ser::Serializer for &'a mut FlexbufferSerializer {
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.start_map();
         self.builder.push_key(variant);
@@ -409,13 +401,9 @@ impl<'a> Serializer for MapKeySerializer<'a> {
         Ok(())
     }
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(
-        self,
-        _name: &'static str,
-        value: &T,
-    ) -> Result<(), Error>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<(), Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         value.serialize(self)
     }
@@ -472,7 +460,7 @@ impl<'a> Serializer for MapKeySerializer<'a> {
     fn serialize_unit_struct(self, _name: &'static str) -> Result<(), Error> {
         key_must_be_a_string()
     }
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -480,16 +468,16 @@ impl<'a> Serializer for MapKeySerializer<'a> {
         _value: &T,
     ) -> Result<(), Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         key_must_be_a_string()
     }
     fn serialize_none(self) -> Result<(), Error> {
         key_must_be_a_string()
     }
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<(), Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<(), Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         key_must_be_a_string()
     }

--- a/rust/flexbuffers/src/builder/vector.rs
+++ b/rust/flexbuffers/src/builder/vector.rs
@@ -36,7 +36,7 @@ impl<'a> VectorBuilder<'a> {
     }
     /// Starts a nested vector that will be pushed onto this vector when it is dropped.
     #[inline]
-    pub fn start_vector(&mut self) -> VectorBuilder {
+    pub fn start_vector(&mut self) -> VectorBuilder<'_> {
         let start = Some(self.builder.values.len());
         VectorBuilder {
             builder: self.builder,
@@ -45,7 +45,7 @@ impl<'a> VectorBuilder<'a> {
     }
     /// Starts a nested map that will be pushed onto this vector when it is dropped.
     #[inline]
-    pub fn start_map(&mut self) -> MapBuilder {
+    pub fn start_map(&mut self) -> MapBuilder<'_> {
         let start = Some(self.builder.values.len());
         MapBuilder {
             builder: self.builder,

--- a/rust/flexbuffers/src/flexbuffer_type.rs
+++ b/rust/flexbuffers/src/flexbuffer_type.rs
@@ -24,21 +24,23 @@
 ///
 /// ### Notes:
 /// * In the binary format, Each element of a `Map` or (heterogenous) `Vector`
-/// is stored with a byte describing its FlexBufferType and BitWidth.
+///   is stored with a byte describing its FlexBufferType and BitWidth.
 ///
 /// * Typed vectors do not store this extra type information and fixed length
-/// typed vectors do not store length. Whether a vector is stored as a typed
-/// vector or fixed length typed vector is determined dymaically from the
-/// given data.
+///   typed vectors do not store length. Whether a vector is stored as a typed
+///   vector or fixed length typed vector is determined dymaically from the
+///   given data.
 ///
 /// * Indirect numbers are stored as an offset instead of inline. Using
-/// indirect numbers instead of their inline counterparts in maps and typed
-/// vectors can reduce the minimum element width and therefore bytes used.
-
+///   indirect numbers instead of their inline counterparts in maps and typed
+///   vectors can reduce the minimum element width and therefore bytes used.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, num_enum::TryFromPrimitive)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default, num_enum::TryFromPrimitive,
+)]
 pub enum FlexBufferType {
     /// Nulls are represented with `()` in Rust.
+    #[default]
     Null = 0,
     /// Variable width signed integer: `i8, i16, i32, i64`
     Int = 1,
@@ -103,12 +105,6 @@ pub enum FlexBufferType {
     Blob = 25,
 }
 use FlexBufferType::*;
-
-impl Default for FlexBufferType {
-    fn default() -> Self {
-        Null
-    }
-}
 
 macro_rules! is_ty {
     ($is_T: ident, $FTy: ident) => {

--- a/rust/flexbuffers/src/reader/de.rs
+++ b/rust/flexbuffers/src/reader/de.rs
@@ -163,7 +163,7 @@ impl<'de> VariantAccess<'de> for Reader<&'de [u8]> {
 impl<'de> Deserializer<'de> for Reader<&'de [u8]> {
     type Error = DeserializationError;
     fn is_human_readable(&self) -> bool {
-        cfg!(deserialize_human_readable)
+        cfg!(feature = "deserialize_human_readable")
     }
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/rust/flexbuffers/src/reader/map.rs
+++ b/rust/flexbuffers/src/reader/map.rs
@@ -155,8 +155,7 @@ impl<B: Buffer> MapReader<B> {
     /// Iterate over the keys of the map.
     pub fn iter_keys(
         &self,
-    ) -> impl Iterator<Item = B::BufferString> + DoubleEndedIterator + ExactSizeIterator + FusedIterator
-    {
+    ) -> impl DoubleEndedIterator<Item = B::BufferString> + ExactSizeIterator + FusedIterator {
         self.keys_vector().iter().map(|k| k.as_str())
     }
 

--- a/rust/flexbuffers/src/reader/mod.rs
+++ b/rust/flexbuffers/src/reader/mod.rs
@@ -26,7 +26,7 @@ mod serialize;
 mod vector;
 pub use de::DeserializationError;
 pub use iter::ReaderIterator;
-pub use map::{MapReader, MapReaderIndexer};
+pub use map::MapReader;
 pub use vector::VectorReader;
 
 /// All the possible errors when reading a flexbuffer.
@@ -139,11 +139,11 @@ macro_rules! as_default {
 /// by calling `get_root` on your flexbuffer `&[u8]`.
 ///
 /// - The `get_T` methods return a `Result<T, Error>`. They return an OK value if and only if the
-/// flexbuffer type matches `T`. This is analogous to the behavior of Rust's json library, though
-/// with Result instead of Option.
+///   flexbuffer type matches `T`. This is analogous to the behavior of Rust's json library, though
+///   with Result instead of Option.
 /// - The `as_T` methods will try their best to return to a value of type `T`
-/// (by casting or even parsing a string if necessary) but ultimately returns `T::default` if it
-/// fails. This behavior is analogous to that of flexbuffers C++.
+///   (by casting or even parsing a string if necessary) but ultimately returns `T::default` if it
+///   fails. This behavior is analogous to that of flexbuffers C++.
 pub struct Reader<B> {
     fxb_type: FlexBufferType,
     width: BitWidth,
@@ -429,7 +429,7 @@ impl<B: Buffer> Reader<B> {
             .buffer
             .get(self.address..self.address + self.width.n_bytes());
         match self.width {
-            BitWidth::W8 => cursor.map(|s| s[0] as u8).map(Into::into),
+            BitWidth::W8 => cursor.map(|s| s[0]).map(Into::into),
             BitWidth::W16 => cursor
                 .and_then(|s| s.try_into().ok())
                 .map(<u16>::from_le_bytes)
@@ -492,7 +492,7 @@ impl<B: Buffer> Reader<B> {
             Bool => self.get_bool().unwrap_or_default(),
             UInt => self.as_u64() != 0,
             Int => self.as_i64() != 0,
-            Float => self.as_f64().abs() > std::f64::EPSILON,
+            Float => self.as_f64().abs() > f64::EPSILON,
             String | Key => !self.as_str().is_empty(),
             Null => false,
             Blob => self.length() != 0,

--- a/rust/reflection/src/reflection_verifier.rs
+++ b/rust/reflection/src/reflection_verifier.rs
@@ -340,16 +340,14 @@ fn verify_vector<'a, 'b, 'c>(
             }
             Ok(table_verifier)
         }
-        _ => {
-            return Err(FlatbufferError::TypeNotSupported(
-                field
-                    .type_()
-                    .base_type()
-                    .variant_name()
-                    .unwrap_or_default()
-                    .to_string(),
-            ))
-        }
+        _ => Err(FlatbufferError::TypeNotSupported(
+            field
+                .type_()
+                .base_type()
+                .variant_name()
+                .unwrap_or_default()
+                .to_string(),
+        )),
     }
 }
 

--- a/tests/rust_usage_test/bin/flatbuffers_alloc_check.rs
+++ b/tests/rust_usage_test/bin/flatbuffers_alloc_check.rs
@@ -3,7 +3,6 @@
 // global variable).
 use std::alloc::{GlobalAlloc, Layout, System};
 
-
 static mut N_ALLOCS: usize = 0;
 
 struct TrackingAllocator;
@@ -55,7 +54,7 @@ fn create_serialized_example_with_generated_code(builder: &mut flatbuffers::Flat
             builder.create_string("check"),
             builder.create_string("the"),
             builder.create_string("create_vector_of_strings"),
-            builder.create_string("function")
+            builder.create_string("function"),
         ];
         let _ = builder.create_vector(&strings);
 
@@ -88,7 +87,7 @@ fn create_serialized_example_with_generated_code(builder: &mut flatbuffers::Flat
                         ..Default::default()
                     },
                 )
-                    .as_union_value(),
+                .as_union_value(),
             ),
             inventory: Some(builder.create_vector(&[0u8, 1, 2, 3, 4])),
             test4: Some(builder.create_vector(&[
@@ -103,7 +102,7 @@ fn create_serialized_example_with_generated_code(builder: &mut flatbuffers::Flat
     my_game::example::finish_monster_buffer(builder, mon);
 }
 
-#[cfg(not(miri))]  // slow.
+#[cfg(not(miri))] // slow.
 fn main() {
     // test the allocation tracking:
     {
@@ -146,10 +145,10 @@ fn main() {
             // We know the bits should be exactly equal here but compilers may
             // optimize floats in subtle ways so we're playing it safe and using
             // epsilon comparison
-            assert!((pos.x() - 1.0f32).abs() < std::f32::EPSILON);
-            assert!((pos.y() - 2.0f32).abs() < std::f32::EPSILON);
-            assert!((pos.z() - 3.0f32).abs() < std::f32::EPSILON);
-            assert!((pos.test1() - 3.0f64).abs() < std::f64::EPSILON);
+            assert!((pos.x() - 1.0f32).abs() < f32::EPSILON);
+            assert!((pos.y() - 2.0f32).abs() < f32::EPSILON);
+            assert!((pos.z() - 3.0f32).abs() < f32::EPSILON);
+            assert!((pos.test1() - 3.0f64).abs() < f64::EPSILON);
             assert_eq!(pos.test2(), my_game::example::Color::Green);
             let pos_test3 = pos.test3();
             assert_eq!(pos_test3.a(), 5i16);


### PR DESCRIPTION
This PR includes a general cleanup of the rust code itself.
1. Cleaning up all clippy warnings
2. Trying to upgrade the dependencies in flexbuffers - this might cause a failure which I'm interested in seeing, because locally I couldn't reproduce anything, but this change can be easily reverted.
