### PR TITLE
Require Python sdists in release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -464,6 +464,15 @@ jobs:
     - name: test
       working-directory: tests
       run: bash PythonTest.sh
+    - name: build python package
+      working-directory: python
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install build twine
+        python3 -m build .
+        python3 -m twine check dist/*
+        test -n "$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+        test -n "$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)"
 
   build-go:
     name: Build Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Build
         run: |
           python3 -m build .
+          python3 -m twine check dist/*
+          test -n "$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)"
 
       - name: Upload to PyPi
         run: |


### PR DESCRIPTION
## Summary
Add release guards so Python packaging workflows require both a wheel and a source distribution.

## Problem
Issue #8895 reports that the PyPI release for `25.12.19` was uploaded without an sdist.

That is a release-process failure rather than a runtime code bug, and it is useful to prevent directly in CI and release automation.

## Fix
- extend the Python CI job to build the Python package
- run `twine check` on the built artifacts
- assert that both a wheel and an sdist are present
- add the same checks to the PyPI release workflow before upload

## Testing
- ran `python -m build` in `python/`
- confirmed the build produces both:
  - `flatbuffers-25.12.19-py3-none-any.whl`
  - `flatbuffers-25.12.19.tar.gz`
- verified the new workflow checks match those artifact expectations

Fixes #8895.