### PR TITLE
[Python] Fix inconsistent creator function naming in generated code

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -1239,7 +1239,7 @@ class PythonGenerator : public BaseGenerator {
     auto& code = *code_ptr;
 
     code += "\n";
-    code += "def Create" + namer_.Type(struct_def);
+    code += "def Create" + namer_.Function(struct_def);
     code += "(builder";
   }
 


### PR DESCRIPTION
fixes #8791 