### PR TITLE
[rust] Unimpl Eq, PartialEq for FlatBufferBuilder

### DIFF
--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -129,7 +129,7 @@ struct FieldLoc {
 /// FlatBufferBuilder builds a FlatBuffer through manipulating its internal
 /// state. It has an owned `Vec<u8>` that grows as needed (up to the hardcoded
 /// limit of 2GiB, which is set by the FlatBuffers format).
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct FlatBufferBuilder<'fbb, A: Allocator = DefaultAllocator> {
     allocator: A,
     head: ReverseIndex,


### PR DESCRIPTION
There's no clear semantics, what exactly we are comparing. For example, when `strings_pool` are supposed to be equal and does it matter?

Let's remove these for clarity.

Encountered it while implementing #8995.