### PR TITLE
Remove invalid JsonSchemaGenerator c'tor

### DIFF
--- a/src/idl_gen_json_schema.cpp
+++ b/src/idl_gen_json_schema.cpp
@@ -153,9 +153,6 @@ class JsonSchemaGenerator : public BaseGenerator {
                       const std::string &file_name)
       : BaseGenerator(parser, path, file_name, "", "", "json") {}
 
-  explicit JsonSchemaGenerator(const BaseGenerator &base_generator)
-      : BaseGenerator(base_generator) {}
-
   std::string GeneratedFileName(const std::string &path,
                                 const std::string &file_name,
                                 const IDLOptions &options /* unused */) const {


### PR DESCRIPTION
`BaseGenerator` does not implement a copy c'tor (see `code_generators.h` line 118, the comment suggests this is intentional), so this `JsonSchemaGenerator` c'tor fails to compile without optimizations.
```
ld64.lld: error: undefined symbol: flatbuffers::BaseGenerator::BaseGenerator(flatbuffers::BaseGenerator const&)
>>> referenced by /Users/tal/proj/k2dqsc.git/external/flatbuffers.git/src/idl_gen_json_schema.cpp
>>>               flatbuffers_build/CMakeFiles/flatc.dir/src/idl_gen_json_schema.cpp.o:(symbol flatbuffers::jsons::JsonSchemaGenerator::JsonSchemaGenerator(flatbuffers::BaseGenerator const&)+0x20)
```