### PR TITLE
[Swift] Fixes windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -526,8 +526,6 @@ jobs:
       - uses: SwiftyLab/setup-swift@latest
         with:
           swift-version: '6.1'
-          # To be removed when swiftylab fixes the CI
-          visual-studio-components: Microsoft.VisualStudio.Component.Windows11SDK.22621
       - run: swift build
       - run: swift test
 


### PR DESCRIPTION
This addresses #8686 and reverts the CI back to use the proper CI values

closes #8686
