### PR TITLE
`MODULE.bazel`: Upgrade `rules_swift` version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -592,11 +592,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      # Explicitly use 8.5.1 until we can update or https://github.com/actions/runner-images/issues/13564 is fixed.
+      - name: Set env
+        run: >
+          echo "USE_BAZEL_VERSION=8.5.1" >> $GITHUB_ENV
       - name: bazel build
         run: >
           bazel build
           //:flatc
           //:flatbuffers
+          //tests:flatbuffers_test
       - name: bazel test
         run: >
           bazel test

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 
 bazel_dep(
     name = "aspect_bazel_lib",
-    version = "2.11.0",
+    version = "2.14.0",
 )
 bazel_dep(
     name = "aspect_rules_esbuild",
@@ -28,11 +28,11 @@ bazel_dep(
 )
 bazel_dep(
     name = "platforms",
-    version = "0.0.10",
+    version = "0.0.11",
 )
 bazel_dep(
     name = "rules_cc",
-    version = "0.0.16",
+    version = "0.1.1",
 )
 bazel_dep(
     name = "rules_go",


### PR DESCRIPTION
Update swifts versions and use the correct bazel version.

Was caused by the github ubuntu runner updating underneath us: https://github.com/actions/runner-images/issues/13564