### PR TITLE
Deprecate `--ts-flat-files` and `--ts-entry-points`

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -707,8 +707,6 @@ struct IDLOptions {
   bool json_nested_flatbuffers;
   bool json_nested_flexbuffers;
   bool json_nested_legacy_flatbuffers;
-  bool ts_flat_files;
-  bool ts_entry_points;
   bool ts_no_import_ext;
   bool no_leak_private_annotations;
   bool require_json_eof;
@@ -852,8 +850,6 @@ struct IDLOptions {
         json_nested_flatbuffers(true),
         json_nested_flexbuffers(true),
         json_nested_legacy_flatbuffers(false),
-        ts_flat_files(false),
-        ts_entry_points(false),
         ts_no_import_ext(false),
         no_leak_private_annotations(false),
         require_json_eof(true),

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -248,11 +248,8 @@ const static FlatCOption flatc_options[] = {
     {"", "json-nested-bytes", "",
      "Allow a nested_flatbuffer field to be parsed as a vector of bytes "
      "in JSON, which is unsafe unless checked by a verifier afterwards."},
-    {"", "ts-flat-files", "",
-     "Generate a single typescript file per .fbs file. Implies "
-     "ts_entry_points."},
-    {"", "ts-entry-points", "",
-     "Generate entry point typescript per namespace. Implies gen-all."},
+    {"", "ts-flat-files", "", "(deprecated) Alias for --gen-all."},
+    {"", "ts-entry-points", "", "(deprecated) Alias for --gen-all."},
     {"", "annotate-sparse-vectors", "", "Don't annotate every vector element."},
     {"", "annotate", "SCHEMA",
      "Annotate the provided BINARY_FILE with the specified SCHEMA file."},
@@ -680,11 +677,12 @@ FlatCOptions FlatCompiler::ParseFromCommandLineArguments(int argc,
       } else if (arg == "--json-nested-bytes") {
         opts.json_nested_legacy_flatbuffers = true;
       } else if (arg == "--ts-flat-files") {
-        opts.ts_flat_files = true;
-        opts.ts_entry_points = true;
+        // deprecated -- just enables generate_all
+        Warn("--ts-flat-files is deprecated; use --gen-all instead.\n");
         opts.generate_all = true;
       } else if (arg == "--ts-entry-points") {
-        opts.ts_entry_points = true;
+        // deprecated -- just enables generate_all
+        Warn("--ts-entry-points is deprecated; use --gen-all instead.\n");
         opts.generate_all = true;
       } else if (arg == "--ts-no-import-ext") {
         opts.ts_no_import_ext = true;

--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -118,7 +118,6 @@ class TsGenerator : public BaseGenerator {
     if (!parser_.opts.ts_omit_entrypoint) {
       generateEntry();
     }
-    if (!generateBundle()) return false;
     return true;
   }
 
@@ -323,29 +322,6 @@ class TsGenerator : public BaseGenerator {
         parser_.opts.file_saver->SaveFile(it.second.filepath.c_str(), code,
                                           false);
     }
-  }
-
-  bool generateBundle() {
-    if (parser_.opts.ts_flat_files) {
-      std::string inputpath;
-      std::string symbolic_name = file_name_;
-      inputpath = path_ + file_name_ + ".ts";
-      std::string bundlepath =
-          GeneratedFileName(path_, file_name_, parser_.opts);
-      bundlepath = bundlepath.substr(0, bundlepath.size() - 3) + ".js";
-      std::string cmd = "esbuild";
-      cmd += " ";
-      cmd += inputpath;
-      // cmd += " --minify";
-      cmd += " --format=cjs --bundle --outfile=";
-      cmd += bundlepath;
-      cmd += " --external:flatbuffers";
-      std::cout << "Entry point " << inputpath << " generated." << std::endl;
-      std::cout << "A single file bundle can be created using fx. esbuild with:"
-                << std::endl;
-      std::cout << "> " << cmd << std::endl;
-    }
-    return true;
   }
 
   // Generate a documentation comment, if available.


### PR DESCRIPTION
Fixes #8696 

These two flags have no effect anymore - this change explicitly marks them as deprecated.

@bjornharrtell I think it would be good for us to still document somewhere how to run the esbuild steps you recommend -- deferring to you for what you think we need. 