### PR TITLE
 build: pin actions/github-script to commit SHA in pull_request_target workflow

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Pin `actions/github-script` to full commit SHA instead of mutable `v8` tag
  in the `pr_test.yml` workflow.

  This workflow uses `pull_request_target` trigger with access to
  `secrets.TFLM_BOT_REPO_TOKEN`. Pinning to SHA ensures immutability
  and prevents supply chain attacks via tag manipulation.

  Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions