### PR TITLE
rust/flexbuffers: set MSRV and modernize

### DIFF
--- a/rust/flexbuffers/Cargo.toml
+++ b/rust/flexbuffers/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://google.github.io/flatbuffers/flexbuffers"
 repository = "https://github.com/google/flatbuffers"
 keywords = ["flatbuffers", "flexbuffers", "serialization", "zero-copy"]
 categories = ["encoding", "data-structures", "memory-management"]
+rust-version = "1.82"
 
 [features]
 # Sets serde::Serializer::is_human_readable() to true.

--- a/rust/flexbuffers/src/bitwidth.rs
+++ b/rust/flexbuffers/src/bitwidth.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::bitwidth::BitWidth::*;
+use serde_derive::{Deserialize, Serialize};
 use std::slice::Iter;
 
 /// Represents the size of Flexbuffers data.
@@ -68,13 +69,13 @@ macro_rules! impl_bitwidth_from {
         impl From<$from> for BitWidth {
             fn from(x: $from) -> BitWidth {
                 let x = x as $w64;
-                if x >= $w8::min_value() as $w64 && x <= $w8::max_value() as $w64 {
+                if x >= $w8::MIN as $w64 && x <= $w8::MAX as $w64 {
                     return W8;
                 }
-                if x >= $w16::min_value() as $w64 && x <= $w16::max_value() as $w64 {
+                if x >= $w16::MIN as $w64 && x <= $w16::MAX as $w64 {
                     return W16;
                 }
-                if x >= $w32::min_value() as $w64 && x <= $w32::max_value() as $w64 {
+                if x >= $w32::MIN as $w64 && x <= $w32::MAX as $w64 {
                     return W32;
                 }
                 W64
@@ -107,7 +108,7 @@ pub fn align(buffer: &mut Vec<u8>, width: BitWidth) {
     let bytes = 1 << width as u8;
     let alignment = (bytes - buffer.len() % bytes) % bytes;
     // Profiling reveals the loop is faster than Vec::resize.
-    for _ in 0..alignment as usize {
+    for _ in 0..alignment {
         buffer.push(0);
     }
 }

--- a/rust/flexbuffers/src/builder/map.rs
+++ b/rust/flexbuffers/src/builder/map.rs
@@ -48,7 +48,10 @@ impl<'a> MapBuilder<'a> {
         self.builder.push_key(key);
         // Nested vector.
         let start = Some(self.builder.values.len());
-        VectorBuilder { builder: self.builder, start }
+        VectorBuilder {
+            builder: self.builder,
+            start,
+        }
     }
     /// Starts a nested map which that will be pushed onto this map
     /// with key `key` when it is dropped.
@@ -60,7 +63,10 @@ impl<'a> MapBuilder<'a> {
         self.builder.push_key(key);
         // Nested map.
         let start = Some(self.builder.values.len());
-        MapBuilder { builder: self.builder, start }
+        MapBuilder {
+            builder: self.builder,
+            start,
+        }
     }
     /// `end_map` sorts the map by key and writes it to the buffer. This happens anyway
     /// when the map builder is dropped.

--- a/rust/flexbuffers/src/builder/mod.rs
+++ b/rust/flexbuffers/src/builder/mod.rs
@@ -15,6 +15,7 @@
 use crate::bitwidth::{align, BitWidth};
 mod value;
 use crate::FlexBufferType;
+use bitflags::bitflags;
 use std::cmp::max;
 use value::{find_vector_type, store_value, Value};
 mod map;
@@ -35,8 +36,12 @@ macro_rules! push_slice {
             S: AsRef<[T]>,
         {
             let mut value = Value::$new_vec(xs.as_ref().len());
-            let mut width =
-                xs.as_ref().iter().map(|x| BitWidth::from((*x).into())).max().unwrap_or_default();
+            let mut width = xs
+                .as_ref()
+                .iter()
+                .map(|x| BitWidth::from((*x).into()))
+                .max()
+                .unwrap_or_default();
             if !value.is_fixed_length_vector() {
                 let length = Value::UInt(xs.as_ref().len() as u64);
                 width = std::cmp::max(width, length.width_or_child_width());
@@ -131,8 +136,16 @@ impl Default for Builder {
 
 impl<'a> Builder {
     pub fn new(opts: BuilderOptions) -> Self {
-        let key_pool = if opts.contains(BuilderOptions::SHARE_KEYS) { Some(vec![]) } else { None };
-        Builder { key_pool, values: Vec::new(), buffer: Vec::new() }
+        let key_pool = if opts.contains(BuilderOptions::SHARE_KEYS) {
+            Some(vec![])
+        } else {
+            None
+        };
+        Builder {
+            key_pool,
+            values: Vec::new(),
+            buffer: Vec::new(),
+        }
     }
     /// Shows the internal flexbuffer. It will either be empty or populated with the most
     /// recently built flexbuffer.
@@ -155,7 +168,10 @@ impl<'a> Builder {
         }
     }
     fn push_key(&mut self, key: &str) {
-        debug_assert!(key.bytes().all(|b| b != b'\0'), "Keys must not have internal nulls.");
+        debug_assert!(
+            key.bytes().all(|b| b != b'\0'),
+            "Keys must not have internal nulls."
+        );
         // Search key pool if there is one.
         let found = self.key_pool.as_ref().map(|pool| {
             pool.binary_search_by(|&CachedKey(addr)| {
@@ -202,7 +218,11 @@ impl<'a> Builder {
         store_value(&mut self.buffer, length, width);
         let address = self.buffer.len();
         self.buffer.extend_from_slice(xs);
-        Value::Reference { fxb_type: FlexBufferType::Blob, address, child_width: width }
+        Value::Reference {
+            fxb_type: FlexBufferType::Blob,
+            address,
+            child_width: width,
+        }
     }
     fn push_str(&mut self, x: &str) {
         let mut string = self.store_blob(x.as_bytes());
@@ -242,12 +262,18 @@ impl<'a> Builder {
     /// The exact Flexbuffer vector type is dynamically inferred.
     pub fn start_vector(&'a mut self) -> VectorBuilder<'a> {
         self.reset();
-        VectorBuilder { builder: self, start: None }
+        VectorBuilder {
+            builder: self,
+            start: None,
+        }
     }
     /// Resets the builder and builds a new flexbuffer with a map at the root.
     pub fn start_map(&'a mut self) -> MapBuilder<'a> {
         self.reset();
-        MapBuilder { builder: self, start: None }
+        MapBuilder {
+            builder: self,
+            start: None,
+        }
     }
     /// Resets the builder and builds a new flexbuffer with the pushed value at the root.
     pub fn build_singleton<P: Pushable>(&mut self, p: P) {

--- a/rust/flexbuffers/src/builder/ser.rs
+++ b/rust/flexbuffers/src/builder/ser.rs
@@ -49,13 +49,19 @@ impl FlexbufferSerializer {
         Ok(())
     }
     fn start_vector(&mut self) {
-        let previous_end =
-            if self.nesting.is_empty() { None } else { Some(self.builder.values.len()) };
+        let previous_end = if self.nesting.is_empty() {
+            None
+        } else {
+            Some(self.builder.values.len())
+        };
         self.nesting.push(previous_end);
     }
     fn start_map(&mut self) {
-        let previous_end =
-            if self.nesting.is_empty() { None } else { Some(self.builder.values.len()) };
+        let previous_end = if self.nesting.is_empty() {
+            None
+        } else {
+            Some(self.builder.values.len())
+        };
         self.nesting.push(previous_end);
     }
     fn end_vector(&mut self) -> Result<(), Error> {

--- a/rust/flexbuffers/src/builder/value.rs
+++ b/rust/flexbuffers/src/builder/value.rs
@@ -47,10 +47,26 @@ macro_rules! new_typed_vector {
             let address = 0;
             let child_width = W8;
             match n {
-                2 => Value::Reference { address, child_width, fxb_type: $v2 },
-                3 => Value::Reference { address, child_width, fxb_type: $v3 },
-                4 => Value::Reference { address, child_width, fxb_type: $v4 },
-                _ => Value::Reference { address, child_width, fxb_type: $vn },
+                2 => Value::Reference {
+                    address,
+                    child_width,
+                    fxb_type: $v2,
+                },
+                3 => Value::Reference {
+                    address,
+                    child_width,
+                    fxb_type: $v3,
+                },
+                4 => Value::Reference {
+                    address,
+                    child_width,
+                    fxb_type: $v4,
+                },
+                _ => Value::Reference {
+                    address,
+                    child_width,
+                    fxb_type: $vn,
+                },
             }
         }
     };
@@ -58,14 +74,40 @@ macro_rules! new_typed_vector {
 
 impl Value {
     pub fn new_vector() -> Self {
-        Value::Reference { address: 0, child_width: W8, fxb_type: Vector }
+        Value::Reference {
+            address: 0,
+            child_width: W8,
+            fxb_type: Vector,
+        }
     }
     pub fn new_map() -> Self {
-        Value::Reference { address: 0, child_width: W8, fxb_type: Map }
+        Value::Reference {
+            address: 0,
+            child_width: W8,
+            fxb_type: Map,
+        }
     }
-    new_typed_vector!(new_int_vector, VectorInt2, VectorInt3, VectorInt4, VectorInt);
-    new_typed_vector!(new_uint_vector, VectorUInt2, VectorUInt3, VectorUInt4, VectorUInt);
-    new_typed_vector!(new_float_vector, VectorFloat2, VectorFloat3, VectorFloat4, VectorFloat);
+    new_typed_vector!(
+        new_int_vector,
+        VectorInt2,
+        VectorInt3,
+        VectorInt4,
+        VectorInt
+    );
+    new_typed_vector!(
+        new_uint_vector,
+        VectorUInt2,
+        VectorUInt3,
+        VectorUInt4,
+        VectorUInt
+    );
+    new_typed_vector!(
+        new_float_vector,
+        VectorFloat2,
+        VectorFloat3,
+        VectorFloat4,
+        VectorFloat
+    );
     pub fn fxb_type(&self) -> FlexBufferType {
         match *self {
             Value::Null => Null,
@@ -87,11 +129,7 @@ impl Value {
         !self.is_inline()
     }
     pub fn is_key(&self) -> bool {
-        if let Value::Key(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Value::Key(_))
     }
     pub fn is_typed_vector_or_map(&self) -> bool {
         if let Value::Reference { fxb_type, .. } = self {
@@ -222,7 +260,11 @@ where
         // Note that VectorString is deprecated for writing
         _ => return Value::new_vector(),
     };
-    Value::Reference { address: 0, child_width: W8, fxb_type: vector_type }
+    Value::Reference {
+        address: 0,
+        child_width: W8,
+        fxb_type: vector_type,
+    }
 }
 
 #[inline]
@@ -253,6 +295,9 @@ pub fn store_value(buffer: &mut Vec<u8>, mut value: Value, width: BitWidth) {
         _ => unreachable!("Variant not considered: {:?}", value),
     };
     write_result.unwrap_or_else(|err| {
-        panic!("Error writing value {:?} with width {:?}: {:?}", value, width, err)
+        panic!(
+            "Error writing value {:?} with width {:?}: {:?}",
+            value, width, err
+        )
     });
 }

--- a/rust/flexbuffers/src/builder/vector.rs
+++ b/rust/flexbuffers/src/builder/vector.rs
@@ -38,13 +38,19 @@ impl<'a> VectorBuilder<'a> {
     #[inline]
     pub fn start_vector(&mut self) -> VectorBuilder<'_> {
         let start = Some(self.builder.values.len());
-        VectorBuilder { builder: self.builder, start }
+        VectorBuilder {
+            builder: self.builder,
+            start,
+        }
     }
     /// Starts a nested map that will be pushed onto this vector when it is dropped.
     #[inline]
     pub fn start_map(&mut self) -> MapBuilder<'_> {
         let start = Some(self.builder.values.len());
-        MapBuilder { builder: self.builder, start }
+        MapBuilder {
+            builder: self.builder,
+            start,
+        }
     }
     /// `end_vector` determines the type of the vector and writes it to the buffer.
     /// This will happen automatically if the VectorBuilder is dropped.

--- a/rust/flexbuffers/src/flexbuffer_type.rs
+++ b/rust/flexbuffers/src/flexbuffer_type.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #![allow(deprecated)]
+
+use serde_derive::{Deserialize, Serialize};
+
 /// Represents all the valid types in a flexbuffer.
 ///
 /// Flexbuffers supports
@@ -34,7 +37,6 @@
 /// * Indirect numbers are stored as an offset instead of inline. Using
 /// indirect numbers instead of their inline counterparts in maps and typed
 /// vectors can reduce the minimum element width and therefore bytes used.
-
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, num_enum::TryFromPrimitive)]
 pub enum FlexBufferType {
@@ -122,10 +124,7 @@ macro_rules! is_ty {
 impl FlexBufferType {
     /// Returns true for flexbuffer types that are stored inline.
     pub fn is_inline(self) -> bool {
-        match self {
-            Null | Int | UInt | Float | Bool => true,
-            _ => false,
-        }
+        matches!(self, Null | Int | UInt | Float | Bool)
     }
     /// Returns true for flexbuffer types that are stored by offset.
     pub fn is_reference(self) -> bool {

--- a/rust/flexbuffers/src/lib.rs
+++ b/rust/flexbuffers/src/lib.rs
@@ -28,18 +28,6 @@
 //             Serializable structs are Pushable
 //             Serde with maps - field names and type names.
 
-// Until flat/flexbuffers is on Rust v1.42, we cannot use the previously unstable matches! macro.
-#![allow(unknown_lints)]
-#![allow(clippy::match_like_matches_macro)]
-
-#[macro_use]
-extern crate bitflags;
-extern crate byteorder;
-#[macro_use]
-extern crate serde_derive;
-extern crate num_enum;
-extern crate serde;
-
 mod bitwidth;
 mod buffer;
 mod builder;

--- a/rust/flexbuffers/src/reader/de.rs
+++ b/rust/flexbuffers/src/reader/de.rs
@@ -153,7 +153,10 @@ impl<'de> VariantAccess<'de> for Reader<&'de [u8]> {
         V: Visitor<'de>,
     {
         let m = self.get_map()?;
-        visitor.visit_map(MapAccessor { keys: m.keys_vector().iter(), vals: m.iter_values() })
+        visitor.visit_map(MapAccessor {
+            keys: m.keys_vector().iter(),
+            vals: m.iter_values(),
+        })
     }
 }
 
@@ -187,8 +190,10 @@ impl<'de> Deserializer<'de> for Reader<&'de [u8]> {
             (Blob, _) => visitor.visit_borrowed_bytes(self.get_blob()?.0),
             (Map, _) => {
                 let m = self.get_map()?;
-                visitor
-                    .visit_map(MapAccessor { keys: m.keys_vector().iter(), vals: m.iter_values() })
+                visitor.visit_map(MapAccessor {
+                    keys: m.keys_vector().iter(),
+                    vals: m.iter_values(),
+                })
             }
             (ty, _) if ty.is_vector() => visitor.visit_seq(self.as_vector().iter()),
             (ty, bw) => unreachable!("TODO deserialize_any {:?} {:?}.", ty, bw),

--- a/rust/flexbuffers/src/reader/iter.rs
+++ b/rust/flexbuffers/src/reader/iter.rs
@@ -27,7 +27,11 @@ pub struct ReaderIterator<B> {
 impl<B: Buffer> ReaderIterator<B> {
     pub(super) fn new(reader: VectorReader<B>) -> Self {
         let end = reader.len();
-        ReaderIterator { reader, front: 0, end }
+        ReaderIterator {
+            reader,
+            front: 0,
+            end,
+        }
     }
 }
 

--- a/rust/flexbuffers/src/reader/map.rs
+++ b/rust/flexbuffers/src/reader/map.rs
@@ -34,7 +34,10 @@ pub struct MapReader<B> {
 
 impl<B: Buffer> Clone for MapReader<B> {
     fn clone(&self) -> Self {
-        MapReader { buffer: self.buffer.shallow_copy(), ..*self }
+        MapReader {
+            buffer: self.buffer.shallow_copy(),
+            ..*self
+        }
     }
 }
 
@@ -122,7 +125,13 @@ impl<B: Buffer> MapReader<B> {
             .get(type_address)
             .ok_or(Error::FlexbufferOutOfBounds)
             .and_then(|&b| unpack_type(b))?;
-        Reader::new(self.buffer.shallow_copy(), data_address, fxb_type, width, self.values_width)
+        Reader::new(
+            self.buffer.shallow_copy(),
+            data_address,
+            fxb_type,
+            width,
+            self.values_width,
+        )
     }
 
     fn key_index(&self, k: &str) -> Result<Reader<B>, Error> {

--- a/rust/flexbuffers/src/reader/mod.rs
+++ b/rust/flexbuffers/src/reader/mod.rs
@@ -15,6 +15,7 @@
 use crate::bitwidth::BitWidth;
 use crate::flexbuffer_type::FlexBufferType;
 use crate::{Blob, Buffer};
+use serde_derive::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::ops::Rem;
@@ -217,7 +218,12 @@ impl<B: Buffer> Reader<B> {
                 fxb_type = t;
             }
         }
-        Ok(Reader { address, fxb_type, width, buffer })
+        Ok(Reader {
+            address,
+            fxb_type,
+            width,
+            buffer,
+        })
     }
 
     /// Parses the flexbuffer from the given buffer. Assumes the flexbuffer root is the last byte
@@ -258,7 +264,11 @@ impl<B: Buffer> Reader<B> {
         if let Some(len) = self.fxb_type.fixed_length_vector_length() {
             len
         } else if self.fxb_type.has_length_slot() && self.address >= self.width.n_bytes() {
-            read_usize(&self.buffer, self.address - self.width.n_bytes(), self.width)
+            read_usize(
+                &self.buffer,
+                self.address - self.width.n_bytes(),
+                self.width,
+            )
         } else {
             0
         }
@@ -278,14 +288,20 @@ impl<B: Buffer> Reader<B> {
         if self.fxb_type == ty {
             Ok(())
         } else {
-            Err(Error::UnexpectedFlexbufferType { expected: ty, actual: self.fxb_type })
+            Err(Error::UnexpectedFlexbufferType {
+                expected: ty,
+                actual: self.fxb_type,
+            })
         }
     }
     fn expect_bw(&self, bw: BitWidth) -> Result<(), Error> {
         if self.width == bw {
             Ok(())
         } else {
-            Err(Error::UnexpectedBitWidth { expected: bw, actual: self.width })
+            Err(Error::UnexpectedBitWidth {
+                expected: bw,
+                actual: self.width,
+            })
         }
     }
 
@@ -305,8 +321,10 @@ impl<B: Buffer> Reader<B> {
             self.expect_bw(T::WIDTH)?;
         }
         let end = self.address + self.length() * std::mem::size_of::<T>();
-        let slice: &[u8] =
-            self.buffer.get(self.address..end).ok_or(Error::FlexbufferOutOfBounds)?;
+        let slice: &[u8] = self
+            .buffer
+            .get(self.address..end)
+            .ok_or(Error::FlexbufferOutOfBounds)?;
 
         // `align_to` is required because the point of this function is to directly hand back a
         // slice of scalars. This can fail because Rust's default allocator is not 16byte aligned
@@ -323,7 +341,11 @@ impl<B: Buffer> Reader<B> {
     /// Otherwise Returns error.
     pub fn get_bool(&self) -> Result<bool, Error> {
         self.expect_type(FlexBufferType::Bool)?;
-        Ok(self.buffer[self.address..self.address + self.width.n_bytes()].iter().any(|&b| b != 0))
+        Ok(
+            self.buffer[self.address..self.address + self.width.n_bytes()]
+                .iter()
+                .any(|&b| b != 0),
+        )
     }
 
     /// Gets the length of the key if this type is a key.
@@ -366,7 +388,9 @@ impl<B: Buffer> Reader<B> {
     /// is out of bounds.
     pub fn get_str(&self) -> Result<B::BufferString, Error> {
         self.expect_type(FlexBufferType::String)?;
-        let bytes = self.buffer.slice(self.address..self.address + self.length());
+        let bytes = self
+            .buffer
+            .slice(self.address..self.address + self.length());
         Ok(bytes.ok_or(Error::ReadUsizeOverflowed)?.buffer_str()?)
     }
 
@@ -402,16 +426,22 @@ impl<B: Buffer> Reader<B> {
     /// address is out of bounds.
     pub fn get_u64(&self) -> Result<u64, Error> {
         self.expect_type(FlexBufferType::UInt)?;
-        let cursor = self.buffer.get(self.address..self.address + self.width.n_bytes());
+        let cursor = self
+            .buffer
+            .get(self.address..self.address + self.width.n_bytes());
         match self.width {
-            BitWidth::W8 => cursor.map(|s| s[0] as u8).map(Into::into),
-            BitWidth::W16 => {
-                cursor.and_then(|s| s.try_into().ok()).map(<u16>::from_le_bytes).map(Into::into)
-            }
-            BitWidth::W32 => {
-                cursor.and_then(|s| s.try_into().ok()).map(<u32>::from_le_bytes).map(Into::into)
-            }
-            BitWidth::W64 => cursor.and_then(|s| s.try_into().ok()).map(<u64>::from_le_bytes),
+            BitWidth::W8 => cursor.map(|s| s[0]).map(Into::into),
+            BitWidth::W16 => cursor
+                .and_then(|s| s.try_into().ok())
+                .map(<u16>::from_le_bytes)
+                .map(Into::into),
+            BitWidth::W32 => cursor
+                .and_then(|s| s.try_into().ok())
+                .map(<u32>::from_le_bytes)
+                .map(Into::into),
+            BitWidth::W64 => cursor
+                .and_then(|s| s.try_into().ok())
+                .map(<u64>::from_le_bytes),
         }
         .ok_or(Error::FlexbufferOutOfBounds)
     }
@@ -419,16 +449,22 @@ impl<B: Buffer> Reader<B> {
     /// address is out of bounds.
     pub fn get_i64(&self) -> Result<i64, Error> {
         self.expect_type(FlexBufferType::Int)?;
-        let cursor = self.buffer.get(self.address..self.address + self.width.n_bytes());
+        let cursor = self
+            .buffer
+            .get(self.address..self.address + self.width.n_bytes());
         match self.width {
             BitWidth::W8 => cursor.map(|s| s[0] as i8).map(Into::into),
-            BitWidth::W16 => {
-                cursor.and_then(|s| s.try_into().ok()).map(<i16>::from_le_bytes).map(Into::into)
-            }
-            BitWidth::W32 => {
-                cursor.and_then(|s| s.try_into().ok()).map(<i32>::from_le_bytes).map(Into::into)
-            }
-            BitWidth::W64 => cursor.and_then(|s| s.try_into().ok()).map(<i64>::from_le_bytes),
+            BitWidth::W16 => cursor
+                .and_then(|s| s.try_into().ok())
+                .map(<i16>::from_le_bytes)
+                .map(Into::into),
+            BitWidth::W32 => cursor
+                .and_then(|s| s.try_into().ok())
+                .map(<i32>::from_le_bytes)
+                .map(Into::into),
+            BitWidth::W64 => cursor
+                .and_then(|s| s.try_into().ok())
+                .map(<i64>::from_le_bytes),
         }
         .ok_or(Error::FlexbufferOutOfBounds)
     }
@@ -436,13 +472,18 @@ impl<B: Buffer> Reader<B> {
     /// address is out of bounds, or if its a f16 or f8 (not currently supported).
     pub fn get_f64(&self) -> Result<f64, Error> {
         self.expect_type(FlexBufferType::Float)?;
-        let cursor = self.buffer.get(self.address..self.address + self.width.n_bytes());
+        let cursor = self
+            .buffer
+            .get(self.address..self.address + self.width.n_bytes());
         match self.width {
             BitWidth::W8 | BitWidth::W16 => return Err(Error::InvalidPackedType),
-            BitWidth::W32 => {
-                cursor.and_then(|s| s.try_into().ok()).map(f32_from_le_bytes).map(Into::into)
-            }
-            BitWidth::W64 => cursor.and_then(|s| s.try_into().ok()).map(f64_from_le_bytes),
+            BitWidth::W32 => cursor
+                .and_then(|s| s.try_into().ok())
+                .map(f32_from_le_bytes)
+                .map(Into::into),
+            BitWidth::W64 => cursor
+                .and_then(|s| s.try_into().ok())
+                .map(f64_from_le_bytes),
         }
         .ok_or(Error::FlexbufferOutOfBounds)
     }
@@ -452,7 +493,7 @@ impl<B: Buffer> Reader<B> {
             Bool => self.get_bool().unwrap_or_default(),
             UInt => self.as_u64() != 0,
             Int => self.as_i64() != 0,
-            Float => self.as_f64().abs() > std::f64::EPSILON,
+            Float => self.as_f64().abs() > f64::EPSILON,
             String | Key => !self.as_str().is_empty(),
             Null => false,
             Blob => self.length() != 0,
@@ -465,9 +506,11 @@ impl<B: Buffer> Reader<B> {
     pub fn as_u64(&self) -> u64 {
         match self.fxb_type {
             FlexBufferType::UInt => self.get_u64().unwrap_or_default(),
-            FlexBufferType::Int => {
-                self.get_i64().unwrap_or_default().try_into().unwrap_or_default()
-            }
+            FlexBufferType::Int => self
+                .get_i64()
+                .unwrap_or_default()
+                .try_into()
+                .unwrap_or_default(),
             FlexBufferType::Float => self.get_f64().unwrap_or_default() as u64,
             FlexBufferType::String => {
                 if let Ok(s) = self.get_str() {
@@ -490,9 +533,11 @@ impl<B: Buffer> Reader<B> {
     pub fn as_i64(&self) -> i64 {
         match self.fxb_type {
             FlexBufferType::Int => self.get_i64().unwrap_or_default(),
-            FlexBufferType::UInt => {
-                self.get_u64().unwrap_or_default().try_into().unwrap_or_default()
-            }
+            FlexBufferType::UInt => self
+                .get_u64()
+                .unwrap_or_default()
+                .try_into()
+                .unwrap_or_default(),
             FlexBufferType::Float => self.get_f64().unwrap_or_default() as i64,
             FlexBufferType::String => {
                 if let Ok(s) = self.get_str() {
@@ -546,7 +591,10 @@ impl<B: Buffer> Reader<B> {
         if !self.fxb_type.is_vector() {
             self.expect_type(FlexBufferType::Vector)?;
         };
-        Ok(VectorReader { reader: self.clone(), length: self.length() })
+        Ok(VectorReader {
+            reader: self.clone(),
+            length: self.length(),
+        })
     }
 }
 

--- a/rust/flexbuffers/src/reader/vector.rs
+++ b/rust/flexbuffers/src/reader/vector.rs
@@ -29,13 +29,19 @@ pub struct VectorReader<B> {
 
 impl<B: Buffer> Clone for VectorReader<B> {
     fn clone(&self) -> Self {
-        VectorReader { reader: self.reader.clone(), ..*self }
+        VectorReader {
+            reader: self.reader.clone(),
+            ..*self
+        }
     }
 }
 
 impl<B: Buffer> Default for VectorReader<B> {
     fn default() -> Self {
-        VectorReader { reader: Reader::default(), length: usize::default() }
+        VectorReader {
+            reader: Reader::default(),
+            length: usize::default(),
+        }
     }
 }
 


### PR DESCRIPTION
`flexbuffers` don't use a lockfile, so they have a pretty recent minimum stable Rust version because of the transitive `indexmap` dependency.  [`cargo-msrv`](https://github.com/foresterre/cargo-msrv) put it at 1.82, so that's what I set `rust-version` to.

<details>

<summary>cargo-msrv on gnu</summary>

```
  [Meta]   cargo-msrv 0.18.4

Compatibility Check #1: Rust 1.63.0
  [FAIL]   Is incompatible

  ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │ error: failed to parse lock file at: /home/akolchin/fork/flatbuffers/rust/flexbuffers/Cargo.lock                                    │
  │                                                                                                                                     │
  │ Caused by:                                                                                                                          │
  │   lock file version `4` was found, but this version of Cargo does not understand this lock file, perhaps Cargo needs to be updated? │
  │                                                                                                                                     │
  ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯


Compatibility Check #2: Rust 1.79.0
  [FAIL]   Is incompatible

  ╭────────────────────────────────────────────────────────────────────────╮
  │     Updating crates.io index                                           │
  │  Downloading crates ...                                                │
  │   Downloaded num_enum_derive v0.5.11                                   │
  │   Downloaded equivalent v1.0.2                                         │
  │   Downloaded toml_datetime v0.6.11                                     │
  │   Downloaded proc-macro-crate v1.3.1                                   │
  │   Downloaded num_enum v0.5.11                                          │
  │   Downloaded byteorder v1.5.0                                          │
  │   Downloaded bitflags v1.3.2                                           │
  │   Downloaded once_cell v1.21.3                                         │
  │   Downloaded quote v1.0.45                                             │
  │   Downloaded unicode-ident v1.0.24                                     │
  │   Downloaded serde_core v1.0.228                                       │
  │   Downloaded serde_derive v1.0.228                                     │
  │   Downloaded proc-macro2 v1.0.106                                      │
  │   Downloaded memchr v2.8.0                                             │
  │   Downloaded toml_edit v0.19.15                                        │
  │   Downloaded serde v1.0.228                                            │
  │   Downloaded indexmap v2.13.0                                          │
  │   Downloaded hashbrown v0.16.1                                         │
  │   Downloaded winnow v0.5.40                                            │
  │   Downloaded syn v2.0.117                                              │
  │   Downloaded syn v1.0.109                                              │
  │ error: rustc 1.79.0 is not supported by the following package:         │
  │   indexmap@2.13.0 requires rustc 1.82                                  │
  │ Either upgrade rustc or select compatible dependency versions with     │
  │ `cargo update <name>@<current-ver> --precise <compatible-ver>`         │
  │ where `<compatible-ver>` is the latest version supporting rustc 1.79.0 │
  │                                                                        │
  │                                                                        │
  ╰────────────────────────────────────────────────────────────────────────╯


Compatibility Check #3: Rust 1.87.0
  [OK]     Is compatible

Compatibility Check #4: Rust 1.83.0
  [OK]     Is compatible

Compatibility Check #5: Rust 1.81.0
  [FAIL]   Is incompatible

  ╭────────────────────────────────────────────────────────────────────────╮
  │ error: rustc 1.81.0 is not supported by the following package:         │
  │   indexmap@2.13.0 requires rustc 1.82                                  │
  │ Either upgrade rustc or select compatible dependency versions with     │
  │ `cargo update <name>@<current-ver> --precise <compatible-ver>`         │
  │ where `<compatible-ver>` is the latest version supporting rustc 1.81.0 │
  │                                                                        │
  │                                                                        │
  ╰────────────────────────────────────────────────────────────────────────╯


Compatibility Check #6: Rust 1.82.0
  [OK]     Is compatible

Result:
   Considered (min … max):   Rust 1.31.1 … Rust 1.94.0
   Search method:            bisect
   MSRV:                     1.82.0
   Target:                   x86_64-unknown-linux-gnu
```

</details>

<details>

<summary>cargo-msrv on musl</summary>

```
  [Meta]   cargo-msrv 0.19.2

Compatibility Check #1: Rust 1.63.0
  [FAIL]   Is incompatible

  ╭──────────────────────────────────────────────────────────────────────────────╮
  │ error: failed to parse lock file at: /home/kaathewise/fork/flatbuffers/rust/ │
  │ flexbuffers/Cargo.lock                                                       │
  │                                                                              │
  │ Caused by:                                                                   │
  │   lock file version `4` was found, but this                                  │
  │ version of Cargo does not understand this lock file, perhaps Cargo needs to  │
  │ be updated?                                                                  │
  │                                                                              │
  ╰──────────────────────────────────────────────────────────────────────────────╯


Compatibility Check #2: Rust 1.79.0
  [FAIL]   Is incompatible

  ╭─────────────────────────────────────────────────────────────────╮
  │ error: rustc 1.79.0 is not supported by the following packages: │
  │   flexbuffers@25.12.19 requires rustc 1.82                      │
  │   indexmap@2.13.0 requires rustc 1.82                           │
  │                                                                 │
  │                                                                 │
  ╰─────────────────────────────────────────────────────────────────╯


Compatibility Check #3: Rust 1.87.0
  [OK]     Is compatible

Compatibility Check #4: Rust 1.83.0
  [OK]     Is compatible

Compatibility Check #5: Rust 1.81.0
  [FAIL]   Is incompatible

  ╭─────────────────────────────────────────────────────────────────╮
  │ error: rustc 1.81.0 is not supported by the following packages: │
  │   flexbuffers@25.12.19 requires rustc 1.82                      │
  │   indexmap@2.13.0 requires rustc 1.82                           │
  │                                                                 │
  │                                                                 │
  ╰─────────────────────────────────────────────────────────────────╯


Compatibility Check #6: Rust 1.82.0
  [OK]     Is compatible

Result:
   Considered (min … max):   Rust 1.31.1 … Rust 1.94.0
   Search method:            bisect
   MSRV:                     1.82.0
   Target:                   x86_64-unknown-linux-musl
```

</details>

All of the other changes were made with the 1.82 toolchain:

- There are a lot of formatting updates because `rustfmt` has changed its rules since then.
- Replaced `min_value` and `max_value` integer methods with `MIN` and `MAX` associated constants
- `extern crate` declarations replaced with imports
- Outdated 1.42 lint silencer removed and `matches` is now used where the lint was failing
- I also replaced a few redundant casts (u8 as u8, usize as usize) because they showed up as warnings

Most of the other clippy warnings are about doc comment formatting.

This PR should unblock this feature:

```
// TODO(cneo): serde stuff are behind a default-on feature flag
```

which I initially wanted to implement but didn't because I unsure what effect on MSRV it would have