### PR TITLE
fix: assert on null enumval in GetUnionType to prevent null dereference

### DIFF
--- a/include/flatbuffers/reflection.h
+++ b/include/flatbuffers/reflection.h
@@ -443,9 +443,15 @@ inline const reflection::Object& GetUnionType(
   auto enumval = enumdef->values()->LookupByKey(union_type);
   // enumval is null when the data contains a union type value that is not
   // present in the schema (e.g. data produced by a newer schema version).
-  // Dereferencing a null pointer here would be undefined behaviour and
-  // typically a crash, so assert explicitly instead.
+  // Generated VerifyAny functions use `default: return true` for
+  // forward-compatibility, so such data passes Verify() without error.
+  // A null dereference here is undefined behaviour and typically a crash.
+  //
+  // FLATBUFFERS_ASSERT fires in debug builds (NDEBUG not defined).  The
+  // explicit abort() below ensures the process terminates predictably in
+  // release builds too, rather than silently corrupting memory.
   FLATBUFFERS_ASSERT(enumval != nullptr);
+  if (!enumval) { std::abort(); }
   return *schema.objects()->Get(enumval->union_type()->index());
 }
 

--- a/include/flatbuffers/reflection.h
+++ b/include/flatbuffers/reflection.h
@@ -425,6 +425,12 @@ pointer_inside_vector<T, U> piv(T* ptr, std::vector<U>& vec) {
 constexpr const char* UnionTypeFieldSuffix() { return "_type"; }
 
 // Helper to figure out the actual table type a union refers to.
+// Precondition: `table` must have been verified and the union type field must
+// correspond to a known enum value in the schema.  Generated verifiers use
+// `default: return true` for forward-compatibility, so they pass unknown union
+// type values — callers must validate that the union type is known before
+// calling this function, or the LookupByKey call below will return nullptr and
+// cause undefined behaviour.
 inline const reflection::Object& GetUnionType(
     const reflection::Schema& schema, const reflection::Object& parent,
     const reflection::Field& unionfield, const Table& table) {
@@ -435,6 +441,11 @@ inline const reflection::Object& GetUnionType(
   FLATBUFFERS_ASSERT(type_field);
   auto union_type = GetFieldI<uint8_t>(table, *type_field);
   auto enumval = enumdef->values()->LookupByKey(union_type);
+  // enumval is null when the data contains a union type value that is not
+  // present in the schema (e.g. data produced by a newer schema version).
+  // Dereferencing a null pointer here would be undefined behaviour and
+  // typically a crash, so assert explicitly instead.
+  FLATBUFFERS_ASSERT(enumval != nullptr);
   return *schema.objects()->Get(enumval->union_type()->index());
 }
 


### PR DESCRIPTION
## Problem

`GetUnionType` (in `include/flatbuffers/reflection.h`) reads a union type
byte from user-supplied table data and looks it up in the schema enum with
`LookupByKey`.  `LookupByKey` returns `nullptr` when the byte value has no
matching enum entry — which can happen legitimately with data produced by a
*newer* schema version that added union variants unknown to the older reader.

Generated `VerifyAny` functions use `default: return true` for
forward-compatibility, so such data passes `Verify()` without error.  A
subsequent call to `GetUnionType` then reaches:

```cpp
auto enumval = enumdef->values()->LookupByKey(union_type);  // returns nullptr
return *schema.objects()->Get(enumval->union_type()->index());  // null deref
```

Dereferencing `enumval` when it is `nullptr` is undefined behaviour.  In
practice this produces a crash whenever the reflection API is used on data
containing a union type value not present in the reader's schema.

## Fix

Add `FLATBUFFERS_ASSERT(enumval != nullptr)` before the dereference so the
failure is caught with a clear assertion rather than manifesting as a
hard-to-diagnose crash or silent memory corruption.

Also document the precondition on the function comment so callers are aware
they must either reject unknown union types themselves before calling
`GetUnionType`, or ensure through another mechanism that the union type is
always a known value.

## Affected paths

- Applications that use the reflection API (`ResizeTable`, generic
  FlatBuffer manipulation tools) and process data that may have been
  serialised with a schema newer than the one the reader was compiled
  against.