### PR TITLE
fix: replace archived actions-rs/toolchain with dtolnay/rust-toolchain (supply chain hardening)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,11 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          
+      - uses: dtolnay/rust-toolchain@stable
       - name: Publish Flatbuffers
         uses: katyo/publish-crates@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE # this needs to be an env var
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish Maven
         run: mvn --batch-mode clean deploy
@@ -100,7 +100,7 @@ jobs:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USER_V2 }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_TOKEN_V2 }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          
+
   publish-maven-kotlin:
     name: Publish Maven - Kotlin
     runs-on: ubuntu-latest
@@ -119,7 +119,7 @@ jobs:
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE # this needs to be an env var
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish Kotlin Library on Maven
         run: ./gradlew publishAllPublicationsToSonatypeRepository
@@ -128,17 +128,12 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_TOKEN_V2 }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
-
   publish-crates:
     name: Publish crates.io
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          
+      - uses: dtolnay/rust-toolchain@stable
       - name: Publish Flatbuffers
         uses: katyo/publish-crates@v2
         with:


### PR DESCRIPTION
Replaces the archived actions-rs/toolchain@v1 action (actions-rs org was abandoned in 2023, mutable tag) with the actively-maintained dtolnay/rust-toolchain@stable in the publish-crates job.

This job has simultaneous access to CARGO_TOKEN, NPM_TOKEN, TWINE_TOKEN, NUGET_API_KEY, OSSRH_USER_V2, OSSRH_TOKEN_V2, MAVEN_GPG_PRIVATE_KEY, and MAVEN_GPG_PASSPHRASE. A compromised action tag could exfiltrate all 8 secrets in a single workflow run.