### PR TITLE
[Swift] Migrate to use Swift Testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -534,7 +534,7 @@ jobs:
          run: |
            swift sdk list
            swift build --build-tests --swift-sdk swift-6.2.1-RELEASE_wasm
-           wasmtime --dir . .build/wasm32-unknown-wasip1/debug/FlatBuffers.Test.Swift.WasmPackageTests.xctest
+           wasmtime --dir . .build/wasm32-unknown-wasip1/debug/FlatBuffers.Test.Swift.WasmPackageTests.xctest --testing-library swift-testing
 
   build-ts:
     name: Build TS

--- a/tests/swift/Tests/Flatbuffers/ByteBufferTests.swift
+++ b/tests/swift/Tests/Flatbuffers/ByteBufferTests.swift
@@ -14,51 +14,58 @@
  * limitations under the License.
  */
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import FlatBuffers
 
-final class ByteBufferTests: XCTestCase {
+struct ByteBufferTests {
+
+  @Test
   func testCopyingMemory() {
     let count = 100
     let ptr = UnsafeMutableRawPointer.allocate(byteCount: count, alignment: 1)
     let byteBuffer = ByteBuffer(copyingMemoryBound: ptr, capacity: count)
     byteBuffer.withUnsafeBytes { memory in
-      XCTAssertNotEqual(memory.baseAddress, ptr)
+      #expect(memory.baseAddress! != ptr)
     }
   }
 
+  @Test
   func testSamePointer() {
     let count = 100
     let ptr = UnsafeMutableRawPointer.allocate(byteCount: count, alignment: 1)
     let byteBuffer = ByteBuffer(assumingMemoryBound: ptr, capacity: count)
     byteBuffer.withUnsafeBytes { memory in
-      XCTAssertEqual(memory.baseAddress!, ptr)
+      #expect(memory.baseAddress! == ptr)
     }
   }
 
+  @Test
   func testSameDataPtr() {
     let count = 100
     let ptr = Data(repeating: 0, count: count)
     let byteBuffer = ByteBuffer(data: ptr)
     byteBuffer.withUnsafeBytes { memory in
       ptr.withUnsafeBytes { ptr in
-        XCTAssertEqual(memory.baseAddress!, ptr.baseAddress!)
+        #expect(memory.baseAddress! == ptr.baseAddress!)
       }
     }
   }
 
+  @Test
   func testSameArrayPtr() {
     let count = 100
     let ptr: [UInt8] = Array(repeating: 0, count: count)
     let byteBuffer = ByteBuffer(bytes: ptr)
     ptr.withUnsafeBytes { ptr in
       byteBuffer.withUnsafeBytes { memory in
-        XCTAssertEqual(memory.baseAddress, ptr.baseAddress)
+        #expect(memory.baseAddress == ptr.baseAddress)
       }
     }
   }
 
+  @Test
   func testReadingDoubleBuffer() {
     let count = 8
     let array: [Double] = Array(repeating: 8.8, count: count)
@@ -69,15 +76,16 @@ final class ByteBufferTests: XCTestCase {
     }
     let byteBuffer = ByteBuffer(bytes: bytes)
     byteBuffer.withUnsafePointerToSlice(index: 0, count: count) { ptr in
-      XCTAssertEqual(ptr.count, count)
+      #expect(ptr.count == count)
       bytes.withUnsafeBufferPointer {
-        XCTAssertEqual(
-          UnsafeRawPointer($0.baseAddress),
-          UnsafeRawPointer(ptr.baseAddress))
+        #expect(
+          UnsafeRawPointer($0.baseAddress) ==
+            UnsafeRawPointer(ptr.baseAddress))
       }
     }
   }
 
+  @Test
   func testReadingNativeStructs() {
     let array = [
       MyGame_Example_Vec3(
@@ -111,11 +119,11 @@ final class ByteBufferTests: XCTestCase {
     let byteBuffer = ByteBuffer(bytes: bytes)
     byteBuffer
       .withUnsafePointerToSlice(index: 0, count: count) { bufferPointer in
-        XCTAssertEqual(bufferPointer.count, count)
+        #expect(bufferPointer.count == count)
         bytes.withUnsafeBufferPointer { ptr in
-          XCTAssertEqual(
-            UnsafeRawPointer(ptr.baseAddress),
-            UnsafeRawPointer(bufferPointer.baseAddress))
+          #expect(
+            UnsafeRawPointer(ptr.baseAddress) ==
+              UnsafeRawPointer(bufferPointer.baseAddress))
         }
       }
   }
@@ -125,12 +133,4 @@ private struct TestNativeStructs: NativeStruct {
   let x: Double
   let y: Double
   let z: Int
-}
-
-extension MyGame_Example_Color: CaseIterable {
-  public static let allCases: [MyGame_Example_Color] = [
-    .red,
-    .blue,
-    .green,
-  ]
 }

--- a/tests/swift/Tests/Flatbuffers/FlatBuffersArraysTests.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatBuffersArraysTests.swift
@@ -16,19 +16,22 @@
 
 #if compiler(>=6.2)
 
-import XCTest
+import Testing
 
 @testable import FlatBuffers
 
-@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, *)
-final class FlatBuffersArraysTests: XCTestCase {
+struct FlatBuffersArraysTests {
 
+  @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, *)
+  @Test
   func testStructSizes() {
-    XCTAssertEqual(MemoryLayout<MyGame_Example_NestedStruct>.size, 32)
-    XCTAssertEqual(MemoryLayout<MyGame_Example_ArrayStruct>.size, 160)
-    XCTAssertEqual(MemoryLayout<MyGame_Example_LargeArrayStruct>.size, 2496)
+    #expect(MemoryLayout<MyGame_Example_NestedStruct>.size == 32)
+    #expect(MemoryLayout<MyGame_Example_ArrayStruct>.size == 160)
+    #expect((MemoryLayout<MyGame_Example_LargeArrayStruct>.size == 2496))
   }
 
+  @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, *)
+  @Test
   func testGoldenData() {
     // swiftformat:disable all
     let data: [UInt8] = [
@@ -45,9 +48,11 @@ final class FlatBuffersArraysTests: XCTestCase {
     ]
     // swiftformat:enable all
 
-    XCTAssertEqual(data, createArrayTable())
+    #expect(data == createArrayTable())
   }
 
+  @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, *)
+  @Test
   func testData() throws {
     var buf = ByteBuffer(bytes: createArrayTable())
     let table: MyGame_Example_ArrayTable = try getCheckedRoot(
@@ -58,6 +63,8 @@ final class FlatBuffersArraysTests: XCTestCase {
     verifyNativeStruct(a: table.a)
   }
 
+  @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, *)
+  @Test
   func testObjectAPI() throws {
     var buf = ByteBuffer(bytes: createArrayTable())
     let table: MyGame_Example_ArrayTable = try getCheckedRoot(
@@ -66,105 +73,110 @@ final class FlatBuffersArraysTests: XCTestCase {
     verifyNativeStruct(a: table.unpack().a)
   }
 
+  @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, *)
+  @Test
   func testDefaults() {
-    XCTAssertEqual(
-      MyGame_Example_NestedStruct(),
-      MyGame_Example_NestedStruct(
-        a: [0, 0],
-        b: .a,
-        c: [0, 0],
-        d: [0, 0]))
+    #expect(
+      MyGame_Example_NestedStruct() ==
+        MyGame_Example_NestedStruct(
+          a: [0, 0],
+          b: .a,
+          c: [0, 0],
+          d: [0, 0]))
   }
 
+  @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, *)
   func verifyNativeStruct(a: MyGame_Example_ArrayStruct?) {
     let a = a!
-    XCTAssertEqual(a.a, 12.34)
-    XCTAssertEqual(a.b.count, 15)
+    #expect(a.a == 12.34)
+    #expect(a.b.count == 15)
     var sum: Int32 = 0
     for i in a.b.startIndex..<a.b.endIndex {
       sum += a.b[i]
     }
-    XCTAssertEqual(sum, 120)
-    XCTAssertEqual(a.c, -127)
-    XCTAssertEqual(a.d.count, 2)
+    #expect(sum == 120)
+    #expect(a.c == -127)
+    #expect(a.d.count == 2)
     let nestedStruct1 = a.d[0]
-    XCTAssertEqual(nestedStruct1.a.toArray(), [-1, 2])
-    XCTAssertEqual(nestedStruct1.b, .a)
-    XCTAssertEqual(nestedStruct1.c.toArray(), [.c, .b])
-    XCTAssertEqual(
-      nestedStruct1.d.toArray(),
-      [0x1122334455667788, -0x1122334455667788])
+    #expect(nestedStruct1.a.toArray() == [-1, 2])
+    #expect(nestedStruct1.b == .a)
+    #expect(nestedStruct1.c.toArray() == [.c, .b])
+    #expect(
+      nestedStruct1.d.toArray() ==
+        [0x1122334455667788, -0x1122334455667788])
 
     let nestedStruct2 = a.d[1]
-    XCTAssertEqual(nestedStruct2.a.toArray(), [3, -4])
-    XCTAssertEqual(nestedStruct2.b, .b)
-    XCTAssertEqual(nestedStruct2.c.toArray(), [.b, .a])
-    XCTAssertEqual(
-      nestedStruct2.d.toArray(),
-      [-0x1122334455667788, 0x1122334455667788])
+    #expect(nestedStruct2.a.toArray() == [3, -4])
+    #expect(nestedStruct2.b == .b)
+    #expect(nestedStruct2.c.toArray() == [.b, .a])
+    #expect(
+      nestedStruct2.d.toArray() ==
+        [-0x1122334455667788, 0x1122334455667788])
 
-    XCTAssertEqual(a.e, 1)
-    XCTAssertEqual(a.f.count, 2)
+    #expect(a.e == 1)
+    #expect(a.f.count == 2)
   }
 
+  @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, *)
   func verifyMutations(in table: MyGame_Example_ArrayTable) {
     let a = table.mutableA!
-    XCTAssertEqual(a.a, 12.34)
-    XCTAssertEqual(a.b.count, 15)
+    #expect(a.a == 12.34)
+    #expect(a.b.count == 15)
     var sum: Int32 = 0
     for i in a.b.startIndex..<a.b.endIndex {
       sum += a.b[i]
     }
-    XCTAssertEqual(sum, 120)
-    XCTAssertEqual(a.c, -127)
-    XCTAssertEqual(a.d.count, 2)
+    #expect(sum == 120)
+    #expect(a.c == -127)
+    #expect(a.d.count == 2)
     let nestedStruct1 = a.d[0]
 
-    XCTAssertEqual(nestedStruct1.a.reduce(0) { $0 + $1 }, 1)
-    XCTAssertEqual(nestedStruct1.b, .a)
-    XCTAssertEqual(nestedStruct1.c[0], .c)
-    XCTAssertEqual(nestedStruct1.c[1], .b)
+    #expect(nestedStruct1.a.reduce(0) { $0 + $1 } == 1)
+    #expect(nestedStruct1.b == .a)
+    #expect(nestedStruct1.c[0] == .c)
+    #expect(nestedStruct1.c[1] == .b)
 
     let nestedStruct2 = a.d[1]
-    XCTAssertEqual(nestedStruct2.a.reduce(0) { $0 + $1 }, -1)
-    XCTAssertEqual(nestedStruct2.b, .b)
-    XCTAssertEqual(nestedStruct2.c[0], .b)
-    XCTAssertEqual(nestedStruct2.c[1], .a)
-    XCTAssertEqual(nestedStruct2.d[0], -0x1122334455667788)
-    XCTAssertEqual(nestedStruct2.d[1], 0x1122334455667788)
+    #expect(nestedStruct2.a.reduce(0) { $0 + $1 } == -1)
+    #expect(nestedStruct2.b == .b)
+    #expect(nestedStruct2.c[0] == .b)
+    #expect(nestedStruct2.c[1] == .a)
+    #expect(nestedStruct2.d[0] == -0x1122334455667788)
+    #expect(nestedStruct2.d[1] == 0x1122334455667788)
 
-    XCTAssertTrue(a.mutate(b: 1000, at: 0))
-    XCTAssertTrue(a.mutate(b: 2000, at: 1))
+    #expect(a.mutate(b: 1000, at: 0) == true)
+    #expect(a.mutate(b: 2000, at: 1) == true)
 
-    XCTAssertTrue(nestedStruct2.mutate(c: .a, at: 0))
-    XCTAssertTrue(nestedStruct2.mutate(c: .b, at: 1))
+    #expect(nestedStruct2.mutate(c: .a, at: 0) == true)
+    #expect(nestedStruct2.mutate(c: .b, at: 1) == true)
 
-    XCTAssertEqual(nestedStruct2.c[0], .a)
-    XCTAssertEqual(nestedStruct2.c[1], .b)
+    #expect(nestedStruct2.c[0] == .a)
+    #expect(nestedStruct2.c[1] == .b)
 
-    XCTAssertTrue(nestedStruct2.mutate(d: 0, at: 0))
-    XCTAssertTrue(nestedStruct2.mutate(d: 0, at: 1))
+    #expect(nestedStruct2.mutate(d: 0, at: 0) == true)
+    #expect(nestedStruct2.mutate(d: 0, at: 1) == true)
 
-    XCTAssertEqual(nestedStruct2.d.reduce(0) { $0 + $1 }, 0)
+    #expect(nestedStruct2.d.reduce(0) { $0 + $1 } == 0)
 
     let nativeStruct = table.a?.d[1]
 
-    XCTAssertEqual(nativeStruct?.c[0], .a)
-    XCTAssertEqual(nativeStruct?.c[1], .b)
+    #expect(nativeStruct?.c[0] == .a)
+    #expect(nativeStruct?.c[1] == .b)
 
-    XCTAssertEqual(nativeStruct?.d[0], 0)
-    XCTAssertEqual(nativeStruct?.d[1], 0)
+    #expect(nativeStruct?.d[0] == 0)
+    #expect(nativeStruct?.d[1] == 0)
 
-    XCTAssertTrue(a.mutate(b: 1, at: 0))
-    XCTAssertTrue(a.mutate(b: 2, at: 1))
+    #expect(a.mutate(b: 1, at: 0) == true)
+    #expect(a.mutate(b: 2, at: 1) == true)
 
-    XCTAssertTrue(nestedStruct2.mutate(c: .b, at: 0))
-    XCTAssertTrue(nestedStruct2.mutate(c: .a, at: 1))
+    #expect(nestedStruct2.mutate(c: .b, at: 0) == true)
+    #expect(nestedStruct2.mutate(c: .a, at: 1) == true)
 
-    XCTAssertTrue(nestedStruct2.mutate(d: -0x1122334455667788, at: 0))
-    XCTAssertTrue(nestedStruct2.mutate(d: 0x1122334455667788, at: 1))
+    #expect(nestedStruct2.mutate(d: -0x1122334455667788, at: 0) == true)
+    #expect(nestedStruct2.mutate(d: 0x1122334455667788, at: 1) == true)
   }
 
