### PR TITLE
[C++] Harden FlexBuffers scalar mutation verification

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -762,7 +762,8 @@ class Reference {
   }
 
   bool MutateBool(bool b) {
-    return type_ == FBT_BOOL && Mutate(data_, b, parent_width_, BIT_WIDTH_8);
+    return type_ == FBT_BOOL &&
+           Mutate(data_, static_cast<uint64_t>(b), parent_width_, BIT_WIDTH_8);
   }
 
   bool MutateUInt(uint64_t u) {
@@ -1905,6 +1906,11 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
            off <= static_cast<uint64_t>(p - buf_);
   }
 
+  bool VerifyNoOverlap(const uint8_t* p1, size_t len1, const uint8_t* p2,
+                       size_t len2) {
+    return Check(p1 + len1 <= p2 || p2 + len2 <= p1);
+  }
+
   bool VerifyAlignment(const uint8_t* p, size_t size) const {
     auto o = static_cast<size_t>(p - buf_);
     return Check((o & (size - 1)) == 0 || !check_alignment_);
@@ -2005,7 +2011,8 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
       case FBT_INDIRECT_INT:
       case FBT_INDIRECT_UINT:
       case FBT_INDIRECT_FLOAT:
-        return VerifyFromPointer(p, r.byte_width_);
+        return VerifyFromPointer(p, r.byte_width_) &&
+               VerifyNoOverlap(p, r.byte_width_, r.data_, r.parent_width_);
       case FBT_KEY:
         return VerifyKey(p);
       case FBT_MAP:

--- a/tests/flexbuffers_test.cpp
+++ b/tests/flexbuffers_test.cpp
@@ -128,6 +128,31 @@ void FlexBuffersTest() {
   TEST_EQ(vec[5].MutateBool(true), true);       // Can change a bool
   TEST_EQ(vec[5].AsBool(), true);               // Changed bool is now true
 
+  // A forced-width bool should mutate without reading beyond the source bool.
+  slb.Clear();
+  slb.ForceMinimumBitWidth(flexbuffers::BIT_WIDTH_64);
+  slb.Vector([&]() { slb.Bool(false); });
+  slb.ForceMinimumBitWidth();
+  slb.Finish();
+  TEST_EQ(flexbuffers::VerifyBuffer(slb.GetBuffer().data(),
+                                    slb.GetBuffer().size(), &reuse_tracker),
+          true);
+  auto wide_bool = flexbuffers::GetRoot(slb.GetBuffer()).AsVector()[0];
+  TEST_EQ(wide_bool.MutateBool(true), true);
+  TEST_EQ(wide_bool.AsBool(), true);
+
+  // Indirect scalars must not overlap their own offset field. Otherwise,
+  // mutating the scalar also mutates the offset used by later accesses.
+  const uint8_t self_referential_indirect_int[] = {
+      0, 0, 0, 0, 0, 0, 0, 0,  // root offset aliases the indirect value
+      flexbuffers::PackedType(flexbuffers::BIT_WIDTH_64,
+                              flexbuffers::FBT_INDIRECT_INT),
+      8};
+  TEST_EQ(flexbuffers::VerifyBuffer(self_referential_indirect_int,
+                                    sizeof(self_referential_indirect_int),
+                                    &reuse_tracker),
+          false);
+
   // Parse from JSON:
   flatbuffers::Parser parser;
   slb.Clear();


### PR DESCRIPTION
## Summary

- Reject FlexBuffers indirect scalar references whose target scalar bytes overlap the offset field that points to them.
- Make `Reference::MutateBool()` copy from a scalar source wide enough for forced-width bool storage.
- Add regression coverage for overlapping indirect scalar verification and forced-width bool mutation.

## Motivation

FlexBuffers scalar mutation assumes the resolved scalar storage is distinct from the metadata used to resolve an indirect scalar. A malformed buffer can make those byte ranges overlap, so mutating the scalar can also mutate the offset used by later accesses. Rejecting this overlap during verification keeps verified indirect scalar references stable before callers use the public mutation APIs.

The bool mutation change preserves existing behavior while avoiding a wide copy from a 1-byte `bool` object when the parent storage width is larger.

## Tests

- `env ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 LD_LIBRARY_PATH=$PWD/toolchains/apt/usr/lib/x86_64-linux-gnu toolchains/apt/usr/bin/ctest --test-dir build/flatbuffers-patch-asan --output-on-failure`
- Local ASan repro: previously accepted overlapping indirect-int buffer now fails `VerifyBuffer()`.
- Local ASan repro: forced-width bool mutation succeeds without sanitizer findings.