### PR TITLE
Fix flaky flexbuffers_alloc_check test in cargo test

### DIFF
--- a/tests/rust_usage_test/Cargo.toml
+++ b/tests/rust_usage_test/Cargo.toml
@@ -25,10 +25,12 @@ path = "bin/monster_example.rs"
 [[bin]]
 name = "flatbuffers_alloc_check"
 path = "bin/flatbuffers_alloc_check.rs"
+test = false
 
 [[bin]]
 name = "flexbuffers_alloc_check"
 path = "bin/flexbuffers_alloc_check.rs"
+test = false
 
 [[bin]]
 name = "sample_flexbuffers"


### PR DESCRIPTION
The alloc check binaries use a global non-thread-safe allocation counter (static mut NUM_ALLOCS) to assert zero heap allocations on warm builder reuse. 
When run via `cargo test`, the test harness's background threads occasionally allocate, inflating the counter and causing intermittent assertion failures. These binaries are already run reliably via `cargo run --bin` in RustTest.sh, so disabling them as test targets avoids the flaky behavior with no loss of coverage.
Closes https://github.com/google/flatbuffers/issues/8961