### PR TITLE
Fix missing null-terminator content check in FlexBuffers VerifyTerminator

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -1983,8 +1983,10 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
 #undef FLEX_CHECK_VERIFIED
 
   bool VerifyTerminator(const String& s) {
-    return VerifyFromPointer(reinterpret_cast<const uint8_t*>(s.c_str()),
-                             s.size() + 1);
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(s.c_str());
+    // First make sure the terminator byte is in-buffer, then check it is 0.
+    // Mirrors the non-flex VerifyString() in verifier.h.
+    return VerifyFromPointer(p, s.size() + 1) && p[s.size()] == 0;
   }
 
   bool VerifyRef(Reference r) {

--- a/tests/flexbuffers_test.cpp
+++ b/tests/flexbuffers_test.cpp
@@ -314,5 +314,37 @@ void ParseFlexbuffersFromJsonWithNullTest() {
   }
 }
 
+// Regression: VerifyBuffer must reject an FBT_STRING whose terminator byte
+// is non-zero. Before VerifyTerminator() was hardened to check the
+// terminator's *content* (not just its in-buffer position), this passed
+// verification and a downstream strlen() on c_str() read OOB.
+//
+// Layout (1-byte width throughout, total 10 bytes):
+//   [0] 0x05               size prefix = 5
+//   [1..5] 'h','e','l','l','o'   string bytes
+//   [6] 'X'                terminator slot — INTENTIONALLY non-zero
+//   [7] 0x06               root offset: (7) - 6 = byte [1], string data start
+//   [8] (FBT_STRING<<2)|0  packed_type = FBT_STRING with BIT_WIDTH_8
+//   [9] 0x01               root byte_width
+void FlexBuffersVerifyStringTerminatorTest() {
+  const uint8_t buf[] = {
+      0x05,
+      'h', 'e', 'l', 'l', 'o',
+      'X',                                // non-zero terminator
+      0x06,
+      static_cast<uint8_t>((flexbuffers::FBT_STRING << 2) |
+                           flexbuffers::BIT_WIDTH_8),
+      0x01,
+  };
+  // Sanity: the buffer parses to an FBT_STRING root of length 5.
+  auto root = flexbuffers::GetRoot(buf, sizeof(buf));
+  TEST_EQ(root.IsString(), true);
+  TEST_EQ(root.AsString().size(), 5);
+  // Verifier must reject the buffer because byte [6] is not 0x00.
+  TEST_EQ(flexbuffers::VerifyBuffer(buf, sizeof(buf), nullptr), false);
+  std::vector<uint8_t> reuse_tracker;
+  TEST_EQ(flexbuffers::VerifyBuffer(buf, sizeof(buf), &reuse_tracker), false);
+}
+
 }  // namespace tests
 }  // namespace flatbuffers


### PR DESCRIPTION
**Fixes #9085**
Sibling fix to #9072 ("Fix logic inversion in FlexBuffers VerifyKey()", commit `a6979fe`).

### Summary

`flexbuffers::Verifier::VerifyTerminator()` is intended to verify that an `FBT_STRING` value has a valid null terminator at offset `size`, but the current implementation only verifies that the byte at that offset lies inside the buffer; it does not check that the byte equals `0x00`.

```cpp
// include/flatbuffers/flexbuffers.h, current code:
bool VerifyTerminator(const String& s) {
  return VerifyFromPointer(reinterpret_cast<const uint8_t*>(s.c_str()),
                           s.size() + 1);
}
```

`VerifyFromPointer(p, size + 1)` only confirms that the range `[p, p + size + 1)` lies within `buf_`. The terminator byte's *value* is never read.

As a result, `VerifyBuffer()` accepts FlexBuffers whose strings are not actually null-terminated. A subsequent call to `AsString().c_str()` followed by `strlen()` / `strcmp()` / any C-API call that expects a NUL-terminated string then reads past the verified region.

### Why this is the same bug class as #9072

#9072 fixed `VerifyKey()`, which had the same shape: the verifier accepted a key whose terminator was missing, and downstream `strlen()`/`strcmp()` then ran past the buffer. `VerifyTerminator()` is the FBT_STRING equivalent helper, in the same class, called from the same `VerifyRef()` switch (`case FBT_STRING:`).

Compare to the **non-flex** `VerifyString()` in `include/flatbuffers/verifier.h`, which gets it right by also checking the terminator byte's value:

```cpp
bool VerifyString(const String* const str) const {
  size_t end;
  return !str || (VerifyVectorOrString<uoffset_t>(...) &&
                  Verify(end, 1) &&
                  Check(buf_[end] == '\0'));   // <-- content check
}
```

This PR aligns the FlexBuffers verifier with the non-flex one.

### Fix

```cpp
bool VerifyTerminator(const String& s) {
  const uint8_t* p = reinterpret_cast<const uint8_t*>(s.c_str());
  // First make sure the terminator byte is in-buffer, then check it is 0.
  // Mirrors the non-flex VerifyString() in verifier.h.
  return VerifyFromPointer(p, s.size() + 1) && p[s.size()] == 0;
}
```

### Test

Adds `FlexBuffersVerifyStringTerminatorTest()` in `tests/flexbuffers_test.cpp`. The test constructs a hand-rolled flexbuffer with an `FBT_STRING` whose terminator byte is `'X'` (non-zero) and asserts `VerifyBuffer()` returns `false`. Without this PR, the same test fails (verifier returns `true`).

I also confirmed under AddressSanitizer that, on the unpatched tree, the buffer is accepted by `VerifyBuffer()` and a follow-up `strlen(root.AsString().c_str())` triggers a heap-buffer-overflow read; with this PR the buffer is rejected and the OOB read does not occur.



