### PR TITLE
Fix out-of-bounds read in flexbuffers::GetRoot

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -1007,9 +1007,14 @@ inline Reference Map::operator[](const std::string& key) const {
 inline Reference GetRoot(const uint8_t* buffer, size_t size) {
   // See Finish() below for the serialization counterpart of this.
   // The root starts at the end of the buffer, so we parse backwards from there.
+  // A valid FlexBuffer needs at minimum: 1 data byte + 1 packed_type byte +
+  // 1 byte_width byte = 3 bytes.
+  if (size < 3) return Reference();
   auto end = buffer + size;
   auto byte_width = *--end;
   auto packed_type = *--end;
+  // Guard: byte_width must not push 'end' before the start of the buffer.
+  if (byte_width > static_cast<size_t>(end - buffer)) return Reference();
   end -= byte_width;  // The root data item.
   return Reference(end, byte_width, packed_type);
 }


### PR DESCRIPTION
This fixes a missing bounds check in flexbuffers::GetRoot.

Currently, the function reads byte_width and packed_type by moving backwards from the end of the buffer, but it doesn’t check if the buffer is large enough or if byte_width is valid. This can cause the pointer to move before the start of the buffer and lead to an out-of-bounds read.

I added two small checks:

Return early if the buffer size is less than 3 bytes
Ensure byte_width does not move the pointer before the buffer start

If the input is invalid, it now safely returns a null Reference(), which is already consistent with how other parts of the code handle invalid access.

