### PR TITLE
fix(rust: builder): add lifetime bounds to finish methods

### DIFF
--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -773,7 +773,10 @@ impl<'fbb, A: Allocator> FlatBufferBuilder<'fbb, A> {
         &mut self,
         root: WIPOffset<T>,
         file_identifier: Option<&str>,
-    ) -> Result<(), A::Error> {
+    ) -> Result<(), A::Error>
+    where
+        T: 'fbb,
+    {
         self.finish_with_opts(root, file_identifier, true)
     }
 
@@ -782,7 +785,10 @@ impl<'fbb, A: Allocator> FlatBufferBuilder<'fbb, A> {
     /// internal state of the FlatBufferBuilder as `finished`. Afterwards,
     /// users can call `finished_data` to get the resulting data.
     #[inline]
-    pub fn finish_size_prefixed<T>(&mut self, root: WIPOffset<T>, file_identifier: Option<&str>) {
+    pub fn finish_size_prefixed<T>(&mut self, root: WIPOffset<T>, file_identifier: Option<&str>)
+    where
+        T: 'fbb,
+    {
         self.try_finish_size_prefixed(root, file_identifier)
             .expect("Flatbuffer allocation failure")
     }
@@ -793,7 +799,10 @@ impl<'fbb, A: Allocator> FlatBufferBuilder<'fbb, A> {
         &mut self,
         root: WIPOffset<T>,
         file_identifier: Option<&str>,
-    ) -> Result<(), A::Error> {
+    ) -> Result<(), A::Error>
+    where
+        T: 'fbb,
+    {
         self.finish_with_opts(root, file_identifier, false)
     }
 
@@ -802,14 +811,20 @@ impl<'fbb, A: Allocator> FlatBufferBuilder<'fbb, A> {
     /// FlatBufferBuilder as `finished`. Afterwards, users can call
     /// `finished_data` to get the resulting data.
     #[inline]
-    pub fn finish<T>(&mut self, root: WIPOffset<T>, file_identifier: Option<&str>) {
+    pub fn finish<T>(&mut self, root: WIPOffset<T>, file_identifier: Option<&str>)
+    where
+        T: 'fbb,
+    {
         self.try_finish(root, file_identifier)
             .expect("Flatbuffer allocation failure")
     }
 
     /// Fallible version of [`finish_minimal`](Self::finish_minimal).
     #[inline]
-    pub fn try_finish_minimal<T>(&mut self, root: WIPOffset<T>) -> Result<(), A::Error> {
+    pub fn try_finish_minimal<T>(&mut self, root: WIPOffset<T>) -> Result<(), A::Error>
+    where
+        T: 'fbb,
+    {
         self.finish_with_opts(root, None, false)
     }
 
@@ -817,7 +832,10 @@ impl<'fbb, A: Allocator> FlatBufferBuilder<'fbb, A> {
     /// of the FlatBufferBuilder as `finished`. Afterwards, users can call
     /// `finished_data` to get the resulting data.
     #[inline]
-    pub fn finish_minimal<T>(&mut self, root: WIPOffset<T>) {
+    pub fn finish_minimal<T>(&mut self, root: WIPOffset<T>)
+    where
+        T: 'fbb,
+    {
         self.try_finish_minimal(root)
             .expect("Flatbuffer allocation failure")
     }
@@ -978,7 +996,10 @@ impl<'fbb, A: Allocator> FlatBufferBuilder<'fbb, A> {
         root: WIPOffset<T>,
         file_identifier: Option<&str>,
         size_prefixed: bool,
-    ) -> Result<(), A::Error> {
+    ) -> Result<(), A::Error>
+    where
+        T: 'fbb,
+    {
         self.assert_not_finished("buffer cannot be finished when it is already finished");
         self.assert_not_nested(
             "buffer cannot be finished when a table or vector is under construction",


### PR DESCRIPTION
This change addresses a reported issue where a FlatBufferBuilder could be finished with a WIPOffset created by a different builder.

Calling builder1.finish(offset_from_builder2) would compile but result in a runtime panic or data corruption, as the offset is meaningless in builder1's buffer.

The fix enforces the builder's lifetime ('fbb) on the generic type T of the WIPOffset in all finish methods (finish, finish_minimal, finish_size_prefixed, and finish_with_opts).

https://github.com/google/flatbuffers/issues/8698