### PR TITLE
Fix C++ union verifier to reject unknown type tags

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -1693,7 +1693,7 @@ class CppGenerator : public BaseGenerator {
         code_ += "    }";
       }
     }
-    code_ += "    default: return true;";  // unknown values are OK.
+    code_ += "    default: return false;";  // Reject unknown union types.
     code_ += "  }";
     code_ += "}";
     code_ += "";


### PR DESCRIPTION
## Summary

The C++ code generator (`src/idl_gen_cpp.cpp`) emits `default: return true;` in every generated union verification function (`Verify<UnionName>`). This causes the verifier to accept buffers containing unknown/out-of-range union type values without validating the union's data field.

When application code subsequently accesses the union through typed accessors (the standard verify-then-use pattern), the unvalidated data is interpreted as a table, leading to out-of-bounds memory access.

## Root Cause

In `src/idl_gen_cpp.cpp` line 1696, the generated switch statement for union verification has:

```cpp
default: return true;  // unknown values are OK.
```

This should return `false` to reject unknown union types, consistent with the verifier's purpose of ensuring buffer integrity before access.

## Fix

One-line change: `default: return true` → `default: return false`

After this fix, buffers with unknown union type tags will correctly fail verification.

## Impact

Affects all C++ applications that:
1. Receive FlatBuffer data from untrusted sources
2. Call the generated `Verify*Buffer()` function
3. Access union fields afterward

This is the standard recommended usage pattern in FlatBuffers documentation.

## Test plan
- [x] Verified that known union types still pass verification
- [x] Verified that unknown union types are now correctly rejected
- [x] Related: PR #9047 adds a fuzz target covering verify-then-access patterns