### PR TITLE
fix: add buffer verification in GenTextFile to prevent OOB heap reads

### DIFF
--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -447,6 +447,25 @@ const char* GenTextFile(const Parser& parser, const std::string& path,
                : "SaveFile failed";
   }
   if (!parser.builder_.GetSize() || !parser.root_struct_def_) return nullptr;
+  // Verify buffer integrity before text generation to prevent OOB reads
+  // from corrupted vector lengths or field offsets (see #9051).
+  {
+    flatbuffers::Verifier verifier(parser.builder_.GetBufferPointer(),
+                                   parser.builder_.GetSize());
+    if (!parser.root_struct_def_->fixed
+            ? !verifier.VerifyBuffer<flatbuffers::Table>(
+                  parser.file_identifier_.length()
+                      ? parser.file_identifier_.c_str()
+                      : nullptr)
+            : !verifier.VerifyBufferFromStart<flatbuffers::Table>(
+                  parser.file_identifier_.length()
+                      ? parser.file_identifier_.c_str()
+                      : nullptr,
+                  parser.builder_.GetSize())) {
+      return "buffer failed verification, refusing to generate JSON from "
+             "potentially corrupt data";
+    }
+  }
   std::string text;
   auto err = GenText(parser, parser.builder_.GetBufferPointer(), &text);
   if (err) return err;


### PR DESCRIPTION
Fixes #9051

## Summary

`GenTextFile()` passes the internal buffer to `GenText()` without running the `Verifier` first. When a binary FlatBuffer has a corrupted vector length field, `GenText()` iterates past the buffer boundary, causing **heap-buffer-overflow reads** in release builds (where `FLATBUFFERS_ASSERT` is stripped).

This is exploitable: `flatc --json schema.fbs -- corrupt.bin` silently reads and outputs heap memory as JSON array elements, constituting **information disclosure** (CWE-125).

## Root Cause

`Vector::Get()` uses `FLATBUFFERS_ASSERT` for bounds checking, which is a no-op in release builds. The `GenText()` path trusts the vector length from the buffer without verification, unlike the FlexBuffers path which calls `VerifyBuffer()` in `flatc.cpp`.

## Fix

Add `Verifier` check in `GenTextFile()` before calling `GenText()`. This is consistent with how the FlexBuffers path already verifies buffers before `ToString()`. The verifier rejects corrupt buffers with an error message rather than silently reading OOB memory.

## Testing

The fix can be verified with the PoC from #9051:
1. Create a valid binary with `flatc -b schema.fbs valid.json`
2. Corrupt the vector length field
3. `flatc --json schema.fbs -- corrupt.bin` now returns an error instead of leaking heap contents