+  @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, *)
   private func createArrayTable() -> [UInt8] {
     var builder = FlatBufferBuilder(initialSize: 1024)
 

--- a/tests/swift/Tests/Flatbuffers/FlatBuffersMonsterWriterTests.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatBuffersMonsterWriterTests.swift
@@ -15,7 +15,7 @@
  */
 
 import Foundation
-import XCTest
+import Testing
 
 @testable import FlatBuffers
 
@@ -24,8 +24,9 @@ typealias Monster = MyGame_Example_Monster
 typealias Vec3 = MyGame_Example_Vec3
 typealias Stat = MyGame_Example_Stat
 
-class FlatBuffersMonsterWriterTests: XCTestCase {
+struct FlatBuffersMonsterWriterTests {
 
+  @Test
   func testData() {
     // swiftformat:disable all
     let data = Data([
@@ -47,6 +48,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readVerifiedMonster(fb: _data)
   }
 
+  @Test
   func testReadFromOtherLanguages() {
     let path = {
       #if os(macOS)
@@ -71,6 +73,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readVerifiedMonster(fb: _data)
   }
 
+  @Test
   func testCreateMonsterData() {
     let bytes = createMonster(withPrefix: false)
     var buffer = ByteBuffer(data: bytes.data)
@@ -80,30 +83,32 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readMonster(monster: monster)
   }
 
+  @Test(.bug("https://github.com/google/flatbuffers/issues/8642"))
   func testCreateMonsterResetTests() {
     var builder = createMonster(withPrefix: false)
     var buffer = ByteBuffer(data: builder.data)
     let monster: MyGame_Example_Monster = getRoot(byteBuffer: &buffer)
     readMonster(monster: monster)
     builder.clear()
-    XCTAssertEqual(builder.capacity, 1)
-    XCTAssertEqual(builder.size, 0)
+    #expect(builder.capacity == 1)
+    #expect(builder.size == 0)
 
     write(fbb: &builder, prefix: false)
     var _buffer = ByteBuffer(data: builder.data)
-    XCTAssertEqual(_buffer.capacity, 304)
+    #expect(_buffer.capacity == 304)
     let _monster: MyGame_Example_Monster = getRoot(byteBuffer: &_buffer)
     readMonster(monster: _monster)
     builder.clear(keepingCapacity: true)
-    XCTAssertEqual(builder.capacity, 512)
-    XCTAssertEqual(builder.size, 0)
+    #expect(builder.capacity == 512)
+    #expect(builder.size == 0)
   }
 
+  @Test
   func testCreateMonster() {
     let bytes = createMonster(withPrefix: false)
     // swiftformat:disable all
-    XCTAssertEqual(
-      bytes.sizedByteArray,
+    #expect(
+      bytes.sizedByteArray ==
       [
         48, 0, 0, 0, 77, 79, 78, 83, 0, 0, 0, 0, 36, 0, 72, 0, 40, 0, 0, 0, 38, 0, 32, 0, 0, 0, 28,
         0, 0, 0, 27, 0, 20, 0, 16, 0, 12, 0, 4, 0, 0, 0, 0, 0, 0, 0, 11, 0, 36, 0, 0, 0, 164, 0, 0,
@@ -127,11 +132,12 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readMonster(monster: monster)
   }
 
+  @Test
   func testCreateMonsterResizedBuffer() {
     let bytes = createMonster(withPrefix: false)
     // swiftformat:disable all
-    XCTAssertEqual(
-      bytes.sizedByteArray,
+    #expect(
+      bytes.sizedByteArray ==
       [
         48, 0, 0, 0, 77, 79, 78, 83, 0, 0, 0, 0, 36, 0, 72, 0, 40, 0, 0, 0, 38, 0, 32, 0, 0, 0, 28,
         0, 0, 0, 27, 0, 20, 0, 16, 0, 12, 0, 4, 0, 0, 0, 0, 0, 0, 0, 11, 0, 36, 0, 0, 0, 164, 0, 0,
@@ -150,11 +156,12 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readVerifiedMonster(fb: bytes.sizedBuffer)
   }
 
+  @Test
   func testCreateMonsterPrefixed() {
     let bytes = createMonster(withPrefix: true)
     // swiftformat:disable all
-    XCTAssertEqual(
-      bytes.sizedByteArray,
+    #expect(
+      bytes.sizedByteArray ==
       [
         44, 1, 0, 0, 44, 0, 0, 0, 77, 79, 78, 83, 36, 0, 72, 0, 40, 0, 0, 0, 38, 0, 32, 0, 0, 0, 28,
         0, 0, 0, 27, 0, 20, 0, 16, 0, 12, 0, 4, 0, 0, 0, 0, 0, 0, 0, 11, 0, 36, 0, 0, 0, 164, 0, 0,
@@ -175,6 +182,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readMonster(monster: getPrefixedSizeRoot(byteBuffer: &buffer))
   }
 
+  @Test
   func testCreateMonsterUsingCreateMonsterMethodWithNilPos() {
     var fbb = FlatBufferBuilder(initialSize: 1)
     let name = fbb.create(string: "Frodo")
@@ -184,10 +192,11 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     fbb.finish(offset: root)
     var buffer = fbb.sizedBuffer
     let newMonster: Monster = getRoot(byteBuffer: &buffer)
-    XCTAssertNil(newMonster.pos)
-    XCTAssertEqual(newMonster.name, "Frodo")
+    #expect(newMonster.pos == nil)
+    #expect(newMonster.name == "Frodo")
   }
 
+  @Test
   func testCreateMonsterUsingCreateMonsterMethodWithPosX() {
     var fbb = FlatBufferBuilder(initialSize: 1)
     let name = fbb.create(string: "Barney")
@@ -207,10 +216,11 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
 
     var buffer = fbb.sizedBuffer
     let newMonster: Monster = getRoot(byteBuffer: &buffer)
-    XCTAssertEqual(newMonster.pos!.x, 10)
-    XCTAssertEqual(newMonster.name, "Barney")
+    #expect(newMonster.pos!.x == 10)
+    #expect(newMonster.name == "Barney")
   }
 
+  @Test
   func testReadMonsterFromUnsafePointerWithoutCopying() {
     // swiftformat:disable all
     var array: [UInt8] = [
@@ -242,6 +252,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readObjectApi(monster: unpacked)
   }
 
+  @Test
   func testArrayOfBools() {
     let boolArray = [false, true, false, true, false, true, false]
     var fbb = FlatBufferBuilder(initialSize: 1)
@@ -257,37 +268,41 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     let monster: Monster = getRoot(byteBuffer: &buffer)
     let values = monster.testarrayofbools
 
-    XCTAssertEqual(boolArray.count, values.count)
+    #expect(boolArray.count == values.count)
 
     for (index, bool) in monster.testarrayofbools.enumerated() {
-      XCTAssertEqual(bool, boolArray[index])
+      #expect(bool == boolArray[index])
     }
   }
 
   func readVerifiedMonster(fb: ByteBuffer) {
     var byteBuffer = fb
-    XCTAssertNoThrow(
+    do {
       try readMonster(
         monster: getCheckedRoot(
-          byteBuffer: &byteBuffer) as MyGame_Example_Monster))
+          byteBuffer: &byteBuffer) as MyGame_Example_Monster)
+    } catch {
+      Issue.record(error)
+    }
   }
 
+  @Test(.bug("https://github.com/google/flatbuffers/issues/8133"))
   func testUnalignedRead() {
     // Aligned read
     let fbb = createMonster(withPrefix: false)
     let testAligned: () -> Bool = {
       var buffer = fbb.sizedBuffer
       var monster: Monster = getRoot(byteBuffer: &buffer)
-      self.readFlatbufferMonster(monster: &monster)
+      readFlatbufferMonster(monster: &monster)
       return true
     }
-    XCTAssertEqual(testAligned(), true)
+    #expect(testAligned() == true)
     let testUnaligned: () -> Bool = {
       var bytes: [UInt8] = [0x00]
       bytes.append(contentsOf: fbb.sizedByteArray)
       return bytes.withUnsafeMutableBytes { ptr in
         guard var baseAddress = ptr.baseAddress else {
-          XCTFail("Base pointer is not defined")
+          Issue.record("Base pointer is not defined")
           return false
         }
         baseAddress = baseAddress.advanced(by: 1)
@@ -296,13 +311,14 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
           assumingMemoryBound: unlignedPtr,
           capacity: ptr.count - 1)
         var monster: Monster = getRoot(byteBuffer: &bytes)
-        self.readFlatbufferMonster(monster: &monster)
+        readFlatbufferMonster(monster: &monster)
         return true
       }
     }
-    XCTAssertEqual(testUnaligned(), true)
+    #expect(testUnaligned() == true)
   }
 
+  @Test
   func testReadingRemovedSizeUnalignedBuffer() {
     // Aligned read
     let fbb = createMonster(withPrefix: true)
@@ -311,7 +327,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
       bytes.append(contentsOf: fbb.sizedByteArray)
       return bytes.withUnsafeMutableBytes { ptr in
         guard var baseAddress = ptr.baseAddress else {
-          XCTFail("Base pointer is not defined")
+          Issue.record("Base pointer is not defined")
           return false
         }
         baseAddress = baseAddress.advanced(by: 1)
@@ -321,13 +337,14 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
           capacity: ptr.count - 1)
         var newBuf = FlatBuffersUtils.removeSizePrefix(bb: bytes)
         var monster: Monster = getRoot(byteBuffer: &newBuf)
-        self.readFlatbufferMonster(monster: &monster)
+        readFlatbufferMonster(monster: &monster)
         return true
       }
     }
-    XCTAssertEqual(testUnaligned(), true)
+    #expect(testUnaligned() == true)
   }
 
+  @Test
   func testCreateMessage() {
     let fbb = createMonster(withPrefix: false)
     let byteBuffer = fbb.buffer
@@ -335,7 +352,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     firstMessage.withUnsafeReadableBytes { ptr in
       var bytes = ByteBuffer(contiguousBytes: ptr, count: ptr.count)
       var monster: Monster = getRoot(byteBuffer: &bytes)
-      self.readFlatbufferMonster(monster: &monster)
+      readFlatbufferMonster(monster: &monster)
     }
 
     let secondByteBuffer = fbb.sizedBuffer
@@ -343,10 +360,11 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     secondMessage.withUnsafeReadableBytes { ptr in
       var bytes = ByteBuffer(contiguousBytes: ptr, count: ptr.count)
       var monster: Monster = getRoot(byteBuffer: &bytes)
-      self.readFlatbufferMonster(monster: &monster)
+      readFlatbufferMonster(monster: &monster)
     }
   }
 
+  @Test
   func testForceRetainedObject() {
     let byteBuffer = {
       // swiftformat:disable all
@@ -452,95 +470,95 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     var fb = fb
 
     let monster: Monster = getRoot(byteBuffer: &fb)
-    XCTAssertFalse(monster.mutate(mana: 10))
-    XCTAssertEqual(monster.testarrayoftables[0].name, "Barney")
-    XCTAssertEqual(monster.testarrayoftables[1].name, "Frodo")
-    XCTAssertEqual(monster.testarrayoftables[2].name, "Wilma")
+    #expect(monster.mutate(mana: 10) == false)
+    #expect(monster.testarrayoftables[0].name == "Barney")
+    #expect(monster.testarrayoftables[1].name == "Frodo")
+    #expect(monster.testarrayoftables[2].name == "Wilma")
 
     // Example of searching for a table by the key
-    XCTAssertNotNil(monster.testarrayoftablesBy(key: "Frodo"))
-    XCTAssertNotNil(monster.testarrayoftablesBy(key: "Barney"))
-    XCTAssertNotNil(monster.testarrayoftablesBy(key: "Wilma"))
+    #expect(monster.testarrayoftablesBy(key: "Frodo") != nil)
+    #expect(monster.testarrayoftablesBy(key: "Barney") != nil)
+    #expect(monster.testarrayoftablesBy(key: "Wilma") != nil)
 
-    XCTAssertEqual(monster.testType, .monster)
+    #expect(monster.testType == .monster)
 
-    XCTAssertEqual(monster.mutate(inventory: 1, at: 0), true)
-    XCTAssertEqual(monster.mutate(inventory: 2, at: 1), true)
-    XCTAssertEqual(monster.mutate(inventory: 3, at: 2), true)
-    XCTAssertEqual(monster.mutate(inventory: 4, at: 3), true)
-    XCTAssertEqual(monster.mutate(inventory: 5, at: 4), true)
+    #expect(monster.mutate(inventory: 1, at: 0) == true)
+    #expect(monster.mutate(inventory: 2, at: 1) == true)
+    #expect(monster.mutate(inventory: 3, at: 2) == true)
+    #expect(monster.mutate(inventory: 4, at: 3) == true)
+    #expect(monster.mutate(inventory: 5, at: 4) == true)
 
     for i in 0..<monster.inventory.count {
-      XCTAssertEqual(monster.inventory[i], Byte(i + 1))
+      #expect(monster.inventory[i] == Byte(i + 1))
     }
 
-    XCTAssertEqual(monster.mutate(inventory: 0, at: 0), true)
-    XCTAssertEqual(monster.mutate(inventory: 1, at: 1), true)
-    XCTAssertEqual(monster.mutate(inventory: 2, at: 2), true)
-    XCTAssertEqual(monster.mutate(inventory: 3, at: 3), true)
-    XCTAssertEqual(monster.mutate(inventory: 4, at: 4), true)
+    #expect(monster.mutate(inventory: 0, at: 0) == true)
+    #expect(monster.mutate(inventory: 1, at: 1) == true)
+    #expect(monster.mutate(inventory: 2, at: 2) == true)
+    #expect(monster.mutate(inventory: 3, at: 3) == true)
+    #expect(monster.mutate(inventory: 4, at: 4) == true)
 
     let vec = monster.mutablePos
-    XCTAssertEqual(vec?.x, 1)
-    XCTAssertTrue(vec?.mutate(x: 55.0) ?? false)
-    XCTAssertTrue(vec?.mutate(test1: 55) ?? false)
-    XCTAssertEqual(vec?.x, 55.0)
-    XCTAssertEqual(vec?.test1, 55.0)
-    XCTAssertTrue(vec?.mutate(x: 1) ?? false)
-    XCTAssertEqual(vec?.x, 1)
-    XCTAssertTrue(vec?.mutate(test1: 3) ?? false)
+    #expect(vec?.x == 1)
+    #expect(vec?.mutate(x: 55.0) == true)
+    #expect(vec?.mutate(test1: 55) == true)
+    #expect(vec?.x == 55.0)
+    #expect(vec?.test1 == 55.0)
+    #expect(vec?.mutate(x: 1) == true)
+    #expect(vec?.x == 1)
+    #expect(vec?.mutate(test1: 3) == true)
 
     let mutableTest4 = monster.mutableTest4
     let orignalValues = mutableTest4[0].a
-    XCTAssertEqual(mutableTest4[0].mutate(a: 100), true)
-    XCTAssertNotEqual(monster.test4[0].a, orignalValues)
-    XCTAssertEqual(monster.test4[0].a, 100)
-    XCTAssertEqual(mutableTest4[0].mutate(a: orignalValues), true)
+    #expect(mutableTest4[0].mutate(a: 100) == true)
+    #expect(monster.test4[0].a != orignalValues)
+    #expect(monster.test4[0].a == 100)
+    #expect(mutableTest4[0].mutate(a: orignalValues) == true)
   }
 
   func readFlatbufferMonster(monster: inout MyGame_Example_Monster) {
-    XCTAssertEqual(monster.hp, 80)
-    XCTAssertEqual(monster.mana, 150)
-    XCTAssertEqual(monster.name, "MyMonster")
+    #expect(monster.hp == 80)
+    #expect(monster.mana == 150)
+    #expect(monster.name == "MyMonster")
     let pos = monster.pos
-    XCTAssertEqual(pos?.x, 1)
-    XCTAssertEqual(pos?.y, 2)
-    XCTAssertEqual(pos?.z, 3)
-    XCTAssertEqual(pos?.test1, 3)
-    XCTAssertEqual(pos?.test2, .green)
+    #expect(pos?.x == 1)
+    #expect(pos?.y == 2)
+    #expect(pos?.z == 3)
+    #expect(pos?.test1 == 3)
+    #expect(pos?.test2 == .green)
     let test = pos?.test3
-    XCTAssertEqual(test?.a, 5)
-    XCTAssertEqual(test?.b, 6)
-    XCTAssertEqual(monster.testType, .monster)
+    #expect(test?.a == 5)
+    #expect(test?.b == 6)
+    #expect(monster.testType == .monster)
     let monster2 = monster.test(type: Monster.self)
-    XCTAssertEqual(monster2?.name, "Fred")
+    #expect(monster2?.name == "Fred")
 
-    XCTAssertEqual(monster.mutate(mana: 10), false)
+    #expect(monster.mutate(mana: 10) == false)
 
-    XCTAssertEqual(monster.mana, 150)
-    XCTAssertEqual(monster.inventory.count, 5)
+    #expect(monster.mana == 150)
+    #expect(monster.inventory.count == 5)
     var sum: Byte = 0
     for inventory in monster.inventory {
       sum += inventory
     }
-    XCTAssertEqual(sum, 10)
+    #expect(sum == 10)
 
     monster.withUnsafePointerToInventory { ptr, count in
       var sum: UInt8 = 0
       for pointee in ptr.startIndex..<ptr.endIndex {
         sum += ptr[pointee]
       }
-      XCTAssertEqual(sum, 10)
+      #expect(sum == 10)
     }
 
-    XCTAssertEqual(monster.test4.count, 2)
+    #expect(monster.test4.count == 2)
 
     let test4 = monster.test4
     var sum0 = 0
     for test0 in test4 {
       sum0 += Int(test0.a) + Int(test0.b)
     }
-    XCTAssertEqual(sum0, 100)
+    #expect(sum0 == 100)
 
     monster.withUnsafePointerToTest4 { ptr, count in
       guard let ptr = ptr.baseAddress else { return }
@@ -556,7 +574,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
         pointerSum += Int(bindedMemory[pointee].a) +
           Int(bindedMemory[pointee].b)
       }
-      XCTAssertEqual(pointerSum, 100)
+      #expect(pointerSum == 100)
     }
 
     let mutableTest4 = monster.mutableTest4
@@ -564,87 +582,84 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     for test0 in mutableTest4 {
       sum2 += Int(test0.a) + Int(test0.b)
     }
-    XCTAssertEqual(sum2, 100)
+    #expect(sum2 == 100)
 
     let stringArray = monster.testarrayofstring
-    XCTAssertEqual(stringArray.count, 2)
-    XCTAssertEqual(stringArray[0], "test1")
-    XCTAssertEqual(stringArray[1], "test2")
-    XCTAssertEqual(monster.testbool, true)
+    #expect(stringArray.count == 2)
+    #expect(stringArray[0] == "test1")
+    #expect(stringArray[1] == "test2")
+    #expect(monster.testbool == true)
 
     let array = monster.nameSegmentArray
-    XCTAssertEqual(String(bytes: array ?? [], encoding: .utf8), "MyMonster")
+    #expect(String(bytes: array ?? [], encoding: .utf8) == "MyMonster")
 
     if 0 == monster.testarrayofbools.count {
-      XCTAssertEqual(monster.testarrayofbools.isEmpty, true)
+      #expect(monster.testarrayofbools.isEmpty == true)
     } else {
-      XCTAssertEqual(monster.testarrayofbools.isEmpty, false)
+      #expect(monster.testarrayofbools.isEmpty == false)
     }
   }
 
   func readObjectApi(monster: MyGame_Example_MonsterT) {
-    XCTAssertEqual(monster.hp, 80)
-    XCTAssertEqual(monster.mana, 150)
-    XCTAssertEqual(monster.name, "MyMonster")
+    #expect(monster.hp == 80)
+    #expect(monster.mana == 150)
+    #expect(monster.name == "MyMonster")
     let pos = monster.pos
-    XCTAssertEqual(pos?.x, 1)
-    XCTAssertEqual(pos?.y, 2)
-    XCTAssertEqual(pos?.z, 3)
-    XCTAssertEqual(pos?.test1, 3)
-    XCTAssertEqual(pos?.test2, .green)
+    #expect(pos?.x == 1)
+    #expect(pos?.y == 2)
+    #expect(pos?.z == 3)
+    #expect(pos?.test1 == 3)
+    #expect(pos?.test2 == .green)
     let test = pos?.test3
-    XCTAssertEqual(test?.a, 5)
-    XCTAssertEqual(test?.b, 6)
+    #expect(test?.a == 5)
+    #expect(test?.b == 6)
     let monster2 = monster.test?.value as? MyGame_Example_MonsterT
-    XCTAssertEqual(monster2?.name, "Fred")
-    XCTAssertEqual(monster.mana, 150)
+    #expect(monster2?.name == "Fred")
+    #expect(monster.mana == 150)
     monster.mana = 10
-    XCTAssertEqual(monster.mana, 10)
+    #expect(monster.mana == 10)
     monster.mana = 150
-    XCTAssertEqual(monster.mana, 150)
+    #expect(monster.mana == 150)
 
-    XCTAssertEqual(monster.inventory.count, 5)
+    #expect(monster.inventory.count == 5)
     var sum: Byte = 0
     for i in monster.inventory {
       sum += i
     }
-    XCTAssertEqual(sum, 10)
-    XCTAssertEqual(monster.test4.count, 2)
+    #expect(sum == 10)
+    #expect(monster.test4.count == 2)
     var sum0 = 0
     for test in monster.test4 {
       sum0 += Int(test.a) + Int(test.b)
     }
-    XCTAssertEqual(sum0, 100)
-    XCTAssertEqual(monster.testbool, true)
+    #expect(sum0 == 100)
+    #expect(monster.testbool == true)
   }
 
-  func testEncoding() {
+  @Test
+  func testEncoding() throws {
     let fbb = createMonster(withPrefix: false)
     var sizedBuffer = fbb.sizedBuffer
-    do {
-      struct Test: Decodable {
-        struct Pos: Decodable {
-          let x, y, z: Int
-        }
-        let hp: Int
-        let inventory: [UInt8]
-        let name: String
-        let pos: Pos
+    struct Test: Decodable {
+      struct Pos: Decodable {
+        let x, y, z: Int
       }
-      let reader: Monster = try getCheckedRoot(byteBuffer: &sizedBuffer)
-      let encoder = JSONEncoder()
-      encoder.keyEncodingStrategy = .convertToSnakeCase
-      let data = try encoder.encode(reader)
-      let decoder = JSONDecoder()
-      decoder.keyDecodingStrategy = .convertFromSnakeCase
-      let value = try decoder.decode(Test.self, from: data)
-      XCTAssertEqual(value.name, "MyMonster")
-      XCTAssertEqual(value.pos.x, 1)
-      XCTAssertEqual(value.pos.y, 2)
-      XCTAssertEqual(value.pos.z, 3)
-    } catch {
-      XCTFail(error.localizedDescription)
+      let hp: Int
+      let inventory: [UInt8]
+      let name: String
+      let pos: Pos
     }
+    let reader: Monster = try getCheckedRoot(byteBuffer: &sizedBuffer)
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let data = try encoder.encode(reader)
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let value = try decoder.decode(Test.self, from: data)
+    #expect(value.name == "MyMonster")
+    #expect(value.pos.x == 1)
+    #expect(value.pos.y == 2)
+    #expect(value.pos.z == 3)
   }
 
   var jsonData: String {
@@ -653,6 +668,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     """
   }
 
+  @Test
   func testContiguousBytes() {
     let byteArray: [UInt8] = [3, 1, 4, 1, 5, 9]
     var fbb = FlatBufferBuilder(initialSize: 1)
@@ -670,7 +686,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     monster.withUnsafePointerToInventory { ptr, count in
       let array = Array(ptr)
       for (index, value) in values.enumerated() {
-        XCTAssertEqual(array[index], value)
+        #expect(array[index] == value)
       }
     }
   }

--- a/tests/swift/Tests/Flatbuffers/FlatBuffersNanInfTests.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatBuffersNanInfTests.swift
@@ -14,11 +14,59 @@
  * limitations under the License.
  */
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import FlatBuffers
 
-final class FlatBuffersNanInfTests: XCTestCase {
+struct FlatBuffersNanInfTests {
+
+  @Test
+  func testInfNanBinary() {
+    let fbb = createTestTable()
+    let data = fbb.sizedByteArray
+
+    var buffer = ByteBuffer(bytes: data)
+    let table: Swift_Tests_NanInfTable = getRoot(byteBuffer: &buffer)
+    #expect(table.defaultNan.isNaN)
+    #expect(table.defaultInf == .infinity)
+    #expect(table.defaultNinf == -.infinity)
+    #expect(table.valueNan.isNaN)
+    #expect(table.valueInf == .infinity)
+    #expect(table.valueNinf == -.infinity)
+    #expect(table.value == 100.0)
+  }
+
+  @Test
+  func testInfNanJSON() throws {
+    let fbb = createTestTable()
+    var bb = fbb.sizedBuffer
+    struct Test: Decodable {
+      let valueInf: Double
+      let value: Int
+      let valueNan: Double
+      let valueNinf: Double
+    }
+    let reader: Swift_Tests_NanInfTable = try getCheckedRoot(byteBuffer: &bb)
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    encoder.nonConformingFloatEncodingStrategy =
+      .convertToString(
+        positiveInfinity: "inf",
+        negativeInfinity: "-inf",
+        nan: "nan")
+    let data = try encoder.encode(reader)
+    let decoder = JSONDecoder()
+    decoder.nonConformingFloatDecodingStrategy = .convertFromString(
+      positiveInfinity: "inf",
+      negativeInfinity: "-inf",
+      nan: "nan")
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let value = try decoder.decode(Test.self, from: data)
+    #expect(value.value == 100)
+    #expect(value.valueInf == .infinity)
+    #expect(value.valueNinf == -.infinity)
+  }
 
   func createTestTable() -> FlatBufferBuilder {
     var fbb = FlatBufferBuilder()
@@ -31,54 +79,4 @@ final class FlatBuffersNanInfTests: XCTestCase {
     fbb.finish(offset: msg)
     return fbb
   }
-
-  func testInfNanBinary() {
-    let fbb = createTestTable()
-    let data = fbb.sizedByteArray
-
-    var buffer = ByteBuffer(bytes: data)
-    let table: Swift_Tests_NanInfTable = getRoot(byteBuffer: &buffer)
-    XCTAssert(table.defaultNan.isNaN)
-    XCTAssertEqual(table.defaultInf, .infinity)
-    XCTAssertEqual(table.defaultNinf, -.infinity)
-    XCTAssert(table.valueNan.isNaN)
-    XCTAssertEqual(table.valueInf, .infinity)
-    XCTAssertEqual(table.valueNinf, -.infinity)
-    XCTAssertEqual(table.value, 100.0)
-  }
-
-  func testInfNanJSON() {
-    let fbb = createTestTable()
-    var bb = fbb.sizedBuffer
-    do {
-      struct Test: Decodable {
-        let valueInf: Double
-        let value: Int
-        let valueNan: Double
-        let valueNinf: Double
-      }
-      let reader: Swift_Tests_NanInfTable = try getCheckedRoot(byteBuffer: &bb)
-      let encoder = JSONEncoder()
-      encoder.keyEncodingStrategy = .convertToSnakeCase
-      encoder.nonConformingFloatEncodingStrategy =
-        .convertToString(
-          positiveInfinity: "inf",
-          negativeInfinity: "-inf",
-          nan: "nan")
-      let data = try encoder.encode(reader)
-      let decoder = JSONDecoder()
-      decoder.nonConformingFloatDecodingStrategy = .convertFromString(
-        positiveInfinity: "inf",
-        negativeInfinity: "-inf",
-        nan: "nan")
-      decoder.keyDecodingStrategy = .convertFromSnakeCase
-      let value = try decoder.decode(Test.self, from: data)
-      XCTAssertEqual(value.value, 100)
-      XCTAssertEqual(value.valueInf, .infinity)
-      XCTAssertEqual(value.valueNinf, -.infinity)
-    } catch {
-      XCTFail(error.localizedDescription)
-    }
-  }
-
 }

--- a/tests/swift/Tests/Flatbuffers/FlatBuffersStructsTests.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatBuffersStructsTests.swift
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import XCTest
+import Testing
 
 @testable import FlatBuffers
 
-final class FlatBuffersStructsTests: XCTestCase {
+struct FlatBuffersStructsTests {
 
+  @Test
   func testWritingAndMutatingBools() {
     var fbb = FlatBufferBuilder()
     let start = TestMutatingBool.startTestMutatingBool(&fbb)
@@ -30,11 +31,11 @@ final class FlatBuffersStructsTests: XCTestCase {
     var buffer = fbb.sizedBuffer
     let testMutatingBool: TestMutatingBool = getRoot(byteBuffer: &buffer)
     let property = testMutatingBool.mutableB
-    XCTAssertEqual(property?.property, false)
+    #expect(property?.property == false)
     property?.mutate(property: false)
-    XCTAssertEqual(property?.property, false)
+    #expect(property?.property == false)
     property?.mutate(property: true)
-    XCTAssertEqual(property?.property, true)
+    #expect(property?.property == true)
   }
 
 }

--- a/tests/swift/Tests/Flatbuffers/FlatBuffersTests.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatBuffersTests.swift
@@ -14,44 +14,49 @@
  * limitations under the License.
  */
 
-import XCTest
+import Testing
 
 @testable import Common
 @testable import FlatBuffers
 
-final class FlatBuffersTests: XCTestCase {
+struct FlatBuffersTests {
 
   let country = "Norway"
 
-  func testEndian() { XCTAssertEqual(isLitteEndian, true) }
+  @Test
+  func testEndian() { #expect(isLitteEndian == true) }
 
+  @Test
   func testOffset() {
     let o = Offset()
     let b = Offset(offset: 1)
-    XCTAssertEqual(o.isEmpty, true)
-    XCTAssertEqual(b.isEmpty, false)
+    #expect(o.isEmpty == true)
+    #expect(b.isEmpty == false)
   }
 
+  @Test
   func testCreateString() {
     let helloWorld = "Hello, world!"
     var b = FlatBufferBuilder(initialSize: 16)
-    XCTAssertEqual(b.create(string: country).o, 12)
-    XCTAssertEqual(b.create(string: helloWorld).o, 32)
+    #expect(b.create(string: country).o == 12)
+    #expect(b.create(string: helloWorld).o == 32)
     b.clear()
-    XCTAssertEqual(b.create(string: helloWorld).o, 20)
-    XCTAssertEqual(b.create(string: country).o, 32)
+    #expect(b.create(string: helloWorld).o == 20)
+    #expect(b.create(string: country).o == 32)
     b.clear()
-    XCTAssertEqual(b.create(string: String(repeating: "a", count: 257)).o, 264)
+    #expect(b.create(string: String(repeating: "a", count: 257)).o == 264)
   }
 
+  @Test
   func testStartTable() {
     var b = FlatBufferBuilder(initialSize: 16)
-    XCTAssertNoThrow(b.startTable(with: 0))
+    _ = b.startTable(with: 0)
     b.clear()
-    XCTAssertEqual(b.create(string: country).o, 12)
-    XCTAssertEqual(b.startTable(with: 0), 12)
+    #expect(b.create(string: country).o == 12)
+    #expect(b.startTable(with: 0) == 12)
   }
 
+  @Test
   func testCreateFinish() {
     var b = FlatBufferBuilder(initialSize: 16)
     let countryOff = Country.createCountry(
@@ -66,9 +71,10 @@ final class FlatBuffersTests: XCTestCase {
       200, 0, 0, 0, 6, 0, 0, 0, 78, 111, 114, 119, 97, 121, 0, 0,
     ]
     // swiftformat:enable all
-    XCTAssertEqual(b.sizedByteArray, v)
+    #expect(b.sizedByteArray == v)
   }
 
+  @Test
   func testCreateFinishWithPrefix() {
     var b = FlatBufferBuilder(initialSize: 16)
     let countryOff = Country.createCountry(
@@ -83,9 +89,10 @@ final class FlatBuffersTests: XCTestCase {
       100, 0, 0, 0, 200, 0, 0, 0, 6, 0, 0, 0, 78, 111, 114, 119, 97, 121, 0, 0,
     ]
     // swiftformat:enable all
-    XCTAssertEqual(b.sizedByteArray, v)
+    #expect(b.sizedByteArray == v)
   }
 
+  @Test
   func testReadCountry() {
     // swiftformat:disable all
     let v: [UInt8] = [
@@ -95,18 +102,20 @@ final class FlatBuffersTests: XCTestCase {
     // swiftformat:enable all
     let buffer = ByteBuffer(bytes: v)
     let c = Country.getRootAsCountry(buffer)
-    XCTAssertEqual(c.lan, 100)
-    XCTAssertEqual(c.log, 200)
-    XCTAssertEqual(c.nameVector, [78, 111, 114, 119, 97, 121])
-    XCTAssertEqual(c.name, country)
+    #expect(c.lan == 100)
+    #expect(c.log == 200)
+    #expect(c.nameVector == [78, 111, 114, 119, 97, 121])
+    #expect(c.name == country)
   }
 
+  @Test
   func testWriteNullableStrings() {
     var b = FlatBufferBuilder()
-    XCTAssertTrue(b.create(string: nil).isEmpty)
-    XCTAssertTrue(b.createShared(string: nil).isEmpty)
+    #expect(b.create(string: nil).isEmpty)
+    #expect(b.createShared(string: nil).isEmpty)
   }
 
+  @Test
   func testWriteOptionalValues() {
     var b = FlatBufferBuilder()
     let root = optional_scalars_ScalarStuff.createScalarStuff(
@@ -121,16 +130,17 @@ final class FlatBuffersTests: XCTestCase {
     b.finish(offset: root)
     var buffer = b.sizedBuffer
     let scalarTable: optional_scalars_ScalarStuff = getRoot(byteBuffer: &buffer)
-    XCTAssertEqual(scalarTable.justI8, 80)
-    XCTAssertNil(scalarTable.maybeI8)
-    XCTAssertEqual(scalarTable.maybeBool, true)
-    XCTAssertEqual(scalarTable.defaultI8, 42)
-    XCTAssertEqual(scalarTable.justU8, 100)
-    XCTAssertEqual(scalarTable.maybeU8, 10)
-    XCTAssertEqual(scalarTable.justEnum, .one)
-    XCTAssertNil(scalarTable.maybeEnum)
+    #expect(scalarTable.justI8 == 80)
+    #expect(scalarTable.maybeI8 == nil)
+    #expect(scalarTable.maybeBool == true)
+    #expect(scalarTable.defaultI8 == 42)
+    #expect(scalarTable.justU8 == 100)
+    #expect(scalarTable.maybeU8 == 10)
+    #expect(scalarTable.justEnum == .one)
+    #expect(scalarTable.maybeEnum == nil)
   }
 
+  @Test
   func testAlignmentCrash() {
     var builder = FlatBufferBuilder(initialSize: 256)
 

--- a/tests/swift/Tests/Flatbuffers/FlatBuffersUnionTests.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatBuffersUnionTests.swift
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import FlatBuffers
 
-final class FlatBuffersUnionTests: XCTestCase {
+struct FlatBuffersUnionTests {
 
+  @Test
   func testCreateMonstor() {
 
     var b = FlatBufferBuilder(initialSize: 20)
@@ -36,8 +38,8 @@ final class FlatBuffersUnionTests: XCTestCase {
     b.finish(offset: root)
     let buffer = b.sizedByteArray
     // swiftformat:disable all
-    XCTAssertEqual(
-      buffer,
+    #expect(
+      buffer ==
       [
         16, 0, 0, 0, 0, 0, 10, 0, 16, 0, 8, 0, 7, 0, 12, 0, 10, 0, 0, 0, 0, 0, 0, 1, 8, 0, 0, 0, 20,
         0, 0, 0, 1, 0, 0, 0, 12, 0, 0, 0, 8, 0, 12, 0, 8, 0, 6, 0, 8, 0, 0, 0, 0, 0, 5, 0, 4, 0, 0,
@@ -45,15 +47,16 @@ final class FlatBuffersUnionTests: XCTestCase {
       ])
     // swiftformat:enable all
     let monster = LocalMonster.getRootAsMonster(bb: ByteBuffer(bytes: buffer))
-    XCTAssertEqual(monster.weapon(at: 0)?.dmg, dmg)
-    XCTAssertEqual(monster.weapon(at: 0)?.name, str)
-    XCTAssertEqual(monster.weapon(at: 0)?.nameVector, [65, 120, 101])
+    #expect(monster.weapon(at: 0)?.dmg == dmg)
+    #expect(monster.weapon(at: 0)?.name == str)
+    #expect(monster.weapon(at: 0)?.nameVector == [65, 120, 101])
     let p: Weapon? = monster.equiped()
-    XCTAssertEqual(p?.dmg, dmg)
-    XCTAssertEqual(p?.name, str)
-    XCTAssertEqual(p?.nameVector, [65, 120, 101])
+    #expect(p?.dmg == dmg)
+    #expect(p?.name == str)
+    #expect(p?.nameVector == [65, 120, 101])
   }
 
+  @Test
   func testEndTableFinish() {
     var builder = FlatBufferBuilder(initialSize: 20)
     let sword = builder.create(string: "Sword")
@@ -84,8 +87,8 @@ final class FlatBuffersUnionTests: XCTestCase {
       path: path)
     builder.finish(offset: orc)
     // swiftformat:disable all
-    XCTAssertEqual(
-      builder.sizedByteArray,
+    #expect(
+      builder.sizedByteArray ==
       [
         32, 0, 0, 0, 0, 0, 26, 0, 48, 0, 36, 0, 0, 0, 34, 0, 28, 0, 0, 0, 24, 0, 23, 0, 16, 0, 15,
         0, 8, 0, 4, 0, 26, 0, 0, 0, 44, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 1, 60, 0, 0, 0, 0, 0, 0, 0,
@@ -99,6 +102,7 @@ final class FlatBuffersUnionTests: XCTestCase {
     // swiftformat:enable all
   }
 
+  @Test
   func testEnumVector() {
     let vectorOfEnums: [ColorsNameSpace.RGB] = [.blue, .green]
 
@@ -109,8 +113,8 @@ final class FlatBuffersUnionTests: XCTestCase {
     let end = ColorsNameSpace.Monster.endMonster(&builder, start: start)
     builder.finish(offset: end)
     // swiftformat:disable all
-    XCTAssertEqual(
-      builder.sizedByteArray,
+    #expect(
+      builder.sizedByteArray ==
       [
         12, 0, 0, 0, 0, 0, 6, 0, 8, 0, 4, 0, 6, 0, 0, 0, 4, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 1, 0,
         0, 0,
@@ -118,12 +122,13 @@ final class FlatBuffersUnionTests: XCTestCase {
     // swiftformat:enable all
     let monster = ColorsNameSpace.Monster
       .getRootAsMonster(bb: builder.sizedBuffer)
-    XCTAssertEqual(monster.colorsCount, 2)
+    #expect(monster.colorsCount == 2)
     let colors = monster.colors
-    XCTAssertEqual(colors[0], .blue)
-    XCTAssertEqual(colors[1], .green)
+    #expect(colors[0] == .blue)
+    #expect(colors[1] == .green)
   }
 
+  @Test
   func testUnionVector() {
     var fb = FlatBufferBuilder()
 
@@ -149,30 +154,30 @@ final class FlatBuffersUnionTests: XCTestCase {
 
     var buffer = fb.sizedBuffer
     let movie: Movie = getRoot(byteBuffer: &buffer)
-    XCTAssertEqual(movie.charactersType.count, characterType.count)
-    XCTAssertEqual(movie.characters.count, characters.count)
+    #expect(movie.charactersType.count == characterType.count)
+    #expect(movie.characters.count == characters.count)
 
     let bufferCharactersType = movie.charactersType
     for (index, element) in bufferCharactersType.enumerated() {
-      XCTAssertEqual(element, characterType[index])
+      #expect(element == characterType[index])
     }
 
-    XCTAssertEqual(
-      movie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead,
-      7)
-    XCTAssertEqual(
-      movie.characters(at: 1, type: Attacker.self)?.swordAttackDamage,
-      swordDmg)
-    XCTAssertEqual(
-      movie.characters(at: 2, type: BookReader_Mutable.self)?.booksRead,
-      2)
+    #expect(
+      movie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead ==
+        7)
+    #expect(
+      movie.characters(at: 1, type: Attacker.self)?.swordAttackDamage ==
+        swordDmg)
+    #expect(
+      movie.characters(at: 2, type: BookReader_Mutable.self)?.booksRead ==
+        2)
 
     var objc: MovieT? = movie.unpack()
-    XCTAssertEqual(
-      movie.charactersType.count, objc?.characters.count ?? 0)
-    XCTAssertEqual(
-      movie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead,
-      (objc?.characters[0]?.value as? BookReader)?.booksRead)
+    #expect(
+      movie.charactersType.count == objc?.characters.count ?? 0)
+    #expect(
+      movie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead ==
+        (objc?.characters[0]?.value as? BookReader)?.booksRead)
     fb.clear()
     let newMovie = Movie.pack(&fb, obj: &objc)
     fb.finish(offset: newMovie)
@@ -180,17 +185,18 @@ final class FlatBuffersUnionTests: XCTestCase {
     var _buffer = fb.sizedBuffer
     let packedMovie: Movie = getRoot(byteBuffer: &_buffer)
 
-    XCTAssertEqual(
-      packedMovie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead,
-      movie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead)
-    XCTAssertEqual(
-      packedMovie.characters(at: 1, type: Attacker.self)?.swordAttackDamage,
-      movie.characters(at: 1, type: Attacker.self)?.swordAttackDamage)
-    XCTAssertEqual(
-      packedMovie.characters(at: 2, type: BookReader_Mutable.self)?.booksRead,
-      movie.characters(at: 2, type: BookReader_Mutable.self)?.booksRead)
+    #expect(
+      packedMovie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead ==
+        movie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead)
+    #expect(
+      packedMovie.characters(at: 1, type: Attacker.self)?.swordAttackDamage ==
+        movie.characters(at: 1, type: Attacker.self)?.swordAttackDamage)
+    #expect(
+      packedMovie.characters(at: 2, type: BookReader_Mutable.self)?.booksRead ==
+        movie.characters(at: 2, type: BookReader_Mutable.self)?.booksRead)
   }
 
+  @Test
   func testStringUnion() {
     let string = "Awesome \\\\t\t\nstring!"
     var fb = FlatBufferBuilder()
@@ -214,30 +220,31 @@ final class FlatBuffersUnionTests: XCTestCase {
 
     var buffer = fb.sizedBuffer
     let movie: Movie = getRoot(byteBuffer: &buffer)
-    XCTAssertEqual(movie.mainCharacter(type: String.self), string)
-    XCTAssertEqual(
-      movie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead,
-      7)
-    XCTAssertEqual(movie.characters(at: 1, type: String.self), string)
+    #expect(movie.mainCharacter(type: String.self) == string)
+    #expect(
+      movie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead ==
+        7)
+    #expect(movie.characters(at: 1, type: String.self) == string)
 
     var objc: MovieT? = movie.unpack()
-    XCTAssertEqual(objc?.mainCharacter?.value as? String, string)
-    XCTAssertEqual((objc?.characters[0]?.value as? BookReader)?.booksRead, 7)
-    XCTAssertEqual(objc?.characters[1]?.value as? String, string)
+    #expect(objc?.mainCharacter?.value as? String == string)
+    #expect((objc?.characters[0]?.value as? BookReader)?.booksRead == 7)
+    #expect(objc?.characters[1]?.value as? String == string)
     fb.clear()
     let newMovie = Movie.pack(&fb, obj: &objc)
     fb.finish(offset: newMovie)
 
     var _buffer = fb.sizedBuffer
     let packedMovie: Movie = getRoot(byteBuffer: &_buffer)
-    XCTAssertEqual(packedMovie.mainCharacter(type: String.self), string)
-    XCTAssertEqual(
-      packedMovie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead,
-      7)
-    XCTAssertEqual(packedMovie.characters(at: 1, type: String.self), string)
+    #expect(packedMovie.mainCharacter(type: String.self) == string)
+    #expect(
+      packedMovie.characters(at: 0, type: BookReader_Mutable.self)?.booksRead ==
+        7)
+    #expect(packedMovie.characters(at: 1, type: String.self) == string)
   }
 
-  func testEncoding() {
+  @Test
+  func testEncoding() throws {
     let string = "Awesome \\\\t\t\nstring!"
     var fb = FlatBufferBuilder()
 
@@ -265,16 +272,12 @@ final class FlatBuffersUnionTests: XCTestCase {
     Movie.finish(&fb, end: end)
 
     var sizedBuffer = fb.sizedBuffer
-    do {
-      let reader: Movie = try getCheckedRoot(byteBuffer: &sizedBuffer)
-      let encoder = JSONEncoder()
-      encoder.keyEncodingStrategy = .convertToSnakeCase
-      encoder.outputFormatting = [.sortedKeys]
-      let data = try encoder.encode(reader)
-      XCTAssertEqual(String(data: data, encoding: .utf8), jsonData)
-    } catch {
-      XCTFail(error.localizedDescription)
-    }
+    let reader: Movie = try getCheckedRoot(byteBuffer: &sizedBuffer)
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(reader)
+    #expect(String(data: data, encoding: .utf8) == jsonData)
   }
 
   var jsonData: String {

--- a/tests/swift/Tests/Flatbuffers/FlatBuffersVectorsTests.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatBuffersVectorsTests.swift
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import XCTest
+import Testing
 
 @testable import FlatBuffers
 
-final class FlatBuffersVectors: XCTestCase {
+struct FlatBuffersVectors {
 
+  @Test
   func testCreatingTwoCountries() {
     let norway = "Norway"
     let denmark = "Denmark"
@@ -40,8 +41,8 @@ final class FlatBuffersVectors: XCTestCase {
     let vectorOffset = b.createVector(ofOffsets: vector)
     b.finish(offset: vectorOffset)
     // swiftformat:disable all
-    XCTAssertEqual(
-      b.sizedByteArray,
+    #expect(
+      b.sizedByteArray ==
       [
         4, 0, 0, 0, 2, 0, 0, 0, 48, 0, 0, 0, 16, 0, 0, 0, 0, 0, 10, 0, 18, 0, 4, 0, 8, 0, 12, 0, 10,
         0, 0, 0, 40, 0, 0, 0, 100, 0, 0, 0, 200, 0, 0, 0, 0, 0, 10, 0, 16, 0, 4, 0, 8, 0, 12, 0, 10,
@@ -51,18 +52,20 @@ final class FlatBuffersVectors: XCTestCase {
     // swiftformat:enable all
   }
 
+  @Test
   func testCreateIntArray() {
     let numbers: [Int32] = [1, 2, 3, 4, 5]
     var b = FlatBufferBuilder(initialSize: 20)
     let o = b.createVector(numbers, size: numbers.count)
     b.finish(offset: o)
     // swiftformat:disable all
-    XCTAssertEqual(
-      b.sizedByteArray,
+    #expect(
+      b.sizedByteArray ==
       [4, 0, 0, 0, 5, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0])
     // swiftformat:enable all
   }
 
+  @Test
   func testCreateStructArray() {
     struct Vec: NativeStruct {
       let x, y, z: Float32
@@ -76,8 +79,8 @@ final class FlatBuffersVectors: XCTestCase {
     let o = b.createVector(ofStructs: vector)
     b.finish(offset: o)
     // swiftformat:disable all
-    XCTAssertEqual(
-      b.sizedByteArray,
+    #expect(
+      b.sizedByteArray ==
       [
         4, 0, 0, 0, 3, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 128, 64, 0, 0, 160,
         64, 0, 0, 192, 64, 0, 0, 224, 64, 0, 0, 0, 65, 0, 0, 16, 65,
@@ -85,28 +88,31 @@ final class FlatBuffersVectors: XCTestCase {
     // swiftformat:enable all
   }
 
+  @Test
   func testCreateEmptyIntArray() {
     let numbers: [Int32] = []
     var b = FlatBufferBuilder(initialSize: 20)
     let o = b.createVector(numbers, size: numbers.count)
     b.finish(offset: o)
-    XCTAssertEqual(b.sizedByteArray, [4, 0, 0, 0, 0, 0, 0, 0])
+    #expect(b.sizedByteArray == [4, 0, 0, 0, 0, 0, 0, 0])
   }
 
+  @Test
   func testCreateVectorOfStrings() {
     let strs = ["Denmark", "Norway"]
     var b = FlatBufferBuilder(initialSize: 20)
     let o = b.createVector(ofStrings: strs)
     b.finish(offset: o)
     // swiftformat:disable all
-    XCTAssertEqual(
-      b.sizedByteArray,
+    #expect(
+      b.sizedByteArray ==
       [
         4, 0, 0, 0, 2, 0, 0, 0, 20, 0, 0, 0, 4, 0, 0, 0, 6, 0, 0, 0, 78, 111, 114, 119, 97, 121, 0,
         0, 7, 0, 0, 0, 68, 101, 110, 109, 97, 114, 107, 0,
       ])
     // swiftformat:enable all
   }
+  @Test
   func testCreateSharedStringVector() {
     let norway = "Norway"
     let denmark = "Denmark"
@@ -119,8 +125,8 @@ final class FlatBuffersVectors: XCTestCase {
     let end = b.createVector(ofOffsets: v)
     b.finish(offset: end)
     // swiftformat:disable all
-    XCTAssertEqual(
-      b.sizedByteArray,
+    #expect(
+      b.sizedByteArray ==
       [
         4, 0, 0, 0, 4, 0, 0, 0, 28, 0, 0, 0, 12, 0, 0, 0, 20, 0, 0, 0, 4, 0, 0, 0, 7, 0, 0, 0, 68,
         101, 110, 109, 97, 114, 107, 0, 6, 0, 0, 0, 78, 111, 114, 119, 97, 121, 0, 0,
@@ -128,6 +134,7 @@ final class FlatBuffersVectors: XCTestCase {
     // swiftformat:enable all
   }
 
+  @Test
   func testReadInt32Array() {
     let data: [Int32] = [1, 2, 3, 4, 5]
     var b = FlatBufferBuilder(initialSize: 20)
@@ -136,10 +143,11 @@ final class FlatBuffersVectors: XCTestCase {
     b.finish(offset: end)
     let number = Numbers.getRootAsNumbers(ByteBuffer(bytes: b.sizedByteArray))
     for (index, num) in number.vArrayInt32.enumerated() {
-      XCTAssertEqual(num, data[index])
+      #expect(num == data[index])
     }
   }
 
+  @Test
   func testReadDoubleArray() {
     let data: [Double] = [1, 2, 3, 4, 5]
     var b = FlatBufferBuilder(initialSize: 20)
@@ -148,10 +156,11 @@ final class FlatBuffersVectors: XCTestCase {
     b.finish(offset: end)
     let number = Numbers.getRootAsNumbers(ByteBuffer(bytes: b.sizedByteArray))
     for (index, num) in number.vArrayDouble.enumerated() {
-      XCTAssertEqual(num, data[index])
+      #expect(num == data[index])
     }
   }
 
+  @Test
   func testHasForArray() {
     var builder = FlatBufferBuilder(initialSize: 20)
     let emptyVector = [UInt8]()
@@ -166,14 +175,14 @@ final class FlatBuffersVectors: XCTestCase {
 
     var byteBuffer = ByteBuffer(bytes: builder.sizedByteArray)
     let msg: Swift_Tests_Vectors = getRoot(byteBuffer: &byteBuffer)
-    XCTAssertEqual(msg.none_.isEmpty, true)
-    XCTAssertEqual(msg.empty.isEmpty, true)
-    XCTAssertEqual(msg.empty.count, 0)
-    XCTAssertEqual(msg.array.isEmpty, false)
-    XCTAssertEqual(msg.array.count, 3)
+    #expect(msg.none_.isEmpty == true)
+    #expect(msg.empty.isEmpty == true)
+    #expect(msg.empty.count == 0)
+    #expect(msg.array.isEmpty == false)
+    #expect(msg.array.count == 3)
 
     for i in msg.array.startIndex..<msg.array.endIndex {
-      XCTAssertEqual(msg.array[i], 1 + UInt64(i))
+      #expect(msg.array[i] == 1 + UInt64(i))
     }
 
     let array = msg.withUnsafePointerToArray { ptr, count in
@@ -185,7 +194,7 @@ final class FlatBuffersVectors: XCTestCase {
       return Array(ptr)
     }
 
-    XCTAssertEqual(array, [1, 2, 3])
+    #expect(array == [1, 2, 3])
   }
 }
 

--- a/tests/swift/Tests/Flatbuffers/FlatbuffersDoubleTests.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatbuffersDoubleTests.swift
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-import XCTest
+import Testing
 
 @testable import FlatBuffers
 
-final class FlatBuffersDoubleTests: XCTestCase {
+struct FlatBuffersDoubleTests {
 
   let country = "Norway"
 
+  @Test
   func testCreateFinish() {
     var b = FlatBufferBuilder(initialSize: 16)
     let countryOff = CountryDouble.createCountry(
@@ -38,9 +39,10 @@ final class FlatBuffersDoubleTests: XCTestCase {
       97, 121, 0, 0,
     ]
     // swiftformat:enable all
-    XCTAssertEqual(b.sizedByteArray, v)
+    #expect(b.sizedByteArray == v)
   }
 
+  @Test
   func testCreateFinishWithPrefix() {
     var b = FlatBufferBuilder(initialSize: 16)
     let countryOff = CountryDouble.createCountry(
@@ -57,7 +59,7 @@ final class FlatBuffersDoubleTests: XCTestCase {
       0, 6, 0, 0, 0, 78, 111, 114, 119, 97, 121, 0, 0,
     ]
     // swiftformat:enable all
-    XCTAssertEqual(b.sizedByteArray, v)
+    #expect(b.sizedByteArray == v)
   }
 }
 

--- a/tests/swift/Tests/Flatbuffers/FlatbuffersMoreDefaults.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatbuffersMoreDefaults.swift
@@ -15,11 +15,11 @@
  */
 
 import Foundation
-import XCTest
+import Testing
 
 @testable import FlatBuffers
 
-class FlatBuffersMoreDefaults: XCTestCase {
+struct FlatBuffersMoreDefaults {
 
   func testFlatbuffersObject() {
     var fbb = FlatBufferBuilder()
@@ -27,61 +27,58 @@ class FlatBuffersMoreDefaults: XCTestCase {
     fbb.finish(offset: root)
     var byteBuffer = fbb.sizedBuffer
     let defaults: MoreDefaults = getRoot(byteBuffer: &byteBuffer)
-    XCTAssertEqual(defaults.emptyString, "")
-    XCTAssertEqual(defaults.someString, "some")
-    XCTAssertEqual(defaults.ints.isEmpty, true)
-    XCTAssertEqual(defaults.floats.isEmpty, true)
-    XCTAssertEqual(defaults.bools.isEmpty, true)
-    XCTAssertEqual(defaults.ints.count, 0)
-    XCTAssertEqual(defaults.floats.count, 0)
-    XCTAssertEqual(defaults.abcs.count, 0)
-    XCTAssertEqual(defaults.bools.count, 0)
+    #expect(defaults.emptyString == "")
+    #expect(defaults.someString == "some")
+    #expect(defaults.ints.isEmpty == true)
+    #expect(defaults.floats.isEmpty == true)
+    #expect(defaults.bools.isEmpty == true)
+    #expect(defaults.ints.count == 0)
+    #expect(defaults.floats.count == 0)
+    #expect(defaults.abcs.count == 0)
+    #expect(defaults.bools.count == 0)
   }
 
   func testFlatbuffersObjectAPI() {
     var fbb = FlatBufferBuilder()
     let defaults = MoreDefaultsT()
-    XCTAssertEqual(defaults.emptyString, "")
-    XCTAssertEqual(defaults.someString, "some")
-    XCTAssertEqual(defaults.ints, [])
-    XCTAssertEqual(defaults.floats, [])
-    XCTAssertEqual(defaults.abcs, [])
-    XCTAssertEqual(defaults.bools, [])
+    #expect(defaults.emptyString == "")
+    #expect(defaults.someString == "some")
+    #expect(defaults.ints == [])
+    #expect(defaults.floats == [])
+    #expect(defaults.abcs == [])
+    #expect(defaults.bools == [])
 
     var buffer = defaults.serialize(builder: &fbb, type: MoreDefaults.self)
     let fDefaults: MoreDefaults = getRoot(byteBuffer: &buffer)
-    XCTAssertEqual(fDefaults.emptyString, "")
-    XCTAssertEqual(fDefaults.someString, "some")
-    XCTAssertEqual(fDefaults.ints.isEmpty, true)
-    XCTAssertEqual(fDefaults.floats.isEmpty, true)
-    XCTAssertEqual(fDefaults.ints.count, 0)
-    XCTAssertEqual(fDefaults.floats.count, 0)
-    XCTAssertEqual(fDefaults.abcs.count, 0)
-    XCTAssertEqual(fDefaults.bools.count, 0)
+    #expect(fDefaults.emptyString == "")
+    #expect(fDefaults.someString == "some")
+    #expect(fDefaults.ints.isEmpty == true)
+    #expect(fDefaults.floats.isEmpty == true)
+    #expect(fDefaults.ints.count == 0)
+    #expect(fDefaults.floats.count == 0)
+    #expect(fDefaults.abcs.count == 0)
+    #expect(fDefaults.bools.count == 0)
   }
 
-  func testEncoding() {
+  @Test
+  func testEncoding() throws {
     var fbb = FlatBufferBuilder()
     let root = MoreDefaults.createMoreDefaults(&fbb)
     fbb.finish(offset: root)
     var sizedBuffer = fbb.sizedBuffer
-    do {
-      struct Test: Decodable {
-        var emptyString: String
-        var someString: String
-      }
-      let reader: MoreDefaults = try getCheckedRoot(byteBuffer: &sizedBuffer)
-      let encoder = JSONEncoder()
-      encoder.keyEncodingStrategy = .convertToSnakeCase
-      let data = try encoder.encode(reader)
-      let decoder = JSONDecoder()
-      decoder.keyDecodingStrategy = .convertFromSnakeCase
-      let value = try decoder.decode(Test.self, from: data)
-      XCTAssertEqual(value.someString, "some")
-      XCTAssertEqual(value.emptyString, "")
-    } catch {
-      XCTFail(error.localizedDescription)
+    struct Test: Decodable {
+      var emptyString: String
+      var someString: String
     }
+    let reader: MoreDefaults = try getCheckedRoot(byteBuffer: &sizedBuffer)
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let data = try encoder.encode(reader)
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let value = try decoder.decode(Test.self, from: data)
+    #expect(value.someString == "some")
+    #expect(value.emptyString == "")
   }
 
 }

--- a/tests/swift/Tests/Flatbuffers/FlatbuffersVerifierTests.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatbuffersVerifierTests.swift
@@ -14,25 +14,20 @@
  * limitations under the License.
  */
 
-import XCTest
+import Testing
 
 @testable import FlatBuffers
 
-final class FlatbuffersVerifierTests: XCTestCase {
+final class FlatbuffersVerifierTests {
 
-  var buffer: ByteBuffer!
-  var validFlatbuffersObject: ByteBuffer!
-  var invalidFlatbuffersObject: ByteBuffer!
-  var invalidFlatbuffersObject2: ByteBuffer!
-  var invalidFlatbuffersObject3: ByteBuffer!
+  private var buffer: ByteBuffer
+  private var validFlatbuffersObject: ByteBuffer
+  private var invalidFlatbuffersObject: ByteBuffer
+  private var invalidFlatbuffersObject2: ByteBuffer
+  private var invalidFlatbuffersObject3: ByteBuffer
 
-  override func setUp() {
+  init() {
     // swiftformat:disable all
-    let memory = UnsafeMutableRawPointer.allocate(byteCount: 32, alignment: 1)
-    buffer = ByteBuffer(assumingMemoryBound: memory, capacity: 32)
-    add(buffer: &buffer, v: 4, p: 16)
-    add(buffer: &buffer, v: 4, p: 20)
-
     validFlatbuffersObject = ByteBuffer(bytes: [
       48, 0, 0, 0, 77, 79, 78, 83, 0, 0, 0, 0, 36, 0, 72, 0, 40, 0, 0, 0, 38, 0, 32, 0, 0, 0, 28, 0,
       0, 0, 27, 0, 20, 0, 16, 0, 12, 0, 4, 0, 0, 0, 0, 0, 0, 0, 11, 0, 36, 0, 0, 0, 164, 0, 0, 0, 0,
@@ -94,186 +89,250 @@ final class FlatbuffersVerifierTests: XCTestCase {
       109, 97, 0, 0, 0, 6, 0, 0, 0, 66, 97, 114, 110, 101, 121, 0, 0, 5, 0, 0, 0, 70, 114, 111, 100,
       0x00, 111, 0, 0, 0,
     ])
+
+    let memory = UnsafeMutableRawPointer.allocate(byteCount: 32, alignment: 1)
+    buffer = ByteBuffer(assumingMemoryBound: memory, capacity: 32)
+
+    add(buffer: &buffer, v: 4, p: 16)
+    add(buffer: &buffer, v: 4, p: 20)
     // swiftformat:enable all
   }
 
-  func testVeriferInitPassing() {
+  @Test
+  func testVeriferInitPassing() throws {
     let memory = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 1)
     var buffer = ByteBuffer(
       assumingMemoryBound: memory,
       capacity: Int(FlatBufferMaxSize) - 1)
-    XCTAssertNoThrow(try Verifier(buffer: &buffer))
+    _ = try Verifier(buffer: &buffer)
   }
 
+  @Test
   func testVeriferInitFailing() {
     let memory = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 1)
     var buffer = ByteBuffer(
       assumingMemoryBound: memory,
       capacity: Int(FlatBufferMaxSize) + 1)
-    XCTAssertThrowsError(try Verifier(buffer: &buffer))
+    #expect(throws: FlatbuffersErrors.exceedsMaxSizeAllowed) {
+      try Verifier(buffer: &buffer)
+    }
   }
 
+  @Test
   func testFailingID() {
     let dutData: [UInt8] = [1, 2, 3, 4, 5, 6, 7]
     var buff = ByteBuffer(bytes: dutData)
-    do {
+    #expect(throws: FlatbuffersErrors.bufferDoesntContainID) {
       let _: Monster = try getCheckedRoot(byteBuffer: &buff, fileId: "ABCD")
-      XCTFail("This should always fail")
-    } catch {
-      XCTAssertEqual(error as? FlatbuffersErrors, .bufferDoesntContainID)
     }
   }
 
-  func testVerifierCheckAlignment() {
+  @Test
+  func testVerifierCheckAlignment() throws {
     let verifier = try! Verifier(buffer: &buffer)
-    do {
+    #expect(throws: FlatbuffersErrors.missAlignedPointer(
+      position: 20,
+      type: "Int"))
+    {
       try verifier.isAligned(position: 20, type: Int.self)
-    } catch {
-      XCTAssertEqual(
-        error as? FlatbuffersErrors,
-        .missAlignedPointer(position: 20, type: "Int"))
     }
-    XCTAssertNoThrow(try verifier.isAligned(position: 16, type: Int.self))
+
+    try verifier.isAligned(position: 16, type: Int.self)
 
     let newVerifer = try! Verifier(buffer: &buffer, checkAlignment: false)
-    XCTAssertNoThrow(try newVerifer.isAligned(position: 16, type: Int.self))
+    try newVerifer.isAligned(position: 16, type: Int.self)
   }
 
-  func testRangeInBuffer() {
+  @Test
+  func testRangeInBuffer() throws {
     var verifier = try! Verifier(buffer: &buffer)
     let size = MemoryLayout<Int64>.size
-    XCTAssertNoThrow(try verifier.rangeInBuffer(position: 24, size: size))
-    XCTAssertThrowsError(try verifier.rangeInBuffer(position: 26, size: size))
-    XCTAssertThrowsError(try verifier.rangeInBuffer(position: 26, size: size))
-    XCTAssertThrowsError(try verifier.rangeInBuffer(position: 30, size: size))
-    XCTAssertThrowsError(try verifier.rangeInBuffer(position: 32, size: size))
-    XCTAssertThrowsError(try verifier.rangeInBuffer(position: 34, size: size))
+    try verifier.rangeInBuffer(position: 24, size: size)
+    #expect(throws: FlatbuffersErrors.outOfBounds(position: 34, end: 32)) {
+      try verifier.rangeInBuffer(position: 26, size: size)
+    }
+    #expect(throws: FlatbuffersErrors.outOfBounds(position: 34, end: 32)) {
+      try verifier.rangeInBuffer(
+        position: 26,
+        size: size)
+    }
+    #expect(throws: FlatbuffersErrors.outOfBounds(position: 38, end: 32)) {
+      try verifier.rangeInBuffer(
+        position: 30,
+        size: size)
+    }
+    #expect(throws: FlatbuffersErrors.outOfBounds(position: 40, end: 32)) {
+      try verifier.rangeInBuffer(
+        position: 32,
+        size: size)
+    }
+    #expect(throws: FlatbuffersErrors.outOfBounds(position: 42, end: 32)) {
+      try verifier.rangeInBuffer(
+        position: 34,
+        size: size)
+    }
 
     verifier = try! Verifier(
       buffer: &buffer,
       options: .init(maxDepth: 0, maxTableCount: 0, maxApparentSize: 4))
-    do {
+
+    #expect(throws: FlatbuffersErrors.apparentSizeTooLarge) {
       try verifier.rangeInBuffer(position: 24, size: size)
-    } catch {
-      XCTAssertEqual(
-        error as! FlatbuffersErrors,
-        .apparentSizeTooLarge)
     }
   }
 
-  func testPositionInBuffer() {
+  @Test
+  func testPositionInBuffer() throws {
     let verifier = try! Verifier(buffer: &buffer)
-    XCTAssertNoThrow(try verifier.inBuffer(position: 0, of: Int64.self))
-    XCTAssertNoThrow(try verifier.inBuffer(position: 24, of: Int64.self))
-    XCTAssertThrowsError(try verifier.inBuffer(position: -9, of: Int64.self))
-    XCTAssertThrowsError(try verifier.inBuffer(position: 25, of: Int64.self))
-    XCTAssertThrowsError(try verifier.inBuffer(position: 26, of: Int32.self))
-    XCTAssertThrowsError(try verifier.inBuffer(position: 26, of: Int64.self))
-    XCTAssertThrowsError(try verifier.inBuffer(position: 30, of: Int64.self))
-    XCTAssertThrowsError(try verifier.inBuffer(position: 32, of: Int64.self))
-    XCTAssertThrowsError(try verifier.inBuffer(position: 34, of: Int64.self))
+    try verifier.inBuffer(position: 0, of: Int64.self)
+    try verifier.inBuffer(position: 24, of: Int64.self)
+
+    #expect(
+      throws: FlatbuffersErrors.missAlignedPointer(
+        position: -9,
+        type: "Int64"))
+    {
+      try verifier.inBuffer(position: -9, of: Int64.self)
+    }
+    #expect(
+      throws: FlatbuffersErrors.missAlignedPointer(
+        position: 25,
+        type: "Int64"))
+    {
+      try verifier.inBuffer(position: 25, of: Int64.self)
+    }
+    #expect(
+      throws: FlatbuffersErrors.missAlignedPointer(
+        position: 26,
+        type: "Int32"))
+    {
+      try verifier.inBuffer(position: 26, of: Int32.self)
+    }
+    #expect(
+      throws: FlatbuffersErrors.missAlignedPointer(
+        position: 26,
+        type: "Int64"))
+    {
+      try verifier.inBuffer(position: 26, of: Int64.self)
+    }
+    #expect(
+      throws: FlatbuffersErrors.missAlignedPointer(
+        position: 30,
+        type: "Int64"))
+    {
+      try verifier.inBuffer(position: 30, of: Int64.self)
+    }
+    #expect(throws: FlatbuffersErrors.outOfBounds(position: 40, end: 32)) {
+      try verifier.inBuffer(
+        position: 32,
+        of: Int64.self)
+    }
+    #expect(
+      throws: FlatbuffersErrors.missAlignedPointer(
+        position: 34,
+        type: "Int64"))
+    {
+      try verifier.inBuffer(position: 34, of: Int64.self)
+    }
   }
 
-  func testVisitTable() {
+  @Test
+  func testVisitTable() throws {
     var verifier = try! Verifier(buffer: &validFlatbuffersObject)
-    XCTAssertNoThrow(try verifier.visitTable(at: 48))
+    _ = try verifier.visitTable(at: 48)
     verifier.reset()
   }
 
-  func testTableVerifier() {
+  @Test
+  func testTableVerifier() throws {
     var verifier = try! Verifier(buffer: &validFlatbuffersObject)
 
     var tableVerifer = try! verifier.visitTable(at: 48)
-    XCTAssertEqual(verifier.depth, 1)
-    XCTAssertEqual(verifier.tableCount, 1)
+    #expect(verifier.depth == 1)
+    #expect(verifier.tableCount == 1)
 
-    XCTAssertNoThrow(
-      try tableVerifer.visit(
-        field: 4,
-        fieldName: "Vec",
-        required: false,
-        type: Vec3.self))
-    XCTAssertNoThrow(
-      try tableVerifer.visit(
-        field: 8,
-        fieldName: "hp",
-        required: false,
-        type: Int16.self))
+    try tableVerifer.visit(
+      field: 4,
+      fieldName: "Vec",
+      required: false,
+      type: Vec3.self)
 
-    XCTAssertNoThrow(
-      try tableVerifer.visit(
-        field: 10,
-        fieldName: "name",
-        required: true,
-        type: ForwardOffset<String>.self))
+    try tableVerifer.visit(
+      field: 8,
+      fieldName: "hp",
+      required: false,
+      type: Int16.self)
 
-    XCTAssertNoThrow(
-      try tableVerifer.visit(
-        field: 14,
-        fieldName: "inventory",
-        required: false,
-        type: ForwardOffset<Vector<UInt8, UInt8>>.self))
+    try tableVerifer.visit(
+      field: 10,
+      fieldName: "name",
+      required: true,
+      type: ForwardOffset<String>.self)
 
-    XCTAssertNoThrow(
-      try tableVerifer.visit(
-        field: 22,
-        fieldName: "test4",
-        required: false,
-        type: ForwardOffset<Vector<MyGame_Example_Test, MyGame_Example_Test>>
-          .self))
+    try tableVerifer.visit(
+      field: 14,
+      fieldName: "inventory",
+      required: false,
+      type: ForwardOffset<Vector<UInt8, UInt8>>.self)
 
-    XCTAssertNoThrow(
-      try tableVerifer.visit(
-        field: 24,
-        fieldName: "Vector of strings",
-        required: false,
-        type: ForwardOffset<Vector<ForwardOffset<String>, String>>.self))
+    try tableVerifer.visit(
+      field: 22,
+      fieldName: "test4",
+      required: false,
+      type: ForwardOffset<Vector<MyGame_Example_Test, MyGame_Example_Test>>
+        .self)
 
-    do {
+    try tableVerifer.visit(
+      field: 24,
+      fieldName: "Vector of strings",
+      required: false,
+      type: ForwardOffset<Vector<ForwardOffset<String>, String>>.self)
+
+    #expect(throws: FlatbuffersErrors.missAlignedPointer(
+      position: 25,
+      type: "UInt16"))
+    {
       try tableVerifer.visit(
         field: 13,
         fieldName: "notvalid",
         required: false,
         type: Int16.self)
-    } catch {
-      XCTAssertEqual(
-        error as! FlatbuffersErrors,
-        .missAlignedPointer(position: 25, type: "UInt16"))
     }
 
-    do {
-      try tableVerifer.visit(
-        unionKey: 18,
-        unionField: 20,
-        unionKeyName: "testType",
-        fieldName: "test",
-        required: false,
-        completion: { (verifier, key: MyGame_Example_Any_, pos) in
-          switch key {
-          case .none_:
-            break
-          case .monster:
-            try ForwardOffset<MyGame_Example_Monster>.verify(
-              &verifier,
-              at: pos,
-              of: MyGame_Example_Monster.self)
+    try tableVerifer.visit(
+      unionKey: 18,
+      unionField: 20,
+      unionKeyName: "testType",
+      fieldName: "test",
+      required: false,
+      completion: { (verifier, key: MyGame_Example_Any_, pos) in
+        switch key {
+        case .none_:
+          break // NOTE - SWIFT doesnt support none
+        case .monster:
+          try ForwardOffset<MyGame_Example_Monster>.verify(
+            &verifier,
+            at: pos,
+            of: MyGame_Example_Monster.self)
+        case .testsimpletablewithenum:
+          try ForwardOffset<MyGame_Example_TestSimpleTableWithEnum>.verify(
+            &verifier,
+            at: pos,
+            of: MyGame_Example_TestSimpleTableWithEnum.self)
+        case .mygameExample2Monster:
+          try ForwardOffset<MyGame_Example2_Monster>.verify(
+            &verifier,
+            at: pos,
+            of: MyGame_Example2_Monster.self)
+        }
+      })
 
-          case .testsimpletablewithenum:
-            break
-          case .mygameExample2Monster:
-            break
-          }
-        })
-    } catch {
-      XCTAssertEqual(
-        error as! FlatbuffersErrors,
-        .missAlignedPointer(position: 25, type: "UInt16"))
-    }
     tableVerifer.finish()
-    XCTAssertEqual(verifier.depth, 0)
+    #expect(verifier.depth == 0)
   }
 
-  func testVerifyUnionVectors() {
+  @Test
+  func testVerifyUnionVectors() throws {
     // swiftformat:disable all
     var byteBuffer = ByteBuffer(bytes: [
       20, 0, 0, 0, 77, 79, 86, 73, 12, 0, 12, 0, 0, 0, 0, 0, 8, 0, 4, 0, 12, 0, 0, 0, 8, 0, 0, 0,
@@ -281,10 +340,11 @@ final class FlatbuffersVerifierTests: XCTestCase {
       0, 0, 7, 0, 0, 0, 0, 0, 6, 0, 8, 0, 4, 0, 6, 0, 0, 0, 8, 0, 0, 0,
     ])
     // swiftformat:enable all
-    XCTAssertNoThrow(try getCheckedRoot(byteBuffer: &byteBuffer) as Movie)
+    _ = try getCheckedRoot(byteBuffer: &byteBuffer) as Movie
   }
 
-  func testErrorWrongFileId() {
+  @Test
+  func testErrorWrongFileId() throws{
     // swiftformat:disable all
     var byteBuffer = ByteBuffer(bytes: [
       20, 0, 0, 0, 77, 79, 86, 73, 12, 0, 12, 0, 0, 0, 0, 0, 8, 0, 4, 0, 12, 0, 0, 0, 8, 0, 0, 0,
@@ -292,12 +352,14 @@ final class FlatbuffersVerifierTests: XCTestCase {
       0, 0, 7, 0, 0, 0, 0, 0, 6, 0, 8, 0, 4, 0, 6, 0, 0, 0, 8, 0, 0, 0,
     ])
     // swiftformat:enable all
-    XCTAssertThrowsError(
+    #expect(throws: FlatbuffersErrors.bufferIdDidntMatchPassedId) {
       try getCheckedRoot(
         byteBuffer: &byteBuffer,
-        fileId: "FLEX") as Movie)
+        fileId: "FLEX") as Movie
+    }
   }
 
+  @Test
   func testVerifyPrefixedBuffer() {
     // swiftformat:disable all
     var byteBuffer = ByteBuffer(bytes: [
@@ -306,41 +368,50 @@ final class FlatbuffersVerifierTests: XCTestCase {
       0, 2, 0, 0, 0, 7, 0, 0, 0, 0, 0, 6, 0, 8, 0, 4, 0, 6, 0, 0, 0, 8, 0, 0, 0,
     ])
     // swiftformat:enable all
-    XCTAssertThrowsError(
-      try getCheckedPrefixedSizeRoot(byteBuffer: &byteBuffer) as Movie)
+    #expect(throws: FlatbuffersErrors.prefixedSizeNotEqualToBufferSize) {
+      try getCheckedPrefixedSizeRoot(byteBuffer: &byteBuffer) as Movie
+    }
   }
 
-  func testFullVerifier() {
-    XCTAssertNoThrow(
+  @Test
+  func testFullVerifier() throws {
+    _ =
       try getCheckedRoot(
-        byteBuffer: &validFlatbuffersObject) as MyGame_Example_Monster)
+        byteBuffer: &validFlatbuffersObject) as MyGame_Example_Monster
   }
 
-  func testFullVerifierWithFileId() {
-    XCTAssertNoThrow(
-      try getCheckedRoot(
-        byteBuffer: &validFlatbuffersObject,
-        fileId: MyGame_Example_Monster.id) as MyGame_Example_Monster)
+  @Test
+  func testFullVerifierWithFileId() throws {
+    _ = try getCheckedRoot(
+      byteBuffer: &validFlatbuffersObject,
+      fileId: MyGame_Example_Monster.id) as MyGame_Example_Monster
   }
 
+  @Test
   func testInvalidBuffer() {
-    XCTAssertThrowsError(
+    #expect(throws: FlatbuffersErrors.self) {
       try getCheckedRoot(
-        byteBuffer: &invalidFlatbuffersObject) as MyGame_Example_Monster)
+        byteBuffer: &self.invalidFlatbuffersObject) as MyGame_Example_Monster
+    }
   }
 
+  @Test
   func testInvalidBuffer2() {
-    XCTAssertThrowsError(
+    #expect(throws: FlatbuffersErrors.self) {
       try getCheckedRoot(
-        byteBuffer: &invalidFlatbuffersObject2) as MyGame_Example_Monster)
+        byteBuffer: &self.invalidFlatbuffersObject2) as MyGame_Example_Monster
+    }
   }
 
+  @Test
   func testInvalidBuffer3() {
-    XCTAssertThrowsError(
+    #expect(throws: FlatbuffersErrors.self) {
       try getCheckedRoot(
-        byteBuffer: &invalidFlatbuffersObject3) as MyGame_Example_Monster)
+        byteBuffer: &self.invalidFlatbuffersObject3) as MyGame_Example_Monster
+    }
   }
 
+  @Test
   func testValidUnionBuffer() {
     let string = "Awesome \\\\t\t\nstring!"
     var fb = FlatBufferBuilder()
@@ -362,9 +433,14 @@ final class FlatbuffersVerifierTests: XCTestCase {
       charactersVectorOffset: characterVector)
     Movie.finish(&fb, end: end)
     var buf = fb.sizedBuffer
-    XCTAssertNoThrow(try getCheckedRoot(byteBuffer: &buf) as Movie)
+    do {
+      _ = try getCheckedRoot(byteBuffer: &buf) as Movie
+    } catch {
+      Issue.record(error)
+    }
   }
 
+  @Test
   func testNestedTables() throws {
     var builder = FlatBufferBuilder()
     let name = builder.create(string: "Monster")
@@ -383,22 +459,22 @@ final class FlatbuffersVerifierTests: XCTestCase {
     var verifier = try! Verifier(buffer: &sizedBuffer)
     var tableVerifer = try! verifier.visitTable(
       at: try getOffset(at: 0, within: verifier))
-    XCTAssertEqual(verifier.depth, 1)
-    XCTAssertEqual(verifier.tableCount, 1)
+    #expect(verifier.depth == 1)
+    #expect(verifier.tableCount == 1)
 
     let position = try tableVerifer.dereference(28)!
 
     var nestedTable = try verifier.visitTable(
       at: try getOffset(at: position, within: verifier))
 
-    XCTAssertEqual(verifier.depth, 2)
-    XCTAssertEqual(verifier.tableCount, 2)
+    #expect(verifier.depth == 2)
+    #expect(verifier.tableCount == 2)
     nestedTable.finish()
-    XCTAssertEqual(verifier.depth, 1)
-    XCTAssertEqual(verifier.tableCount, 2)
+    #expect(verifier.depth == 1)
+    #expect(verifier.tableCount == 2)
     tableVerifer.finish()
-    XCTAssertEqual(verifier.depth, 0)
-    XCTAssertEqual(verifier.tableCount, 2)
+    #expect(verifier.depth == 0)
+    #expect(verifier.tableCount == 2)
   }
 
   func add(buffer: inout ByteBuffer, v: Int32, p: Int) {

--- a/tests/swift/Tests/Flexbuffers/FlexBuffersJSONTests.swift
+++ b/tests/swift/Tests/Flexbuffers/FlexBuffersJSONTests.swift
@@ -16,17 +16,19 @@
 
 import Common
 import FlexBuffers
-import XCTest
+import Foundation
+import Testing
 
-final class FlexBuffersJSONTests: XCTestCase {
+struct FlexBuffersJSONTests {
+  @Test
   func testEncodingJSON() throws {
     let buf: ByteBuffer = createProperBuffer().sizedByteBuffer
     let reference = try getRoot(buffer: buf)!
 
     let json = reference.jsonString()
     // swiftformat:disable all
-    XCTAssertEqual(
-      json,
+    #expect(
+      json ==
       "{\"bar\": [1, 2, 3], \"bar3\": [1, 2, 3], \"bool\": true, \"bools\": [true, false, true, false], \"foo\": 100.0, \"mymap\": {\"foo\": \"Fred\"}, \"vec\": [-100, \"Fred\", 4.0, \"M\", false, 4.0]}"
     )
     // swiftformat:enable all
@@ -37,15 +39,15 @@ final class FlexBuffersJSONTests: XCTestCase {
         with: data,
         options: []) as! [String: Any]
 
-    XCTAssertEqual(decodedData["bar"] as! [Int], [1, 2, 3])
-    XCTAssertEqual(decodedData["bar3"] as! [Int], [1, 2, 3])
+    #expect(decodedData["bar"] as! [Int] == [1, 2, 3])
+    #expect(decodedData["bar3"] as! [Int] == [1, 2, 3])
 
     let vec: [Any] = decodedData["vec"] as! [Any]
-    XCTAssertEqual(vec[0] as! Int, -100)
-    XCTAssertEqual(vec[1] as! String, "Fred")
-    XCTAssertEqual(vec[2] as! Double, 4.0)
-    XCTAssertEqual(vec[3] as! String, "M")
-    XCTAssertEqual(vec[4] as! Bool, false)
-    XCTAssertEqual(vec[5] as! Double, 4.0)
+    #expect(vec[0] as! Int == -100)
+    #expect(vec[1] as! String == "Fred")
+    #expect(vec[2] as! Double == 4.0)
+    #expect(vec[3] as! String == "M")
+    #expect(vec[4] as! Bool == false)
+    #expect(vec[5] as! Double == 4.0)
   }
 }

--- a/tests/swift/Tests/Flexbuffers/FlexBuffersReaderTests.swift
+++ b/tests/swift/Tests/Flexbuffers/FlexBuffersReaderTests.swift
@@ -15,22 +15,26 @@
  */
 
 import Common
-import XCTest
+import Foundation
+import Testing
 
 @testable import FlexBuffers
 
-final class FlexBuffersReaderTests: XCTestCase {
+struct FlexBuffersReaderTests {
 
+  @Test
   func testReadingProperBuffer() throws {
     let buf: ByteBuffer = createProperBuffer().byteBuffer
     try validate(buffer: buf)
   }
 
+  @Test
   func testReadingSizedBuffer() throws {
     let buf: ByteBuffer = createSizedBuffer()
     try validate(buffer: buf)
   }
 
+  @Test(.bug("https://github.com/google/flatbuffers/issues/8642"))
   func testReset() throws {
     var fbx = FlexBuffersWriter(
       initialSize: 8,
@@ -38,87 +42,87 @@ final class FlexBuffersReaderTests: XCTestCase {
     write(fbx: &fbx)
 
     try validate(buffer: ByteBuffer(data: fbx.data))
-    XCTAssertEqual(fbx.capacity, 512)
+    #expect(fbx.capacity == 512)
     fbx.reset()
-    XCTAssertEqual(fbx.writerIndex, 0)
-    XCTAssertEqual(fbx.capacity, 8)
+    #expect(fbx.writerIndex == 0)
+    #expect(fbx.capacity == 8)
 
     write(fbx: &fbx)
     try validate(buffer: ByteBuffer(data: fbx.data))
     fbx.reset(keepingCapacity: true)
-    XCTAssertEqual(fbx.writerIndex, 0)
-    XCTAssertEqual(fbx.capacity, 512)
+    #expect(fbx.writerIndex == 0)
+    #expect(fbx.capacity == 512)
 
     write(fbx: &fbx)
     try validate(buffer: ByteBuffer(data: fbx.data))
-    XCTAssertEqual(fbx.capacity, 512)
+    #expect(fbx.capacity == 512)
   }
 
   private func validate(buffer buf: ByteBuffer) throws {
     let reference = try getRoot(buffer: buf)!
-    XCTAssertEqual(reference.type, .map)
+    #expect(reference.type == .map)
     let map = reference.map!
-    XCTAssertEqual(map.count, 7)
+    #expect(map.count == 7)
     let vecRef = map["vec"]!
-    XCTAssertEqual(vecRef.type, .vector)
+    #expect(vecRef.type == .vector)
     let vec = vecRef.vector!
-    XCTAssertEqual(vec.count, 6)
-    XCTAssertEqual(vec[0]?.type, .int)
-    XCTAssertEqual(vec[0]?.int, -100)
-    XCTAssertEqual(vec[1]?.type, .string)
-    XCTAssertEqual(vec[1]?.cString, "Fred")
-    XCTAssertNil(vec[1]?.int)
-    XCTAssertEqual(vec[2]?.double, 4.0)
-    XCTAssertTrue(vec[3]?.type == .blob)
+    #expect(vec.count == 6)
+    #expect(vec[0]?.type == .int)
+    #expect(vec[0]?.int == -100)
+    #expect(vec[1]?.type == .string)
+    #expect(vec[1]?.cString == "Fred")
+    #expect(vec[1]?.int == nil)
+    #expect(vec[2]?.double == 4.0)
+    #expect(vec[3]?.type == .blob)
 
     let blob = vec[3]!.blob { pointer in
       Array(pointer)
     }
 
-    XCTAssertEqual(blob?.count, 1)
-    XCTAssertEqual(blob?[0], 77)
-    XCTAssertEqual(vec[4]?.type, .bool)
-    XCTAssertEqual(vec[4]?.bool, false)
-    XCTAssertEqual(vec[5]?.double, 4.0)  // Shared with vec[2]
+    #expect(blob?.count == 1)
+    #expect(blob?[0] == 77)
+    #expect(vec[4]?.type == .bool)
+    #expect(vec[4]?.bool == false)
+    #expect(vec[5]?.double == 4.0)  // Shared with vec[2]
 
     let barVec = map["bar"]!.typedVector!
-    XCTAssertEqual(barVec.count, 3)
-    XCTAssertEqual(barVec[2]?.int, 3)
-    XCTAssertEqual(barVec[2]?.asInt(), UInt8(3))
+    #expect(barVec.count == 3)
+    #expect(barVec[2]?.int == 3)
+    #expect(barVec[2]?.asInt() == UInt8(3))
 
     let fixedVec = map["bar3"]!.fixedTypedVector!
-    XCTAssertEqual(fixedVec.count, 3)
-    XCTAssertEqual(fixedVec[2]?.int, 3)
-    XCTAssertEqual(fixedVec[2]?.asInt(), UInt8(3))
-    XCTAssertEqual(map["bool"]?.bool, true)
+    #expect(fixedVec.count == 3)
+    #expect(fixedVec[2]?.int == 3)
+    #expect(fixedVec[2]?.asInt() == UInt8(3))
+    #expect(map["bool"]?.bool == true)
 
     let boolsVector = map["bools"]!.typedVector!
-    XCTAssertEqual(boolsVector.type, .bool)
-    XCTAssertEqual(boolsVector[0]?.bool, true)
-    XCTAssertEqual(boolsVector[1]?.bool, false)
+    #expect(boolsVector.type == .bool)
+    #expect(boolsVector[0]?.bool == true)
+    #expect(boolsVector[1]?.bool == false)
 
     let bools = [true, false, true, false]
     boolsVector.withUnsafeRawBufferPointer { buff in
       for i in 0..<boolsVector.count {
-        XCTAssertEqual(buff.load(fromByteOffset: i, as: Bool.self), bools[i])
+        #expect(buff.load(fromByteOffset: i, as: Bool.self) == bools[i])
       }
     }
-    XCTAssertEqual(map["foo"]?.double, 100)
-    XCTAssertNil(map["unknown"])
+    #expect(map["foo"]?.double == 100)
+    #expect(map["unknown"] == nil)
     let mymap = map["mymap"]?.map
 
     // Check if both addresses used are the same for keys and strings
-    XCTAssertEqual(mymap?.keys[0]?.cString, map.keys[4]?.cString)
+    #expect(mymap?.keys[0]?.cString == map.keys[4]?.cString)
     map.keys[4]?.withUnsafeRawPointer { pointer in
       mymap?.keys[0]?.withUnsafeRawPointer { mymapPointer in
-        XCTAssertEqual(pointer, mymapPointer)
+        #expect(pointer == mymapPointer)
       }
     }
 
-    XCTAssertEqual(mymap?.values[0]?.cString, vec[1]?.cString)
+    #expect(mymap?.values[0]?.cString == vec[1]?.cString)
     vec[1]?.withUnsafeRawPointer { pointer in
       mymap?.values[0]?.withUnsafeRawPointer { mymapPointer in
-        XCTAssertEqual(pointer, mymapPointer)
+        #expect(pointer == mymapPointer)
       }
     }
   }

--- a/tests/swift/Tests/Flexbuffers/FlexBuffersStringTests.swift
+++ b/tests/swift/Tests/Flexbuffers/FlexBuffersStringTests.swift
@@ -16,10 +16,12 @@
 
 import Common
 import FlexBuffers
-import XCTest
+import Foundation
+import Testing
 
-final class FlexBuffersStringTests: XCTestCase {
+struct FlexBuffersStringTests {
 
+  @Test
   func testEncodingUnicodeString() {
     let text = "プ画をみて✋"
 
@@ -38,6 +40,6 @@ final class FlexBuffersStringTests: XCTestCase {
       return String(data: data, encoding: .unicode)
     }
 
-    XCTAssertEqual(builtString, text)
+    #expect(builtString == text)
   }
 }

--- a/tests/swift/Tests/Flexbuffers/FlexBuffersWriterTests.swift
+++ b/tests/swift/Tests/Flexbuffers/FlexBuffersWriterTests.swift
@@ -16,9 +16,10 @@
 
 import Common
 import FlexBuffers
-import XCTest
+import Testing
 
-final class FlexBuffersWriterTests: XCTestCase {
+struct FlexBuffersWriterTests {
+  @Test
   func testDeallocation() {
     let buf: ByteBuffer = {
       var fbx = FlexBuffersWriter()
@@ -28,12 +29,13 @@ final class FlexBuffersWriterTests: XCTestCase {
     }()
 
     buf.withUnsafeBytes {
-      XCTAssertEqual(
-        Array($0),
-        [5, 72, 101, 108, 108, 111, 0, 6, 20, 1])
+      #expect(
+        Array($0) ==
+          [5, 72, 101, 108, 108, 111, 0, 6, 20, 1])
     }
   }
 
+  @Test
   func testAddingVectorOfScalars() {
     var fbx = FlexBuffersWriter()
     fbx.vector {
@@ -45,8 +47,8 @@ final class FlexBuffersWriterTests: XCTestCase {
 
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [
           10, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 7, 0,
           0, 0, 8, 0, 0, 0, 9, 0, 0, 0, 20, 0, 0, 0, 1, 41, 46, 2, 40, 1,
@@ -55,6 +57,7 @@ final class FlexBuffersWriterTests: XCTestCase {
     }
   }
 
+  @Test
   func testAddingVectorOfUnsignedScalars() {
     var fbx = FlexBuffersWriter()
     fbx.vector {
@@ -66,8 +69,8 @@ final class FlexBuffersWriterTests: XCTestCase {
 
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [
           10, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0,
           0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0,
@@ -78,6 +81,7 @@ final class FlexBuffersWriterTests: XCTestCase {
     }
   }
 
+  @Test
   func testAddingVectorOfBools() {
     var fbx = FlexBuffersWriter()
     fbx.vector {
@@ -89,13 +93,14 @@ final class FlexBuffersWriterTests: XCTestCase {
 
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [4, 1, 0, 1, 0, 1, 5, 144, 2, 40, 1])
       // swiftformat:enable all
     }
   }
 
+  @Test
   func testSortingWithinMap() {
     var fbx = FlexBuffersWriter()
     fbx.map {
@@ -106,8 +111,8 @@ final class FlexBuffersWriterTests: XCTestCase {
     let buf: ByteBuffer = fbx.sizedByteBuffer
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [
           98, 111, 111, 108, 50, 0, 98, 111, 111, 108, 49, 0, 2, 7, 14, 2, 1, 2, 1, 0, 104, 104, 4,
           36, 1,
@@ -117,6 +122,7 @@ final class FlexBuffersWriterTests: XCTestCase {
     }
   }
 
+  @Test
   func testSharingKeyWithinMap() {
     var fbx = FlexBuffersWriter(initialSize: 1000, flags: .shareKeysAndStrings)
     fbx.map {
@@ -128,8 +134,8 @@ final class FlexBuffersWriterTests: XCTestCase {
     let buf: ByteBuffer = fbx.sizedByteBuffer
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [
           119, 101, 108, 99, 111, 109, 101, 0, 7, 119, 101, 108, 99, 111, 109, 101, 0, 3, 18, 19,
           20, 3, 1, 3, 15, 16, 17, 20, 20, 20, 6, 36, 1,
@@ -139,19 +145,21 @@ final class FlexBuffersWriterTests: XCTestCase {
     }
   }
 
+  @Test
   func testNestingVectorInMap() {
     let buf: ByteBuffer = createSizedBuffer()
 
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         flexbufferGolden
       )
       // swiftformat:enable all
     }
   }
 
+  @Test
   func testAddingNil() {
     var fbx = FlexBuffersWriter(
       initialSize: 8,
@@ -165,14 +173,15 @@ final class FlexBuffersWriterTests: XCTestCase {
     let buf: ByteBuffer = fbx.sizedByteBuffer
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [118, 0, 1, 3, 1, 1, 1, 0, 0, 2, 36, 1]
       )
       // swiftformat:enable all
     }
   }
 
+  @Test
   func testAddingManually() {
     var fbx = FlexBuffersWriter(
       initialSize: 8,
@@ -209,14 +218,15 @@ final class FlexBuffersWriterTests: XCTestCase {
     let buf: ByteBuffer = fbx.sizedByteBuffer
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         flexbufferGolden
       )
       // swiftformat:enable all
     }
   }
 
+  @Test
   func testEncodingAllTypes() {
     var fbx = FlexBuffersWriter()
     fbx.vector {
@@ -240,8 +250,8 @@ final class FlexBuffersWriterTests: XCTestCase {
 
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         allTypesGolden)
       // swiftformat:enable all
     }

--- a/tests/swift/Wasm.tests/Tests/FlatBuffers.Test.Swift.WasmTests/FlatBuffersMonsterWriterTests.swift
+++ b/tests/swift/Wasm.tests/Tests/FlatBuffers.Test.Swift.WasmTests/FlatBuffersMonsterWriterTests.swift
@@ -15,7 +15,7 @@
  */
 
 import Foundation
-import XCTest
+import Testing
 
 @testable import FlatBuffers
 
@@ -24,8 +24,9 @@ typealias Monster = MyGame_Example_Monster
 typealias Vec3 = MyGame_Example_Vec3
 typealias Stat = MyGame_Example_Stat
 
-class FlatBuffersMonsterWriterTests: XCTestCase {
+struct FlatBuffersMonsterWriterTests {
 
+  @Test
   func testData() {
     // swiftformat:disable all
     let data: [UInt8] = [
@@ -47,11 +48,12 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readVerifiedMonster(fb: _data)
   }
 
+  @Test
   func testCreateMonster() {
     let bytes = createMonster(withPrefix: false)
     // swiftformat:disable all
-    XCTAssertEqual(
-      bytes.sizedByteArray,
+    #expect(
+      bytes.sizedByteArray ==
       [
         48, 0, 0, 0, 77, 79, 78, 83, 0, 0, 0, 0, 36, 0, 72, 0, 40, 0, 0, 0, 38, 0, 32, 0, 0, 0, 28,
         0, 0, 0, 27, 0, 20, 0, 16, 0, 12, 0, 4, 0, 0, 0, 0, 0, 0, 0, 11, 0, 36, 0, 0, 0, 164, 0, 0,
@@ -75,11 +77,12 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readMonster(monster: monster)
   }
 
+  @Test
   func testCreateMonsterResizedBuffer() {
     let bytes = createMonster(withPrefix: false)
     // swiftformat:disable all
-    XCTAssertEqual(
-      bytes.sizedByteArray,
+    #expect(
+      bytes.sizedByteArray ==
       [
         48, 0, 0, 0, 77, 79, 78, 83, 0, 0, 0, 0, 36, 0, 72, 0, 40, 0, 0, 0, 38, 0, 32, 0, 0, 0, 28,
         0, 0, 0, 27, 0, 20, 0, 16, 0, 12, 0, 4, 0, 0, 0, 0, 0, 0, 0, 11, 0, 36, 0, 0, 0, 164, 0, 0,
@@ -98,11 +101,12 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readVerifiedMonster(fb: bytes.sizedBuffer)
   }
 
+  @Test
   func testCreateMonsterPrefixed() {
     let bytes = createMonster(withPrefix: true)
     // swiftformat:disable all
-    XCTAssertEqual(
-      bytes.sizedByteArray,
+    #expect(
+      bytes.sizedByteArray ==
       [
         44, 1, 0, 0, 44, 0, 0, 0, 77, 79, 78, 83, 36, 0, 72, 0, 40, 0, 0, 0, 38, 0, 32, 0, 0, 0, 28,
         0, 0, 0, 27, 0, 20, 0, 16, 0, 12, 0, 4, 0, 0, 0, 0, 0, 0, 0, 11, 0, 36, 0, 0, 0, 164, 0, 0,
@@ -123,6 +127,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readMonster(monster: getPrefixedSizeRoot(byteBuffer: &buffer))
   }
 
+  @Test
   func testCreateMonsterUsingCreateMonsterMethodWithNilPos() {
     var fbb = FlatBufferBuilder(initialSize: 1)
     let name = fbb.create(string: "Frodo")
@@ -132,10 +137,11 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     fbb.finish(offset: root)
     var buffer = fbb.sizedBuffer
     let newMonster: Monster = getRoot(byteBuffer: &buffer)
-    XCTAssertNil(newMonster.pos)
-    XCTAssertEqual(newMonster.name, "Frodo")
+    #expect(newMonster.pos == nil)
+    #expect(newMonster.name == "Frodo")
   }
 
+  @Test
   func testCreateMonsterUsingCreateMonsterMethodWithPosX() {
     var fbb = FlatBufferBuilder(initialSize: 1)
     let name = fbb.create(string: "Barney")
@@ -155,10 +161,11 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
 
     var buffer = fbb.sizedBuffer
     let newMonster: Monster = getRoot(byteBuffer: &buffer)
-    XCTAssertEqual(newMonster.pos!.x, 10)
-    XCTAssertEqual(newMonster.name, "Barney")
+    #expect(newMonster.pos!.x == 10)
+    #expect(newMonster.name == "Barney")
   }
 
+  @Test
   func testReadMonsterFromUnsafePointerWithoutCopying() {
     // swiftformat:disable all
     var array: [UInt8] = [
@@ -190,6 +197,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     readObjectApi(monster: unpacked)
   }
 
+  @Test
   func testArrayOfBools() {
     let boolArray = [false, true, false, true, false, true, false]
     var fbb = FlatBufferBuilder(initialSize: 1)
@@ -205,37 +213,41 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     let monster: Monster = getRoot(byteBuffer: &buffer)
     let values = monster.testarrayofbools
 
-    XCTAssertEqual(boolArray.count, values.count)
+    #expect(boolArray.count == values.count)
 
     for (index, bool) in monster.testarrayofbools.enumerated() {
-      XCTAssertEqual(bool, boolArray[index])
+      #expect(bool == boolArray[index])
     }
   }
 
   func readVerifiedMonster(fb: ByteBuffer) {
     var byteBuffer = fb
-    XCTAssertNoThrow(
+    do {
       try readMonster(
         monster: getCheckedRoot(
-          byteBuffer: &byteBuffer) as MyGame_Example_Monster))
+          byteBuffer: &byteBuffer) as MyGame_Example_Monster)
+    } catch {
+      Issue.record(error)
+    }
   }
 
+  @Test(.bug("https://github.com/google/flatbuffers/issues/8133"))
   func testUnalignedRead() {
     // Aligned read
     let fbb = createMonster(withPrefix: false)
     let testAligned: () -> Bool = {
       var buffer = fbb.sizedBuffer
       var monster: Monster = getRoot(byteBuffer: &buffer)
-      self.readFlatbufferMonster(monster: &monster)
+      readFlatbufferMonster(monster: &monster)
       return true
     }
-    XCTAssertEqual(testAligned(), true)
+    #expect(testAligned() == true)
     let testUnaligned: () -> Bool = {
       var bytes: [UInt8] = [0x00]
       bytes.append(contentsOf: fbb.sizedByteArray)
       return bytes.withUnsafeMutableBytes { ptr in
         guard var baseAddress = ptr.baseAddress else {
-          XCTFail("Base pointer is not defined")
+          Issue.record("Base pointer is not defined")
           return false
         }
         baseAddress = baseAddress.advanced(by: 1)
@@ -244,13 +256,14 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
           assumingMemoryBound: unlignedPtr,
           capacity: ptr.count - 1)
         var monster: Monster = getRoot(byteBuffer: &bytes)
-        self.readFlatbufferMonster(monster: &monster)
+        readFlatbufferMonster(monster: &monster)
         return true
       }
     }
-    XCTAssertEqual(testUnaligned(), true)
+    #expect(testUnaligned() == true)
   }
 
+  @Test
   func testReadingRemovedSizeUnalignedBuffer() {
     // Aligned read
     let fbb = createMonster(withPrefix: true)
@@ -259,7 +272,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
       bytes.append(contentsOf: fbb.sizedByteArray)
       return bytes.withUnsafeMutableBytes { ptr in
         guard var baseAddress = ptr.baseAddress else {
-          XCTFail("Base pointer is not defined")
+          Issue.record("Base pointer is not defined")
           return false
         }
         baseAddress = baseAddress.advanced(by: 1)
@@ -269,13 +282,14 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
           capacity: ptr.count - 1)
         var newBuf = FlatBuffersUtils.removeSizePrefix(bb: bytes)
         var monster: Monster = getRoot(byteBuffer: &newBuf)
-        self.readFlatbufferMonster(monster: &monster)
+        readFlatbufferMonster(monster: &monster)
         return true
       }
     }
-    XCTAssertEqual(testUnaligned(), true)
+    #expect(testUnaligned() == true)
   }
 
+  @Test
   func testForceRetainedObject() {
     let byteBuffer = {
       // swiftformat:disable all
@@ -381,95 +395,95 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     var fb = fb
 
     let monster: Monster = getRoot(byteBuffer: &fb)
-    XCTAssertFalse(monster.mutate(mana: 10))
-    XCTAssertEqual(monster.testarrayoftables[0].name, "Barney")
-    XCTAssertEqual(monster.testarrayoftables[1].name, "Frodo")
-    XCTAssertEqual(monster.testarrayoftables[2].name, "Wilma")
+    #expect(monster.mutate(mana: 10) == false)
+    #expect(monster.testarrayoftables[0].name == "Barney")
+    #expect(monster.testarrayoftables[1].name == "Frodo")
+    #expect(monster.testarrayoftables[2].name == "Wilma")
 
     // Example of searching for a table by the key
-    XCTAssertNotNil(monster.testarrayoftablesBy(key: "Frodo"))
-    XCTAssertNotNil(monster.testarrayoftablesBy(key: "Barney"))
-    XCTAssertNotNil(monster.testarrayoftablesBy(key: "Wilma"))
+    #expect(monster.testarrayoftablesBy(key: "Frodo") != nil)
+    #expect(monster.testarrayoftablesBy(key: "Barney") != nil)
+    #expect(monster.testarrayoftablesBy(key: "Wilma") != nil)
 
-    XCTAssertEqual(monster.testType, .monster)
+    #expect(monster.testType == .monster)
 
-    XCTAssertEqual(monster.mutate(inventory: 1, at: 0), true)
-    XCTAssertEqual(monster.mutate(inventory: 2, at: 1), true)
-    XCTAssertEqual(monster.mutate(inventory: 3, at: 2), true)
-    XCTAssertEqual(monster.mutate(inventory: 4, at: 3), true)
-    XCTAssertEqual(monster.mutate(inventory: 5, at: 4), true)
+    #expect(monster.mutate(inventory: 1, at: 0) == true)
+    #expect(monster.mutate(inventory: 2, at: 1) == true)
+    #expect(monster.mutate(inventory: 3, at: 2) == true)
+    #expect(monster.mutate(inventory: 4, at: 3) == true)
+    #expect(monster.mutate(inventory: 5, at: 4) == true)
 
     for i in 0..<monster.inventory.count {
-      XCTAssertEqual(monster.inventory[i], Byte(i + 1))
+      #expect(monster.inventory[i] == Byte(i + 1))
     }
 
-    XCTAssertEqual(monster.mutate(inventory: 0, at: 0), true)
-    XCTAssertEqual(monster.mutate(inventory: 1, at: 1), true)
-    XCTAssertEqual(monster.mutate(inventory: 2, at: 2), true)
-    XCTAssertEqual(monster.mutate(inventory: 3, at: 3), true)
-    XCTAssertEqual(monster.mutate(inventory: 4, at: 4), true)
+    #expect(monster.mutate(inventory: 0, at: 0) == true)
+    #expect(monster.mutate(inventory: 1, at: 1) == true)
+    #expect(monster.mutate(inventory: 2, at: 2) == true)
+    #expect(monster.mutate(inventory: 3, at: 3) == true)
+    #expect(monster.mutate(inventory: 4, at: 4) == true)
 
     let vec = monster.mutablePos
-    XCTAssertEqual(vec?.x, 1)
-    XCTAssertTrue(vec?.mutate(x: 55.0) ?? false)
-    XCTAssertTrue(vec?.mutate(test1: 55) ?? false)
-    XCTAssertEqual(vec?.x, 55.0)
-    XCTAssertEqual(vec?.test1, 55.0)
-    XCTAssertTrue(vec?.mutate(x: 1) ?? false)
-    XCTAssertEqual(vec?.x, 1)
-    XCTAssertTrue(vec?.mutate(test1: 3) ?? false)
+    #expect(vec?.x == 1)
+    #expect(vec?.mutate(x: 55.0) == true)
+    #expect(vec?.mutate(test1: 55) == true)
+    #expect(vec?.x == 55.0)
+    #expect(vec?.test1 == 55.0)
+    #expect(vec?.mutate(x: 1) == true)
+    #expect(vec?.x == 1)
+    #expect(vec?.mutate(test1: 3) == true)
 
     let mutableTest4 = monster.mutableTest4
     let orignalValues = mutableTest4[0].a
-    XCTAssertEqual(mutableTest4[0].mutate(a: 100), true)
-    XCTAssertNotEqual(monster.test4[0].a, orignalValues)
-    XCTAssertEqual(monster.test4[0].a, 100)
-    XCTAssertEqual(mutableTest4[0].mutate(a: orignalValues), true)
+    #expect(mutableTest4[0].mutate(a: 100) == true)
+    #expect(monster.test4[0].a != orignalValues)
+    #expect(monster.test4[0].a == 100)
+    #expect(mutableTest4[0].mutate(a: orignalValues) == true)
   }
 
   func readFlatbufferMonster(monster: inout MyGame_Example_Monster) {
-    XCTAssertEqual(monster.hp, 80)
-    XCTAssertEqual(monster.mana, 150)
-    XCTAssertEqual(monster.name, "MyMonster")
+    #expect(monster.hp == 80)
+    #expect(monster.mana == 150)
+    #expect(monster.name == "MyMonster")
     let pos = monster.pos
-    XCTAssertEqual(pos?.x, 1)
-    XCTAssertEqual(pos?.y, 2)
-    XCTAssertEqual(pos?.z, 3)
-    XCTAssertEqual(pos?.test1, 3)
-    XCTAssertEqual(pos?.test2, .green)
+    #expect(pos?.x == 1)
+    #expect(pos?.y == 2)
+    #expect(pos?.z == 3)
+    #expect(pos?.test1 == 3)
+    #expect(pos?.test2 == .green)
     let test = pos?.test3
-    XCTAssertEqual(test?.a, 5)
-    XCTAssertEqual(test?.b, 6)
-    XCTAssertEqual(monster.testType, .monster)
+    #expect(test?.a == 5)
+    #expect(test?.b == 6)
+    #expect(monster.testType == .monster)
     let monster2 = monster.test(type: Monster.self)
-    XCTAssertEqual(monster2?.name, "Fred")
+    #expect(monster2?.name == "Fred")
 
-    XCTAssertEqual(monster.mutate(mana: 10), false)
+    #expect(monster.mutate(mana: 10) == false)
 
-    XCTAssertEqual(monster.mana, 150)
-    XCTAssertEqual(monster.inventory.count, 5)
+    #expect(monster.mana == 150)
+    #expect(monster.inventory.count == 5)
     var sum: Byte = 0
     for inventory in monster.inventory {
       sum += inventory
     }
-    XCTAssertEqual(sum, 10)
+    #expect(sum == 10)
 
     monster.withUnsafePointerToInventory { ptr, count in
       var sum: UInt8 = 0
       for pointee in ptr.startIndex..<ptr.endIndex {
         sum += ptr[pointee]
       }
-      XCTAssertEqual(sum, 10)
+      #expect(sum == 10)
     }
 
-    XCTAssertEqual(monster.test4.count, 2)
+    #expect(monster.test4.count == 2)
 
     let test4 = monster.test4
     var sum0 = 0
     for test0 in test4 {
       sum0 += Int(test0.a) + Int(test0.b)
     }
-    XCTAssertEqual(sum0, 100)
+    #expect(sum0 == 100)
 
     monster.withUnsafePointerToTest4 { ptr, count in
       guard let ptr = ptr.baseAddress else { return }
@@ -485,7 +499,7 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
         pointerSum += Int(bindedMemory[pointee].a) +
           Int(bindedMemory[pointee].b)
       }
-      XCTAssertEqual(pointerSum, 100)
+      #expect(pointerSum == 100)
     }
 
     let mutableTest4 = monster.mutableTest4
@@ -493,87 +507,84 @@ class FlatBuffersMonsterWriterTests: XCTestCase {
     for test0 in mutableTest4 {
       sum2 += Int(test0.a) + Int(test0.b)
     }
-    XCTAssertEqual(sum2, 100)
+    #expect(sum2 == 100)
 
     let stringArray = monster.testarrayofstring
-    XCTAssertEqual(stringArray.count, 2)
-    XCTAssertEqual(stringArray[0], "test1")
-    XCTAssertEqual(stringArray[1], "test2")
-    XCTAssertEqual(monster.testbool, true)
+    #expect(stringArray.count == 2)
+    #expect(stringArray[0] == "test1")
+    #expect(stringArray[1] == "test2")
+    #expect(monster.testbool == true)
 
     let array = monster.nameSegmentArray
-    XCTAssertEqual(String(bytes: array ?? [], encoding: .utf8), "MyMonster")
+    #expect(String(bytes: array ?? [], encoding: .utf8) == "MyMonster")
 
     if 0 == monster.testarrayofbools.count {
-      XCTAssertEqual(monster.testarrayofbools.isEmpty, true)
+      #expect(monster.testarrayofbools.isEmpty == true)
     } else {
-      XCTAssertEqual(monster.testarrayofbools.isEmpty, false)
+      #expect(monster.testarrayofbools.isEmpty == false)
     }
   }
 
   func readObjectApi(monster: MyGame_Example_MonsterT) {
-    XCTAssertEqual(monster.hp, 80)
-    XCTAssertEqual(monster.mana, 150)
-    XCTAssertEqual(monster.name, "MyMonster")
+    #expect(monster.hp == 80)
+    #expect(monster.mana == 150)
+    #expect(monster.name == "MyMonster")
     let pos = monster.pos
-    XCTAssertEqual(pos?.x, 1)
-    XCTAssertEqual(pos?.y, 2)
-    XCTAssertEqual(pos?.z, 3)
-    XCTAssertEqual(pos?.test1, 3)
-    XCTAssertEqual(pos?.test2, .green)
+    #expect(pos?.x == 1)
+    #expect(pos?.y == 2)
+    #expect(pos?.z == 3)
+    #expect(pos?.test1 == 3)
+    #expect(pos?.test2 == .green)
     let test = pos?.test3
-    XCTAssertEqual(test?.a, 5)
-    XCTAssertEqual(test?.b, 6)
+    #expect(test?.a == 5)
+    #expect(test?.b == 6)
     let monster2 = monster.test?.value as? MyGame_Example_MonsterT
-    XCTAssertEqual(monster2?.name, "Fred")
-    XCTAssertEqual(monster.mana, 150)
+    #expect(monster2?.name == "Fred")
+    #expect(monster.mana == 150)
     monster.mana = 10
-    XCTAssertEqual(monster.mana, 10)
+    #expect(monster.mana == 10)
     monster.mana = 150
-    XCTAssertEqual(monster.mana, 150)
+    #expect(monster.mana == 150)
 
-    XCTAssertEqual(monster.inventory.count, 5)
+    #expect(monster.inventory.count == 5)
     var sum: Byte = 0
     for i in monster.inventory {
       sum += i
     }
-    XCTAssertEqual(sum, 10)
-    XCTAssertEqual(monster.test4.count, 2)
+    #expect(sum == 10)
+    #expect(monster.test4.count == 2)
     var sum0 = 0
     for test in monster.test4 {
       sum0 += Int(test.a) + Int(test.b)
     }
-    XCTAssertEqual(sum0, 100)
-    XCTAssertEqual(monster.testbool, true)
+    #expect(sum0 == 100)
+    #expect(monster.testbool == true)
   }
 
-  func testEncoding() {
+  @Test
+  func testEncoding() throws {
     let fbb = createMonster(withPrefix: false)
     var sizedBuffer = fbb.sizedBuffer
-    do {
-      struct Test: Decodable {
-        struct Pos: Decodable {
-          let x, y, z: Int
-        }
-        let hp: Int
-        let inventory: [UInt8]
-        let name: String
-        let pos: Pos
+    struct Test: Decodable {
+      struct Pos: Decodable {
+        let x, y, z: Int
       }
-      let reader: Monster = try getCheckedRoot(byteBuffer: &sizedBuffer)
-      let encoder = JSONEncoder()
-      encoder.keyEncodingStrategy = .convertToSnakeCase
-      let data = try encoder.encode(reader)
-      let decoder = JSONDecoder()
-      decoder.keyDecodingStrategy = .convertFromSnakeCase
-      let value = try decoder.decode(Test.self, from: data)
-      XCTAssertEqual(value.name, "MyMonster")
-      XCTAssertEqual(value.pos.x, 1)
-      XCTAssertEqual(value.pos.y, 2)
-      XCTAssertEqual(value.pos.z, 3)
-    } catch {
-      XCTFail(error.localizedDescription)
+      let hp: Int
+      let inventory: [UInt8]
+      let name: String
+      let pos: Pos
     }
+    let reader: Monster = try getCheckedRoot(byteBuffer: &sizedBuffer)
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let data = try encoder.encode(reader)
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let value = try decoder.decode(Test.self, from: data)
+    #expect(value.name == "MyMonster")
+    #expect(value.pos.x == 1)
+    #expect(value.pos.y == 2)
+    #expect(value.pos.z == 3)
   }
 
   var jsonData: String {

--- a/tests/swift/Wasm.tests/Tests/FlexBuffers.Test.Swift.WasmTests/FlexBuffersJSONTests.swift
+++ b/tests/swift/Wasm.tests/Tests/FlexBuffers.Test.Swift.WasmTests/FlexBuffersJSONTests.swift
@@ -16,17 +16,19 @@
 
 import Common
 import FlexBuffers
-import XCTest
+import Foundation
+import Testing
 
-final class FlexBuffersJSONTests: XCTestCase {
+struct FlexBuffersJSONTests {
+  @Test
   func testEncodingJSON() throws {
     let buf: ByteBuffer = createProperBuffer().sizedByteBuffer
     let reference = try getRoot(buffer: buf)!
 
     let json = reference.jsonString()
     // swiftformat:disable all
-    XCTAssertEqual(
-      json,
+    #expect(
+      json ==
       "{\"bar\": [1, 2, 3], \"bar3\": [1, 2, 3], \"bool\": true, \"bools\": [true, false, true, false], \"foo\": 100.0, \"mymap\": {\"foo\": \"Fred\"}, \"vec\": [-100, \"Fred\", 4.0, \"M\", false, 4.0]}"
     )
     // swiftformat:enable all
@@ -37,15 +39,15 @@ final class FlexBuffersJSONTests: XCTestCase {
         with: data,
         options: []) as! [String: Any]
 
-    XCTAssertEqual(decodedData["bar"] as! [Int], [1, 2, 3])
-    XCTAssertEqual(decodedData["bar3"] as! [Int], [1, 2, 3])
+    #expect(decodedData["bar"] as! [Int] == [1, 2, 3])
+    #expect(decodedData["bar3"] as! [Int] == [1, 2, 3])
 
     let vec: [Any] = decodedData["vec"] as! [Any]
-    XCTAssertEqual(vec[0] as! Int, -100)
-    XCTAssertEqual(vec[1] as! String, "Fred")
-    XCTAssertEqual(vec[2] as! Double, 4.0)
-    XCTAssertEqual(vec[3] as! String, "M")
-    XCTAssertEqual(vec[4] as! Bool, false)
-    XCTAssertEqual(vec[5] as! Double, 4.0)
+    #expect(vec[0] as! Int == -100)
+    #expect(vec[1] as! String == "Fred")
+    #expect(vec[2] as! Double == 4.0)
+    #expect(vec[3] as! String == "M")
+    #expect(vec[4] as! Bool == false)
+    #expect(vec[5] as! Double == 4.0)
   }
 }

--- a/tests/swift/Wasm.tests/Tests/FlexBuffers.Test.Swift.WasmTests/FlexBuffersReaderTests.swift
+++ b/tests/swift/Wasm.tests/Tests/FlexBuffers.Test.Swift.WasmTests/FlexBuffersReaderTests.swift
@@ -15,22 +15,26 @@
  */
 
 import Common
-import XCTest
+import Foundation
+import Testing
 
 @testable import FlexBuffers
 
-final class FlexBuffersReaderTests: XCTestCase {
+struct FlexBuffersReaderTests {
 
+  @Test
   func testReadingProperBuffer() throws {
     let buf: ByteBuffer = createProperBuffer().byteBuffer
     try validate(buffer: buf)
   }
 
+  @Test
   func testReadingSizedBuffer() throws {
     let buf: ByteBuffer = createSizedBuffer()
     try validate(buffer: buf)
   }
 
+  @Test(.bug("https://github.com/google/flatbuffers/issues/8642"))
   func testReset() throws {
     var fbx = FlexBuffersWriter(
       initialSize: 8,
@@ -38,87 +42,87 @@ final class FlexBuffersReaderTests: XCTestCase {
     write(fbx: &fbx)
 
     try validate(buffer: ByteBuffer(bytes: fbx.sizedByteArray))
-    XCTAssertEqual(fbx.capacity, 512)
+    #expect(fbx.capacity == 512)
     fbx.reset()
-    XCTAssertEqual(fbx.writerIndex, 0)
-    XCTAssertEqual(fbx.capacity, 8)
+    #expect(fbx.writerIndex == 0)
+    #expect(fbx.capacity == 8)
 
     write(fbx: &fbx)
     try validate(buffer: ByteBuffer(bytes: fbx.sizedByteArray))
     fbx.reset(keepingCapacity: true)
-    XCTAssertEqual(fbx.writerIndex, 0)
-    XCTAssertEqual(fbx.capacity, 512)
+    #expect(fbx.writerIndex == 0)
+    #expect(fbx.capacity == 512)
 
     write(fbx: &fbx)
     try validate(buffer: ByteBuffer(bytes: fbx.sizedByteArray))
-    XCTAssertEqual(fbx.capacity, 512)
+    #expect(fbx.capacity == 512)
   }
 
   private func validate(buffer buf: ByteBuffer) throws {
     let reference = try getRoot(buffer: buf)!
-    XCTAssertEqual(reference.type, .map)
+    #expect(reference.type == .map)
     let map = reference.map!
-    XCTAssertEqual(map.count, 7)
+    #expect(map.count == 7)
     let vecRef = map["vec"]!
-    XCTAssertEqual(vecRef.type, .vector)
+    #expect(vecRef.type == .vector)
     let vec = vecRef.vector!
-    XCTAssertEqual(vec.count, 6)
-    XCTAssertEqual(vec[0]?.type, .int)
-    XCTAssertEqual(vec[0]?.int, -100)
-    XCTAssertEqual(vec[1]?.type, .string)
-    XCTAssertEqual(vec[1]?.cString, "Fred")
-    XCTAssertNil(vec[1]?.int)
-    XCTAssertEqual(vec[2]?.double, 4.0)
-    XCTAssertTrue(vec[3]?.type == .blob)
+    #expect(vec.count == 6)
+    #expect(vec[0]?.type == .int)
+    #expect(vec[0]?.int == -100)
+    #expect(vec[1]?.type == .string)
+    #expect(vec[1]?.cString == "Fred")
+    #expect(vec[1]?.int == nil)
+    #expect(vec[2]?.double == 4.0)
+    #expect(vec[3]?.type == .blob)
 
     let blob = vec[3]!.blob { pointer in
       Array(pointer)
     }
 
-    XCTAssertEqual(blob?.count, 1)
-    XCTAssertEqual(blob?[0], 77)
-    XCTAssertEqual(vec[4]?.type, .bool)
-    XCTAssertEqual(vec[4]?.bool, false)
-    XCTAssertEqual(vec[5]?.double, 4.0)  // Shared with vec[2]
+    #expect(blob?.count == 1)
+    #expect(blob?[0] == 77)
+    #expect(vec[4]?.type == .bool)
+    #expect(vec[4]?.bool == false)
+    #expect(vec[5]?.double == 4.0)  // Shared with vec[2]
 
     let barVec = map["bar"]!.typedVector!
-    XCTAssertEqual(barVec.count, 3)
-    XCTAssertEqual(barVec[2]?.int, 3)
-    XCTAssertEqual(barVec[2]?.asInt(), UInt8(3))
+    #expect(barVec.count == 3)
+    #expect(barVec[2]?.int == 3)
+    #expect(barVec[2]?.asInt() == UInt8(3))
 
     let fixedVec = map["bar3"]!.fixedTypedVector!
-    XCTAssertEqual(fixedVec.count, 3)
-    XCTAssertEqual(fixedVec[2]?.int, 3)
-    XCTAssertEqual(fixedVec[2]?.asInt(), UInt8(3))
-    XCTAssertEqual(map["bool"]?.bool, true)
+    #expect(fixedVec.count == 3)
+    #expect(fixedVec[2]?.int == 3)
+    #expect(fixedVec[2]?.asInt() == UInt8(3))
+    #expect(map["bool"]?.bool == true)
 
     let boolsVector = map["bools"]!.typedVector!
-    XCTAssertEqual(boolsVector.type, .bool)
-    XCTAssertEqual(boolsVector[0]?.bool, true)
-    XCTAssertEqual(boolsVector[1]?.bool, false)
+    #expect(boolsVector.type == .bool)
+    #expect(boolsVector[0]?.bool == true)
+    #expect(boolsVector[1]?.bool == false)
 
     let bools = [true, false, true, false]
     boolsVector.withUnsafeRawBufferPointer { buff in
       for i in 0..<boolsVector.count {
-        XCTAssertEqual(buff.load(fromByteOffset: i, as: Bool.self), bools[i])
+        #expect(buff.load(fromByteOffset: i, as: Bool.self) == bools[i])
       }
     }
-    XCTAssertEqual(map["foo"]?.double, 100)
-    XCTAssertNil(map["unknown"])
+    #expect(map["foo"]?.double == 100)
+    #expect(map["unknown"] == nil)
     let mymap = map["mymap"]?.map
 
     // Check if both addresses used are the same for keys and strings
-    XCTAssertEqual(mymap?.keys[0]?.cString, map.keys[4]?.cString)
+    #expect(mymap?.keys[0]?.cString == map.keys[4]?.cString)
     map.keys[4]?.withUnsafeRawPointer { pointer in
       mymap?.keys[0]?.withUnsafeRawPointer { mymapPointer in
-        XCTAssertEqual(pointer, mymapPointer)
+        #expect(pointer == mymapPointer)
       }
     }
 
-    XCTAssertEqual(mymap?.values[0]?.cString, vec[1]?.cString)
+    #expect(mymap?.values[0]?.cString == vec[1]?.cString)
     vec[1]?.withUnsafeRawPointer { pointer in
       mymap?.values[0]?.withUnsafeRawPointer { mymapPointer in
-        XCTAssertEqual(pointer, mymapPointer)
+        #expect(pointer == mymapPointer)
       }
     }
   }
@@ -127,7 +131,7 @@ final class FlexBuffersReaderTests: XCTestCase {
     #if os(macOS)
     // Gets the current path of this test file then
     // strips out the nested directories.
-    let filePath = URL(filePath: #file)
+    let filePath = URL(filePath: #filePath)
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .deletingLastPathComponent()

--- a/tests/swift/Wasm.tests/Tests/FlexBuffers.Test.Swift.WasmTests/FlexBuffersStringTests.swift
+++ b/tests/swift/Wasm.tests/Tests/FlexBuffers.Test.Swift.WasmTests/FlexBuffersStringTests.swift
@@ -16,10 +16,12 @@
 
 import Common
 import FlexBuffers
-import XCTest
+import Foundation
+import Testing
 
-final class FlexBuffersStringTests: XCTestCase {
+struct FlexBuffersStringTests {
 
+  @Test
   func testEncodingUnicodeString() {
     let text = "プ画をみて✋"
 
@@ -38,6 +40,6 @@ final class FlexBuffersStringTests: XCTestCase {
       return String(data: data, encoding: .unicode)
     }
 
-    XCTAssertEqual(builtString, text)
+    #expect(builtString == text)
   }
 }

--- a/tests/swift/Wasm.tests/Tests/FlexBuffers.Test.Swift.WasmTests/FlexBuffersWriterTests.swift
+++ b/tests/swift/Wasm.tests/Tests/FlexBuffers.Test.Swift.WasmTests/FlexBuffersWriterTests.swift
@@ -16,9 +16,10 @@
 
 import Common
 import FlexBuffers
-import XCTest
+import Testing
 
-final class FlexBuffersWriterTests: XCTestCase {
+struct FlexBuffersWriterTests {
+  @Test
   func testDeallocation() {
     let buf: ByteBuffer = {
       var fbx = FlexBuffersWriter()
@@ -28,12 +29,13 @@ final class FlexBuffersWriterTests: XCTestCase {
     }()
 
     buf.withUnsafeBytes {
-      XCTAssertEqual(
-        Array($0),
-        [5, 72, 101, 108, 108, 111, 0, 6, 20, 1])
+      #expect(
+        Array($0) ==
+          [5, 72, 101, 108, 108, 111, 0, 6, 20, 1])
     }
   }
 
+  @Test
   func testAddingVectorOfScalars() {
     var fbx = FlexBuffersWriter()
     fbx.vector {
@@ -45,8 +47,8 @@ final class FlexBuffersWriterTests: XCTestCase {
 
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [
           10, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 7, 0,
           0, 0, 8, 0, 0, 0, 9, 0, 0, 0, 20, 0, 0, 0, 1, 41, 46, 2, 40, 1,
@@ -55,6 +57,7 @@ final class FlexBuffersWriterTests: XCTestCase {
     }
   }
 
+  @Test
   func testAddingVectorOfUnsignedScalars() {
     var fbx = FlexBuffersWriter()
     fbx.vector {
@@ -66,8 +69,8 @@ final class FlexBuffersWriterTests: XCTestCase {
 
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [
           10, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0,
           0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0,
@@ -78,6 +81,7 @@ final class FlexBuffersWriterTests: XCTestCase {
     }
   }
 
+  @Test
   func testAddingVectorOfBools() {
     var fbx = FlexBuffersWriter()
     fbx.vector {
@@ -89,13 +93,14 @@ final class FlexBuffersWriterTests: XCTestCase {
 
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [4, 1, 0, 1, 0, 1, 5, 144, 2, 40, 1])
       // swiftformat:enable all
     }
   }
 
+  @Test
   func testSortingWithinMap() {
     var fbx = FlexBuffersWriter()
     fbx.map {
@@ -106,8 +111,8 @@ final class FlexBuffersWriterTests: XCTestCase {
     let buf: ByteBuffer = fbx.sizedByteBuffer
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [
           98, 111, 111, 108, 50, 0, 98, 111, 111, 108, 49, 0, 2, 7, 14, 2, 1, 2, 1, 0, 104, 104, 4,
           36, 1,
@@ -117,6 +122,7 @@ final class FlexBuffersWriterTests: XCTestCase {
     }
   }
 
+  @Test
   func testSharingKeyWithinMap() {
     var fbx = FlexBuffersWriter(initialSize: 1000, flags: .shareKeysAndStrings)
     fbx.map {
@@ -128,8 +134,8 @@ final class FlexBuffersWriterTests: XCTestCase {
     let buf: ByteBuffer = fbx.sizedByteBuffer
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [
           119, 101, 108, 99, 111, 109, 101, 0, 7, 119, 101, 108, 99, 111, 109, 101, 0, 3, 18, 19,
           20, 3, 1, 3, 15, 16, 17, 20, 20, 20, 6, 36, 1,
@@ -139,19 +145,21 @@ final class FlexBuffersWriterTests: XCTestCase {
     }
   }
 
+  @Test
   func testNestingVectorInMap() {
     let buf: ByteBuffer = createSizedBuffer()
 
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         flexbufferGolden
       )
       // swiftformat:enable all
     }
   }
 
+  @Test
   func testAddingNil() {
     var fbx = FlexBuffersWriter(
       initialSize: 8,
@@ -165,14 +173,15 @@ final class FlexBuffersWriterTests: XCTestCase {
     let buf: ByteBuffer = fbx.sizedByteBuffer
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         [118, 0, 1, 3, 1, 1, 1, 0, 0, 2, 36, 1]
       )
       // swiftformat:enable all
     }
   }
 
+  @Test
   func testAddingManually() {
     var fbx = FlexBuffersWriter(
       initialSize: 8,
@@ -209,14 +218,15 @@ final class FlexBuffersWriterTests: XCTestCase {
     let buf: ByteBuffer = fbx.sizedByteBuffer
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         flexbufferGolden
       )
       // swiftformat:enable all
     }
   }
 
+  @Test
   func testEncodingAllTypes() {
     var fbx = FlexBuffersWriter()
     fbx.vector {
@@ -240,8 +250,8 @@ final class FlexBuffersWriterTests: XCTestCase {
 
     buf.withUnsafeBytes {
       // swiftformat:disable all
-      XCTAssertEqual(
-        Array($0),
+      #expect(
+        Array($0) ==
         allTypesGolden)
       // swiftformat:enable all
     }


### PR DESCRIPTION
Migrate from the old XCTests framework to use the new shinny Swift testing framework. 


This change will have no harm on users, it only effects our codebase