### PR TITLE
[Python] Fix generating __init__.py for invalid path

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -2884,7 +2884,8 @@ class PythonGenerator : public BaseGenerator {
         parser_.opts.one_file ? path_ : namer_.Directories(ns.components);
     EnsureDirExists(directories);
 
-    for (size_t i = path_.size() + 1; i != std::string::npos;
+    for (size_t i = directories.find(kPathSeparator, path_.size());
+         i != std::string::npos;
          i = directories.find(kPathSeparator, i + 1)) {
       const std::string init_py =
           directories.substr(0, i) + kPathSeparator + "__init__.py";


### PR DESCRIPTION
This tried to generate from a directories "MyGame/Sample/" for a empty path_ in M, MyGame & MyGame/Sample.
Which is incorrect since we want to start with the first kPathSeparator `/` and not position 1.

Fixes #8787

In the future i want to address the issue that the Save does just silently ignore the wrong path.
