### PR TITLE
integer overflow in size-prefixed verifier bounds check

### DIFF
--- a/include/flatbuffers/verifier.h
+++ b/include/flatbuffers/verifier.h
@@ -254,11 +254,12 @@ class VerifierTemplate FLATBUFFERS_FINAL_CLASS {
 
   template <typename T, typename SizeT = uoffset_t>
   bool VerifySizePrefixedBuffer(const char* const identifier) {
-    return Verify<SizeT>(0U) &&
-           // Ensure the prefixed size is within the bounds of the provided
-           // length.
-           Check(ReadScalar<SizeT>(buf_) + sizeof(SizeT) <= size_) &&
-           VerifyBufferFromStart<T>(identifier, sizeof(SizeT));
+    if (!Verify<SizeT>(0U)) return false;
+    // Ensure the prefixed size is within the bounds of the provided length.
+    const auto prefixed_size = static_cast<uint64_t>(ReadScalar<SizeT>(buf_));
+    const auto max_payload_size = static_cast<uint64_t>(size_ - sizeof(SizeT));
+    if (!Check(prefixed_size <= max_payload_size)) return false;
+    return VerifyBufferFromStart<T>(identifier, sizeof(SizeT));
   }
 
   template <typename OffsetT = uoffset_t, typename SOffsetT = soffset_t>

--- a/tests/64bit/offset64_test.cpp
+++ b/tests/64bit/offset64_test.cpp
@@ -374,6 +374,17 @@ void Offset64SizePrefix() {
 
   // Verify the fields.
   TEST_EQ_STR(root_table->near_string()->c_str(), "some near string");
+
+  std::vector<uint8_t> tampered(builder.GetBufferPointer(),
+                                builder.GetBufferPointer() + builder.GetSize());
+  WriteScalar<uoffset64_t>(tampered.data(),
+                           (std::numeric_limits<uoffset64_t>::max)());
+
+  Verifier::Options tampered_options = options;
+  tampered_options.assert = false;
+  Verifier tampered_verifier(tampered.data(), tampered.size(),
+                             tampered_options);
+  TEST_EQ(VerifySizePrefixedRootTableBuffer(tampered_verifier), false);
 }
 
 void Offset64ManyVectors() {


### PR DESCRIPTION
Summary
-------

Fixes an integer overflow risk in the size-prefixed verifier bounds check that could allow malformed buffers to bypass validation.

Problem
-------

The previous check:

ReadScalar(buf\_) + sizeof(SizeT) <= size\_

performs unsigned arithmetic that can overflow for crafted large prefix values.This wraparound may cause invalid size-prefixed buffers to incorrectly pass verification.

Fix
---

Replaces the overflow-prone addition with a safe comparison against the remaining buffer size:

prefixed\_size <= (size\_ - sizeof(SizeT))

*   Preserves original validation logic
    
*   Eliminates overflow possibility
    
*   Ensures fail-closed behaviour for malformed inputs
    

Test
----

Added a targeted regression case in offset64\_test.cpp:

*   Tampered buffer with maximum prefix value
    
*   Verifies that malformed input is correctly rejected
    
*   Uses assert = false locally to avoid aborts in debug verification builds
    

Impact
------

*   No change to valid input behavior
    
*   No API or design changes
    
*   Affects only malformed/overflow cases
    
*   Minimal, two-file patch
    

Validation
----------

*   Built successfully with CMake
    
*   All tests passed (flattests, flattests\_cpp17)
    
*   Verified under strict compiler flags and assertion-enabled mode
    
*   No new warnings or platform-specific issues