### PR TITLE
fix: add bounds checking before GetFieldT in reflection VerifyObject

### DIFF
--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -240,6 +240,14 @@ static bool VerifyObject(flatbuffers::Verifier& v,
             return false;
           }
         } else {
+          // Verify the field offset points within the buffer before
+          // dereferencing it via GetFieldT. Without this check, a malformed
+          // table with an out-of-bounds field offset causes GetFieldT to
+          // compute a pointer outside the buffer, leading to a heap-buffer-
+          // overflow in ReadScalar. See github.com/google/flatbuffers/issues/9040
+          if (!table->VerifyField<uoffset_t>(v, field_def->offset(),
+                                             sizeof(uoffset_t)))
+            return false;
           if (!VerifyObject(v, schema, *child_obj,
                             flatbuffers::GetFieldT(*table, *field_def),
                             field_def->required())) {
@@ -252,6 +260,11 @@ static bool VerifyObject(flatbuffers::Verifier& v,
         //  get union type from the prev field
         voffset_t utype_offset = field_def->offset() - sizeof(voffset_t);
         auto utype = table->GetField<uint8_t>(utype_offset, 0);
+        // Verify the field offset before dereferencing via GetFieldT.
+        // See github.com/google/flatbuffers/issues/9040
+        if (!table->VerifyField<uoffset_t>(v, field_def->offset(),
+                                           sizeof(uoffset_t)))
+          return false;
         auto uval = reinterpret_cast<const uint8_t*>(
             flatbuffers::GetFieldT(*table, *field_def));
         if (!VerifyUnion(v, schema, utype, uval, *field_def)) {


### PR DESCRIPTION
Fixes #9040

## Summary

Heap buffer overflow in `flatbuffers::Verify()` via the reflection verification path. The `VerifyObject` function calls `GetFieldT()` for `Obj` and `Union` field types without first verifying that the field offset points within the buffer. A malformed table with out-of-bounds field offsets causes `GetFieldT` -> `Table::GetPointer` -> `ReadScalar<uoffset_t>` to read past the allocated buffer boundary.

## Root Cause

`VerifyObject` in `reflection.cpp` verifies scalar fields (Bool, Byte, Int, etc.) with `table->VerifyField<T>()` before accessing them, but the `Obj` (line 243) and `Union` (line 255) cases call `GetFieldT()` directly, skipping the bounds check:

```cpp
// BEFORE: No bounds check before GetFieldT
case reflection::Obj: {
    // ...
    if (!VerifyObject(v, schema, *child_obj,
                      flatbuffers::GetFieldT(*table, *field_def),  // OOB read here
                      field_def->required())) {
```

`GetFieldT` does `table.GetPointer<Table*>(field.offset())`, which reads a `uoffset_t` from the table buffer. If the vtable entry points past the end of the buffer, this is an out-of-bounds read.

## Fix

Added `VerifyField<uoffset_t>` calls before each `GetFieldT` call in `VerifyObject`, matching the pattern already used for String fields (line 226):

```cpp
// AFTER: Bounds check before GetFieldT
case reflection::Obj: {
    // ...
    if (!table->VerifyField<uoffset_t>(v, field_def->offset(),
                                       sizeof(uoffset_t)))
      return false;
    if (!VerifyObject(v, schema, *child_obj,
                      flatbuffers::GetFieldT(*table, *field_def),  // Now safe
                      field_def->required())) {
```

## Impact

| Aspect | Details |
|--------|---------|
| Type | Heap-buffer-overflow (CWE-125: Out-of-bounds Read) |
| Severity | High |
| Attack Vector | Malformed FlatBuffers reflection schemas |
| Affected Component | `src/reflection.cpp` VerifyObject |
| Affected Functions | `Verify()`, `VerifySizePrefixed()` |

## ASAN Trace (from #9040)

```
READ of size 4 at 0x511000000448 thread T0
    #0 flatbuffers::ReadScalar<unsigned int>(void const*)
    #1 flatbuffers::Table::GetPointer<flatbuffers::Table*>(unsigned short) const
    #4 flatbuffers::Verify(...) reflection.cpp:790
0x511000000448 is located 789 bytes after 243-byte region [0x511000000040,0x511000000133)
SUMMARY: AddressSanitizer: heap-buffer-overflow
```
