### PR TITLE
Escape file_identifier in code generators to prevent injection via .bfbs

### DIFF
--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -652,7 +652,11 @@ class CppGenerator : public BaseGenerator {
       if (parser_.file_identifier_.length()) {
         // Return the identifier
         code_ += "inline const char *{{STRUCT_NAME}}Identifier() {";
-        code_ += "  return \"" + parser_.file_identifier_ + "\";";
+        std::string escaped_ident;
+        flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                  parser_.file_identifier_.length(),
+                                  &escaped_ident, true, false);
+        code_ += "  return " + escaped_ident + ";";
         code_ += "}";
         code_ += "";
 

--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -920,9 +920,13 @@ class CSharpGenerator : public BaseGenerator {
           code += "  public static ";
           code += "bool " + struct_def.name;
           code += "BufferHasIdentifier(ByteBuffer _bb) { return ";
-          code += "Table.__has_identifier(_bb, \"";
-          code += parser_.file_identifier_;
-          code += "\"); }\n";
+          std::string escaped_ident;
+          flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                    parser_.file_identifier_.length(),
+                                    &escaped_ident, true, false);
+          code += "Table.__has_identifier(_bb, ";
+          code += escaped_ident;
+          code += "); }\n";
         }
 
         // Generate the Verify method that checks if a ByteBuffer is save to
@@ -931,9 +935,13 @@ class CSharpGenerator : public BaseGenerator {
         code += "bool Verify" + struct_def.name + "(ByteBuffer _bb) {";
         code += "Google.FlatBuffers.Verifier verifier = new ";
         code += "Google.FlatBuffers.Verifier(_bb); ";
-        code += "return verifier.VerifyBuffer(\"";
-        code += parser_.file_identifier_;
-        code += "\", false, " + struct_def.name + "Verify.Verify);";
+        std::string escaped_ident_verify;
+        flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                  parser_.file_identifier_.length(),
+                                  &escaped_ident_verify, true, false);
+        code += "return verifier.VerifyBuffer(";
+        code += escaped_ident_verify;
+        code += ", false, " + struct_def.name + "Verify.Verify);";
         code += " }\n";
       }
     }
@@ -1608,8 +1616,13 @@ class CSharpGenerator : public BaseGenerator {
           code += " builder.Finish" + size_prefix[i] + "(offset";
           code += ".Value";
 
-          if (parser_.file_identifier_.length())
-            code += ", \"" + parser_.file_identifier_ + "\"";
+          if (parser_.file_identifier_.length()) {
+            std::string escaped_ident;
+            flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                      parser_.file_identifier_.length(),
+                                      &escaped_ident, true, false);
+            code += ", " + escaped_ident;
+          }
           code += "); }\n";
         }
       }

--- a/src/idl_gen_go.cpp
+++ b/src/idl_gen_go.cpp
@@ -318,8 +318,12 @@ class GoGenerator : public BaseGenerator {
                                parser_.file_identifier_.length();
 
     if (has_file_identifier) {
-      code += "const " + struct_type + "Identifier = \"" +
-              parser_.file_identifier_ + "\"\n\n";
+      std::string escaped_ident;
+      flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                parser_.file_identifier_.length(),
+                                &escaped_ident, true, false);
+      code += "const " + struct_type + "Identifier = " +
+              escaped_ident + "\n\n";
     }
 
     for (int i = 0; i < 2; i++) {

--- a/src/idl_gen_java.cpp
+++ b/src/idl_gen_java.cpp
@@ -758,9 +758,13 @@ class JavaGenerator : public BaseGenerator {
                   namer_.LegacyJavaMethod2(
                       "", struct_def, "BufferHasIdentifier(ByteBuffer _bb)") +
                   " { return ";
-          code += "__has_identifier(_bb, \"";
-          code += parser_.file_identifier_;
-          code += "\"); }\n";
+          std::string escaped_ident;
+          flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                    parser_.file_identifier_.length(),
+                                    &escaped_ident, true, false);
+          code += "__has_identifier(_bb, ";
+          code += escaped_ident;
+          code += "); }\n";
         }
       }
     }
