### PR TITLE
fix: null pointer check in PrintOffset() for union types

### DIFF
--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -182,9 +182,9 @@ struct JsonPrinter {
                           const uint8_t* prev_val, soffset_t vector_index) {
     switch (type.base_type) {
       case BASE_TYPE_UNION: {
-        // If this assert hits, you have an corrupt buffer, a union type field
+        // If this assert hits, you have a corrupt buffer, a union type field
         // was not present or was out of range.
-        FLATBUFFERS_ASSERT(prev_val);
+        if (!prev_val) { return "unknown enum value"; }
         auto union_type_byte = *prev_val;  // Always a uint8_t.
         if (vector_index >= 0) {
           auto type_vec = reinterpret_cast<const Vector<uint8_t>*>(


### PR DESCRIPTION
Good day,

This PR fixes issue #9033 - Null Pointer Dereference in JsonPrinter::PrintOffset() for Union Types.

**Problem:**
The code used `FLATBUFFERS_ASSERT(prev_val)` to check for nullptr, but this assert is removed in release builds (-DNDEBUG). When a malformed FlatBuffer has the union value field present but the union type discriminator field absent (vtable offset zeroed), prev_val is nullptr. Dereferencing it causes an immediate segmentation fault.

**Solution:**
Replace the assert with an explicit nullptr check that returns "unknown enum value" gracefully:

```cpp
// Before (crashes in release):
FLATBUFFERS_ASSERT(prev_val);
auto union_type_bytes = *prev_val;

// After (handles null gracefully):
if (!prev_val) { return "unknown enum value"; }
auto union_type_bytes = *prev_val;
```

This also fixes a typo in the comment: "an corrupt buffer" → "a corrupt buffer".

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof