### PR TITLE
Fix indention level for --no-python-gen-numpy

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -2471,7 +2471,7 @@ class PythonGenerator : public BaseGenerator {
     } else {
       GenPackForScalarVectorFieldHelper(struct_def, field, code_prefix_ptr, 3);
       code_prefix += "(self." + field_field + "[i])";
-      code_prefix += GenIndents(4) + field_field + " = builder.EndVector()";
+      code_prefix += GenIndents(3) + field_field + " = builder.EndVector()";
     }
   }
 


### PR DESCRIPTION
Indention level is wrong. See minimal reproducer example:

monster_extra.fbs
```
table MonsterExtra {
  dvec : [double];
}
```

Generate with `./flatc --python --no-python-gen-numpy --gen-object-api monster_extra.fbs`

without the fix

```
# MonsterExtraT
    def Pack(self, builder):
        if self.dvec is not None:
            MonsterExtraStartDvecVector(builder, len(self.dvec))
            for i in reversed(range(len(self.dvec))):
                builder.PrependFloat64(self.dvec[i])
                dvec = builder.EndVector()
        MonsterExtraStart(builder)
        if self.dvec is not None:
            MonsterExtraAddDvec(builder, dvec)
        monsterExtra = MonsterExtraEnd(builder)
        return monsterExtra
```

note the `dvec = builder.EndVector()` inside the loop


And with the fix ->
```
    # MonsterExtraT
    def Pack(self, builder):
        if self.dvec is not None:
            MonsterExtraStartDvecVector(builder, len(self.dvec))
            for i in reversed(range(len(self.dvec))):
                builder.PrependFloat64(self.dvec[i])
            dvec = builder.EndVector()
        MonsterExtraStart(builder)
        if self.dvec is not None:
            MonsterExtraAddDvec(builder, dvec)
        monsterExtra = MonsterExtraEnd(builder)
        return monsterExtra
```