### PR TITLE
Run clang-format

### DIFF
--- a/android/app/src/main/cpp/animals.cpp
+++ b/android/app/src/main/cpp/animals.cpp
@@ -15,25 +15,27 @@
  */
 
 #include <jni.h>
-#include <string>
 #include <search.h>
+
+#include <string>
+
 #include "generated/animal_generated.h"
 
 using namespace com::fbs::app;
 using namespace flatbuffers;
 
-extern "C" JNIEXPORT jbyteArray JNICALL Java_com_flatbuffers_app_MainActivity_createAnimalFromJNI(
-        JNIEnv* env,
-        jobject /* this */) {
-    // create a new animal flatbuffers
-    auto fb = FlatBufferBuilder(1024);
-    auto tiger = CreateAnimalDirect(fb, "Tiger", "Roar", 300);
-    fb.Finish(tiger);
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_flatbuffers_app_MainActivity_createAnimalFromJNI(JNIEnv* env,
+                                                          jobject /* this */) {
+  // create a new animal flatbuffers
+  auto fb = FlatBufferBuilder(1024);
+  auto tiger = CreateAnimalDirect(fb, "Tiger", "Roar", 300);
+  fb.Finish(tiger);
 
-    // copies it to a Java byte array.
-    auto buf = reinterpret_cast<jbyte*>(fb.GetBufferPointer());
-    int size = fb.GetSize();
-    auto ret = env->NewByteArray(size);
-    env->SetByteArrayRegion (ret, 0, fb.GetSize(), buf);
+  // copies it to a Java byte array.
+  auto buf = reinterpret_cast<jbyte*>(fb.GetBufferPointer());
+  int size = fb.GetSize();
+  auto ret = env->NewByteArray(size);
+  env->SetByteArrayRegion(ret, 0, fb.GetSize(), buf);
   return ret;
 }

--- a/benchmarks/cpp/benchmark_main.cpp
+++ b/benchmarks/cpp/benchmark_main.cpp
@@ -5,8 +5,8 @@
 #include "benchmarks/cpp/flatbuffers/fb_bench.h"
 #include "benchmarks/cpp/raw/raw_bench.h"
 
-static inline void Encode(benchmark::State &state,
-                          std::unique_ptr<Bench> &bench, uint8_t *buffer) {
+static inline void Encode(benchmark::State& state,
+                          std::unique_ptr<Bench>& bench, uint8_t* buffer) {
   int64_t length;
   for (auto _ : state) {
     bench->Encode(buffer, length);
@@ -14,31 +14,33 @@ static inline void Encode(benchmark::State &state,
   }
 }
 
-static inline void Decode(benchmark::State &state,
-                          std::unique_ptr<Bench> &bench, uint8_t *buffer) {
+static inline void Decode(benchmark::State& state,
+                          std::unique_ptr<Bench>& bench, uint8_t* buffer) {
   int64_t length;
-  uint8_t *encoded = bench->Encode(buffer, length);
+  uint8_t* encoded = bench->Encode(buffer, length);
 
   for (auto _ : state) {
-    void *decoded = bench->Decode(encoded, length);
+    void* decoded = bench->Decode(encoded, length);
     benchmark::DoNotOptimize(decoded);
   }
 }
 
-static inline void Use(benchmark::State &state, std::unique_ptr<Bench> &bench,
-                       uint8_t *buffer, int64_t check_sum) {
+static inline void Use(benchmark::State& state, std::unique_ptr<Bench>& bench,
+                       uint8_t* buffer, int64_t check_sum) {
   int64_t length;
-  uint8_t *encoded = bench->Encode(buffer, length);
-  void *decoded = bench->Decode(encoded, length);
+  uint8_t* encoded = bench->Encode(buffer, length);
+  void* decoded = bench->Decode(encoded, length);
 
   int64_t sum = 0;
 
-  for (auto _ : state) { sum = bench->Use(decoded); }
+  for (auto _ : state) {
+    sum = bench->Use(decoded);
+  }
 
   EXPECT_EQ(sum, check_sum);
 }
 
-static void BM_Flatbuffers_Encode(benchmark::State &state) {
+static void BM_Flatbuffers_Encode(benchmark::State& state) {
   const int64_t kBufferLength = 1024;
   uint8_t buffer[kBufferLength];
 
@@ -48,7 +50,7 @@ static void BM_Flatbuffers_Encode(benchmark::State &state) {
 }
 BENCHMARK(BM_Flatbuffers_Encode);
 
-static void BM_Flatbuffers_Decode(benchmark::State &state) {
+static void BM_Flatbuffers_Decode(benchmark::State& state) {
   const int64_t kBufferLength = 1024;
   uint8_t buffer[kBufferLength];
 
@@ -58,7 +60,7 @@ static void BM_Flatbuffers_Decode(benchmark::State &state) {
 }
 BENCHMARK(BM_Flatbuffers_Decode);
 
-static void BM_Flatbuffers_Use(benchmark::State &state) {
+static void BM_Flatbuffers_Use(benchmark::State& state) {
   const int64_t kBufferLength = 1024;
   uint8_t buffer[kBufferLength];
 
@@ -68,7 +70,7 @@ static void BM_Flatbuffers_Use(benchmark::State &state) {
 }
 BENCHMARK(BM_Flatbuffers_Use);
 
-static void BM_Raw_Encode(benchmark::State &state) {
+static void BM_Raw_Encode(benchmark::State& state) {
   const int64_t kBufferLength = 1024;
   uint8_t buffer[kBufferLength];
 
@@ -77,7 +79,7 @@ static void BM_Raw_Encode(benchmark::State &state) {
 }
 BENCHMARK(BM_Raw_Encode);
 
-static void BM_Raw_Decode(benchmark::State &state) {
+static void BM_Raw_Decode(benchmark::State& state) {
   const int64_t kBufferLength = 1024;
   uint8_t buffer[kBufferLength];
 
@@ -86,7 +88,7 @@ static void BM_Raw_Decode(benchmark::State &state) {
 }
 BENCHMARK(BM_Raw_Decode);
 
-static void BM_Raw_Use(benchmark::State &state) {
+static void BM_Raw_Use(benchmark::State& state) {
   const int64_t kBufferLength = 1024;
   uint8_t buffer[kBufferLength];
 

--- a/benchmarks/cpp/flatbuffers/fb_bench.cpp
+++ b/benchmarks/cpp/flatbuffers/fb_bench.cpp
@@ -13,10 +13,10 @@ using namespace benchmarks_flatbuffers;
 namespace {
 
 struct FlatBufferBench : Bench {
-  explicit FlatBufferBench(int64_t initial_size, Allocator *allocator)
+  explicit FlatBufferBench(int64_t initial_size, Allocator* allocator)
       : fbb(initial_size, allocator, false) {}
 
-  uint8_t *Encode(void *, int64_t &len) override {
+  uint8_t* Encode(void*, int64_t& len) override {
     fbb.Clear();
 
     const int kVectorLength = 3;
@@ -40,7 +40,7 @@ struct FlatBufferBench : Bench {
     return fbb.GetBufferPointer();
   }
 
-  int64_t Use(void *decoded) override {
+  int64_t Use(void* decoded) override {
     sum = 0;
     auto foobarcontainer = GetFooBarContainer(decoded);
     sum = 0;
@@ -56,7 +56,7 @@ struct FlatBufferBench : Bench {
       Add(static_cast<int64_t>(bar->ratio()));
       Add(bar->size());
       Add(bar->time());
-      auto &foo = bar->parent();
+      auto& foo = bar->parent();
       Add(foo.count());
       Add(foo.id());
       Add(foo.length());
@@ -65,8 +65,8 @@ struct FlatBufferBench : Bench {
     return sum;
   }
 
-  void *Decode(void *buffer, int64_t) override { return buffer; }
-  void Dealloc(void *) override {};
+  void* Decode(void* buffer, int64_t) override { return buffer; }
+  void Dealloc(void*) override {};
 
   FlatBufferBuilder fbb;
 };
@@ -74,7 +74,7 @@ struct FlatBufferBench : Bench {
 }  // namespace
 
 std::unique_ptr<Bench> NewFlatBuffersBench(int64_t initial_size,
-                                           Allocator *allocator) {
+                                           Allocator* allocator) {
   return std::unique_ptr<FlatBufferBench>(
       new FlatBufferBench(initial_size, allocator));
 }

--- a/benchmarks/cpp/raw/raw_bench.cpp
+++ b/benchmarks/cpp/raw/raw_bench.cpp
@@ -45,8 +45,8 @@ struct FooBarContainer {
 };
 
 struct RawBench : Bench {
-  uint8_t *Encode(void *buf, int64_t &len) override {
-    FooBarContainer *fbc = new (buf) FooBarContainer;
+  uint8_t* Encode(void* buf, int64_t& len) override {
+    FooBarContainer* fbc = new (buf) FooBarContainer;
     strcpy(fbc->location, "http://google.com/flatbuffers/");  // Unsafe eek!
     fbc->location_len = (int)strlen(fbc->location);
     fbc->fruit = Bananas;
@@ -54,16 +54,16 @@ struct RawBench : Bench {
     for (int i = 0; i < kVectorLength; i++) {
       // We add + i to not make these identical copies for a more realistic
       // compression test.
-      auto &foobar = fbc->list[i];
+      auto& foobar = fbc->list[i];
       foobar.rating = 3.1415432432445543543 + i;
       foobar.postfix = '!' + i;
       strcpy(foobar.name, "Hello, World!");
       foobar.name_len = (int)strlen(foobar.name);
-      auto &bar = foobar.sibling;
+      auto& bar = foobar.sibling;
       bar.ratio = 3.14159f + i;
       bar.size = 10000 + i;
       bar.time = 123456 + i;
-      auto &foo = bar.parent;
+      auto& foo = bar.parent;
       foo.id = 0xABADCAFEABADCAFE + i;
       foo.count = 10000 + i;
       foo.length = 1000000 + i;
@@ -71,11 +71,11 @@ struct RawBench : Bench {
     }
 
     len = sizeof(FooBarContainer);
-    return reinterpret_cast<uint8_t *>(fbc);
+    return reinterpret_cast<uint8_t*>(fbc);
   };
 
-  int64_t Use(void *decoded) override {
-    auto foobarcontainer = reinterpret_cast<FooBarContainer *>(decoded);
+  int64_t Use(void* decoded) override {
+    auto foobarcontainer = reinterpret_cast<FooBarContainer*>(decoded);
     sum = 0;
     Add(foobarcontainer->initialized);
     Add(foobarcontainer->location_len);
@@ -89,7 +89,7 @@ struct RawBench : Bench {
       Add(static_cast<int64_t>(bar->ratio));
       Add(bar->size);
       Add(bar->time);
-      auto &foo = bar->parent;
+      auto& foo = bar->parent;
       Add(foo.count);
       Add(foo.id);
       Add(foo.length);
@@ -98,8 +98,8 @@ struct RawBench : Bench {
     return sum;
   }
 
-  void *Decode(void *buf, int64_t) override { return buf; }
-  void Dealloc(void *) override{};
+  void* Decode(void* buf, int64_t) override { return buf; }
+  void Dealloc(void*) override {};
 };
 
 }  // namespace

--- a/grpc/samples/greeter/client.cpp
+++ b/grpc/samples/greeter/client.cpp
@@ -1,18 +1,18 @@
-#include "greeter.grpc.fb.h"
-#include "greeter_generated.h"
-
 #include <grpcpp/grpcpp.h>
 
 #include <iostream>
 #include <memory>
 #include <string>
 
+#include "greeter.grpc.fb.h"
+#include "greeter_generated.h"
+
 class GreeterClient {
  public:
   GreeterClient(std::shared_ptr<grpc::Channel> channel)
-    : stub_(Greeter::NewStub(channel)) {}
+      : stub_(Greeter::NewStub(channel)) {}
 
-  std::string SayHello(const std::string &name) {
+  std::string SayHello(const std::string& name) {
     flatbuffers::grpc::MessageBuilder mb;
     auto name_offset = mb.CreateString(name);
     auto request_offset = CreateHelloRequest(mb, name_offset);
@@ -25,7 +25,7 @@ class GreeterClient {
 
     auto status = stub_->SayHello(&context, request_msg, &response_msg);
     if (status.ok()) {
-      const HelloReply *response = response_msg.GetRoot();
+      const HelloReply* response = response_msg.GetRoot();
       return response->message()->str();
     } else {
       std::cerr << status.error_code() << ": " << status.error_message()
@@ -34,8 +34,8 @@ class GreeterClient {
     }
   }
 
-  void SayManyHellos(const std::string &name, int num_greetings,
-                     std::function<void(const std::string &)> callback) {
+  void SayManyHellos(const std::string& name, int num_greetings,
+                     std::function<void(const std::string&)> callback) {
     flatbuffers::grpc::MessageBuilder mb;
     auto name_offset = mb.CreateString(name);
     auto request_offset =
@@ -49,7 +49,7 @@ class GreeterClient {
 
     auto stream = stub_->SayManyHellos(&context, request_msg);
     while (stream->Read(&response_msg)) {
-      const HelloReply *response = response_msg.GetRoot();
+      const HelloReply* response = response_msg.GetRoot();
       callback(response->message()->str());
     }
     auto status = stream->Finish();
@@ -64,7 +64,7 @@ class GreeterClient {
   std::unique_ptr<Greeter::Stub> stub_;
 };
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   std::string server_address("localhost:50051");
 
   auto channel =
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
   std::cerr << "Greeter received: " << message << std::endl;
 
   int num_greetings = 10;
-  greeter.SayManyHellos(name, num_greetings, [](const std::string &message) {
+  greeter.SayManyHellos(name, num_greetings, [](const std::string& message) {
     std::cerr << "Greeter received: " << message << std::endl;
   });
 

--- a/grpc/samples/greeter/server.cpp
+++ b/grpc/samples/greeter/server.cpp
@@ -1,25 +1,25 @@
-#include "greeter.grpc.fb.h"
-#include "greeter_generated.h"
-
 #include <grpcpp/grpcpp.h>
 
 #include <iostream>
 #include <memory>
 #include <string>
 
+#include "greeter.grpc.fb.h"
+#include "greeter_generated.h"
+
 class GreeterServiceImpl final : public Greeter::Service {
   virtual grpc::Status SayHello(
-      grpc::ServerContext *context,
-      const flatbuffers::grpc::Message<HelloRequest> *request_msg,
-      flatbuffers::grpc::Message<HelloReply> *response_msg) override {
+      grpc::ServerContext* context,
+      const flatbuffers::grpc::Message<HelloRequest>* request_msg,
+      flatbuffers::grpc::Message<HelloReply>* response_msg) override {
     flatbuffers::grpc::MessageBuilder mb_;
 
     // We call GetRoot to "parse" the message. Verification is already
     // performed by default. See the notes below for more details.
-    const HelloRequest *request = request_msg->GetRoot();
+    const HelloRequest* request = request_msg->GetRoot();
 
     // Fields are retrieved as usual with FlatBuffers
-    const std::string &name = request->name()->str();
+    const std::string& name = request->name()->str();
 
     // `flatbuffers::grpc::MessageBuilder` is a `FlatBufferBuilder` with a
     // special allocator for efficient gRPC buffer transfer, but otherwise
@@ -39,14 +39,14 @@ class GreeterServiceImpl final : public Greeter::Service {
   }
 
   virtual grpc::Status SayManyHellos(
-      grpc::ServerContext *context,
-      const flatbuffers::grpc::Message<ManyHellosRequest> *request_msg,
-      grpc::ServerWriter<flatbuffers::grpc::Message<HelloReply>> *writer)
+      grpc::ServerContext* context,
+      const flatbuffers::grpc::Message<ManyHellosRequest>* request_msg,
+      grpc::ServerWriter<flatbuffers::grpc::Message<HelloReply>>* writer)
       override {
     // The streaming usage below is simply a combination of standard gRPC
     // streaming with the FlatBuffers usage shown above.
-    const ManyHellosRequest *request = request_msg->GetRoot();
-    const std::string &name = request->name()->str();
+    const ManyHellosRequest* request = request_msg->GetRoot();
+    const std::string& name = request->name()->str();
     int num_greetings = request->num_greetings();
 
     for (int i = 0; i < num_greetings; i++) {
@@ -75,7 +75,7 @@ void RunServer() {
   server->Wait();
 }
 
-int main(int argc, const char *argv[]) {
+int main(int argc, const char* argv[]) {
   RunServer();
   return 0;
 }

--- a/include/flatbuffers/array.h
+++ b/include/flatbuffers/array.h
@@ -42,8 +42,8 @@ class Array {
   // If T is a non-pointer and a LE-scalar or a struct (!scalar_tag::value).
   static FLATBUFFERS_CONSTEXPR bool is_span_observable =
       !std::is_pointer<T>::value &&
-          ((scalar_tag::value && (FLATBUFFERS_LITTLEENDIAN || sizeof(T) == 1)) ||
-      !scalar_tag::value);
+      ((scalar_tag::value && (FLATBUFFERS_LITTLEENDIAN || sizeof(T) == 1)) ||
+       !scalar_tag::value);
 
   FLATBUFFERS_CONSTEXPR uint16_t size() const { return length; }
 

--- a/include/flatbuffers/flatbuffer_builder.h
+++ b/include/flatbuffers/flatbuffer_builder.h
@@ -469,8 +469,9 @@ class FlatBufferBuilderImpl {
     if (dedup_vtables_) {
       for (auto it = buf_.scratch_data(); it < buf_.scratch_end();
            it += sizeof(uoffset_t)) {
-        auto vt_offset_ptr = reinterpret_cast<uoffset_t *>(it);
-        auto vt2 = reinterpret_cast<voffset_t *>(buf_.data_at(*vt_offset_ptr + length_of_64_bit_region_));
+        auto vt_offset_ptr = reinterpret_cast<uoffset_t*>(it);
+        auto vt2 = reinterpret_cast<voffset_t*>(
+            buf_.data_at(*vt_offset_ptr + length_of_64_bit_region_));
         auto vt2_size = ReadScalar<voffset_t>(vt2);
         if (vt1_size != vt2_size || 0 != memcmp(vt2, vt1, vt1_size)) continue;
         vt_use = *vt_offset_ptr;

--- a/include/flatbuffers/vector.h
+++ b/include/flatbuffers/vector.h
@@ -410,7 +410,6 @@ FLATBUFFERS_CONSTEXPR_CPP11 flatbuffers::span<const U> make_structs_span(
 
 #endif
 
-
 // Represent a vector much like the template above, but in this case we
 // don't know what the element types are (used with reflection.h).
 class VectorOfAny {

--- a/src/file_manager.cpp
+++ b/src/file_manager.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#include "flatbuffers/file_manager.h"
+
 #include <fstream>
 #include <set>
 #include <string>
-
-#include "flatbuffers/file_manager.h"
 
 namespace flatbuffers {
 

--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -652,19 +652,23 @@ class CSharpGenerator : public BaseGenerator {
     // Get the getter for the key of the struct.
     if (IsString(key_field->value.type)) {
       return "string.CompareOrdinal(" +
-         GenGetterForLookupByKey(struct_def, key_field, "builder.DataBuffer", 
-           "builder.DataBuffer.Length - o1.Value") +
-         ", " +
-         GenGetterForLookupByKey(struct_def, key_field, "builder.DataBuffer",
-           "builder.DataBuffer.Length - o2.Value") + 
-         ")";
+             GenGetterForLookupByKey(struct_def, key_field,
+                                     "builder.DataBuffer",
+                                     "builder.DataBuffer.Length - o1.Value") +
+             ", " +
+             GenGetterForLookupByKey(struct_def, key_field,
+                                     "builder.DataBuffer",
+                                     "builder.DataBuffer.Length - o2.Value") +
+             ")";
     } else {
-      return GenGetterForLookupByKey(struct_def, key_field, "builder.DataBuffer",
-                     "builder.DataBuffer.Length - o1.Value") +
-         ".CompareTo(" +
-         GenGetterForLookupByKey(struct_def, key_field, "builder.DataBuffer", 
-                     "builder.DataBuffer.Length - o2.Value") +
-         ")";
+      return GenGetterForLookupByKey(struct_def, key_field,
+                                     "builder.DataBuffer",
+                                     "builder.DataBuffer.Length - o1.Value") +
+             ".CompareTo(" +
+             GenGetterForLookupByKey(struct_def, key_field,
+                                     "builder.DataBuffer",
+                                     "builder.DataBuffer.Length - o2.Value") +
+             ")";
     }
   }
 
@@ -1596,7 +1600,8 @@ class CSharpGenerator : public BaseGenerator {
 
       code += "      obj_.__assign(tableOffset, bb);\n";
       if (IsString(key_field->value.type)) {
-        code += "      int comp = string.CompareOrdinal(obj_." + name + ", key);\n";
+        code +=
+            "      int comp = string.CompareOrdinal(obj_." + name + ", key);\n";
       } else {
         code += "      int comp = obj_." + name + ".CompareTo(key);\n";
       }

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -56,16 +56,16 @@ static Namer::Config JavaDefaultConfig() {
 
 static std::set<std::string> JavaKeywords() {
   return {
-      "abstract", "assert",   "boolean",    "break",     "byte",
-      "case",     "catch",    "char",       "class",     "const",
-      "continue", "default",  "do",         "double",    "else",
-      "enum",     "extends",  "final",      "finally",   "float",
-      "for",      "goto",     "if",         "implements","import",
-      "instanceof","int",     "interface",  "long",      "native",
-      "new",      "notify",   "package",    "private",   "protected",
-      "public",   "return",   "short",      "static",    "strictfp",
-      "super",    "switch",   "synchronized","this",     "throw",
-      "throws",   "transient","try",        "void",      "volatile",
+      "abstract",   "assert",    "boolean",      "break",      "byte",
+      "case",       "catch",     "char",         "class",      "const",
+      "continue",   "default",   "do",           "double",     "else",
+      "enum",       "extends",   "final",        "finally",    "float",
+      "for",        "goto",      "if",           "implements", "import",
+      "instanceof", "int",       "interface",    "long",       "native",
+      "new",        "notify",    "package",      "private",    "protected",
+      "public",     "return",    "short",        "static",     "strictfp",
+      "super",      "switch",    "synchronized", "this",       "throw",
+      "throws",     "transient", "try",          "void",       "volatile",
       "while",
   };
 }
@@ -1468,7 +1468,8 @@ class JavaGenerator : public BaseGenerator {
             " " + variable_name + "Type = " + field_name + "Type(" +
             type_params + ");\n";
     code += indent + variable_name + ".setType(" + variable_name + "Type);\n";
-    code += indent + "com.google.flatbuffers.Table " + variable_name + "Value;\n";
+    code +=
+        indent + "com.google.flatbuffers.Table " + variable_name + "Value;\n";
     code += indent + "switch (" + variable_name + "Type) {\n";
     for (auto eit = enum_def.Vals().begin(); eit != enum_def.Vals().end();
          ++eit) {

--- a/src/idl_gen_kotlin.cpp
+++ b/src/idl_gen_kotlin.cpp
@@ -1216,8 +1216,8 @@ class KotlinGenerator : public BaseGenerator {
         // fun inventoryInByteBuffer(_bb: Bytebuffer):
         //     ByteBuffer? = __vector_as_bytebuffer(_bb, 14, 1)
         GenerateFunOneLine(
-            writer, field_name + "InByteBuffer", "_bb: ByteBuffer",
-            buffer_type, [&]() {
+            writer, field_name + "InByteBuffer", "_bb: ByteBuffer", buffer_type,
+            [&]() {
               writer.SetValue("end", end_idx);
               writer += "__vector_in_bytebuffer(_bb, {{offset}}, {{end}})";
             });

--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -2885,8 +2885,7 @@ class PythonGenerator : public BaseGenerator {
     EnsureDirExists(directories);
 
     for (size_t i = directories.find(kPathSeparator, path_.size());
-         i != std::string::npos;
-         i = directories.find(kPathSeparator, i + 1)) {
+         i != std::string::npos; i = directories.find(kPathSeparator, i + 1)) {
       const std::string init_py =
           directories.substr(0, i) + kPathSeparator + "__init__.py";
       parser_.opts.file_saver->SaveFile(init_py.c_str(), "", false);
@@ -2904,7 +2903,7 @@ class PythonGenerator : public BaseGenerator {
 }  // namespace python
 
 static const char* GeneratePython(const Parser& parser, const std::string& path,
-                           const std::string& file_name) {
+                                  const std::string& file_name) {
   python::Version version{parser.opts.python_version};
   if (!version.IsValid()) return "The provided Python version is not valid";
 
@@ -2913,7 +2912,8 @@ static const char* GeneratePython(const Parser& parser, const std::string& path,
 
   if (parser.opts.python_typing) {
     python::PythonStubGenerator stub_generator(parser, path, version);
-    if (!stub_generator.Generate()) return "could not generate Python type stubs";
+    if (!stub_generator.Generate())
+      return "could not generate Python type stubs";
   }
   return nullptr;
 }
@@ -2948,7 +2948,8 @@ class PythonCodeGenerator : public CodeGenerator {
 
   Status GenerateGrpcCode(const Parser& parser, const std::string& path,
                           const std::string& filename) override {
-    if (!GeneratePythonGRPC(parser, path, filename)) { // TODO add status GeneratePythonGRPC
+    if (!GeneratePythonGRPC(parser, path,
+                            filename)) {  // TODO add status GeneratePythonGRPC
       return Status::ERROR;
     }
     return Status::OK;

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -1347,7 +1347,8 @@ class SwiftGenerator : public BaseGenerator {
   }
 
   void GenerateObjectAPIStructConstructor(const StructDef& struct_def) {
-    code_ += "{{ACCESS_TYPE}} init(_ _t: borrowing {{STRUCTNAME}}" + Mutable() + ") {";
+    code_ += "{{ACCESS_TYPE}} init(_ _t: borrowing {{STRUCTNAME}}" + Mutable() +
+             ") {";
     Indent();
     for (auto it = struct_def.fields.vec.begin();
          it != struct_def.fields.vec.end(); ++it) {
@@ -1393,8 +1394,9 @@ class SwiftGenerator : public BaseGenerator {
                                     base_constructor);
     }
     code_ += "";
-    BuildObjectConstructor(buffer_constructor,
-                           "_ _t: borrowing " + namer_.NamespacedType(struct_def));
+    BuildObjectConstructor(
+        buffer_constructor,
+        "_ _t: borrowing " + namer_.NamespacedType(struct_def));
     BuildObjectConstructor(base_constructor);
     if (!struct_def.fixed)
       code_ +=
@@ -1960,7 +1962,7 @@ class SwiftGenerator : public BaseGenerator {
   std::string GenType(const Type& type,
                       const bool should_consider_suffix = false) const {
     return IsScalar(type.base_type) ? GenTypeBasic(type)
-           : IsArray(type)          ? GenType(type.VectorType())
+           : IsArray(type) ? GenType(type.VectorType())
                            : GenTypePointer(type, should_consider_suffix);
   }
 

--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -339,8 +339,7 @@ class TsGenerator : public BaseGenerator {
     for (auto it = dc.begin(); it != dc.end(); ++it) {
       if (indent) code += indent;
       std::string safe = *it;
-      for (size_t pos = 0;
-           (pos = safe.find("*/", pos)) != std::string::npos;) {
+      for (size_t pos = 0; (pos = safe.find("*/", pos)) != std::string::npos;) {
         safe.replace(pos, 2, "*\\/");
         pos += 3;
       }

--- a/tests/64bit/offset64_test.cpp
+++ b/tests/64bit/offset64_test.cpp
@@ -79,7 +79,7 @@ void Offset64Test() {
   }
 
   {
-    const RootTable *root_table = GetRootTable(builder.GetBufferPointer());
+    const RootTable* root_table = GetRootTable(builder.GetBufferPointer());
 
     // Expect the far vector to be properly sized.
     TEST_EQ(root_table->far_vector()->size(), far_vector_size);
@@ -130,12 +130,12 @@ void Offset64NestedFlatBuffer() {
   fbb.Finish(root_table_offset);
 
   // Ensure the buffer is valid.
-  const RootTable *root_table = GetRootTable(fbb.GetBufferPointer());
+  const RootTable* root_table = GetRootTable(fbb.GetBufferPointer());
   TEST_EQ_STR(root_table->near_string()->c_str(), "nested: some near string");
 
   // Copy the data out of the builder.
-  std::vector<uint8_t> nested_data{ fbb.GetBufferPointer(),
-                                    fbb.GetBufferPointer() + fbb.GetSize() };
+  std::vector<uint8_t> nested_data{fbb.GetBufferPointer(),
+                                   fbb.GetBufferPointer() + fbb.GetSize()};
 
   {
     // Clear so we can reuse the builder.
@@ -167,7 +167,7 @@ void Offset64NestedFlatBuffer() {
   }
 
   {
-    const RootTable *root_table = GetRootTable(fbb.GetBufferPointer());
+    const RootTable* root_table = GetRootTable(fbb.GetBufferPointer());
 
     // Test that the parent buffer field is ok.
     TEST_EQ_STR(root_table->near_string()->c_str(), "some near string");
@@ -185,7 +185,7 @@ void Offset64CreateDirect() {
   FlatBufferBuilder64 fbb;
 
   // Create a vector of some data
-  std::vector<uint8_t> data{ 0, 1, 2 };
+  std::vector<uint8_t> data{0, 1, 2};
 
   // Call the "Direct" creation method to ensure that things are added to the
   // buffer in the correct order, Offset64 first followed by any Offsets.
@@ -205,7 +205,7 @@ void Offset64CreateDirect() {
   TEST_EQ(VerifyRootTableBuffer(verifier), true);
 
   // Verify the data.
-  const RootTable *root_table = GetRootTable(fbb.GetBufferPointer());
+  const RootTable* root_table = GetRootTable(fbb.GetBufferPointer());
   TEST_EQ(root_table->far_vector()->size(), data.size());
   TEST_EQ(root_table->big_vector()->size(), data.size());
   TEST_EQ_STR(root_table->far_string()->c_str(), "some far string");
@@ -214,8 +214,8 @@ void Offset64CreateDirect() {
 
 void Offset64Evolution() {
   // Some common data for the tests.
-  const std::vector<uint8_t> data = { 1, 2, 3, 4 };
-  const std::vector<uint8_t> big_data = { 6, 7, 8, 9, 10 };
+  const std::vector<uint8_t> data = {1, 2, 3, 4};
+  const std::vector<uint8_t> big_data = {6, 7, 8, 9, 10};
 
   // Built V1 read V2
   {
@@ -301,13 +301,13 @@ void Offset64VectorOfStructs() {
   FlatBufferBuilder64 builder;
 
   std::vector<LeafStruct> far_leaves;
-  far_leaves.emplace_back(LeafStruct{ 123, 4.567 });
-  far_leaves.emplace_back(LeafStruct{ 987, 6.543 });
+  far_leaves.emplace_back(LeafStruct{123, 4.567});
+  far_leaves.emplace_back(LeafStruct{987, 6.543});
 
   std::vector<LeafStruct> big_leaves;
-  big_leaves.emplace_back(LeafStruct{ 72, 72.8 });
-  big_leaves.emplace_back(LeafStruct{ 82, 82.8 });
-  big_leaves.emplace_back(LeafStruct{ 92, 92.8 });
+  big_leaves.emplace_back(LeafStruct{72, 72.8});
+  big_leaves.emplace_back(LeafStruct{82, 82.8});
+  big_leaves.emplace_back(LeafStruct{92, 92.8});
 
   // Add the two vectors of leaf structs.
   const Offset<RootTable> root_table_offset =
@@ -327,7 +327,7 @@ void Offset64VectorOfStructs() {
   TEST_EQ(VerifyRootTableBuffer(verifier), true);
 
   // Verify the data.
-  const RootTable *root_table = GetRootTable(builder.GetBufferPointer());
+  const RootTable* root_table = GetRootTable(builder.GetBufferPointer());
   TEST_EQ(root_table->far_struct_vector()->size(), far_leaves.size());
   TEST_EQ(root_table->far_struct_vector()->Get(0)->a(), 123);
   TEST_EQ(root_table->far_struct_vector()->Get(0)->b(), 4.567);
@@ -369,7 +369,7 @@ void Offset64SizePrefix() {
 
   TEST_EQ(VerifySizePrefixedRootTableBuffer(verifier), true);
 
-  const RootTable *root_table =
+  const RootTable* root_table =
       GetSizePrefixedRootTable(builder.GetBufferPointer());
 
   // Verify the fields.
@@ -432,7 +432,7 @@ void Offset64ManyVectors() {
 
   TEST_EQ(VerifyRootTableBuffer(verifier), true);
 
-  const RootTable *root_table = GetRootTable(builder.GetBufferPointer());
+  const RootTable* root_table = GetRootTable(builder.GetBufferPointer());
 
   // Verify the fields.
   TEST_EQ_STR(root_table->far_string()->c_str(), "some far string");
@@ -449,7 +449,7 @@ void Offset64ForceAlign() {
 
   // Setup some data to serialize that is less than the force_align size of 32
   // bytes.
-  std::vector<uint8_t> data{ 1, 2, 3 };
+  std::vector<uint8_t> data{1, 2, 3};
 
   // Use the CreateDirect which calls the ForceVectorAlign
   const auto root_table_offset =

--- a/tests/cpp17/test_cpp17.cpp
+++ b/tests/cpp17/test_cpp17.cpp
@@ -48,22 +48,22 @@ using ::cpp17::MyGame::Example::Vec3;
 ** Build some FB objects.
 *******************************************************************************/
 namespace {
-const Monster *BuildMonster(flatbuffers::FlatBufferBuilder &fbb) {
+const Monster* BuildMonster(flatbuffers::FlatBufferBuilder& fbb) {
   using ::cpp17::MyGame::Example::Color;
   using ::cpp17::MyGame::Example::MonsterBuilder;
   using ::cpp17::MyGame::Example::Test;
   auto name = fbb.CreateString("my_monster");
-  auto inventory = fbb.CreateVector(std::vector<uint8_t>{ 4, 5, 6, 7 });
+  auto inventory = fbb.CreateVector(std::vector<uint8_t>{4, 5, 6, 7});
   MonsterBuilder builder(fbb);
-  auto vec3 = Vec3{ /*x=*/1.1f,
-                    /*y=*/2.2f,
-                    /*z=*/3.3f,
-                    /*test1=*/6.6,
-                    /*test2=*/Color::Green,
-                    /*test3=*/
-                    Test(
-                        /*a=*/11,
-                        /*b=*/90) };
+  auto vec3 = Vec3{/*x=*/1.1f,
+                   /*y=*/2.2f,
+                   /*z=*/3.3f,
+                   /*test1=*/6.6,
+                   /*test2=*/Color::Green,
+                   /*test3=*/
+                   Test(
+                       /*a=*/11,
+                       /*b=*/90)};
   builder.add_pos(&vec3);
   builder.add_name(name);
   builder.add_mana(1);
@@ -85,7 +85,7 @@ const Monster *BuildMonster(flatbuffers::FlatBufferBuilder &fbb) {
   builder.add_non_owning_reference(17);
   builder.add_inventory(inventory);
   fbb.Finish(builder.Finish());
-  const Monster *monster =
+  const Monster* monster =
       flatbuffers::GetRoot<Monster>(fbb.GetBufferPointer());
   return monster;
 }
@@ -103,7 +103,7 @@ void StringifyAnyFlatbuffersTypeTest() {
   flatbuffers::FlatBufferBuilder fbb;
   // We are using a Monster here, but we could have used any type, because the
   // code that follows is totally generic!
-  const auto *monster = BuildMonster(fbb);
+  const auto* monster = BuildMonster(fbb);
 
   std::string expected = R"(MyGame.Example.Monster{
         pos = MyGame.Example.Vec3{
@@ -179,13 +179,13 @@ void StringifyAnyFlatbuffersTypeTest() {
 ** Test Traits::FieldType
 *******************************************************************************/
 using pos_type = Monster::Traits::FieldType<0>;
-static_assert(std::is_same_v<pos_type, const Vec3 *>);
+static_assert(std::is_same_v<pos_type, const Vec3*>);
 
 using mana_type = Monster::Traits::FieldType<1>;
 static_assert(std::is_same_v<mana_type, int16_t>);
 
 using name_type = Monster::Traits::FieldType<3>;
-static_assert(std::is_same_v<name_type, const flatbuffers::String *>);
+static_assert(std::is_same_v<name_type, const flatbuffers::String*>);
 
 /*******************************************************************************
 ** Generic Create Function Test.
@@ -263,7 +263,7 @@ int FlatBufferCpp17Tests() {
 }
 }  // namespace
 
-int main(int /*argc*/, const char * /*argv*/[]) {
+int main(int /*argc*/, const char* /*argv*/[]) {
   InitTestEngine();
 
   FlatBufferCpp17Tests();

--- a/tests/fuzzer/flatbuffers_codegen_fuzzer.cc
+++ b/tests/fuzzer/flatbuffers_codegen_fuzzer.cc
@@ -1,31 +1,32 @@
-#include <stddef.h>
-#include <stdint.h>
-#include <string>
-#include "flatbuffers/idl.h"  // For Parser and generation functions
-#include "test_init.h"
-#include <memory>
+#include <bfbs_gen_lua.h>
+#include <bfbs_gen_nim.h>
 #include <flatbuffers/flatc.h>
-#include "idl_gen_cpp.h"  // For C++ generator
-#include <idl_gen_csharp.h>
-#include <iostream>
-#include "flatbuffers/code_generator.h"
 #include <idl_gen_binary.h>
+#include <idl_gen_csharp.h>
 #include <idl_gen_dart.h>
 #include <idl_gen_fbs.h>
 #include <idl_gen_go.h>
 #include <idl_gen_java.h>
 #include <idl_gen_json_schema.h>
 #include <idl_gen_kotlin.h>
-#include <idl_gen_kotlin.h>
 #include <idl_gen_lobster.h>
-#include <bfbs_gen_lua.h>
-#include <bfbs_gen_nim.h>
-#include <idl_gen_python.h>
 #include <idl_gen_php.h>
+#include <idl_gen_python.h>
 #include <idl_gen_rust.h>
-#include <idl_gen_text.h>
 #include <idl_gen_swift.h>
+#include <idl_gen_text.h>
 #include <idl_gen_ts.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "flatbuffers/code_generator.h"
+#include "flatbuffers/idl.h"  // For Parser and generation functions
+#include "idl_gen_cpp.h"      // For C++ generator
+#include "test_init.h"
 
 static constexpr size_t kMinInputLength = 1;
 static constexpr size_t kMaxInputLength = 16384;
@@ -98,8 +99,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (parser.Parse(parse_input)) {
     parser.Serialize();
     const uint8_t* buf = parser.builder_.GetBufferPointer();
-    flatbuffers::Verifier verifier(buf,
-                                   parser.builder_.GetSize());
+    flatbuffers::Verifier verifier(buf, parser.builder_.GetSize());
     TEST_EQ(true, reflection::VerifySchemaBuffer(verifier));
 
     auto root = flatbuffers::GetRoot<flatbuffers::Table>(buf);
@@ -126,8 +126,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     generators.emplace_back(flatbuffers::NewKotlinCodeGenerator());
     generators.emplace_back(flatbuffers::NewKotlinKMPCodeGenerator());
     generators.emplace_back(flatbuffers::NewLobsterCodeGenerator());
-    generators.emplace_back(flatbuffers::NewLuaBfbsGenerator(flatbuffers_version));
-    generators.emplace_back(flatbuffers::NewNimBfbsGenerator(flatbuffers_version));
+    generators.emplace_back(
+        flatbuffers::NewLuaBfbsGenerator(flatbuffers_version));
+    generators.emplace_back(
+        flatbuffers::NewNimBfbsGenerator(flatbuffers_version));
     generators.emplace_back(flatbuffers::NewPythonCodeGenerator());
     generators.emplace_back(flatbuffers::NewPhpCodeGenerator());
     generators.emplace_back(flatbuffers::NewRustCodeGenerator());

--- a/tests/fuzzer/monster_debug.cpp
+++ b/tests/fuzzer/monster_debug.cpp
@@ -1,11 +1,12 @@
-#include <iostream>
 #include <assert.h>
+
+#include <iostream>
 
 #include "flatbuffers/util.h"
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   if (argc < 2) {
     std::cerr << "Usage: monster_debug <path to fuzzer crash file>\n";
     return 0;
@@ -23,7 +24,7 @@ int main(int argc, char *argv[]) {
     return -2;
   }
   auto rc = LLVMFuzzerTestOneInput(
-      reinterpret_cast<const uint8_t *>(crash_file_data.data()),
+      reinterpret_cast<const uint8_t*>(crash_file_data.data()),
       crash_file_data.size());
   std::cout << "LLVMFuzzerTestOneInput finished with code " << rc << "\n\n";
   return rc;

--- a/tests/fuzzer/scalar_debug.cpp
+++ b/tests/fuzzer/scalar_debug.cpp
@@ -1,9 +1,10 @@
 #include <iostream>
+
 #include "flatbuffers/util.h"
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   if (argc < 2) {
     std::cerr << "Usage: scalar_debug <path to fuzzer crash file>\n";
     return 0;
@@ -21,7 +22,7 @@ int main(int argc, char *argv[]) {
     return -2;
   }
   auto rc = LLVMFuzzerTestOneInput(
-      reinterpret_cast<const uint8_t *>(crash_file_data.data()),
+      reinterpret_cast<const uint8_t*>(crash_file_data.data()),
       crash_file_data.size());
   std::cout << "LLVMFuzzerTestOneInput finished with code " << rc << "\n\n";
   return rc;

--- a/tests/native_type_test_impl.cpp
+++ b/tests/native_type_test_impl.cpp
@@ -22,15 +22,19 @@ const Native::Vector3D UnPackVector3DAlt(const Geometry::Vector3DAlt& obj) {
 
 namespace Geometry {
 void Matrix::UnPackTo(
-    Native::Matrix *_o,
-    const ::flatbuffers::resolver_function_t *_resolver) const {
+    Native::Matrix* _o,
+    const ::flatbuffers::resolver_function_t* _resolver) const {
   (void)_resolver;
 
   auto _rows = rows();
-  if (_rows) { _o->rows = _rows; }
+  if (_rows) {
+    _o->rows = _rows;
+  }
 
   auto _columns = columns();
-  if (_columns) { _o->columns = _columns; }
+  if (_columns) {
+    _o->columns = _columns;
+  }
 
   auto _values = values();
   if (_values) {
@@ -42,8 +46,8 @@ void Matrix::UnPackTo(
 }
 
 ::flatbuffers::Offset<Matrix> Matrix::Pack(
-    ::flatbuffers::FlatBufferBuilder &_fbb, const Native::Matrix *_o,
-    const ::flatbuffers::rehasher_function_t *_rehasher) {
+    ::flatbuffers::FlatBufferBuilder& _fbb, const Native::Matrix* _o,
+    const ::flatbuffers::rehasher_function_t* _rehasher) {
   (void)_rehasher;
 
   return CreateMatrix(_fbb, _o->rows, _o->columns,

--- a/tests/native_type_test_impl.h
+++ b/tests/native_type_test_impl.h
@@ -20,7 +20,7 @@ struct Vector3D {
     this->z = _z;
   }
 
-  bool operator==(const Vector3D &other) const {
+  bool operator==(const Vector3D& other) const {
     return (x == other.x) && (y == other.y) && (z == other.z);
   }
 };
@@ -38,7 +38,7 @@ struct Matrix {
     values.resize(_rows * _columns);
   }
 
-  bool operator==(const Matrix &other) const {
+  bool operator==(const Matrix& other) const {
     return (rows == other.rows) && (columns == other.columns) &&
            (values == other.values);
   }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -771,15 +771,15 @@ void FixedLengthArrayTest() {
   // set memory chunk of size ArrayStruct to 1's
   std::memset(static_cast<void*>(non_zero_memory), 1, arr_size);
   // after placement-new it should be all 0's
-#if defined(FLATBUFFERS_MEMORY_LEAK_TRACKING) && \
-    defined(_MSC_VER) && defined(_DEBUG)
+#if defined(FLATBUFFERS_MEMORY_LEAK_TRACKING) && defined(_MSC_VER) && \
+    defined(_DEBUG)
 #undef new
 #endif
   MyGame::Example::ArrayStruct* ap =
       new (non_zero_memory) MyGame::Example::ArrayStruct;
-#if defined(FLATBUFFERS_MEMORY_LEAK_TRACKING) && \
-    defined(_MSC_VER) && defined(_DEBUG)
-  #define new DEBUG_NEW
+#if defined(FLATBUFFERS_MEMORY_LEAK_TRACKING) && defined(_MSC_VER) && \
+    defined(_DEBUG)
+#define new DEBUG_NEW
 #endif
   (void)ap;
   for (size_t i = 0; i < arr_size; ++i) {
@@ -925,7 +925,8 @@ void NativeTypeTest() {
   src_data.matrix->values = {3, 4};
 
   for (int i = 0; i < N; ++i) {
-    src_data.matrices.push_back(std::unique_ptr<Native::Matrix>(new Native::Matrix(1, i)));
+    src_data.matrices.push_back(
+        std::unique_ptr<Native::Matrix>(new Native::Matrix(1, i)));
     std::fill(src_data.matrices[i]->values.begin(),
               src_data.matrices[i]->values.end(), i + 0.5f);
   }
@@ -960,7 +961,7 @@ void NativeTypeTest() {
   TEST_EQ(dstDataT->matrix->values[1], 4);
 
   for (int i = 0; i < N; ++i) {
-    const Native::Matrix &m = *dstDataT->matrices[i];
+    const Native::Matrix& m = *dstDataT->matrices[i];
     TEST_EQ(m.rows, 1);
     TEST_EQ(m.columns, i);
     for (int j = 0; j < i; ++j) {


### PR DESCRIPTION
Runs `clang-format -i` on non-generated C++ files to conform them to the style guide which is currently based on Google.