### PR TITLE
Fix FlexBuffers ArrayBufferView serialization bounds handling

### DIFF
--- a/tests/ts/JavaScriptFlexBuffersTest.js
+++ b/tests/ts/JavaScriptFlexBuffersTest.js
@@ -7,6 +7,7 @@ function main() {
   testSingleValueBuffers();
   testGoldBuffer();
   testEncode();
+  testArrayBufferViewBlobBounds();
   testIndirectAdd();
   testIndirectWithCache();
   testMapBuilder();
@@ -137,6 +138,25 @@ function testEncode() {
     115, 111, 109, 101, 116, 104, 105, 110, 103, 0, 1,  11, 1, 1,  1,
     12,  4,   6,   1,   1,   45,  4,   2,   8,   4, 36, 36, 4, 40, 1
   ]);
+}
+
+function testArrayBufferViewBlobBounds() {
+  const encoder = new TextEncoder();
+  const prefix = 'PREFIX_SECRET:';
+  const publicData = 'PUBLIC';
+  const suffix = ':SUFFIX_SECRET';
+  const backing = encoder.encode(prefix + publicData + suffix);
+  const publicOffset = prefix.length;
+  const publicLength = publicData.length;
+  const expected = encoder.encode(publicData);
+
+  function _assertView(value) {
+    const buffer = flexbuffers.encode(value).buffer;
+    assert.deepStrictEqual(flexbuffers.toObject(buffer), expected);
+  }
+
+  _assertView(backing.subarray(publicOffset, publicOffset + publicLength));
+  _assertView(new DataView(backing.buffer, publicOffset, publicLength));
 }
 
 function testDeduplicationOff() {

--- a/ts/flexbuffers/builder.ts
+++ b/ts/flexbuffers/builder.ts
@@ -110,13 +110,27 @@ export class Builder {
   }
 
   private writeBlob(arrayBuffer: ArrayBuffer) {
-    const length = arrayBuffer.byteLength;
+    this.writeBlobBytes(new Uint8Array(arrayBuffer));
+  }
+
+  private writeBlobView(arrayBufferView: ArrayBufferView) {
+    this.writeBlobBytes(
+      new Uint8Array(
+        arrayBufferView.buffer,
+        arrayBufferView.byteOffset,
+        arrayBufferView.byteLength,
+      ),
+    );
+  }
+
+  private writeBlobBytes(bytes: Uint8Array) {
+    const length = bytes.byteLength;
     const bitWidth = uwidth(length);
     const byteWidth = this.align(bitWidth);
     this.writeUInt(length, byteWidth);
     const blobOffset = this.offset;
     const newOffset = this.computeOffset(length);
-    new Uint8Array(this.buffer).set(new Uint8Array(arrayBuffer), blobOffset);
+    new Uint8Array(this.buffer).set(bytes, blobOffset);
     this.stack.push(
       this.offsetStackValue(blobOffset, ValueType.BLOB, bitWidth),
     );
@@ -524,7 +538,7 @@ export class Builder {
         this.stack.push(this.floatStackValue(value));
       }
     } else if (ArrayBuffer.isView(value)) {
-      this.writeBlob(value.buffer);
+      this.writeBlobView(value);
     } else if (typeof value === 'string' || value instanceof String) {
       this.writeString(value as string);
     } else if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary

Preserve `byteOffset` and `byteLength` when serializing `ArrayBufferView` inputs in the TypeScript FlexBuffers builder.

Previously, `ArrayBuffer.isView(value)` passed `value.buffer` directly to `writeBlob()`, which serialized the entire backing `ArrayBuffer` instead of the visible view range. That could cause `Uint8Array.subarray()`, `DataView`, and Node.js `Buffer` views to serialize adjacent bytes outside the caller-selected bounds.

## Fix

- Add `writeBlobView()` for `ArrayBufferView` inputs.
- Preserve `byteOffset` and `byteLength` when copying blob bytes.
- Keep raw `ArrayBuffer` blob behavior unchanged.
- Add regression coverage for `Uint8Array.subarray()` and `DataView` inputs.

## Tests

- `npm run compile`
- `npm run lint`
- `node JavaScriptFlexBuffersTest.js` from `tests/ts` with a temporary local workspace package link
- Targeted Node repro for `Uint8Array.subarray()` and `DataView` view bounds