### PR TITLE
[Dart] Fix struct vector ordering in pack function

### DIFF
--- a/dart/test/monster_test_my_game.example_generated.dart
+++ b/dart/test/monster_test_my_game.example_generated.dart
@@ -1578,7 +1578,7 @@ class MonsterT implements fb.Packable {
     final int? testOffset = test?.pack(fbBuilder);
     int? test4Offset;
     if (test4 != null) {
-      for (var e in test4!) {
+      for (var e in test4!.reversed) {
         e.pack(fbBuilder);
       }
       test4Offset = fbBuilder.endStructVector(test4!.length);
@@ -1608,7 +1608,7 @@ class MonsterT implements fb.Packable {
           );
     int? testarrayofsortedstructOffset;
     if (testarrayofsortedstruct != null) {
-      for (var e in testarrayofsortedstruct!) {
+      for (var e in testarrayofsortedstruct!.reversed) {
         e.pack(fbBuilder);
       }
       testarrayofsortedstructOffset = fbBuilder.endStructVector(
@@ -1620,7 +1620,7 @@ class MonsterT implements fb.Packable {
         : fbBuilder.writeListUint8(flex!);
     int? test5Offset;
     if (test5 != null) {
-      for (var e in test5!) {
+      for (var e in test5!.reversed) {
         e.pack(fbBuilder);
       }
       test5Offset = fbBuilder.endStructVector(test5!.length);

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -1025,8 +1025,8 @@ class DartGenerator : public BaseGenerator {
           field.value.type.struct_def->fixed) {
         code += "    int? " + offset_name + ";\n";
         code += "    if (" + field_name + " != null) {\n";
-        code +=
-            "      for (var e in " + field_name + "!) { e.pack(fbBuilder); }\n";
+        code += "      for (var e in " + field_name +
+                "!.reversed) { e.pack(fbBuilder); }\n";
         code += "      " + namer_.Variable(field) +
                 "Offset = fbBuilder.endStructVector(" + field_name +
                 "!.length);\n";

--- a/tests/monster_test_my_game.example_generated.dart
+++ b/tests/monster_test_my_game.example_generated.dart
@@ -1412,7 +1412,7 @@ class MonsterT implements fb.Packable {
     final int? testOffset = test?.pack(fbBuilder);
     int? test4Offset;
     if (test4 != null) {
-      for (var e in test4!) { e.pack(fbBuilder); }
+      for (var e in test4!.reversed) { e.pack(fbBuilder); }
       test4Offset = fbBuilder.endStructVector(test4!.length);
     }
     final int? testarrayofstringOffset = testarrayofstring == null ? null
@@ -1429,14 +1429,14 @@ class MonsterT implements fb.Packable {
         : fbBuilder.writeList(testarrayofstring2!.map(fbBuilder.writeString).toList());
     int? testarrayofsortedstructOffset;
     if (testarrayofsortedstruct != null) {
-      for (var e in testarrayofsortedstruct!) { e.pack(fbBuilder); }
+      for (var e in testarrayofsortedstruct!.reversed) { e.pack(fbBuilder); }
       testarrayofsortedstructOffset = fbBuilder.endStructVector(testarrayofsortedstruct!.length);
     }
     final int? flexOffset = flex == null ? null
         : fbBuilder.writeListUint8(flex!);
     int? test5Offset;
     if (test5 != null) {
-      for (var e in test5!) { e.pack(fbBuilder); }
+      for (var e in test5!.reversed) { e.pack(fbBuilder); }
       test5Offset = fbBuilder.endStructVector(test5!.length);
     }
     final int? vectorOfLongsOffset = vectorOfLongs == null ? null


### PR DESCRIPTION
* Fix the order of elements when packing a vector of structs