### PR TITLE
Fix reflection verifier: missing VerifyField calls and OOB root read

### DIFF
--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -240,6 +240,9 @@ static bool VerifyObject(flatbuffers::Verifier& v,
             return false;
           }
         } else {
+          if (!table->VerifyField<uoffset_t>(v, field_def->offset(),
+                                             sizeof(uoffset_t)))
+            return false;
           if (!VerifyObject(v, schema, *child_obj,
                             flatbuffers::GetFieldT(*table, *field_def),
                             field_def->required())) {
@@ -249,6 +252,9 @@ static bool VerifyObject(flatbuffers::Verifier& v,
         break;
       }
       case reflection::Union: {
+        if (!table->VerifyField<uoffset_t>(v, field_def->offset(),
+                                           sizeof(uoffset_t)))
+          return false;
         //  get union type from the prev field
         voffset_t utype_offset = field_def->offset() - sizeof(voffset_t);
         auto utype = table->GetField<uint8_t>(utype_offset, 0);
@@ -786,6 +792,7 @@ Offset<const Table*> CopyTable(FlatBufferBuilder& fbb,
 bool Verify(const reflection::Schema& schema, const reflection::Object& root,
             const uint8_t* const buf, const size_t length,
             const uoffset_t max_depth, const uoffset_t max_tables) {
+  if (length < sizeof(uoffset_t)) return false;
   Verifier v(buf, length, max_depth, max_tables);
   return VerifyObject(v, schema, root, flatbuffers::GetAnyRoot(buf),
                       /*required=*/true);
@@ -795,6 +802,7 @@ bool VerifySizePrefixed(const reflection::Schema& schema,
                         const reflection::Object& root,
                         const uint8_t* const buf, const size_t length,
                         const uoffset_t max_depth, const uoffset_t max_tables) {
+  if (length < sizeof(uoffset_t) * 2) return false;
   Verifier v(buf, length, max_depth, max_tables);
   return VerifyObject(v, schema, root, flatbuffers::GetAnySizePrefixedRoot(buf),
                       /*required=*/true);


### PR DESCRIPTION
## Summary

- **Missing VerifyField for Obj/Union fields:** In `VerifyObject()`, the `reflection::Obj` (non-struct table) and `reflection::Union` cases call `GetFieldT()` to dereference a uoffset without first calling `VerifyField<uoffset_t>()` to validate the offset is in bounds. All other field types (scalars, strings, vectors) already had proper VerifyField checks. A crafted buffer could cause GetFieldT to follow an unvalidated offset, leading to an out-of-bounds read. Added the missing `VerifyField<uoffset_t>()` calls before each `GetFieldT()`.

- **Verify() / VerifySizePrefixed() OOB root read:** Both entry points call `GetAnyRoot()` / `GetAnySizePrefixedRoot()` which read `sizeof(uoffset_t)` bytes from the buffer *before* the Verifier performs any checks. If the buffer is shorter than 4 bytes (or 8 bytes for size-prefixed), this is an out-of-bounds read. Added minimum length checks before dereferencing the root offset.

## Test plan

- [ ] Verify existing reflection tests pass with `cmake --build . && ctest`
- [ ] Fuzz with short/empty buffers to confirm the Verify() length check prevents the OOB root read
- [ ] Fuzz with crafted flatbuffers containing Obj/Union fields with invalid offsets to confirm VerifyField rejects them