### PR TITLE
Add constexpr variant of --bfbs-gen-embed for compile-time schema processing

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -694,6 +694,7 @@ struct IDLOptions {
   bool binary_schema_comments;
   bool binary_schema_builtins;
   bool binary_schema_gen_embed;
+  bool binary_schema_gen_embed_constexpr;
   bool binary_schema_absolute_paths;
   std::string go_import;
   std::string go_namespace;
@@ -846,6 +847,7 @@ struct IDLOptions {
         binary_schema_comments(false),
         binary_schema_builtins(false),
         binary_schema_gen_embed(false),
+        binary_schema_gen_embed_constexpr(false),
         binary_schema_absolute_paths(false),
         protobuf_ascii_alike(false),
         size_prefixed(false),

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -201,6 +201,8 @@ const static FlatCOption flatc_options[] = {
      "Add builtin attributes to the binary schema files."},
     {"", "bfbs-gen-embed", "",
      "Generate code to embed the bfbs schema to the source."},
+    {"", "bfbs-gen-embed-constexpr", "",
+     "Generate file-scope constexpr array to embed the bfbs schema."},
     {"", "conform", "FILE",
      "Specify a schema the following schemas should be an evolution of. Gives "
      "errors if not."},
@@ -629,6 +631,9 @@ FlatCOptions FlatCompiler::ParseFromCommandLineArguments(int argc,
         opts.binary_schema_builtins = true;
       } else if (arg == "--bfbs-gen-embed") {
         opts.binary_schema_gen_embed = true;
+      } else if (arg == "--bfbs-gen-embed-constexpr") {
+        opts.binary_schema_gen_embed = true;
+        opts.binary_schema_gen_embed_constexpr = true;
       } else if (arg == "--bfbs-absolute-paths") {
         opts.binary_schema_absolute_paths = true;
       } else if (arg == "--reflect-types") {

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -397,29 +397,41 @@ class CppGenerator : public BaseGenerator {
       code_.SetValue("STRUCT_NAME", name);
 
       // Create code to return the binary schema data.
-      auto binary_schema_hex_text =
-          BufferToHexText(parser_.builder_.GetBufferPointer(),
-                          parser_.builder_.GetSize(), 105, "      ", "");
-
-      code_ += "struct {{STRUCT_NAME}}BinarySchema {";
-      code_ += "  static const uint8_t *data() {";
-      code_ += "    // Buffer containing the binary schema.";
-      code_ += "    static const uint8_t bfbsData[" +
-               NumToString(parser_.builder_.GetSize()) + "] = {";
-      code_ += binary_schema_hex_text;
-      code_ += "    };";
-      code_ += "    return bfbsData;";
-      code_ += "  }";
-      code_ += "  static size_t size() {";
-      code_ += "    return " + NumToString(parser_.builder_.GetSize()) + ";";
-      code_ += "  }";
-      code_ += "  const uint8_t *begin() {";
-      code_ += "    return data();";
-      code_ += "  }";
-      code_ += "  const uint8_t *end() {";
-      code_ += "    return data() + size();";
-      code_ += "  }";
-      code_ += "};";
+      if (parser_.opts.binary_schema_gen_embed_constexpr) {
+        // File-scope constexpr array, usable in constant expressions.
+        auto binary_schema_hex_text =
+            BufferToHexText(parser_.builder_.GetBufferPointer(),
+                            parser_.builder_.GetSize(), 105, "  ", "");
+        code_ += "inline constexpr uint8_t {{STRUCT_NAME}}BinarySchema[] = {";
+        code_ += binary_schema_hex_text;
+        code_ += "};";
+        code_ += "inline constexpr size_t {{STRUCT_NAME}}BinarySchemaSize = " +
+                 NumToString(parser_.builder_.GetSize()) + ";";
+      } else {
+        // Struct wrapper with function-local static.
+        auto binary_schema_hex_text =
+            BufferToHexText(parser_.builder_.GetBufferPointer(),
+                            parser_.builder_.GetSize(), 105, "      ", "");
+        code_ += "struct {{STRUCT_NAME}}BinarySchema {";
+        code_ += "  static const uint8_t *data() {";
+        code_ += "    // Buffer containing the binary schema.";
+        code_ += "    static const uint8_t bfbsData[" +
+                 NumToString(parser_.builder_.GetSize()) + "] = {";
+        code_ += binary_schema_hex_text;
+        code_ += "    };";
+        code_ += "    return bfbsData;";
+        code_ += "  }";
+        code_ += "  static size_t size() {";
+        code_ += "    return " + NumToString(parser_.builder_.GetSize()) + ";";
+        code_ += "  }";
+        code_ += "  const uint8_t *begin() {";
+        code_ += "    return data();";
+        code_ += "  }";
+        code_ += "  const uint8_t *end() {";
+        code_ += "    return data() + size();";
+        code_ += "  }";
+        code_ += "};";
+      }
       code_ += "";
 
       if (cur_name_space_) SetNameSpace(nullptr);
@@ -2378,9 +2390,11 @@ class CppGenerator : public BaseGenerator {
   }
 
   // Adds a typedef to the binary schema type so one could get the bfbs based
-  // on the type at runtime.
+  // on the type at runtime. Skipped in constexpr mode because the schema is a
+  // file-scope array, not a struct with data()/size() methods.
   void GenBinarySchemaTypeDef(const StructDef* struct_def) {
-    if (struct_def && opts_.binary_schema_gen_embed) {
+    if (struct_def && opts_.binary_schema_gen_embed &&
+        !opts_.binary_schema_gen_embed_constexpr) {
       code_ += "  typedef " + WrapInNameSpace(*struct_def) +
                "BinarySchema BinarySchema;";
     }


### PR DESCRIPTION
## Summary

Add `--bfbs-gen-embed-constexpr` flag that generates a file-scope `inline constexpr` array for the binary schema, as an alternative to the existing `--bfbs-gen-embed` struct wrapper.

## Motivation

The current `--bfbs-gen-embed` wraps the binary schema in a struct with a function-local static:

```cpp
struct FooBinarySchema {
  static const uint8_t *data() {
    static const uint8_t bfbsData[N] = { ... };
    return bfbsData;
  }
};
```

Function-local statics are not usable in constant expressions which prevents compile-time schema processing, e.g. computing worst-case serialized sizes from `(capacity: N)` attributes at compile time.

## What this PR does

Adds a new flag `--bfbs-gen-embed-constexpr` that produces:

```cpp
inline constexpr uint8_t FooBinarySchema[] = { ... };
inline constexpr size_t FooBinarySchemaSize = N;
```

The existing `--bfbs-gen-embed` output is unchanged. The two flags are mutually exclusive (same output filename, different content).

## Changes

- `include/flatbuffers/idl.h` — new `binary_schema_gen_embed_constexpr` option
- `src/flatc.cpp` — flag declaration and parsing
- `src/idl_gen_cpp.cpp` — conditional codegen in `generate_bfbs_embed()`; skip `BinarySchema` typedef in `GenBinarySchemaTypeDef()` in constexpr mode (the typedef references a struct type, but constexpr mode generates a bare array instead)

The generated output requires C++17 (`inline constexpr`), which is expected since the flag is opt-in for users who need `constexpr`.

## Testing

- Built flatc, ran `flattests` — ALL TESTS PASSED
- Ran `scripts/generate_code.py` — no C++ diff
- Ran `scripts/clang-format-git.sh` — no modifications
- Verified generated output for `monster_test.fbs` with the new flag

## Note on goldens

Both flags produce the same output filename (`<name>_bfbs_generated.h`). Happy to add a golden for the new flag if you'd like. Would you prefer a separate filename suffix (e.g. `_bfbs_constexpr_generated.h`) so both can coexist, or is the current shared filename appropriate?

<details>                                                                                                             
<summary>Generated output for basic.fbs</summary>                                                                    
                                                                                                                       
```cpp                                                                                                               
// automatically generated by the FlatBuffers compiler, do not modify


#ifndef FLATBUFFERS_GENERATED_BASIC_FLATBUFFERS_GOLDENS_BFBS_H_
#define FLATBUFFERS_GENERATED_BASIC_FLATBUFFERS_GOLDENS_BFBS_H_

#include <cstddef>
#include <cstdint>
namespace flatbuffers {
namespace goldens {

inline constexpr uint8_t UniverseBinarySchema[] = {
  0x1C,0x00,0x00,0x00,0x42,0x46,0x42,0x53,0x14,0x00,0x20,0x00,0x04,0x00,0x08,0x00,0x0C,0x00,0x10,0x00,0x14,
  0x00,0x18,0x00,0x00,0x00,0x1C,0x00,0x14,0x00,0x00,0x00,0x34,0x00,0x00,0x00,0x2C,0x00,0x00,0x00,0x20,0x00,
  0x00,0x00,0x14,0x00,0x00,0x00,0x50,0x00,0x00,0x00,0x08,0x00,0x00,0x00,0x28,0x00,0x00,0x00,0x00,0x00,0x00,
  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
  0x02,0x00,0x00,0x00,0x08,0x01,0x00,0x00,0x24,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x0C,0x00,0x00,0x00,0x08,
  0x00,0x0C,0x00,0x04,0x00,0x08,0x00,0x08,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x04,0x00,0x00,0x00,0x00,0x00,
  0x00,0x00,0x34,0xFF,0xFF,0xFF,0x1C,0x00,0x00,0x00,0x0C,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0xE4,0x00,0x00,
  0x00,0x02,0x00,0x00,0x00,0x8C,0x00,0x00,0x00,0x44,0x00,0x00,0x00,0x1C,0x00,0x00,0x00,0x66,0x6C,0x61,0x74,
  0x62,0x75,0x66,0x66,0x65,0x72,0x73,0x2E,0x67,0x6F,0x6C,0x64,0x65,0x6E,0x73,0x2E,0x55,0x6E,0x69,0x76,0x65,
  0x72,0x73,0x65,0x00,0x00,0x00,0x00,0x1C,0x00,0x14,0x00,0x0C,0x00,0x10,0x00,0x08,0x00,0x0A,0x00,0x00,0x00,
  0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x07,0x00,0x1C,0x00,0x00,0x00,0x00,0x00,0x00,
  0x01,0x01,0x00,0x06,0x00,0x28,0x00,0x00,0x00,0x14,0x00,0x00,0x00,0x10,0x00,0x10,0x00,0x06,0x00,0x07,0x00,
  0x08,0x00,0x00,0x00,0x00,0x00,0x0C,0x00,0x10,0x00,0x00,0x00,0x00,0x00,0x0E,0x0F,0x00,0x00,0x00,0x00,0x04,
  0x00,0x00,0x00,0x08,0x00,0x00,0x00,0x67,0x61,0x6C,0x61,0x78,0x69,0x65,0x73,0x00,0x00,0x00,0x00,0x78,0xFF,
  0xFF,0xFF,0x00,0x00,0x04,0x00,0x18,0x00,0x00,0x00,0x04,0x00,0x00,0x00,0x6C,0xFF,0xFF,0xFF,0x00,0x00,0x00,
  0x0C,0x08,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x03,0x00,0x00,0x00,0x61,0x67,0x65,0x00,0x14,0x00,0x14,0x00,
  0x04,0x00,0x08,0x00,0x00,0x00,0x0C,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x10,0x00,0x14,0x00,0x00,0x00,0x28,
  0x00,0x00,0x00,0x1C,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x04,0x00,0x00,0x00,0x0B,0x00,0x00,0x00,0x2F,0x2F,
  0x62,0x61,0x73,0x69,0x63,0x2E,0x66,0x62,0x73,0x00,0x01,0x00,0x00,0x00,0x30,0x00,0x00,0x00,0x1A,0x00,0x00,
  0x00,0x66,0x6C,0x61,0x74,0x62,0x75,0x66,0x66,0x65,0x72,0x73,0x2E,0x67,0x6F,0x6C,0x64,0x65,0x6E,0x73,0x2E,
  0x47,0x61,0x6C,0x61,0x78,0x79,0x00,0x00,0x0C,0x00,0x10,0x00,0x08,0x00,0x0C,0x00,0x00,0x00,0x06,0x00,0x0C,
  0x00,0x00,0x00,0x00,0x00,0x04,0x00,0x28,0x00,0x00,0x00,0x14,0x00,0x00,0x00,0x10,0x00,0x10,0x00,0x07,0x00,
  0x00,0x00,0x00,0x00,0x00,0x00,0x08,0x00,0x0C,0x00,0x10,0x00,0x00,0x00,0x00,0x00,0x00,0x09,0x08,0x00,0x00,
  0x00,0x01,0x00,0x00,0x00,0x09,0x00,0x00,0x00,0x6E,0x75,0x6D,0x5F,0x73,0x74,0x61,0x72,0x73,0x00,0x00,0x00
};
inline constexpr size_t UniverseBinarySchemaSize = 504;

}  // namespace goldens
}  // namespace flatbuffers

#endif  // FLATBUFFERS_GENERATED_BASIC_FLATBUFFERS_GOLDENS_BFBS_H_  
```


