### PR TITLE
Stage the Python license file during builds

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -12,33 +12,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+import shutil
+
 from setuptools import setup
 
-setup(
-    name='flatbuffers',
-    version='25.12.19',
-    license='Apache 2.0',
-    author='Derek Bailey',
-    author_email='derekbailey@google.com',
-    url='https://google.github.io/flatbuffers/',
-    long_description=(
-        'Python runtime library for use with the '
-        '`Flatbuffers <https://google.github.io/flatbuffers/>`_ '
-        'serialization format.'
-    ),
-    packages=['flatbuffers'],
-    include_package_data=True,
-    requires=[],
-    description='The FlatBuffers serialization format for Python',
-    classifiers=[
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
-    project_urls={
-        'Documentation': 'https://google.github.io/flatbuffers/',
-        'Source': 'https://github.com/google/flatbuffers',
-    },
-)
+
+_THIS_DIR = Path(__file__).resolve().parent
+_ROOT_LICENSE = _THIS_DIR.parent / 'LICENSE'
+_LOCAL_LICENSE = _THIS_DIR / 'LICENSE'
+
+
+def _stage_license_file():
+    if _LOCAL_LICENSE.exists() or not _ROOT_LICENSE.exists():
+        return False
+    shutil.copyfile(_ROOT_LICENSE, _LOCAL_LICENSE)
+    return True
+
+_remove_staged_license = _stage_license_file()
+
+try:
+    setup(
+        name='flatbuffers',
+        version='25.12.19',
+        license='Apache 2.0',
+        author='Derek Bailey',
+        author_email='derekbailey@google.com',
+        url='https://google.github.io/flatbuffers/',
+        long_description=(
+            'Python runtime library for use with the '
+            '`Flatbuffers <https://google.github.io/flatbuffers/>`_ '
+            'serialization format.'
+        ),
+        packages=['flatbuffers'],
+        include_package_data=True,
+        requires=[],
+        description='The FlatBuffers serialization format for Python',
+        classifiers=[
+            'Intended Audience :: Developers',
+            'Operating System :: OS Independent',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 3',
+            'Topic :: Software Development :: Libraries :: Python Modules',
+        ],
+        project_urls={
+            'Documentation': 'https://google.github.io/flatbuffers/',
+            'Source': 'https://github.com/google/flatbuffers',
+        },
+    )
+finally:
+    if _remove_staged_license and _LOCAL_LICENSE.exists():
+        _LOCAL_LICENSE.unlink()


### PR DESCRIPTION
## Summary
Stage the repo-root `LICENSE` file into the Python package directory during builds.

## Problem
The Python package can no longer use `../LICENSE` in `license_files` but the current `license_files = LICENSE` configuration also warns because `python/LICENSE` does not exist at build time.

## Fix
- copy the repo-root `LICENSE` into the Python package directory before calling `setup()`
- let setuptools include it through `license_files = LICENSE`
- remove the staged copy afterwards so no tracked duplicate is needed in the repo

## Testing
- ran `python -m build` in `python/`
- verified the previous `license_files` warning is gone
- verified the built wheel includes `dist-info/licenses/LICENSE`
- verified the temporary `python/LICENSE` file is removed after the build

Fixes #8789.
