### PR TITLE
Remove root_package from npm_translate_lock.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -63,9 +63,6 @@ npm.npm_translate_lock(
     name = "flatbuffers_npm",
     npmrc = "//:.npmrc",
     pnpm_lock = "//ts:pnpm-lock.yaml",
-    # Override the Bazel package where pnpm-lock.yaml is located and link
-    # to the specified package instead.
-    root_package = "ts",
     verify_node_modules_ignored = "//:.bazelignore",
 )
 use_repo(npm, "flatbuffers_npm")


### PR DESCRIPTION
This attribute is removed in the next major version of `aspect_rules_js`. It's not actually needed here [according to](https://github.com/aspect-build/rules_js/pull/2709#issuecomment-3855183151) a maintainer of `aspect_rules_js`.
