### PR TITLE
fix size-prefixed buffer bounds check to avoid overflow

### DIFF
--- a/include/flatbuffers/verifier.h
+++ b/include/flatbuffers/verifier.h
@@ -255,9 +255,9 @@ class VerifierTemplate FLATBUFFERS_FINAL_CLASS {
   template <typename T, typename SizeT = uoffset_t>
   bool VerifySizePrefixedBuffer(const char* const identifier) {
     return Verify<SizeT>(0U) &&
-           // Ensure the prefixed size is within the bounds of the provided
-           // length.
-           Check(ReadScalar<SizeT>(buf_) + sizeof(SizeT) <= size_) &&
+           // The declared payload size must fit in the bytes remaining after
+           // the size prefix, and subtraction avoids unsigned wraparound.
+           Check(ReadScalar<SizeT>(buf_) <= size_ - sizeof(SizeT)) &&
            VerifyBufferFromStart<T>(identifier, sizeof(SizeT));
   }
 

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -1,5 +1,7 @@
 #include "monster_test.h"
 
+#include <cstdint>
+#include <cstring>
 #include <limits>
 #include <vector>
 
@@ -633,6 +635,35 @@ void SizePrefixedTest() {
                                            fbb.GetSize() - 10);
     TEST_EQ(VerifySizePrefixedMonsterBuffer(verifier_smaller), false);
   }
+
+  {
+    std::vector<uint8_t> corrupted(fbb.GetBufferPointer(),
+                                   fbb.GetBufferPointer() + fbb.GetSize());
+    const size_t buffer_size = corrupted.size();
+    // Mutate only the prefix. Payload remains valid.
+    const uoffset_t invalid_prefix =
+      buffer_size < static_cast<size_t>(std::numeric_limits<uoffset_t>::max())
+        ? static_cast<uoffset_t>(buffer_size) + static_cast<uoffset_t>(1)
+        : std::numeric_limits<uoffset_t>::max();
+    std::memcpy(corrupted.data(), &invalid_prefix, sizeof(invalid_prefix));
+
+    flatbuffers::Verifier verifier_invalid(corrupted.data(), corrupted.size());
+    // The declared payload size must not exceed the bytes after the prefix.
+    TEST_EQ(VerifySizePrefixedMonsterBuffer(verifier_invalid), false);
+  }
+
+#if UINTPTR_MAX == 0xffffffffu
+  {
+    std::vector<uint8_t> corrupted(fbb.GetBufferPointer(),
+                                   fbb.GetBufferPointer() + fbb.GetSize());
+    const uoffset_t overflow_prefix = std::numeric_limits<uoffset_t>::max();
+    std::memcpy(corrupted.data(), &overflow_prefix, sizeof(overflow_prefix));
+
+    flatbuffers::Verifier verifier_overflow(corrupted.data(), corrupted.size());
+    // On 32-bit builds, this documents the old wraparound behavior.
+    TEST_EQ(VerifySizePrefixedMonsterBuffer(verifier_overflow), false);
+  }
+#endif
 }
 
 void TestMonsterExtraFloats(const std::string& tests_data_path) {


### PR DESCRIPTION
## Summary
Fix the bounds check in `VerifierTemplate::VerifySizePrefixedBuffer()` to avoid relying on addition that can wrap on 32-bit builds, and instead enforce the framing invariant directly.

## Root Cause
The previous check used:

prefix + sizeof(SizeT) <= size_

This relies on unsigned addition, which can wrap on 32-bit systems. It also enforces the boundary indirectly rather than checking the invariant itself.

## Change
Replaced the addition-based check with:

prefix <= size_ - sizeof(SizeT)


This:
- avoids potential wraparound
- directly enforces the size-prefixed buffer invariant
- does not change behavior for valid inputs

## Invariant
For size-prefixed buffers, the declared payload size must fit within the remaining bytes after the prefix.

## Impact
- Prevents acceptance of malformed size-prefixed buffers under edge conditions
- Improves correctness of verifier boundary checks
- No behavior change for valid buffers

## Tests
- Added invariant-based test:
  - Mutates only the size prefix
  - Ensures `prefix > remaining buffer` is rejected
- Added 32-bit-only test:
  - Documents previous wraparound behavior
- Tests are deterministic and avoid undefined behavior

## Scope
- Limited strictly to verifier boundary logic
- No changes to helper APIs (e.g. `GetSizePrefixedBufferLength`)
- No refactoring or unrelated modifications

## Notes
- Change is minimal and follows existing coding patterns
- No impact on code generators
- Code formatted using `clang-format`
