### PR TITLE
Refactor CallbackService class output in cpp_generator

### DIFF
--- a/grpc/src/compiler/cpp_generator.cc
+++ b/grpc/src/compiler/cpp_generator.cc
@@ -1122,16 +1122,12 @@ static void PrintHeaderService(grpc_generator::Printer* printer,
   }
   printer->Print(" StreamedService;\n");
 
-  printer->Outdent();
-  printer->Print("};\n");
-  printer->Print(service->GetTrailingComments("//").c_str());
-
   // Optional CallbackService (modern async API)
   if ((*vars)["generate_callback_api"] == "1") {
     (*vars)["Service"] = service->name();
     printer->Print("\n#if defined(GRPC_CALLBACK_API_NONEXPERIMENTAL)\n");
     printer->Print(*vars,
-                   "class $Service$::CallbackService : public ::grpc::Service "
+                   "class CallbackService : public ::grpc::Service "
                    "{\n public:\n  CallbackService();\n  virtual "
                    "~CallbackService();\n");
     printer->Indent();
@@ -1167,6 +1163,10 @@ static void PrintHeaderService(grpc_generator::Printer* printer,
         "};\n#else\n// Callback API requested but not available in this gRPC "
         "version.\n#endif // GRPC_CALLBACK_API_NONEXPERIMENTAL\n");
   }
+
+  printer->Outdent();
+  printer->Print("};\n");
+  printer->Print(service->GetTrailingComments("//").c_str());
 }
 
 }  // namespace


### PR DESCRIPTION
Moves the CallbackService class 'up' into the main gRPC Service class

Currently, if the `--grpc-callback-api` flag is passed to flatc, the $SERVICE$::CallbackService class is defined _outside_ the main $SERVICE$ class. `gcc` (maybe others?) does not like the generated `.grpc.fb.h` file.

This PR moves the callback class 'up' into the main $SERVICE$ class.