### PR TITLE
`flatc --annotate`: don't crash on a `.bfbs` with no `root_table`

### DIFF
--- a/src/binary_annotator.cpp
+++ b/src/binary_annotator.cpp
@@ -131,6 +131,16 @@ std::map<uint64_t, BinarySection> BinaryAnnotator::Annotate() {
     }
   }
 
+  // The bfbs schema's `root_table` field is optional (see
+  // reflection/reflection.fbs Schema.root_table) and `RootTable()` may also
+  // return null when an explicit root-table-name override is set but the
+  // named table is not present in `schema_->objects()`. Without a root
+  // table we cannot meaningfully annotate the binary, so bail gracefully
+  // instead of dereferencing a null pointer in BuildHeader / BuildTable
+  // below. Mirrors the fix applied to bfbs_gen_lua.cpp in #8770.
+  const reflection::Object* const root = RootTable();
+  if (root == nullptr || root->name() == nullptr) { return {}; }
+
   // The binary is too short to read as a flatbuffers.
   if (binary_length_ < FLATBUFFERS_MIN_BUFFER_SIZE) {
     return {};


### PR DESCRIPTION
# `flatc --annotate`: don't crash on a `.bfbs` with no `root_table`

## Summary

`BinaryAnnotator::Annotate()` unconditionally dereferences `RootTable()`
in two places (`src/binary_annotator.cpp:149` and `:210`), but
`reflection::Schema.root_table` is an *optional* field per
[`reflection/reflection.fbs`](../../reflection/reflection.fbs) and the
schema verifier does not enforce its presence. A valid `.bfbs`
compiled from a `.fbs` with no `root_type` directive therefore makes
`flatc --annotate <schema.bfbs> <binary>` crash with a `SIGSEGV` (null
read inside `BuildHeader`).

This PR adds a single defensive early-return at the top of
`Annotate()` — mirroring the existing fix for `bfbs_gen_lua.cpp` in
#8770 — that bails gracefully (returns an empty sections map) when the
schema does not declare a root table or when the
`--root-type`-style override names a table that is not present in
`schema_->objects()`.

## Reproducer (before this PR, on `master @ 1f438bd4`)

```bash
cmake -B build -DCMAKE_BUILD_TYPE=Debug \
      -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined'
cmake --build build --target flatc -j

echo 'namespace x; table T { v:int; }' > empty_root.fbs
./build/flatc -b --schema empty_root.fbs        # produces empty_root.bfbs
printf '\x04\x00\x00\x00ABCDEFGH' > bin.dat
./build/flatc --annotate empty_root.bfbs bin.dat
```

ASAN output (pre-patch):

```
==XXXX==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000
    #0 ... flatbuffers::BinaryAnnotator::BuildHeader
       (src/binary_annotator.cpp:210)
    #1 ... flatbuffers::BinaryAnnotator::Annotate
       (src/binary_annotator.cpp:145)
    #2 ... AnnotateBinaries (src/flatc.cpp:1070)
```

After this PR: `flatc --annotate` exits cleanly with no output (no
annotations possible) and exit code 0.

## Why the verifier does not already catch this

`reflection/reflection.fbs` declares
`root_table:Object;` — without a `(required)` attribute — so
`reflection::VerifySchemaBuffer()` rightly accepts schemas that omit
it. The bug lives in the annotator's implicit assumption that the
field is always present.

## Why a single `Annotate()`-level guard is enough

`Annotate()` is the only public entry point on `BinaryAnnotator`.
Returning early there protects every downstream dereference of
`RootTable()` in this code path:

| Site                                  | Now protected by upstream guard |
|---------------------------------------|---------------------------------|
| `binary_annotator.cpp:149`            | `BuildTable(..., RootTable())`  |
| `binary_annotator.cpp:210`            | `RootTable()->name()->str()`    |

## Related work

- #8770 (`ac8b1244`) — applied the equivalent guard to
  `bfbs_gen_lua.cpp` for the same root-table-may-be-null hazard in the
  Lua bfbs generator. This PR closes the parity gap in the binary
  annotator.

## Test impact

- Existing tests (`make test`) continue to pass.
- The existing OSS-Fuzz harness
  `tests/fuzzer/flatbuffers_annotator_fuzzer.cc` hard-codes a schema
  with a `root_table` and is unaffected. (It also did not exercise
  this code path before this PR; a follow-up harness that also fuzzes
  the schema would be valuable but is out of scope here.)

## Files

- `src/binary_annotator.cpp` — `+10 / -0`

## Compatibility / behavior change

The only behavior change is: `flatc --annotate` on a `.bfbs` with no
`root_table` now exits cleanly with no annotation output instead of
crashing. No public API change.
