### PR TITLE
Update docs support table Optional Scalars for Go

### DIFF
--- a/docs/source/support.md
+++ b/docs/source/support.md
@@ -26,7 +26,7 @@ Simple mutation                | Yes    | Yes   | Yes      | Yes   | No     | No
 Reflection                     | Yes    | No    | No       | No    | No     | No    | No  | Basic  | No  | No      | No      | No     | No
 Buffer verifier                | Yes    | No    | No       | No    | No     | No    | No  | Yes    | No  | No      | No      | No     | Yes
 Native Object API              | Yes    | No    | Yes      | Yes   | Yes    | Yes   | Yes | No     | No  | Yes     | No      | No     | Yes
-Optional Scalars               | Yes    | Yes   | Yes      | No    | No     | Yes   | Yes | Yes    | No  | No      | Yes     | Yes    | Yes
+Optional Scalars               | Yes    | Yes   | Yes      | Yes   | No     | Yes   | Yes | Yes    | No  | No      | Yes     | Yes    | Yes
 Flexbuffers                    | Yes    | Yes   | ?        | ?     | ?      | ?     | ?   | ?      | ?   | ?       | ?       | Yes    | Yes
 Testing: basic                 | Yes    | Yes   | Yes      | Yes   | Yes    | Yes   | Yes | Yes    | ?   | Yes     | Yes     | Yes    | Yes
 Testing: fuzz                  | Yes    | No    | No       | Yes   | Yes    | No    | No  | No     | ?   | No      | No      | Yes    | No


### PR DESCRIPTION
It seems like Optional Scalars support for Go was added in https://github.com/google/flatbuffers/pull/7104
This documentation page almost caused me to disregard flatbuffers for my use case but hopefully it's just a documentation miss.