### PR TITLE
Fix code injection via unescaped doc comments in Java/Kotlin/C# generators

### DIFF
--- a/src/code_generators.cpp
+++ b/src/code_generators.cpp
@@ -212,7 +212,14 @@ void GenComment(const std::vector<std::string>& dc, std::string* code_ptr,
            ? config->content_line_prefix
            : "///");
   for (auto it = dc.begin(); it != dc.end(); ++it) {
-    code += line_prefix + *it + "\n";
+    std::string sanitized = *it;
+    // Sanitize comment content: escape block comment closing sequence
+    // to prevent code injection via premature comment termination.
+    for (size_t pos = sanitized.find("*/"); pos != std::string::npos;
+         pos = sanitized.find("*/", pos + 2)) {
+      sanitized.replace(pos, 2, "* /");
+    }
+    code += line_prefix + sanitized + "\n";
   }
   if (config != nullptr && config->last_line != nullptr) {
     code += std::string(prefix) + std::string(config->last_line) + "\n";

--- a/src/idl_gen_kotlin.cpp
+++ b/src/idl_gen_kotlin.cpp
@@ -1410,7 +1410,14 @@ class KotlinGenerator : public BaseGenerator {
              ? config->content_line_prefix
              : "///");
     for (auto it = dc.begin(); it != dc.end(); ++it) {
-      writer += line_prefix + *it;
+      std::string sanitized = *it;
+      // Sanitize comment content: escape block comment closing sequence
+      // to prevent code injection via premature comment termination.
+      for (size_t pos = sanitized.find("*/"); pos != std::string::npos;
+           pos = sanitized.find("*/", pos + 2)) {
+        sanitized.replace(pos, 2, "* /");
+      }
+      writer += line_prefix + sanitized;
     }
     if (config != nullptr && config->last_line != nullptr) {
       writer += std::string(config->last_line);

--- a/src/idl_gen_kotlin_kmp.cpp
+++ b/src/idl_gen_kotlin_kmp.cpp
@@ -1393,7 +1393,14 @@ class KotlinKMPGenerator : public BaseGenerator {
              ? config->content_line_prefix
              : "///");
     for (auto it = dc.begin(); it != dc.end(); ++it) {
-      writer += line_prefix + *it;
+      std::string sanitized = *it;
+      // Sanitize comment content: escape block comment closing sequence
+      // to prevent code injection via premature comment termination.
+      for (size_t pos = sanitized.find("*/"); pos != std::string::npos;
+           pos = sanitized.find("*/", pos + 2)) {
+        sanitized.replace(pos, 2, "* /");
+      }
+      writer += line_prefix + sanitized;
     }
     if (config != nullptr && config->last_line != nullptr) {
       writer += std::string(config->last_line);


### PR DESCRIPTION
### Summary

Fix a **Code Injection** vulnerability (CWE-94 / CWE-116) in the `flatc` compiler where documentation comments (`///`) from `.fbs` schema files were directly concatenated into generated source code without sanitizing the block comment closing sequence `*/`.

### Details

When generating Java, Kotlin, or C# source code, `flatc` wraps documentation comments inside `/** ... */` Javadoc/KDoc-style block comments. An attacker who provides a malicious `.fbs` schema can include the `*/` character sequence in a documentation comment to prematurely close the generated comment block, thereby injecting arbitrary code into the generated source files.

For example, this malicious schema:
```fbs
table Pwn {
  /// */ public static void main(String[] args) { Runtime.getRuntime().exec("malicious_command"); } /*
  name: string;
}
root_type Pwn;
```

Would generate a Java file where the payload escapes the comment block and becomes executable code.

### Fix

This PR sanitizes the `*/` sequence by replacing it with `* /` (inserting a space) before emitting it into the generated output. The fix is applied to all three locations where comment content is written:

1. **`GenComment()`** in `src/code_generators.cpp` — shared by the Java and C# generators
2. **`GenerateComment()`** in `src/idl_gen_kotlin.cpp` — Kotlin generator
3. **`GenerateComment()`** in `src/idl_gen_kotlin_kmp.cpp` — Kotlin KMP generator

### Testing

- Built and verified the fix against a malicious PoC schema — the payload now stays safely inside the comment block
- All existing `flattests` pass: `ALL TESTS PASSED`

**Before the patch** (malicious code escapes the comment):
```java
/**
 * */ public static void main(String[] args) { ... } /*
 */
```

**After the patch** (payload remains inside the comment):
```java
/**
 * * / public static void main(String[] args) { ... } /*
 */
```