### PR TITLE
[Swift] Fix verifier accepting truncated scalar vectors (OOB read/write, RCE)

### DIFF
--- a/swift/Sources/FlatBuffers/Verifiable.swift
+++ b/swift/Sources/FlatBuffers/Verifiable.swift
@@ -56,8 +56,15 @@ extension Verifiable {
     let len: UOffset = try verifier.getValue(at: position)
     let intLen = Int(len)
     let start = Int(clamping: (position &+ MemoryLayout<Int32>.size).magnitude)
+    let byteCount = intLen.multipliedReportingOverflow(
+      by: MemoryLayout<T>.size)
+    guard !byteCount.overflow else {
+      throw FlatbuffersErrors.outOfBounds(
+        position: UInt.max,
+        end: verifier.capacity)
+    }
     try verifier.isAligned(position: start, type: type.self)
-    try verifier.rangeInBuffer(position: start, size: intLen)
+    try verifier.rangeInBuffer(position: start, size: byteCount.partialValue)
     return (start, intLen)
   }
 }

--- a/tests/swift/Tests/Flatbuffers/FlatbuffersVerifierTests.swift
+++ b/tests/swift/Tests/Flatbuffers/FlatbuffersVerifierTests.swift
@@ -411,6 +411,27 @@ final class FlatbuffersVerifierTests {
     }
   }
 
+  @Test(.bug("https://github.com/google/flatbuffers/issues/9082"))
+  func testRejectsTruncatedScalarVector() {
+    // swiftformat:disable all
+    var byteBuffer = ByteBuffer(bytes: [
+      16, 0, 0, 0,
+      6, 0, 8, 0,
+      4, 0, 0, 0,
+      0, 0, 0, 0,
+      12, 0, 0, 0,
+      8, 0, 0, 0,
+      0, 0, 0, 0,
+      2, 0, 0, 0,
+      65, 66,
+    ])
+    // swiftformat:enable all
+
+    #expect(throws: FlatbuffersErrors.self) {
+      try getCheckedRoot(byteBuffer: &byteBuffer) as Swift_Tests_Vectors
+    }
+  }
+
   @Test
   func testValidUnionBuffer() {
     let string = "Awesome \\\\t\t\nstring!"


### PR DESCRIPTION
## Summary

`getCheckedRoot` accepted malformed FlatBuffers whose scalar vector element count did not match the available payload bytes. After verification succeeded, the generated accessors and mutators read and wrote past `ByteBuffer.capacity`, producing out-of-bounds memory disclosure, out-of-bounds memory corruption, and code execution when corrupted adjacent control data was later invoked.

Reported as Google IssueTracker issue 510740173.

## Root cause

`Verifiable.verifyRange` passed the vector element count directly to `rangeInBuffer` as a byte count. For any scalar vector whose element size is greater than one byte (e.g. `[long]`, `[int]`, `[double]`), the declared length only had to fit `byteBuffer.capacity` bytes after the vector header instead of `count * elementSize` bytes, so a buffer declaring N elements but containing only N raw bytes was accepted.

## Fix

Multiply the declared element count by `MemoryLayout<T>.size` with overflow detection and pass the resulting byte size to `rangeInBuffer`, so truncated scalar vectors are rejected at verification time before any unsafe generated access can occur.