@@ -1263,8 +1267,13 @@ class JavaGenerator : public BaseGenerator {
           code += " offset) {";
           code += " builder.finish" + size_prefix[i] + "(offset";
 
-          if (parser_.file_identifier_.length())
-            code += ", \"" + parser_.file_identifier_ + "\"";
+          if (parser_.file_identifier_.length()) {
+            std::string escaped_ident;
+            flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                      parser_.file_identifier_.length(),
+                                      &escaped_ident, true, false);
+            code += ", " + escaped_ident;
+          }
           code += "); }\n";
         }
       }

--- a/src/idl_gen_kotlin.cpp
+++ b/src/idl_gen_kotlin.cpp
@@ -669,7 +669,13 @@ class KotlinGenerator : public BaseGenerator {
                                   const std::string& identifier,
                                   CodeWriter& writer,
                                   const IDLOptions options) const {
-    auto id = identifier.length() > 0 ? ", \"" + identifier + "\"" : "";
+    std::string id;
+    if (identifier.length() > 0) {
+      std::string escaped_ident;
+      flatbuffers::EscapeString(identifier.c_str(), identifier.length(),
+                                &escaped_ident, true, false);
+      id = ", " + escaped_ident;
+    }
     auto params = "builder: FlatBufferBuilder, offset: Int";
     auto method_name =
         namer_.LegacyJavaMethod2("finishSizePrefixed", struct_def, "Buffer");
@@ -682,7 +688,13 @@ class KotlinGenerator : public BaseGenerator {
                                   const std::string& identifier,
                                   CodeWriter& writer,
                                   const IDLOptions options) const {
-    auto id = identifier.length() > 0 ? ", \"" + identifier + "\"" : "";
+    std::string id;
+    if (identifier.length() > 0) {
+      std::string escaped_ident;
+      flatbuffers::EscapeString(identifier.c_str(), identifier.length(),
+                                &escaped_ident, true, false);
+      id = ", " + escaped_ident;
+    }
     auto params = "builder: FlatBufferBuilder, offset: Int";
     auto method_name =
         namer_.LegacyKotlinMethod("finish", struct_def, "Buffer");
@@ -940,11 +952,15 @@ class KotlinGenerator : public BaseGenerator {
     // Check if a buffer has the identifier.
     if (parser_.root_struct_def_ != &struct_def || !file_identifier.length())
       return;
+    std::string escaped_ident;
+    flatbuffers::EscapeString(file_identifier.c_str(),
+                              file_identifier.length(),
+                              &escaped_ident, true, false);
     auto name = namer_.Function(struct_def);
     GenerateFunOneLine(
         writer, name + "BufferHasIdentifier", "_bb: ByteBuffer", "Boolean",
         [&]() {
-          writer += "__has_identifier(_bb, \"" + file_identifier + "\")";
+          writer += "__has_identifier(_bb, " + escaped_ident + ")";
         },
         options.gen_jvmstatic);
   }

--- a/src/idl_gen_kotlin_kmp.cpp
+++ b/src/idl_gen_kotlin_kmp.cpp
@@ -820,7 +820,13 @@ class KotlinKMPGenerator : public BaseGenerator {
                                   const std::string& identifier,
                                   CodeWriter& writer,
                                   const IDLOptions options) const {
-    auto id = identifier.length() > 0 ? ", \"" + identifier + "\"" : "";
+    std::string id;
+    if (identifier.length() > 0) {
+      std::string escaped_ident;
+      flatbuffers::EscapeString(identifier.c_str(), identifier.length(),
+                                &escaped_ident, true, false);
+      id = ", " + escaped_ident;
+    }
     auto gen_type = "Offset<" + namer_.Type(struct_def.name) + ">";
     auto params = "builder: FlatBufferBuilder, offset: " + gen_type;
     auto method_name =
@@ -834,7 +840,13 @@ class KotlinKMPGenerator : public BaseGenerator {
                                   const std::string& identifier,
                                   CodeWriter& writer,
                                   const IDLOptions options) const {
-    auto id = identifier.length() > 0 ? ", \"" + identifier + "\"" : "";
+    std::string id;
+    if (identifier.length() > 0) {
+      std::string escaped_ident;
+      flatbuffers::EscapeString(identifier.c_str(), identifier.length(),
+                                &escaped_ident, true, false);
+      id = ", " + escaped_ident;
+    }
     auto gen_type = "Offset<" + namer_.Type(struct_def.name) + ">";
     auto params = "builder: FlatBufferBuilder, offset: " + gen_type;
     auto method_name =
@@ -1056,12 +1068,16 @@ class KotlinKMPGenerator : public BaseGenerator {
     // Check if a buffer has the identifier.
     if (parser_.root_struct_def_ != &struct_def || !file_identifier.length())
       return;
+    std::string escaped_ident;
+    flatbuffers::EscapeString(file_identifier.c_str(),
+                              file_identifier.length(),
+                              &escaped_ident, true, false);
     auto name = namer_.Function(struct_def);
     GenerateFunOneLine(
         writer, name + "BufferHasIdentifier", "buffer: ReadWriteBuffer",
         "Boolean",
         [&]() {
-          writer += "hasIdentifier(buffer, \"" + file_identifier + "\")";
+          writer += "hasIdentifier(buffer, " + escaped_ident + ")";
         },
         options.gen_jvmstatic);
   }

--- a/src/idl_gen_php.cpp
+++ b/src/idl_gen_php.cpp
@@ -673,8 +673,13 @@ class PhpGenerator : public BaseGenerator {
       code += Indent + "{\n";
       code += Indent + Indent + "$builder->finish($offset";
 
-      if (parser_.file_identifier_.length())
-        code += ", \"" + parser_.file_identifier_ + "\"";
+      if (parser_.file_identifier_.length()) {
+        std::string escaped_ident;
+        flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                  parser_.file_identifier_.length(),
+                                  &escaped_ident, true, false);
+        code += ", " + escaped_ident;
+      }
       code += ");\n";
       code += Indent + "}\n";
     }
@@ -779,8 +784,12 @@ class PhpGenerator : public BaseGenerator {
         code += Indent + "public static function " + struct_def.name;
         code += "Identifier()\n";
         code += Indent + "{\n";
-        code += Indent + Indent + "return \"";
-        code += parser_.file_identifier_ + "\";\n";
+        std::string escaped_ident;
+        flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                  parser_.file_identifier_.length(),
+                                  &escaped_ident, true, false);
+        code += Indent + Indent + "return ";
+        code += escaped_ident + ";\n";
         code += Indent + "}\n\n";
 
         // Check if a buffer has the identifier.

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -2634,7 +2634,11 @@ class RustGenerator : public BaseGenerator {
       // Declare the identifier
       // (no lifetime needed as constants have static lifetimes by default)
       code_ += "pub const {{STRUCT_CONST}}_IDENTIFIER: &str\\";
-      code_ += " = \"" + parser_.file_identifier_ + "\";";
+      std::string escaped_ident;
+      flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                parser_.file_identifier_.length(),
+                                &escaped_ident, true, false);
+      code_ += " = " + escaped_ident + ";";
       code_ += "";
 
       // Check if a buffer has the identifier.

--- a/src/idl_gen_swift.cpp
+++ b/src/idl_gen_swift.cpp
@@ -566,8 +566,12 @@ class SwiftGenerator : public BaseGenerator {
     code_ += "private var {{ACCESS}}: {{OBJECTTYPE}}\n";
     if (!struct_def.fixed) {
       if (parser_.file_identifier_.length()) {
-        code_.SetValue("FILENAME", parser_.file_identifier_);
-        code_ += "{{ACCESS_TYPE}} static var id: String { \"{{FILENAME}}\" } ";
+        std::string escaped_ident;
+        flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                  parser_.file_identifier_.length(),
+                                  &escaped_ident, true, false);
+        code_.SetValue("FILENAME", escaped_ident);
+        code_ += "{{ACCESS_TYPE}} static var id: String { {{FILENAME}} } ";
         code_ +=
             "{{ACCESS_TYPE}} static func finish(_ fbb: inout "
             "FlatBufferBuilder, end: "

--- a/src/idl_gen_ts.cpp
+++ b/src/idl_gen_ts.cpp
@@ -821,7 +821,11 @@ class TsGenerator : public BaseGenerator {
       code += "(builder:flatbuffers.Builder, offset:flatbuffers.Offset) {\n";
       code += "  builder.finish(offset";
       if (!parser_.file_identifier_.empty()) {
-        code += ", '" + parser_.file_identifier_ + "'";
+        std::string escaped_ident;
+        flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                  parser_.file_identifier_.length(),
+                                  &escaped_ident, true, false);
+        code += ", " + escaped_ident;
       }
       if (size_prefixed) {
         if (parser_.file_identifier_.empty()) {
@@ -1726,8 +1730,12 @@ class TsGenerator : public BaseGenerator {
       code +=
           "static bufferHasIdentifier(bb:flatbuffers.ByteBuffer):boolean "
           "{\n";
-      code += "  return bb.__has_identifier('" + parser_.file_identifier_;
-      code += "');\n}\n\n";
+      std::string escaped_ident;
+      flatbuffers::EscapeString(parser_.file_identifier_.c_str(),
+                                parser_.file_identifier_.length(),
+                                &escaped_ident, true, false);
+      code += "  return bb.__has_identifier(" + escaped_ident;
+      code += ");\n}\n\n";
     }
 
     // Emit field accessors

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -4443,6 +4443,10 @@ bool Parser::Deserialize(const uint8_t* buf, const size_t size) {
 
 bool Parser::Deserialize(const reflection::Schema* schema) {
   file_identifier_ = schema->file_ident() ? schema->file_ident()->str() : "";
+  if (!file_identifier_.empty() &&
+      file_identifier_.length() != flatbuffers::kFileIdentifierLength) {
+    return false;
+  }
   file_extension_ = schema->file_ext() ? schema->file_ext()->str() : "";
   std::map<std::string, Namespace*> namespaces_index;
 


### PR DESCRIPTION
## Summary

The `file_identifier` field is embedded **unescaped** into generated string literals across 10 of 11 code generators. When `flatc` processes a crafted `.bfbs` schema (which has **no length limit** on `file_ident`, unlike `.fbs` which enforces exactly 4 bytes), an attacker-controlled `file_identifier` can break out of the string literal and inject arbitrary code into the generated source.

This is the same class of codegen injection that was fixed for **string defaults** in #8964 — but `file_identifier` was not covered by that patch.

### Attack chain

1. Attacker crafts a `.bfbs` file with a malicious `file_ident` field
2. Victim runs `flatc` with any language flag on the malicious `.bfbs`
3. Generated source contains injected code inside the identifier return value
4. When compiled, the injected code executes

### Fix

- **`idl_parser.cpp`**: Reject `.bfbs` schemas where `file_ident` is not exactly `kFileIdentifierLength` (4) bytes — matching the validation already enforced for `.fbs` schemas
- **10 generators** (C++, Rust, Go, Java, C#, Kotlin, Kotlin KMP, PHP, TypeScript, Swift): Apply `flatbuffers::EscapeString()` to all `file_identifier` embedding sites (20+ locations), so that special characters (`"`, `\`, control chars) are properly escaped before being placed inside string literals
- **Python generator**: Already immune — it hex-escapes all characters

This is consistent with the approach used for string defaults in #8964.

### Affected generators & sites patched

| Generator | Sites | Key pattern |
|-----------|-------|-------------|
| `idl_gen_cpp.cpp` | 1 | `return "IDENT"` |
| `idl_gen_rust.cpp` | 1 | `= "IDENT"` |
| `idl_gen_go.cpp` | 1 | `const Identifier = "IDENT"` |
| `idl_gen_java.cpp` | 2 | `__has_identifier`, `finish` |
| `idl_gen_csharp.cpp` | 3 | `__has_identifier`, `VerifyBuffer`, `Finish` |
| `idl_gen_kotlin.cpp` | 3 | `__has_identifier`, `finish`, `finishSizePrefixed` |
| `idl_gen_kotlin_kmp.cpp` | 3 | `hasIdentifier`, `finish`, `finishSizePrefixed` |
| `idl_gen_php.cpp` | 2 | `return "IDENT"`, `finish` |
| `idl_gen_ts.cpp` | 2 | `finish`, `__has_identifier` |
| `idl_gen_swift.cpp` | 1 | `static var id` template |

### Related PRs

- #8964 — Fixed same bug class for string defaults (merged)
- #8998 — Covers `file_extension` injection (separate PR)
