### PR TITLE
Escape */ in block-comment doc generators to prevent code injection (Java, Kotlin)

### DIFF
--- a/src/code_generators.cpp
+++ b/src/code_generators.cpp
@@ -212,7 +212,15 @@ void GenComment(const std::vector<std::string>& dc, std::string* code_ptr,
            ? config->content_line_prefix
            : "///");
   for (auto it = dc.begin(); it != dc.end(); ++it) {
-    code += line_prefix + *it + "\n";
+    std::string line = *it;
+    if (config != nullptr && config->first_line != nullptr) {
+      for (size_t pos = 0;
+           (pos = line.find("*/", pos)) != std::string::npos;) {
+        line.replace(pos, 2, "*\\/");
+        pos += 3;
+      }
+    }
+    code += line_prefix + line + "\n";
   }
   if (config != nullptr && config->last_line != nullptr) {
     code += std::string(prefix) + std::string(config->last_line) + "\n";

--- a/src/idl_gen_kotlin.cpp
+++ b/src/idl_gen_kotlin.cpp
@@ -1410,7 +1410,15 @@ class KotlinGenerator : public BaseGenerator {
              ? config->content_line_prefix
              : "///");
     for (auto it = dc.begin(); it != dc.end(); ++it) {
-      writer += line_prefix + *it;
+      std::string line = *it;
+      if (config != nullptr && config->first_line != nullptr) {
+        for (size_t pos = 0;
+             (pos = line.find("*/", pos)) != std::string::npos;) {
+          line.replace(pos, 2, "*\\/");
+          pos += 3;
+        }
+      }
+      writer += line_prefix + line;
     }
     if (config != nullptr && config->last_line != nullptr) {
       writer += std::string(config->last_line);

--- a/src/idl_gen_kotlin_kmp.cpp
+++ b/src/idl_gen_kotlin_kmp.cpp
@@ -1393,7 +1393,15 @@ class KotlinKMPGenerator : public BaseGenerator {
              ? config->content_line_prefix
              : "///");
     for (auto it = dc.begin(); it != dc.end(); ++it) {
-      writer += line_prefix + *it;
+      std::string line = *it;
+      if (config != nullptr && config->first_line != nullptr) {
+        for (size_t pos = 0;
+             (pos = line.find("*/", pos)) != std::string::npos;) {
+          line.replace(pos, 2, "*\\/");
+          pos += 3;
+        }
+      }
+      writer += line_prefix + line;
     }
     if (config != nullptr && config->last_line != nullptr) {
       writer += std::string(config->last_line);


### PR DESCRIPTION
## Summary

PR #8820 fixed a doc comment injection vulnerability in the **TypeScript** generator where `*/` in a doc comment could close the `/** ... */` JSDoc block and inject arbitrary top-level code. However, the same vulnerability exists in all other generators that use block comments for documentation: **Java**, **Kotlin**, and **Kotlin KMP**.

### Attack chain

1. Attacker adds a field doc comment to a `.fbs` schema:
   ```fbs
   table Monster {
     /// */ static { Runtime.getRuntime().exec("calc"); } /*
     name:string;
   }
   ```
2. Victim runs `flatc --java` (or `--kotlin`)
3. Generated source contains a `static {}` initializer **inside the class body**
4. The injected code auto-executes when the class is loaded

### Proof of concept (Java output before fix)

```java
public final class Monster extends Table {
  /**
   * */ static { Runtime.getRuntime().exec("calc"); } /*
   */
  public String name() { ... }
```

The `*/` on line 2 closes the Javadoc comment. The `static { ... }` block becomes real Java code inside the `Monster` class. The `/*` re-opens a block comment to absorb the remaining `*/`. The static initializer executes automatically when `Monster` is loaded.

### Fix

Escape `*/` to `*\/` in doc comment lines when the generator uses block comments (`/** ... */`), consistent with the TypeScript fix in #8820. The escape is only applied when a block comment config is active (i.e., `first_line != nullptr`), so line-comment generators (`///`, `#`) are unaffected.

**Files changed:**
- `code_generators.cpp` — shared `GenComment()` utility (used by Java)
- `idl_gen_kotlin.cpp` — custom `GenerateComment()`
- `idl_gen_kotlin_kmp.cpp` — custom `GenerateComment()`

**Not affected** (use line comments): C++, C#, Go, Rust, Swift, PHP, Python

### Related PRs

- #8820 — Fixed same bug for TypeScript only (merged)
