### PR TITLE
Guard Parser::Deserialize BFBS identifier probes

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -4421,14 +4421,24 @@ bool Definition::DeserializeAttributes(
 /* DESERIALIZATION                                                      */
 /************************************************************************/
 bool Parser::Deserialize(const uint8_t* buf, const size_t size) {
+  if (!buf) return false;
+
   flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(buf), size);
+  const size_t file_identifier_offset = sizeof(flatbuffers::uoffset_t);
+  const size_t size_prefixed_file_identifier_offset =
+      2 * sizeof(flatbuffers::uoffset_t);
+  const bool has_schema_identifier =
+      size >= file_identifier_offset + flatbuffers::kFileIdentifierLength &&
+      reflection::SchemaBufferHasIdentifier(buf);
+  const bool has_size_prefixed_schema_identifier =
+      size >= size_prefixed_file_identifier_offset +
+                  flatbuffers::kFileIdentifierLength &&
+      flatbuffers::BufferHasIdentifier(buf, reflection::SchemaIdentifier(),
+                                       true);
   bool size_prefixed = false;
-  if (!reflection::SchemaBufferHasIdentifier(buf)) {
-    if (!flatbuffers::BufferHasIdentifier(buf, reflection::SchemaIdentifier(),
-                                          true))
-      return false;
-    else
-      size_prefixed = true;
+  if (!has_schema_identifier) {
+    if (!has_size_prefixed_schema_identifier) return false;
+    size_prefixed = true;
   }
   auto verify_fn = size_prefixed
                        ? &reflection::VerifySizePrefixedSchemaBuffer<false>

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1171,6 +1171,24 @@ void TestEmbeddedBinarySchema(const std::string& tests_data_path) {
 }
 #endif
 
+void TestDeserializeRejectsShortBinarySchemaBuffers() {
+  flatbuffers::Parser null_parser;
+  TEST_EQ(false, null_parser.Deserialize(nullptr, 0));
+  TEST_EQ(false,
+          null_parser.Deserialize(
+              nullptr, sizeof(flatbuffers::uoffset_t) +
+                           flatbuffers::kFileIdentifierLength));
+
+  const size_t size_prefixed_identifier_size =
+      2 * sizeof(flatbuffers::uoffset_t) + flatbuffers::kFileIdentifierLength;
+  for (size_t size = 1; size < size_prefixed_identifier_size; size++) {
+    std::string buf(size, 'x');
+    flatbuffers::Parser parser;
+    TEST_EQ(false, parser.Deserialize(
+                       reinterpret_cast<const uint8_t*>(buf.data()), size));
+  }
+}
+
 template <typename T>
 void EmbeddedSchemaAccessByType() {
   // Get the binary schema from the Type itself.
@@ -1765,6 +1783,7 @@ int FlatBufferTests(const std::string& tests_data_path) {
   MiniReflectFixedLengthArrayTest();
 
   SizePrefixedTest();
+  TestDeserializeRejectsShortBinarySchemaBuffers();
 
   AlignmentTest();
 


### PR DESCRIPTION
Fixes #9023.

`Parser::Deserialize(const uint8_t*, size_t)` probes the BFBS file identifier before running schema verification. The identifier helpers expect normal identifier bytes at offset 4, or size-prefixed identifier bytes at offset 8, so very short caller-owned buffers need to be rejected before those probes run.

This change adds explicit null and minimum-size checks before calling the normal or size-prefixed identifier helpers. Inputs that cannot contain either identifier now return `false` before any identifier comparison.

I also added a regression test for null buffers and short buffers below the size-prefixed identifier boundary.

Before the fix, a standalone ASan/UBSan reproducer against the parent commit aborts for a 1-byte buffer with a heap-buffer-overflow in `flatbuffers::BufferHasIdentifier()`, reached through `reflection::SchemaBufferHasIdentifier()` and `Parser::Deserialize()`. With this patch, the same reproducer returns `deserialize=false` for sizes `0..11`.

Tested with:

```bash
cmake -S . -B build-asan -G Ninja \
  -DFLATBUFFERS_CODE_SANITIZE=address,undefined \
  -DFLATBUFFERS_BUILD_TESTS=ON \
  -DFLATBUFFERS_BUILD_FLATC=ON \
  -DFLATBUFFERS_BUILD_FLATLIB=ON \
  -DFLATBUFFERS_BUILD_SHAREDLIB=OFF \
  -DFLATBUFFERS_BUILD_BENCHMARKS=OFF \
  -DFLATBUFFERS_BUILD_GRPCTEST=OFF \
  -DFLATBUFFERS_BUILD_CPP17=OFF
cmake --build build-asan --target flattests -j2
ASAN_OPTIONS=detect_leaks=0:halt_on_error=1:abort_on_error=1 \
UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1 \
  ./build-asan/flattests
```

Result:

```text
ALL TESTS PASSED
```
