### PR TITLE
Fix logic inversion in FlexBuffers VerifyKey() — null terminator check

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -1976,7 +1976,7 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
   bool VerifyKey(const uint8_t* p) {
     FLEX_CHECK_VERIFIED(p, PackedType(BIT_WIDTH_8, FBT_KEY));
     while (p < buf_ + size_)
-      if (*p++) return true;
+      if (!*p++) return true;
     return false;
   }
 


### PR DESCRIPTION
## Problem

`VerifyKey()` in [include/flatbuffers/flexbuffers.h](cci:7://file:///Users/kakarot/google-vdp/flatbuffers/include/flatbuffers/flexbuffers.h:0:0-0:0) (line 1979) has a logic inversion. It returns `true` on the first non-zero byte instead of checking for a null terminator:

```cpp
while (p < buf_ + size_)
  if (*p++) return true;   // returns true on ANY non-zero byte
```

Since every valid key starts with a non-zero ASCII character, this function effectively always returns `true` regardless of whether the key has a null terminator within the buffer.

## Impact

Buffers with non-null-terminated keys pass `VerifyBuffer()`. When the application then accesses those keys, `strlen()` and `strcmp()` read past the buffer boundary.

```
VerifyBuffer on CORRUPTED buf: PASS (BUG!)

Key[0]: strlen=15 but key was only "name" (4 chars)
  ^^^ 11 bytes of HEAP MEMORY were read out-of-bounds

map["name"].GetType() = 0 (NULL — lookup FAILED)
```

ASan output:

```
==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200000013f
READ of size 16 at 0x60200000013f thread T0
    #0 in strlen
0x60200000013f is located 0 bytes after 15-byte region
```

## Fix

```diff
-      if (*p++) return true;
+      if (!*p++) return true;
```

Return `true` when a zero byte (null terminator) is found. Return `false` when the end of buffer is reached without finding one.

## Verification

After the fix, `VerifyBuffer()` correctly rejects corrupted buffers:

```
VerifyBuffer on CORRUPTED buf: FAIL (correct)
Verifier correctly rejected the corrupted buffer. No bug.
```