### PR TITLE
Update benchmark code location docs

### DIFF
--- a/docs/source/benchmarks.md
+++ b/docs/source/benchmarks.md
@@ -55,9 +55,13 @@ meant to be representative of game data, e.g. a scene format.
 
 ### Code for benchmarks
 
-Code for these benchmarks sits in `benchmarks/` in git branch `benchmarks`.
-It sits in its own branch because it has submodule dependencies that the main
-project doesn't need, and the code standards do not meet those of the main
-project. Please read `benchmarks/cpp/README.txt` before working with the code.
+The benchmark code currently tracked in this repository lives under
+`benchmarks/` on the `master` branch. The checked-in C++ benchmark covers
+FlatBuffers and raw structs, with dependencies configured from
+`benchmarks/CMakeLists.txt`.
+
+The comparison table above is historical. The old standalone benchmark branch
+is no longer available, and the current tree does not contain every third-party
+comparison harness used for those results.
 
 <br>


### PR DESCRIPTION
## What

Updates the benchmark documentation to point at the current `benchmarks/` directory on `master` instead of the old standalone benchmark branch. The old branch and the referenced `benchmarks/cpp/README.txt` file are no longer present, so this also notes that the comparison table is historical and that not every third-party comparison harness is in the current tree.

Fixes #8893.

## Testing

- `git diff --check -- docs/source/benchmarks.md`
- `mkdocs build -f docs/mkdocs.yml --strict` in a temporary venv
