### PR TITLE
[Dart] Actually use resized FlexBuffers buffer

### DIFF
--- a/dart/lib/src/builder.dart
+++ b/dart/lib/src/builder.dart
@@ -5,7 +5,7 @@ import 'types.dart';
 
 /// The main builder class for creation of a FlexBuffer.
 class Builder {
-  final ByteData _buffer;
+  ByteData _buffer;
   List<_StackValue> _stack = [];
   List<_StackPointer> _stackPointers = [];
   int _offset = 0;
@@ -506,6 +506,7 @@ class Builder {
     if (prevSize < size) {
       final newBuf = ByteData(size);
       newBuf.buffer.asUint8List().setAll(0, _buffer.buffer.asUint8List());
+      _buffer = newBuf;
     }
     return newOffset;
   }

--- a/dart/test/flex_builder_test.dart
+++ b/dart/test/flex_builder_test.dart
@@ -318,6 +318,21 @@ void main() {
         1,
       ]);
     }
+    {
+      // Default buffer is 2048 bytes, add 2300 bytes of strings that force it
+      // to grow.
+      final s1 = 'A' * 1000;
+      final s2 = 'B' * 800;
+      final s3 = 'C' * 500;
+
+      var flx = Builder()
+        ..startVector()
+        ..addString(s1)
+        ..addString(s2)
+        ..addString(s3)
+        ..end();
+      expect(flx.finish().length, 2323);
+    }
   });
 
   test('build map', () {


### PR DESCRIPTION
When building a FlexBuffer using the Dart Builder API and adding data that exceeds the default buffer size (2048 bytes), in the _newOffset() method a larger buffer is created, but never used. This results in a RangeError.

Resolve by actually replacing the too small with the new larger buffer. Add a test that verifies this by adding multiple large strings to a vector.

This was originally reported to us by a user, so additional details can be found in https://github.com/objectbox/objectbox-dart/issues/786 (note that for the reporter the data written that exceeds the buffer size is an integer and in my test a string, so the stack traces and error messages vary slightly).