### PR TITLE
fix: add missing bracket

### DIFF
--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -3447,4 +3447,5 @@ fn test_shared_strings_pool_deduplication() {
     assert_eq!(m.enemy().unwrap().name(), "goblin");
 }
 
+} // mod flatbuffers_tests
 }


### PR DESCRIPTION
### Problem

`integration_test.rs` was missing a closing brace for `mod flatbuffers_tests`, causing a compilation error.

### Fix

Add the missing `}` to close the module.

### Changes

- `tests/rust_usage_test/tests/integration_test.rs` — add missing closing brace for `mod flatbuffers_tests`

### Is this a breaking change?

No. This is a build fix only.

### Test plan

```bash
cd tests/rust_usage_test && cargo test
