### PR TITLE
[TS] Support vectors, numerics, and strings with defaults

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2809,7 +2809,8 @@ bool Parser::SupportsOptionalScalars() const {
 bool Parser::SupportsDefaultVectorsAndStrings() const {
   static FLATBUFFERS_CONSTEXPR unsigned long supported_langs =
       IDLOptions::kRust | IDLOptions::kSwift | IDLOptions::kNim |
-      IDLOptions::kCpp | IDLOptions::kBinary | IDLOptions::kJson;
+      IDLOptions::kCpp | IDLOptions::kBinary | IDLOptions::kJson |
+      IDLOptions::kTs;
   return !(opts.lang_to_generate & ~supported_langs);
 }
 

--- a/tests/even_more_defaults.fbs
+++ b/tests/even_more_defaults.fbs
@@ -1,0 +1,23 @@
+
+enum ABC: int { A, B, C }
+
+struct EvenMoreStruct {
+  g:[int64:2];
+}
+
+table EvenMoreDefaults {
+  str: EvenMoreStruct;
+  ints: [int] = [];
+  floats: [float] = [     ];
+  float_optional: [float];
+  bytes_optional: [ubyte];
+  floats_required: [float] (required);
+  empty_string: string = "";
+  some_string: string = "some";
+  zero_string: string = "0";
+  a_string:string (key);
+  required_string: string (required);
+  abcs: [ABC] = [];
+  bools: [bool] = [];
+  one_bool: bool = true;
+}

--- a/tests/ts/TypeScriptTest.py
+++ b/tests/ts/TypeScriptTest.py
@@ -88,6 +88,20 @@ flatc(
 esbuild("monster_test.ts", "monster_test_generated.cjs")
 
 flatc(
+    options=[
+        "--ts",
+        "--reflect-names",
+        "--gen-name-strings",
+        "--gen-mutable",
+        "--gen-object-api",
+        "--ts-entry-points",
+        "--ts-flat-files",
+    ],
+    schema="../even_more_defaults.fbs",
+    include="../include_test",
+)
+
+flatc(
     options=["--gen-object-api", "-b"],
     schema="../monster_test.fbs",
     include="../include_test",

--- a/tests/ts/my-game/example/monster.ts
+++ b/tests/ts/my-game/example/monster.ts
@@ -81,11 +81,11 @@ mutate_hp(value:number):boolean {
   return true;
 }
 
-name():string|null
-name(optionalEncoding:flatbuffers.Encoding):string|Uint8Array|null
-name(optionalEncoding?:any):string|Uint8Array|null {
+name():string
+name(optionalEncoding:flatbuffers.Encoding):string|Uint8Array
+name(optionalEncoding?:any):string|Uint8Array {
   const offset = this.bb!.__offset(this.bb_pos, 10);
-  return offset ? this.bb!.__string(this.bb_pos + offset, optionalEncoding) : null;
+  return this.bb!.__string(this.bb_pos + offset, optionalEncoding);
 }
 
 inventory(index: number):number|null {


### PR DESCRIPTION
This PR enables vector, numeric, and string types in typescript to have default values. The method signature for accessing a string now depends on whether the property is either required, or has a default value. In either case, the signature becomes:

```ts
name():string
name(optionalEncoding:flatbuffers.Encoding):string|Uint8Array
name(optionalEncoding?:any):string|Uint8Array
```

instead of 

```ts
name():string|null
name(optionalEncoding:flatbuffers.Encoding):string|Uint8Array|null
name(optionalEncoding?:any):string|Uint8Array|null
```

For string types, typescript allows you to inline a global/constant, so we just return that if there is no value in the buffer. For vectors, we return a new vector, (I.e. `new Float32Array()`, etc.), since there is no concept of an "inner" default value for vector types.

One significant finding was that the parser parses optional string type properties with a value of `"0"`, meaning that if a user were to create a string with a default value of "0", then it would parse as nullable. I didn't want to disturb the codebase too much, but changing this would seemingly require some new logic in the parser to handle zero vs null values.

Closes https://github.com/google/flatbuffers/issues/8888