### PR TITLE
Fix LeakSanitizer leak in CrossNamespacePackTest

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1739,7 +1739,7 @@ void CrossNamespacePackTest() {
   fbb.Finish(foo::Consumer::Pack(fbb, &consumer));
 
   auto* packed = flatbuffers::GetRoot<foo::Consumer>(fbb.GetBufferPointer());
-  auto unpacked = packed->UnPack();
+  std::unique_ptr<foo::ConsumerT> unpacked(packed->UnPack());
   TEST_EQ(unpacked->c1->value, 42);
   TEST_EQ(unpacked->c2.size(), 1);
   TEST_EQ(unpacked->c2[0]->value, 99);


### PR DESCRIPTION
## Summary
- `Consumer::UnPack()` returns an owning raw pointer; `CrossNamespacePackTest` (added in #8948) dropped it on the floor, leaking the unpacked object and its nested allocations.
- Running `flattests` under ASan/LSan reports `48 byte(s) leaked in 4 allocation(s)` with the top frame at `tests/test.cpp:1742`.
- Fix: wrap the result in `std::unique_ptr`, matching the existing pattern at `tests/test.cpp:298` (which uses `delete movie_object;`).

## Reproduction
```
cmake -S . -B build/san -G Ninja -DCMAKE_BUILD_TYPE=Debug \
  -DFLATBUFFERS_CODE_SANITIZE=ON -DFLATBUFFERS_BUILD_TESTS=ON \
  -DFLATBUFFERS_BUILD_CPP17=OFF -DFLATBUFFERS_BUILD_GRPCTEST=OFF \
  -DFLATBUFFERS_BUILD_BENCHMARKS=OFF -DFLATBUFFERS_INSTALL=OFF
cmake --build build/san --target flattests
ctest --test-dir build/san -R '^flattests$' --output-on-failure
```
Before: `0% tests passed` (LSan failure, 48 bytes / 4 allocations).
After: `100% tests passed`.