### PR TITLE
Fix serialize feature in rust crate flatbuffers

### DIFF
--- a/rust/flatbuffers/src/array.rs
+++ b/rust/flatbuffers/src/array.rs
@@ -149,7 +149,7 @@ where
     T: 'a + Follow<'a>,
     <T as Follow<'a>>::Inner: serde::ser::Serialize,
 {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::ser::Serializer,
     {

--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -1228,12 +1228,14 @@ impl<T> IndexMut<ReverseIndexRange> for [T] {
 mod tests {
     use super::*;
     use core::sync::atomic::{AtomicUsize, Ordering};
+    #[cfg(feature = "std")]
     use std::alloc::{GlobalAlloc, Layout, System};
 
     static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
 
     struct CountingAllocator;
 
+    #[cfg(feature = "std")]
     unsafe impl GlobalAlloc for CountingAllocator {
         unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
             ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
@@ -1244,6 +1246,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "std")]
     #[global_allocator]
     static GLOBAL: CountingAllocator = CountingAllocator;
 

--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -337,7 +337,7 @@ where
     T: 'a + Follow<'a>,
     <T as Follow<'a>>::Inner: serde::ser::Serialize,
 {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
         S: serde::ser::Serializer,
     {


### PR DESCRIPTION
'cargo build --no-default-features --features serialize' fails due to std not being available.

Without this patch:
```
$ cargo build --no-default-features --features serialize
   Compiling flatbuffers v25.12.19 (/tmp/r/flatbuffers-25.12.19)
error[E0433]: cannot find module or crate `std` in this scope
   --> src/array.rs:152:46
    |
152 |     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
    |                                              ^^^ use of unresolved module or unlinked crate `std`
    |
    = help: if you wanted to use a crate named `std`, use `cargo add std` to add it to your `Cargo.toml`
help: consider importing this module
    |
 17 + use core::result;
    |
help: if you import `result`, refer to it directly
    |
152 -     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
152 +     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
    |

error[E0433]: cannot find module or crate `std` in this scope
   --> src/vector.rs:326:46
    |
326 |     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
    |                                              ^^^ use of unresolved module or unlinked crate `std`
    |
    = help: if you wanted to use a crate named `std`, use `cargo add std` to add it to your `Cargo.toml`
help: consider importing this module
    |
 17 + use core::result;
    |
help: if you import `result`, refer to it directly
    |
326 -     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
326 +     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
    |

For more information about this error, try `rustc --explain E0433`.
error: could not compile `flatbuffers` (lib) due to 2 previous errors
```

Also some follow-up test fixes to make sure 'cargo build --no-default-features --features serialize' works.