### PR TITLE
rust: fix OOB write in generated table scalar setters

### DIFF
--- a/tests/rust_namer_test/rust_namer_test/possibly_reserved_words_generated.rs
+++ b/tests/rust_namer_test/rust_namer_test/possibly_reserved_words_generated.rs
@@ -183,14 +183,21 @@ impl<'a> PossiblyReservedWords {
 
   pub fn set_alignment(&mut self, x: f32) {
     let x_le = ::flatbuffers::EndianScalar::to_little_endian(x);
+
+    let __fb_size = ::core::mem::size_of::<<f32 as ::flatbuffers::EndianScalar>::Scalar>();
+    let __fb_dst = self
+      .0
+      .get_mut(12..(12 + __fb_size))
+      .expect("flatbuffers: buffer too short for mutation")
+      .as_mut_ptr();
+
     // Safety:
-    // Created from a valid Table for this object
-    // Which contains a valid value in this slot
+    // Destination is bounds-checked above.
     unsafe {
       ::core::ptr::copy_nonoverlapping(
-        &x_le as *const _ as *const u8,
-        self.0[12..].as_mut_ptr(),
-        ::core::mem::size_of::<<f32 as ::flatbuffers::EndianScalar>::Scalar>(),
+        (&x_le as *const _ as *const u8),
+        __fb_dst,
+        __fb_size,
       );
     }
   }


### PR DESCRIPTION
## Summary

This patch fixes a memory-safety issue in Rust code generated by `flatc`
where table scalar setters and mutators could perform out-of-bounds
writes when operating on malformed or undersized buffers.

## Vulnerability Details

Rust-generated table setters write scalar values directly into the
backing `&mut [u8]` buffer using pointer copies without first verifying
that the buffer is large enough for the write.

If a wrapper is constructed over a buffer shorter than
`OFFSET + sizeof(T)`, calling a generated `set_*` or `mutate_*` method
would write past the end of the slice, causing undefined behavior and
memory corruption. Because these methods are safe (not `unsafe fn`),
this allows memory corruption from safe Rust code.

## Fix

* Updated Rust code generation to first obtain a bounds-checked mutable
  subslice using `get_mut(OFFSET..OFFSET+size)`
* Only perform the unsafe copy after successful bounds validation
* Preserve existing public method signatures and semantics

If the buffer is too short, the code now fails deterministically
instead of corrupting memory.

## Impact

* Prevents out-of-bounds writes from safe Rust APIs
* Hardens generated mutation code against malformed or attacker-
  controlled buffers
* No behavior change for valid buffers

## Testing

* Regenerated Rust test outputs to match the new codegen
* Reasoned verification that all scalar writes now require a successful
  bounds-checked subslice before copying

This change is limited to Rust code generation and does not affect the
binary FlatBuffers format or APIs in other languages.
