### PR TITLE
add assert to fix GCC warning on Ubuntu 24.04 LTS

### DIFF
--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -640,6 +640,7 @@ const uint8_t* AddFlatBuffer(std::vector<uint8_t>& flatbuf,
                              const uint8_t* newbuf, size_t newlen) {
   // Align to sizeof(uoffset_t) past sizeof(largest_scalar_t) since we're
   // going to chop off the root offset.
+  FLATBUFFERS_ASSERT(newlen >= sizeof(uoffset_t));
   while ((flatbuf.size() & (sizeof(uoffset_t) - 1)) ||
          !(flatbuf.size() & (sizeof(largest_scalar_t) - 1))) {
     flatbuf.push_back(0);


### PR DESCRIPTION
This PR adds the suggested assert to fix a compile warning when compiling with GCC on Ubuntu 24.04 LTS

See https://github.com/google/flatbuffers/issues/8802#issuecomment-3575378284