### PR TITLE
Fix Lua table field builder slot generation

### DIFF
--- a/src/bfbs_gen_lua.cpp
+++ b/src/bfbs_gen_lua.cpp
@@ -554,7 +554,7 @@ class LuaBfbsGenerator : public BaseBfbsGenerator {
     if (IsScalar(base_type)) {
       return namer_.Type(GenerateType(base_type));
     }
-    if (IsStructOrTable(base_type)) {
+    if (base_type == r::Obj && GetObject(field->type())->is_struct()) {
       return "Struct";
     }
     return "UOffsetTRelative";

--- a/tests/LuaTest.sh
+++ b/tests/LuaTest.sh
@@ -17,6 +17,8 @@
 pushd "$(dirname $0)" >/dev/null
 test_dir="$(pwd)"
 
+${test_dir}/../flatc -l -o ${test_dir} lua_nested_table_test.fbs
+
 declare -a versions=(luajit lua5.1 lua5.2 lua5.3 lua5.4)
 
 for i in "${versions[@]}"

--- a/tests/lua_nested_table_test.fbs
+++ b/tests/lua_nested_table_test.fbs
@@ -1,0 +1,11 @@
+table Customer {
+  name:string;
+  age:int;
+}
+
+table Sale {
+  amount:int;
+  customer:Customer;
+}
+
+root_type Sale;

--- a/tests/luatest.lua
+++ b/tests/luatest.lua
@@ -317,6 +317,26 @@ local function testAccessByteVectorAsString()
     end
 end
 
+local function testLuaNestedTablePack()
+    local sale = assert(require("Sale"))
+    local customer = assert(require("Customer"))
+    local builder = flatbuffers.Builder(0)
+
+    local name = builder:CreateString("Alice")
+    customer.Start(builder)
+    customer.AddName(builder, name)
+    customer.AddAge(builder, 33)
+    local customerOffset = customer.End(builder)
+
+    sale.Start(builder)
+    sale.AddAmount(builder, 125)
+    sale.AddCustomer(builder, customerOffset)
+    local saleOffset = sale.End(builder)
+    builder:Finish(saleOffset)
+
+    assert(#builder:Output() > 0)
+end
+
 local tests = 
 { 
     {   
@@ -343,6 +363,10 @@ local tests =
     {
         f = testAccessByteVectorAsString,
         d = "Access byte vector as string"
+    },
+    {
+        f = testLuaNestedTablePack,
+        d = "Lua nested table fields pack with UOffset slots"
     },
 }
 


### PR DESCRIPTION
## Summary
Make the Lua generator use `PrependUOffsetTRelativeSlot` for table fields instead of `PrependStructSlot`.

## Problem
The Lua generator treated both structs and tables as `Struct` when selecting the builder slot method for table fields.

For a schema like:
```fbs
table Customer {
  name:string;
  age:int;
}

table Sale {
  amount:int;
  customer:Customer;
}
```

it generated:
```lua
function Sale.AddCustomer(builder, customer)
  builder:PrependStructSlot(1, customer, 0)
end
```

but `customer` is a table offset, not an inline struct. This causes packing to fail with:
`Tried to write a Struct at an Offset that is different from the current Offset of the Builder.`

## Fix
- only use `Struct` builder methods for actual struct fields
- use `UOffsetTRelative` for table fields
- add a focused Lua regression schema and test that packs a nested table successfully

## Testing
- rebuilt `flatc`
- generated Lua for the nested `Customer` / `Sale` schema
- verified the generated `Sale.AddCustomer` now uses `PrependUOffsetTRelativeSlot`
- luatest.lua: `8 / 8` tests passed

Fixes #8611