### PR TITLE
[Swift] Improves the performance creating strings

### DIFF
--- a/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
+++ b/swift/Sources/FlatBuffers/FlatBufferBuilder.swift
@@ -207,7 +207,9 @@ public struct FlatBufferBuilder {
       len: size &+ (prefix ? size : 0) &+ FileIdLength,
       alignment: _minAlignment)
     assert(fileId.count == FileIdLength, "Flatbuffers requires file id to be 4")
-    _bb.push(string: fileId, len: 4)
+    fileId.withCString { ptr in
+      _bb.writeBytes(ptr, len: 4)
+    }
     finish(offset: offset, addPrefix: prefix)
   }
 
@@ -706,8 +708,9 @@ public struct FlatBufferBuilder {
     let len = str.utf8.count
     notNested()
     preAlign(len: len &+ 1, type: UOffset.self)
-    _bb.fill(padding: 1)
-    _bb.push(string: str, len: len)
+    str.withCString { ptr in
+      _bb.writeBytes(ptr, len: len &+ 1)
+    }
     push(element: UOffset(len))
     return Offset(offset: _bb.size)
   }

--- a/swift/Sources/FlatBuffers/_InternalByteBuffer.swift
+++ b/swift/Sources/FlatBuffers/_InternalByteBuffer.swift
@@ -192,41 +192,17 @@ struct _InternalByteBuffer {
     }
   }
 
-  /// Adds a string to the buffer using swift.utf8 object
-  /// - Parameter str: String that will be added to the buffer
-  /// - Parameter len: length of the string
+  /// Adds a RawPointer into the buffer
+  /// - Parameter pointer: pointer to be copied into the buffer
+  /// - Parameter len: length of the data
   @inline(__always)
-  @usableFromInline
-  mutating func push(string str: String, len: Int) {
+  mutating func writeBytes(_ ptr: UnsafeRawPointer, len: Int) {
     ensureSpace(size: len)
-    if str.utf8
-      .withContiguousStorageIfAvailable({ self.push(bytes: $0, len: len) }) !=
-      nil
-    {
-    } else {
-      let utf8View = str.utf8
-      for c in utf8View.reversed() {
-        push(value: c, len: 1)
-      }
-    }
-  }
-
-  /// Writes a string to Bytebuffer using UTF8View
-  /// - Parameters:
-  ///   - bytes: Pointer to the view
-  ///   - len: Size of string
-  @usableFromInline
-  @inline(__always)
-  mutating func push(
-    bytes: UnsafeBufferPointer<String.UTF8View.Element>,
-    len: Int) -> Bool
-  {
     memcpy(
       _storage.memory.advanced(by: writerIndex &- len),
-      bytes.baseAddress!,
+      ptr,
       len)
     _writerSize = _writerSize &+ len
-    return true
   }
 
   /// Write stores an object into the buffer directly or indirectly.


### PR DESCRIPTION
Improves the performance of the implementation in Swift by using `withCString` instead of the `withContiguousStorageIfAvailable`. We already use the `withCString` in the FlexBuffers implementation. So adding it to FlatBuffers was a no-brainer. 