### PR TITLE
Revival of GH-8285: fix: remove a single type hint to retain python 2.7.x compatibility

### DIFF
--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -163,7 +163,7 @@ class Builder(object):
     ## @endcond
     self.finished = False
 
-  def Clear(self) -> None:
+  def Clear(self):
     ## @cond FLATBUFFERS_INTERNAL
     self.current_vtable = None
     self.head = UOffsetTFlags.py_type(len(self.Bytes))


### PR DESCRIPTION
I have simply pulled forward #8525 with a rebase. Credit for discovery and fix goes to @Homeblest. 

See #8798  for current discussion. 
