### PR TITLE
Fix heap buffer overflow in StructDef Deserialize

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -4130,7 +4130,13 @@ bool StructDef::Deserialize(Parser& parser, const reflection::Object* object) {
   sortbysize = attributes.Lookup("original_order") == nullptr && !fixed;
   const auto& of = *(object->fields());
   auto indexes = std::vector<uoffset_t>(of.size());
-  for (uoffset_t i = 0; i < of.size(); i++) indexes[of.Get(i)->id()] = i;
+  for (uoffset_t i = 0; i < of.size(); i++) 
+  {
+    if (of.Get(i)->id() >= of.size()) {
+      return false;
+    }
+    indexes[of.Get(i)->id()] = i;
+  }
   size_t tmp_struct_size = 0;
   for (size_t i = 0; i < indexes.size(); i++) {
     auto field = of.Get(indexes[i]);


### PR DESCRIPTION
Fixes #8932


https://github.com/google/flatbuffers/issues/8932

This PR adds a bounds check in StructDef::Deserialize to prevent a heap buffer overflow when reading malformed bfbs files. If the field ID exceeds the size of the vector, it safely returns false.

Works on my machine to fix the bug