### PR TITLE
chore: switch package to license expression

### DIFF
--- a/net/FlatBuffers/Google.FlatBuffers.csproj
+++ b/net/FlatBuffers/Google.FlatBuffers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
@@ -35,7 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
     <None Include="flatbuffers.png" Pack="true" PackagePath="" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #8838 

switch the nuget package to be using nuget license expression rather than a file to enable better support on nuget.org and tooling support