### PR TITLE
Reject unterminated FlexBuffers keys during verification

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -1976,7 +1976,7 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
   bool VerifyKey(const uint8_t* p) {
     FLEX_CHECK_VERIFIED(p, PackedType(BIT_WIDTH_8, FBT_KEY));
     while (p < buf_ + size_)
-      if (*p++) return true;
+      if (*p++ == '\0') return true;
     return false;
   }
 

--- a/tests/flexbuffers_test.cpp
+++ b/tests/flexbuffers_test.cpp
@@ -187,6 +187,14 @@ void FlexBuffersReuseBugTest() {
           true);
 }
 
+void FlexBuffersInvalidKeyVerifierTest() {
+  const uint8_t invalid_key_root[] = { 0x01, 0x01, 0x12, 0x01 };
+  std::vector<uint8_t> reuse_tracker;
+  TEST_EQ(flexbuffers::VerifyBuffer(invalid_key_root, sizeof(invalid_key_root),
+                                    &reuse_tracker),
+          false);
+}
+
 void FlexBuffersFloatingPointTest() {
 #if defined(FLATBUFFERS_HAS_NEW_STRTOD) && (FLATBUFFERS_HAS_NEW_STRTOD > 0)
   flexbuffers::Builder slb(512,

--- a/tests/flexbuffers_test.h
+++ b/tests/flexbuffers_test.h
@@ -6,6 +6,7 @@ namespace tests {
 
 void FlexBuffersTest();
 void FlexBuffersReuseBugTest();
+void FlexBuffersInvalidKeyVerifierTest();
 void FlexBuffersFloatingPointTest();
 void FlexBuffersDeprecatedTest();
 void ParseFlexbuffersFromJsonWithNullTest();

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1829,6 +1829,7 @@ int FlatBufferTests(const std::string& tests_data_path) {
   CreateSharedStringTest();
   FlexBuffersTest();
   FlexBuffersReuseBugTest();
+  FlexBuffersInvalidKeyVerifierTest();
   FlexBuffersDeprecatedTest();
   UninitializedVectorTest();
   EqualOperatorTest();


### PR DESCRIPTION
## Summary
Reject malformed FlexBuffers keys that are not NUL-terminated within the buffer.

## Problem
`VerifyKey()` returned success after encountering any non-zero byte, which allowed malformed `FBT_KEY` values without a terminating NUL byte to pass `VerifyBuffer()`.

## Fix
Require a NUL terminator before the end of the buffer and add a regression test for the 4-byte malformed input from issue #9008.

## Testing
- built & ran `flattests.exe`
- all tests passed

Fixes #9008