### PR TITLE
Set max_compatibility_level=3 for rules_swift

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -50,6 +50,7 @@ bazel_dep(
 bazel_dep(
     name = "rules_swift",
     version = "2.1.1",
+    max_compatibility_level = 3,
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(


### PR DESCRIPTION
This is necessary to be compatible with both rules_swift 2.x and 3.x.