### PR TITLE
* fix for https://github.com/google/flatbuffers/issues/8759

### DIFF
--- a/net/FlatBuffers/Table.cs
+++ b/net/FlatBuffers/Table.cs
@@ -150,7 +150,7 @@ namespace Google.FlatBuffers
 
             var pos = this.__vector(o);
             var len = this.__vector_len(o);
-            return bb.ToArray<T>(pos, len);
+            return bb.ToArray<T>(pos, len * ByteBuffer.SizeOf<T>());
         }
 
         // Initialize any Table-derived type to point to the union at the given offset.

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2014 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,6 +90,9 @@ namespace Google.FlatBuffers.Test
             fbb.AddOffset(test1.Value);
             var testArrayOfString = fbb.EndVector();
 
+            var longsVector = Monster.CreateVectorOfLongsVector(fbb, new long[] { 1, 100, 10000, 1000000, 100000000 });
+            var doublesVector = Monster.CreateVectorOfDoublesVector(fbb, new double[] { -1.7976931348623157e+308, 0, 1.7976931348623157e+308 });
+
             Monster.StartMonster(fbb);
             Monster.AddPos(fbb, Vec3.CreateVec3(fbb, 1.0f, 2.0f, 3.0f, 3.0,
                                                      Color.Green, (short)5, (sbyte)6));
@@ -102,6 +105,8 @@ namespace Google.FlatBuffers.Test
             Monster.AddTestarrayofstring(fbb, testArrayOfString);
             Monster.AddTestbool(fbb, true);
             Monster.AddTestarrayoftables(fbb, sortMons);
+            Monster.AddVectorOfLongs(fbb, longsVector);
+            Monster.AddVectorOfDoubles(fbb, doublesVector);
             var mon = Monster.EndMonster(fbb);
 
             if (sizePrefix)
@@ -285,6 +290,13 @@ namespace Google.FlatBuffers.Test
                 Assert.IsTrue(monster.GetTestarrayofboolsBytes().HasValue);
             }
             #endif
+
+            var longArray = monster.GetVectorOfLongsArray();
+            Assert.AreEqual(5, longArray.Length);
+            Assert.AreEqual(100, longArray[1]);
+
+            var doublesArray = monster.GetVectorOfDoublesArray();
+            Assert.AreEqual(3, doublesArray.Length);
         }
 
         [FlatBuffersTestMethod]


### PR DESCRIPTION
__vector_as_array<T> calling ByteBuffer.ToArray<T> with the length in bytes by multiplying len with ByteBuffer.Sizeof<T> and FlatBuffersExampleTests extended to call GetVectorOfLongsArray/GetVectorOfDoublesArray which failed without the fix
