### PR TITLE
Rust: codegen + runtime support for vectors of unions (#5024)

### DIFF
--- a/RUST_VECTORS_OF_UNIONS_DESIGN.md
+++ b/RUST_VECTORS_OF_UNIONS_DESIGN.md
@@ -1,0 +1,264 @@
+# Rust: Vectors of Unions — Design Notes
+
+Tracking issue: [#5024](https://github.com/google/flatbuffers/issues/5024).
+
+This document captures the design that the patch on
+`feat/rust-vector-of-unions` implements (and scaffolds). It is intended to be
+read together with the diff in `src/idl_gen_rust.cpp`,
+`rust/flatbuffers/src/lib.rs` and the new test schema in
+`tests/rust_usage_test/`.
+
+The goal is to bring the Rust generator and runtime up to parity with C++,
+Java, Go and TypeScript for the `[Union]` schema construct. Single-union
+fields, which already work, are intentionally left untouched in this patch
+to keep the change focused and avoid the breaking-API churn that previous
+attempts (notably `0x4d0x4b`'s 2018 work) ran into.
+
+## Background
+
+A FlatBuffers union field encodes two pieces of information:
+
+1. a *discriminant* (a small unsigned integer that names the variant), and
+2. a *value* (an offset to a table, struct or string in the buffer).
+
+For a single union field, the schema:
+
+```
+union Character { Attacker, Rapunzel, BookReader }
+table Movie { main_character: Character; }
+```
+
+emits two vtable slots — `main_character_type: u8` and `main_character: u32
+offset` — and `flatc` generates a `main_character_as_attacker()` accessor
+that resolves the offset back to a typed `Attacker` table.
+
+For a vector field, the same idea is applied element-wise: `[Character]`
+produces *two parallel vectors* in the buffer. C++ emits this layout (see
+`tests/union_vector/union_vector_generated.h`):
+
+```cpp
+const Vector<uint8_t> *characters_type();
+const Vector<Offset<void>> *characters();
+```
+
+with a verifier that walks both vectors in lockstep and dispatches per
+element. Go, Java, TS and Swift use the same layout. The buffer wire
+format is therefore unchanged from those languages — what we are adding is
+only Rust codegen + a thin runtime helper.
+
+## Wire format (read side)
+
+For a field `characters: [Character];`, the table contains:
+
+- vtable slot N:   `Vector<u8>` of discriminants (the `_type` vector).
+- vtable slot N+1: `Vector<ForwardsUOffset<Table>>` of values.
+
+Both vectors must be present together (the verifier already requires this
+on other languages and this patch enforces it on Rust). The two vectors
+must have the same length; PR #8853 added that check on the C++ side.
+On Rust we get it for free in `visit_union_vector`.
+
+## Generated Rust shape
+
+For `characters: [Character]` on table `Movie`, the generator emits, in
+addition to the existing scaffolding for a regular vector:
+
+```rust
+impl<'a> Movie<'a> {
+    pub const VT_CHARACTERS_TYPE: VOffsetT = ...;
+    pub const VT_CHARACTERS:      VOffsetT = ...;
+
+    /// Vector of union discriminants.
+    #[inline]
+    pub fn characters_type(&self)
+        -> Option<flatbuffers::Vector<'a, Character>> { ... }
+
+    /// Vector of raw value offsets. Prefer `characters_iter()`.
+    #[inline]
+    pub fn characters(&self)
+        -> Option<flatbuffers::Vector<'a,
+                  flatbuffers::ForwardsUOffset<flatbuffers::Table<'a>>>> { ... }
+
+    /// Iterate as typed `CharacterUnionRef` values. Yields `None` for
+    /// each element whose discriminant is unknown (forward-compat).
+    #[inline]
+    pub fn characters_iter(&self)
+        -> Option<impl Iterator<Item = CharacterUnionRef<'a>> + 'a> { ... }
+
+    // Per-variant accessors (mirrors single-union `<field>_as_<variant>`):
+    pub fn characters_as_mu_lan(&self, i: usize) -> Option<Attacker<'a>>;
+    pub fn characters_as_rapunzel(&self, i: usize) -> Option<&'a Rapunzel>;
+    pub fn characters_as_belle(&self, i: usize) -> Option<&'a BookReader>;
+    pub fn characters_as_book_fan(&self, i: usize) -> Option<&'a BookReader>;
+    pub fn characters_as_other(&self, i: usize) -> Option<&'a str>;
+    pub fn characters_as_unused(&self, i: usize) -> Option<&'a str>;
+}
+```
+
+`CharacterUnionRef<'a>` is a new generated enum, parallel to the existing
+owned-object enum `CharacterT`, that borrows from the buffer:
+
+```rust
+pub enum CharacterUnionRef<'a> {
+    NONE,
+    MuLan(Attacker<'a>),
+    Rapunzel(&'a Rapunzel),
+    Belle(&'a BookReader),
+    BookFan(&'a BookReader),
+    Other(&'a str),
+    Unused(&'a str),
+    /// Discriminant the reader does not recognise.
+    UnknownVariant(Character),
+}
+```
+
+This mirrors the shape of the existing single-union accessor surface
+without forcing a breaking change on `Character` (which is currently a
+value enum used as the discriminant). The owned `CharacterT` enum
+already exists and is unchanged.
+
+## Generated Rust shape (write side, scaffolded)
+
+The write side needs to be careful: the builder must place the two
+vectors into adjacent vtable slots and verify lengths match. Scaffold:
+
+```rust
+impl<'a> MovieArgs<'a> {
+    pub characters_type: Option<WIPOffset<Vector<'a, Character>>>,
+    pub characters:      Option<WIPOffset<Vector<'a,
+                            ForwardsUOffset<UnionWIPOffset>>>>,
+}
+
+// Convenience helper:
+impl<'b> FlatBufferBuilder<'b> {
+    pub fn create_vector_of_unions<'a, U: AsUnion>(
+        &mut self,
+        items: &[U],
+    ) -> (WIPOffset<Vector<'a, U::Tag>>,
+          WIPOffset<Vector<'a, ForwardsUOffset<UnionWIPOffset>>>);
+}
+```
+
+`AsUnion` is a small trait the generator emits for each union enum, with
+`fn tag(&self) -> Self::Tag` and `fn pack(&self, fbb) -> WIPOffset<...>`.
+The trait is the minimum surface needed to keep ordinary `MovieT::pack`
+happy without changing how single-union fields are written.
+
+The current patch generates the read-side accessors and scaffolds the
+write-side codegen entry points behind a `// TODO(#5024): write side`
+marker; see `idl_gen_rust.cpp` cases for `ftVectorOfUnionValue` in
+`TableBuilderArgsAddFunc*`, `MakeNativeNameInTable` and
+`TableBuilderAddVectorOfFn`. This keeps the binary buildable and lets
+follow-up work focus on the builder API alone.
+
+## Verifier
+
+The Rust verifier already has `visit_union` for single fields. For
+vectors we add `visit_union_vector` on `TableVerifier`:
+
+```rust
+impl<'ver, 'opts, 'buf> TableVerifier<'ver, 'opts, 'buf> {
+    pub fn visit_union_vector<Key, UnionVerifier>(
+        self,
+        key_field_name: impl Into<Cow<'static, str>>,
+        key_field_voff: VOffsetT,
+        val_field_name: impl Into<Cow<'static, str>>,
+        val_field_voff: VOffsetT,
+        required: bool,
+        verify_union: UnionVerifier,
+    ) -> Result<Self>
+    where
+        Key: Follow<'buf> + Verifiable,
+        UnionVerifier: Fn(<Key as Follow<'buf>>::Inner,
+                          &mut Verifier, usize) -> Result<()>;
+}
+```
+
+The implementation mirrors the Swift `visitUnionVector` referenced by
+`@mustiikhalil` in #5024:
+
+1. Resolve both vtable slots; if both absent, ok unless required.
+2. If only one is present, return `InconsistentUnion`.
+3. Resolve the two vectors and verify they share a length.
+4. For each index, follow the discriminant and dispatch to
+   `verify_union(discriminant, verifier, value_pos)`.
+
+The matching codegen change in `idl_gen_rust.cpp` is in the verifier
+section that currently handles `ftUnionValue`; the new branch covers
+`ftVectorOfUnionValue` and emits a per-variant `match` arm using
+`verify_union_variant::<ForwardsUOffset<T>>` exactly like the single-
+union case.
+
+## Forward-compatibility / unknown discriminants
+
+Following PR #6797's design (`UnknownVariant`), the iterator yields
+`UnknownVariant(tag)` rather than panicking when a reader sees a tag it
+does not know. This is consistent with how `MovieT::unpack` already
+falls back to `Character::NONE`, but for the by-ref iterator we choose to
+expose the raw tag so callers can choose to error or skip.
+
+## What is in the patch on `feat/rust-vector-of-unions`
+
+Read side (done):
+- `idl_gen_rust.cpp`: `ftVectorOfUnionValue` cases for
+  `TableBuilderArgsDefnType`, `GenTableAccessorFuncReturnType`,
+  `FollowType`, `ObjectFieldType`. Vector-of-discriminants accessor
+  emitted alongside the value-vector accessor; per-variant `_as_*`
+  accessors emitted in the same loop as single-union fields.
+- `rust/flatbuffers/src/verifier.rs`: `visit_union_vector` helper.
+- `idl_gen_rust.cpp`: verifier emit branch for `ftVectorOfUnionValue`.
+
+Test scaffolding (done):
+- `tests/rust_usage_test/tests/union_vector_test.rs`: new test file that
+  builds a `Movie` with three characters via raw offsets (avoiding
+  reliance on the not-yet-built `flatc`) and asserts round-trip read.
+- The generated Rust file
+  `tests/union_vector/union_vector_generated.rs` is hand-written here so
+  the test compiles and exercises the runtime helper. When `flatc` is
+  available the file should be re-emitted from `union_vector.fbs` and
+  diffed against this hand-written copy.
+
+Write side (scaffolded):
+- All four `ftVectorOfUnionValue` cases in `idl_gen_rust.cpp` that
+  participate in the builder/native-object path are reachable but emit
+  `// TODO(#5024): write side` and a panic-stub that mirrors the
+  existing assertion text. This keeps existing schemas (which do not
+  use `[Union]`) compiling while leaving a clear handoff point.
+
+## Known caveats / open questions
+
+- **Aliased variants** (`union AnyAmbiguousAliases { M1: Monster, M2:
+  Monster }`): `0x4d0x4b` and `@CasperN` agreed in the issue thread
+  that the right approach is per-variant constructors
+  (`AnyAmbiguousAliases::create_m1(...)`, etc.) rather than an
+  ambiguous `from_value_offset`. The current patch's read-side accessors
+  emit one `_as_<variant>` per *name* (matching Java), so reads on
+  ambiguous aliases work correctly. The matching constructor design is
+  punted to the write-side patch.
+
+- **Native-object pack**: `MovieT::pack` walks the owned
+  `Vec<CharacterT>`. To round-trip via the native path we need the
+  builder helper above. The patch leaves `MovieT::pack` calling the
+  TODO stub on this field; if a downstream user has `[Union]` in their
+  schema, the native-object path will need follow-up work before it
+  compiles. This is documented and gated by an explicit assertion so
+  callers get a clear error rather than silent corruption.
+
+- **`flatc` regeneration**: this branch was prepared on a host without
+  `cmake`, so the canonical `tests/monster_test/...` Rust files were
+  *not* regenerated. The `monster_test.fbs` schema does not use
+  `[Union]`, so its generated output is unaffected by this patch — but
+  CI should run `scripts/generate_code.py` and confirm a clean diff
+  before merging.
+
+## Follow-up work after this branch lands
+
+1. Implement the write-side `create_vector_of_unions` helper and its
+   codegen, replacing the TODO stubs.
+2. Update `scripts/generate_code.py` to also pass `union_vector.fbs`
+   through the Rust generator.
+3. Regenerate `tests/union_vector/union_vector_generated.rs` from the
+   schema and remove the hand-written copy in this branch.
+4. Extend `MovieT::pack`/`unpack` round-trip to cover the vector field.
+5. Sample: add a `samples/sample_binary.rs` companion that uses
+   `[Character]` so the README sample matches other languages.

--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -497,6 +497,120 @@ impl<'ver, 'opts, 'buf> TableVerifier<'ver, 'opts, 'buf> {
             ),
         }
     }
+
+    /// Vector-of-union counterpart of [`visit_union`]. Verifies that the
+    /// paired discriminant and value vectors are both present (or both
+    /// absent), share a length, and that each element is a valid union
+    /// variant.
+    ///
+    /// Used by code generated for `[Union]` schema fields. Refs
+    /// <https://github.com/google/flatbuffers/issues/5024>.
+    #[inline]
+    pub fn visit_union_vector<Key, UnionVerifier>(
+        mut self,
+        key_field_name: impl Into<Cow<'static, str>>,
+        key_field_voff: VOffsetT,
+        val_field_name: impl Into<Cow<'static, str>>,
+        val_field_voff: VOffsetT,
+        required: bool,
+        verify_union: UnionVerifier,
+    ) -> Result<Self>
+    where
+        Key: 'buf + Follow<'buf> + Verifiable,
+        Vector<'buf, Key>: Verifiable,
+        UnionVerifier:
+            (Fn(<Key as Follow<'buf>>::Inner, &mut Verifier, usize) -> Result<()>),
+    {
+        let key_field_name = key_field_name.into();
+        let val_field_name = val_field_name.into();
+
+        // Resolve both vtable slots up front. Like `visit_union`, both must
+        // be present or both absent — anything else is an inconsistent union.
+        let key_pos = self.deref(key_field_voff)?;
+        let val_pos = self.deref(val_field_voff)?;
+        let (key_vec_pos, val_vec_pos) = match (key_pos, val_pos) {
+            (None, None) => {
+                if required {
+                    return InvalidFlatbuffer::new_missing_required(val_field_name);
+                }
+                return Ok(self);
+            }
+            (Some(k), Some(v)) => (k, v),
+            _ => {
+                return InvalidFlatbuffer::new_inconsistent_union(
+                    val_field_name,
+                    key_field_name,
+                );
+            }
+        };
+
+        // Verify the discriminant vector first. Vector<Key> implements
+        // Verifiable for the simple-scalar Key (the union discriminant
+        // is always a u8/u16/etc enum), so this gives us length + range
+        // checks for free.
+        trace_field(
+            <ForwardsUOffset<Vector<'_, Key>>>::run_verifier(self.verifier, key_vec_pos),
+            key_field_name.clone(),
+            key_vec_pos,
+        )?;
+
+        // Verify the value-offset vector by hand: the elements are
+        // `ForwardsUOffset<Table>`, and `Table` does not implement
+        // `Verifiable` directly (you need a discriminant to know what
+        // table type to verify against). We just check the vector range
+        // and size here; per-element verification happens below.
+        let val_vec_inner_pos = {
+            let off = self.verifier.get_uoffset(val_vec_pos)? as usize;
+            off.saturating_add(val_vec_pos)
+        };
+        let val_range = verify_vector_range::<ForwardsUOffset<crate::Table<'_>>>(
+            self.verifier,
+            val_vec_inner_pos,
+        )?;
+
+        // Safety: discriminant vector verified above, so its length and
+        // contents are in-bounds.
+        let buf = self.verifier.buffer;
+        let key_vec_start =
+            (unsafe { crate::read_scalar_at::<UOffsetT>(buf, key_vec_pos) } as usize)
+                .saturating_add(key_vec_pos);
+        let key_size = core::mem::size_of::<Key>();
+        let key_len =
+            unsafe { crate::read_scalar_at::<UOffsetT>(buf, key_vec_start) } as usize;
+
+        // Same-length invariant; matches the C++ verifier change in
+        // PR #8853 and the Swift visitUnionVector contract.
+        let val_size = core::mem::size_of::<ForwardsUOffset<crate::Table<'_>>>();
+        let val_len = (val_range.end - val_range.start) / val_size;
+        if key_len != val_len {
+            return InvalidFlatbuffer::new_inconsistent_union(
+                val_field_name,
+                key_field_name,
+            );
+        }
+
+        // Walk in lockstep: read discriminant, then dispatch the user-
+        // supplied verifier on the value at the corresponding index.
+        for i in 0..key_len {
+            let key_elem_pos =
+                key_vec_start.saturating_add(SIZE_UOFFSET).saturating_add(key_size * i);
+            // Safety: key vector range was verified above.
+            let discriminant = unsafe { Key::follow(buf, key_elem_pos) };
+
+            let val_elem_pos = val_range.start.saturating_add(val_size * i);
+            // Resolve the value offset to its absolute position before
+            // handing it to the per-variant verifier.
+            let val_offset = self.verifier.get_uoffset(val_elem_pos)? as usize;
+            let val_target = val_offset.saturating_add(val_elem_pos);
+            trace_elem(
+                verify_union(discriminant, self.verifier, val_target),
+                i,
+                val_target,
+            )?;
+        }
+        Ok(self)
+    }
+
     pub fn finish(self) -> &'ver mut Verifier<'opts, 'buf> {
         self.verifier.depth -= 1;
         self.verifier

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -211,10 +211,16 @@ static FullType GetFullType(const Type& type) {
       case ftEnumKey: {
         return ftVectorOfEnumKey;
       }
-      case ftUnionKey:
+      case ftUnionKey: {
+        // [Union] schema fields cause the parser to auto-generate a
+        // parallel `<field>_type` vector-of-discriminants. Treat its
+        // element as a regular enum key so existing `Vec<EnumKey>`
+        // code paths handle it (the type vector is a plain Vec<u8>
+        // tagged with the union's enum_def).
+        return ftVectorOfEnumKey;
+      }
       case ftUnionValue: {
-        FLATBUFFERS_ASSERT(false && "vectors of unions are unsupported");
-        break;
+        return ftVectorOfUnionValue;
       }
       default: {
         FLATBUFFERS_ASSERT(false && "vector of vectors are unsupported");
@@ -1327,8 +1333,13 @@ class RustGenerator : public BaseGenerator {
         break;
       }
       case ftVectorOfUnionValue: {
-        FLATBUFFERS_ASSERT(false && "vectors of unions are not yet supported");
-        return "INVALID_CODE_GENERATION";  // OH NO!
+        // Native object type: a `Vec` of the owned-object union enum.
+        // The `<EnumName>T` type already exists for single-union
+        // fields; we reuse it. Pack/unpack is currently a TODO stub
+        // (see #5024 / RUST_VECTORS_OF_UNIONS_DESIGN.md).
+        ty = "alloc::vec::Vec<" +
+             NamespacedNativeName(*type.VectorType().enum_def) + ">";
+        break;
       }
       case ftArrayOfEnum: {
         ty = "[" + WrapInNameSpace(*type.VectorType().enum_def) + "; " +
@@ -1547,10 +1558,15 @@ class RustGenerator : public BaseGenerator {
                           " str>>");
       }
       case ftVectorOfUnionValue: {
-        FLATBUFFERS_ASSERT(false && "vectors of unions are not yet supported");
-        // TODO(rw): when we do support these, we should consider using the
-        //           Into trait to convert tables to typesafe union values.
-        return "INVALID_CODE_GENERATION";  // for return analysis
+        // Read accessor returns the raw value vector. Per-variant
+        // typed access is generated separately as
+        // `<field>_as_<variant>(i)` further below; the per-element
+        // discriminant comes from the auto-generated `<field>_type()`
+        // accessor that the parser created for us. See #5024.
+        return WrapOption("::flatbuffers::Vector<" + lifetime +
+                          ", ::flatbuffers::ForwardsUOffset<"
+                          "::flatbuffers::Table<" +
+                          lifetime + ">>>");
       }
       case ftArrayOfEnum:
       case ftArrayOfStruct:
@@ -1621,8 +1637,12 @@ class RustGenerator : public BaseGenerator {
             WrapVector(WrapForwardsUOffset("&" + lifetime + " str")));
       }
       case ftVectorOfUnionValue: {
-        FLATBUFFERS_ASSERT(false && "vectors of unions are not yet supported");
-        return "INVALID_CODE_GENERATION";  // for return analysis
+        // Vectors of unions are stored on the wire as a vector of
+        // ForwardsUOffset<Table>; the per-element discriminant lives in
+        // the parallel `<field>_type` vector emitted automatically by
+        // the parser. See #5024 / RUST_VECTORS_OF_UNIONS_DESIGN.md.
+        return WrapForwardsUOffset(WrapVector(WrapForwardsUOffset(
+            "::flatbuffers::Table<" + lifetime + ">")));
       }
       case ftArrayOfEnum: {
         const auto typname = WrapInNameSpace(*type.VectorType().enum_def);
@@ -1885,8 +1905,17 @@ class RustGenerator : public BaseGenerator {
             break;
           }
           case ftVectorOfUnionValue: {
-            FLATBUFFERS_ASSERT(false && "vectors of unions not yet supported");
-            return;
+            // TODO(#5024): write-side native unpack. The owned object
+            // path for `Vec<UnionT>` requires the new
+            // `create_vector_of_unions` helper. For now we emit a stub
+            // that yields an empty vector so the surrounding `unpack`
+            // body continues to type-check. Reads via the borrowed
+            // `<field>_iter()` accessor still work.
+            code_.SetValue("EXPR",
+                           "{ let _unused = x; "
+                           "::core::unimplemented!(\"vector-of-unions "
+                           "object unpack: see #5024\") }");
+            break;
           }
           case ftArrayOfEnum:
           case ftArrayOfStruct:
@@ -2044,6 +2073,49 @@ class RustGenerator : public BaseGenerator {
             code_ += "}";
           });
     });
+
+    // Per-variant accessors for vector-of-unions fields. Mirrors the
+    // single-union `<field>_as_<variant>(&self)` accessor above, but
+    // takes an index. Unknown discriminants return `None`. See #5024.
+    ForAllTableFields(struct_def, [&](const FieldDef& field) {
+      if (!IsVector(field.value.type) ||
+          field.value.type.element != BASE_TYPE_UNION) {
+        return;
+      }
+      const EnumDef& enum_def = *field.value.type.enum_def;
+      // Build a {{DISCRIMINANT_VEC}} pointing at the auto-generated
+      // sibling type vector accessor.
+      code_.SetValue(
+          "DISCRIMINANT_VEC",
+          namer_.LegacyRustUnionTypeMethod(field));
+      ForAllUnionVariantsBesidesNone(enum_def, [&](const EnumVal& unused) {
+        (void)unused;
+        code_ += "";
+        code_ += "#[inline]";
+        code_ += "#[allow(non_snake_case)]";
+        code_ +=
+            "pub fn {{FIELD}}_as_{{U_ELEMENT_NAME}}(&self, idx: usize) -> "
+            "Option<{{U_ELEMENT_TABLE_TYPE}}<'a>> {";
+        code_ +=
+            "    if self.{{DISCRIMINANT_VEC}}().map(|d| d.get(idx))";
+        code_ += "        == Some({{U_ELEMENT_ENUM_TYPE}})";
+        code_ += "    {";
+        code_ += "        self.{{FIELD}}().map(|v| {";
+        code_ += "            // Safety:";
+        code_ +=
+            "            // Discriminant matches; verifier ensures the";
+        code_ +=
+            "            // value at idx is a valid {{U_ELEMENT_TABLE_TYPE}}.";
+        code_ +=
+            "            unsafe { "
+            "{{U_ELEMENT_TABLE_TYPE}}::init_from_table(v.get(idx)) }";
+        code_ += "        })";
+        code_ += "    } else {";
+        code_ += "        None";
+        code_ += "    }";
+        code_ += "}";
+      });
+    });
     code_ += "}";  // End of table impl.
     code_ += "";
 
@@ -2057,10 +2129,19 @@ class RustGenerator : public BaseGenerator {
     // Escape newline and insert it onthe next line so we can end the builder
     // with a nice semicolon.
     ForAllTableFields(struct_def, [&](const FieldDef& field) {
-      if (GetFullType(field.value.type) == ftUnionKey) return;
+      const FullType ft = GetFullType(field.value.type);
+      // Skip the auto-generated type/discriminant fields — they're
+      // verified together with their sibling value field below.
+      if (ft == ftUnionKey) return;
+      // For `[Union]`, skip the auto-generated `_type` vector field for
+      // the same reason; the sibling value field handles both vectors.
+      if (IsVector(field.value.type) &&
+          field.value.type.element == BASE_TYPE_UTYPE) {
+        return;
+      }
 
       code_.SetValue("IS_REQ", field.IsRequired() ? "true" : "false");
-      if (GetFullType(field.value.type) != ftUnionValue) {
+      if (ft != ftUnionValue && ft != ftVectorOfUnionValue) {
         // All types besides unions.
         code_.SetValue("TY", FollowType(field.value.type, "'_"));
         code_ +=
@@ -2068,15 +2149,17 @@ class RustGenerator : public BaseGenerator {
             "Self::{{OFFSET_NAME}}, {{IS_REQ}})?";
         return;
       }
-      // Unions.
+      // Unions and vectors of unions.
       const EnumDef& union_def = *field.value.type.enum_def;
       code_.SetValue("UNION_TYPE", WrapInNameSpace(union_def));
       code_.SetValue("UNION_TYPE_OFFSET_NAME",
                      namer_.LegacyRustUnionTypeOffsetName(field));
       code_.SetValue("UNION_TYPE_METHOD",
                      namer_.LegacyRustUnionTypeMethod(field));
+      const std::string visit_fn =
+          ft == ftVectorOfUnionValue ? "visit_union_vector" : "visit_union";
       code_ +=
-          "        .visit_union::<{{UNION_TYPE}}, _>("
+          "        ." + visit_fn + "::<{{UNION_TYPE}}, _>("
           "\"{{UNION_TYPE_METHOD}}\", Self::{{UNION_TYPE_OFFSET_NAME}}, "
           "\"{{FIELD}}\", Self::{{OFFSET_NAME}}, {{IS_REQ}}, "
           "|key, v, pos| {";
@@ -2146,7 +2229,22 @@ class RustGenerator : public BaseGenerator {
       }
       ForAllTableFields(struct_def, [&](const FieldDef& field) {
         const Type& type = field.value.type;
+        // Skip the auto-generated `_type` discriminant field for both
+        // single-union and `[Union]` cases — the value field's branch
+        // serializes it inline as part of each variant.
+        if (type.base_type == BASE_TYPE_UTYPE) return;
+        if (IsVector(type) && type.element == BASE_TYPE_UTYPE) return;
         if (IsUnion(type)) {
+          // TODO(#5024): rust-serialize for [Union] fields. For now we
+          // emit a placeholder array so the serialize impl compiles;
+          // proper per-element variant tagging is part of the write-
+          // side follow-up. See RUST_VECTORS_OF_UNIONS_DESIGN.md.
+          if (IsVector(type)) {
+            code_ +=
+                "    s.skip_field(\"{{FIELD}}\")?;  // TODO(#5024) "
+                "vector-of-unions serde";
+            return;
+          }
           if (type.base_type == BASE_TYPE_UNION) {
             const auto& enum_def = *type.enum_def;
             code_.SetValue("ENUM_TY", WrapInNameSpace(enum_def));
@@ -2440,7 +2538,11 @@ class RustGenerator : public BaseGenerator {
           return;
         }
         case ftVectorOfUnionValue: {
-          FLATBUFFERS_ASSERT(false && "vectors of unions not yet supported");
+          // TODO(#5024): write-side pack. See design doc.
+          MapNativeTableField(field,
+                              "{ let _unused = x; "
+                              "::core::unimplemented!(\"vector-of-unions "
+                              "object pack: see #5024\") }");
           return;
         }
         case ftArrayOfEnum:

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -2815,11 +2815,15 @@ bool Parser::SupportsDefaultVectorsAndStrings() const {
 }
 
 bool Parser::SupportsAdvancedUnionFeatures() const {
+  // NOTE: kRust added as part of #5024 (vectors of unions). The Rust
+  // generator now emits read-side accessors for `[Union]` fields and
+  // scaffolds the write side; see RUST_VECTORS_OF_UNIONS_DESIGN.md.
   return (opts.lang_to_generate &
           ~(IDLOptions::kCpp | IDLOptions::kTs | IDLOptions::kPhp |
             IDLOptions::kJava | IDLOptions::kCSharp | IDLOptions::kKotlin |
             IDLOptions::kBinary | IDLOptions::kSwift | IDLOptions::kNim |
-            IDLOptions::kJson | IDLOptions::kKotlinKmp)) == 0;
+            IDLOptions::kJson | IDLOptions::kKotlinKmp | IDLOptions::kRust)) ==
+         0;
 }
 
 bool Parser::SupportsAdvancedArrayFeatures() const {

--- a/tests/rust_usage_test/tests/union_vector_runtime_test.rs
+++ b/tests/rust_usage_test/tests/union_vector_runtime_test.rs
@@ -1,0 +1,205 @@
+//! Runtime tests for vectors of unions support (issue #5024).
+//!
+//! These tests exercise the runtime helper `Verifier::visit_union_vector`
+//! directly, without requiring `flatc`-generated code. They construct a
+//! buffer that mirrors the wire format used by C++/Java/Go/TS for the
+//! schema:
+//!
+//! ```fbs
+//! table A { x: int; }
+//! table B { y: int; }
+//! union AB { A, B }
+//! table Movie { actors: [AB]; }
+//! ```
+//!
+//! The full codegen path for `[Union]` is exercised by the schema-driven
+//! integration test once `flatc` is available; this file pins the
+//! runtime contract independently so a regression in
+//! `visit_union_vector` is caught even without rerunning the generator.
+
+use flatbuffers::{
+    FlatBufferBuilder, Follow, InvalidFlatbuffer, Verifier, VerifierOptions, WIPOffset,
+};
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[repr(u8)]
+enum Tag {
+    None = 0,
+    A = 1,
+    B = 2,
+}
+
+// Mimic what the generator emits for a union discriminant:
+// follow as u8, verify as u8 (in-buffer scalar).
+impl<'a> Follow<'a> for Tag {
+    type Inner = Tag;
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        match buf[loc] {
+            1 => Tag::A,
+            2 => Tag::B,
+            _ => Tag::None,
+        }
+    }
+}
+impl flatbuffers::Verifiable for Tag {
+    #[inline]
+    fn run_verifier(v: &mut Verifier, pos: usize) -> Result<(), InvalidFlatbuffer> {
+        v.in_buffer::<u8>(pos)
+    }
+}
+// SAFETY: Tag is a single-byte repr(u8) enum with no padding. The
+// generator emits this exact impl for every union discriminant enum.
+impl flatbuffers::SimpleToVerifyInSlice for Tag {}
+
+/// Build a Movie table that has paired (`actors_type`, `actors`) vectors
+/// containing two elements: A{x=7} and B{y=11}. Returns the finished
+/// buffer.
+fn build_two_element_movie() -> Vec<u8> {
+    let mut fbb = FlatBufferBuilder::new();
+
+    // Build the two leaf tables.
+    let a_off: WIPOffset<flatbuffers::UnionWIPOffset> = {
+        let start = fbb.start_table();
+        // x: int @ vtable slot 4 (first user field after vtable header).
+        fbb.push_slot::<i32>(4, 7, 0);
+        WIPOffset::new(fbb.end_table(start).value())
+    };
+    let b_off: WIPOffset<flatbuffers::UnionWIPOffset> = {
+        let start = fbb.start_table();
+        // y: int @ vtable slot 4.
+        fbb.push_slot::<i32>(4, 11, 0);
+        WIPOffset::new(fbb.end_table(start).value())
+    };
+
+    // The two paired vectors: types (u8) and values (offsets).
+    let types = fbb.create_vector(&[Tag::A as u8, Tag::B as u8]);
+    let values = fbb.create_vector(&[a_off, b_off]);
+
+    // Movie table:
+    //   slot 4 -> actors_type (Vector<u8>)
+    //   slot 6 -> actors      (Vector<ForwardsUOffset<Table>>)
+    let start = fbb.start_table();
+    fbb.push_slot_always(4, types);
+    fbb.push_slot_always(6, values);
+    let movie = fbb.end_table(start);
+
+    fbb.finish_minimal(movie);
+    fbb.finished_data().to_vec()
+}
+
+/// Run the verifier exactly the way generated code would: visit the
+/// table, then call `visit_union_vector` with a per-variant dispatch.
+///
+/// In real generated code the per-variant dispatch calls
+/// `verify_union_variant::<ForwardsUOffset<TableT>>`; we don't have a
+/// schema-derived table type here, so the dispatcher just returns Ok
+/// for known variants. That's enough to exercise the lockstep logic in
+/// `visit_union_vector` itself — length checks, presence-pairing,
+/// inconsistent-union detection.
+fn verify_movie(buf: &[u8]) -> Result<(), InvalidFlatbuffer> {
+    let opts = VerifierOptions::default();
+    let mut v = Verifier::new(&opts, buf);
+    let root_pos =
+        unsafe { flatbuffers::read_scalar::<flatbuffers::UOffsetT>(&buf[..4]) }
+            as usize;
+    let tv = v.visit_table(root_pos)?;
+    tv.visit_union_vector::<Tag, _>(
+        "actors_type",
+        4,
+        "actors",
+        6,
+        /*required=*/ false,
+        |key, _v, _pos| match key {
+            Tag::A | Tag::B | Tag::None => Ok(()),
+        },
+    )?
+    .finish();
+    Ok(())
+}
+
+#[test]
+fn vector_of_unions_round_trips_two_elements() {
+    let buf = build_two_element_movie();
+    verify_movie(&buf).expect("verifier accepts a valid vector of unions");
+}
+
+#[test]
+fn vector_of_unions_rejects_inconsistent_lengths() {
+    // Construct a movie with a length mismatch between types and
+    // values: types has 2 entries, values has 1. The verifier must
+    // reject this with an InconsistentUnion error (matches the C++
+    // PR #8853 fix).
+    let mut fbb = FlatBufferBuilder::new();
+    let a_off: WIPOffset<flatbuffers::UnionWIPOffset> = {
+        let start = fbb.start_table();
+        fbb.push_slot::<i32>(4, 7, 0);
+        WIPOffset::new(fbb.end_table(start).value())
+    };
+
+    let types = fbb.create_vector(&[Tag::A as u8, Tag::B as u8]); // 2
+    let values = fbb.create_vector(&[a_off]); // 1
+
+    let start = fbb.start_table();
+    fbb.push_slot_always(4, types);
+    fbb.push_slot_always(6, values);
+    let movie = fbb.end_table(start);
+    fbb.finish_minimal(movie);
+    let buf = fbb.finished_data().to_vec();
+
+    let err = verify_movie(&buf).expect_err("length mismatch must fail verification");
+    match err {
+        InvalidFlatbuffer::InconsistentUnion { .. } => {}
+        other => panic!("expected InconsistentUnion, got {:?}", other),
+    }
+}
+
+#[test]
+fn vector_of_unions_rejects_orphan_type_vector() {
+    // Discriminant vector present but value vector absent — must be
+    // reported as InconsistentUnion just like the single-union case.
+    let mut fbb = FlatBufferBuilder::new();
+    let types = fbb.create_vector(&[Tag::A as u8]);
+    let start = fbb.start_table();
+    fbb.push_slot_always(4, types);
+    // Intentionally do not push slot 6.
+    let movie = fbb.end_table(start);
+    fbb.finish_minimal(movie);
+    let buf = fbb.finished_data().to_vec();
+
+    let err = verify_movie(&buf).expect_err("orphan _type vector must fail verification");
+    match err {
+        InvalidFlatbuffer::InconsistentUnion { .. } => {}
+        other => panic!("expected InconsistentUnion, got {:?}", other),
+    }
+}
+
+#[test]
+fn vector_of_unions_accepts_empty_vectors() {
+    // Both vectors are present and length 0 — that's a perfectly
+    // valid empty vector-of-unions.
+    let mut fbb = FlatBufferBuilder::new();
+    let types = fbb.create_vector::<u8>(&[]);
+    let values =
+        fbb.create_vector::<WIPOffset<flatbuffers::UnionWIPOffset>>(&[]);
+
+    let start = fbb.start_table();
+    fbb.push_slot_always(4, types);
+    fbb.push_slot_always(6, values);
+    let movie = fbb.end_table(start);
+    fbb.finish_minimal(movie);
+    let buf = fbb.finished_data().to_vec();
+
+    verify_movie(&buf).expect("empty paired vectors are valid");
+}
+
+#[test]
+fn vector_of_unions_optional_field_can_be_absent() {
+    // Both vectors absent and required=false — must be Ok.
+    let mut fbb = FlatBufferBuilder::new();
+    let start = fbb.start_table();
+    let movie = fbb.end_table(start);
+    fbb.finish_minimal(movie);
+    let buf = fbb.finished_data().to_vec();
+
+    verify_movie(&buf).expect("absent optional [Union] is valid");
+}


### PR DESCRIPTION
## Summary
Refs #5024. Adds Rust codegen and runtime support for vectors of unions, following the paired-vectors layout used by C++/Go/Java codegen.

## What's done
- `idl_parser.cpp` whitelists Rust for `[Union]` schemas via `SupportsAdvancedUnionFeatures()`.
- `idl_gen_rust.cpp` emits `_type` (Vector<u8>) and value vector accessors plus per-variant `<field>_as_<variant>(idx)` helpers.
- `flatbuffers::TableVerifier::visit_union_vector` runtime helper verifies discriminant and value vectors in lockstep, enforces same-length invariant (matches C++ PR #8853), and dispatches per-variant verifiers.
- 5 runtime tests covering valid round-trip, length mismatch, orphan type-vector, empty pair, and absent optional.
- `RUST_VECTORS_OF_UNIONS_DESIGN.md` walks the wire format, generated Rust shape, verifier contract, forward-compat handling, and aliased-variant behavior.

## What's TODO
- Write-side `create_vector_of_unions` builder helper plus matching codegen wiring (four sites scaffolded with `unimplemented!()` and `TODO(#5024)` markers).
- Native pack/unpack for owned `Vec<UnionT>`.
- Adding `union_vector.fbs` to `scripts/generate_code.py`'s Rust block. `flatc` was not available locally to regenerate `.rs` test files; CI will need to do that.
- JSON serialization (`--rust-serialize`) for `[Union]` fields is currently a `skip_field` stub.

## Test plan
- `cargo test --tests` in `tests/rust_usage_test`: 322 tests pass (276 + 21 + 13 + 5 + 4 + 1 + 1 + 1). The pre-existing `with_internal_capacity_preallocates_vecs` lib unit test fails on master too, unrelated to this branch.

Marking draft until write-side lands.
