### PR TITLE
Fix FlexBuffers VerifyKey() inverted null-terminator check

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -1976,7 +1976,7 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
   bool VerifyKey(const uint8_t* p) {
     FLEX_CHECK_VERIFIED(p, PackedType(BIT_WIDTH_8, FBT_KEY));
     while (p < buf_ + size_)
-      if (*p++) return true;
+      if (!*p++) return true;
     return false;
   }
 


### PR DESCRIPTION
## Fix FlexBuffers VerifyKey() inverted null-terminator check

`VerifyKey()` incorrectly returned `true` upon encountering a non-null byte instead of verifying that a null terminator exists within the buffer bounds.

### Bug
The condition `if (*p++) return true;` returns true on the first **non-null** byte, meaning any key with at least one non-null byte passes verification regardless of whether a null terminator exists within the buffer.

### Impact
After verification, calls to `AsString()`, `AsKey()`, or `ToString()` on a `FBT_KEY` reference invoke `strlen()` which reads past the buffer boundary (heap/stack OOB read).

### Fix
Negate the condition to check for the null terminator:
```diff
-      if (*p++) return true;
+      if (!*p++) return true;
```

### Reproduction
```cpp
uint8_t poc[] = {0x00, 0x10, 0x01, 0x10, 0x01};
std::vector<uint8_t> rt;
bool valid = flexbuffers::VerifyBuffer(poc, sizeof(poc), &rt);
// valid == true (WRONG, should be false)
auto root = flexbuffers::GetRoot(poc, sizeof(poc));
auto s = root.AsString();  // OOB read via strlen()
```

Compile with: `clang++ -fsanitize=address -I include poc.cc src/util.cpp`

Found via fuzzing with AddressSanitizer.