### PR TITLE
[Swift] Bump minimum supported version of swift to 5.10

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -10,7 +10,7 @@ tasks:
     bazel: ${{ bazel }}
     environment:
       CC: clang
-      SWIFT_VERSION: "5.9"
+      SWIFT_VERSION: "5.10"
       SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
       PATH: "$PATH:$SWIFT_HOME/usr/bin"
     shell_commands:
@@ -26,7 +26,7 @@ tasks:
     bazel: ${{ bazel }}
     environment:
       CC: clang
-      SWIFT_VERSION: "5.9"
+      SWIFT_VERSION: "5.10"
       SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
       PATH: "$PATH:$SWIFT_HOME/usr/bin"
     shell_commands:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -503,7 +503,7 @@ jobs:
     name: Test Swift
     strategy:
       matrix:
-        swift: ["5.9", "5.10", "6.1"]
+        swift: ["5.10", "6.1", "6.2"]
     # Only 22.04 has swift at the moment https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md?plain=1#L30
     runs-on: ubuntu-22.04
     steps:

--- a/FlatBuffers.podspec
+++ b/FlatBuffers.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.14'
 
-  s.swift_version = '5.0'
+  s.swift_version = '5.10'
   s.source_files = 'swift/Sources/Flatbuffers/*.swift'
   s.pod_target_xcconfig = {
     'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 /*
  * Copyright 2020 Google Inc. All rights reserved.
  *

--- a/benchmarks/swift/Package.swift
+++ b/benchmarks/swift/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 /*
  * Copyright 2020 Google Inc. All rights reserved.
  *

--- a/grpc/examples/swift/Greeter/Package.swift
+++ b/grpc/examples/swift/Greeter/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 /*
  * Copyright 2020 Google Inc. All rights reserved.
  *

--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -478,7 +478,7 @@ public struct FlatBufferBuilder {
     return endVector(len: size)
   }
 
-  #if swift(>=5.0) && !os(WASI)
+  #if !os(WASI)
   @inline(__always)
   /// Creates a vector of bytes in the buffer.
   ///

--- a/swift/Sources/FlatBuffers/_InternalByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/_InternalByteBuffer.swift
@@ -143,7 +143,7 @@ struct _InternalByteBuffer {
 
   /// Adds a `ContiguousBytes` to buffer memory
   /// - Parameter value: bytes to copy
-  #if swift(>=5.0) && !os(WASI)
+  #if !os(WASI)
   @inline(__always)
   @usableFromInline
   mutating func push(bytes: ContiguousBytes) {

--- a/tests/swift/Wasm.tests/Package.swift
+++ b/tests/swift/Wasm.tests/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 /*
  * Copyright 2020 Google Inc. All rights reserved.
  *

--- a/tests/swift/fuzzer/Package.swift
+++ b/tests/swift/fuzzer/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 /*
  * Copyright 2020 Google Inc. All rights reserved.
  *


### PR DESCRIPTION
Bump minimum supported version of swift to 5.10 and replace 5.9 with 6.2 on the CI