### PR TITLE
Reject out-of-range reflection Type.index values during verification

### DIFF
--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -24,6 +24,32 @@ namespace flatbuffers {
 
 namespace {
 
+// Safely look up a reflection::Object by its index in the schema. Returns
+// nullptr if the schema has no objects vector, the index is negative (the
+// default for a missing reflection::Type::index field is -1), or the index
+// is past the end of the objects vector. Matches the defensive pattern
+// already used by GetObjectByIndex in src/bfbs_gen.h.
+static inline const reflection::Object* GetObjectByIndex(
+    const reflection::Schema& schema, int32_t index) {
+  if (!schema.objects() || index < 0 ||
+      index >= static_cast<int32_t>(schema.objects()->size())) {
+    return nullptr;
+  }
+  return schema.objects()->Get(static_cast<uoffset_t>(index));
+}
+
+// Safely look up a reflection::Enum by its index in the schema. Returns
+// nullptr if the schema has no enums vector, the index is negative, or the
+// index is past the end of the enums vector.
+static inline const reflection::Enum* GetEnumByIndex(
+    const reflection::Schema& schema, int32_t index) {
+  if (!schema.enums() || index < 0 ||
+      index >= static_cast<int32_t>(schema.enums()->size())) {
+    return nullptr;
+  }
+  return schema.enums()->Get(static_cast<uoffset_t>(index));
+}
+
 static void CopyInline(FlatBufferBuilder& fbb,
                        const reflection::Field& fielddef, const Table& table,
                        size_t align, size_t size) {
@@ -70,12 +96,14 @@ static bool VerifyUnion(flatbuffers::Verifier& v,
                         const uint8_t* elem,
                         const reflection::Field& union_field) {
   if (!utype) return true;  // Not present.
-  auto fb_enum = schema.enums()->Get(union_field.type()->index());
+  auto fb_enum = GetEnumByIndex(schema, union_field.type()->index());
+  if (!fb_enum) return false;
   if (utype >= fb_enum->values()->size()) return false;
   auto elem_type = fb_enum->values()->Get(utype)->union_type();
   switch (elem_type->base_type()) {
     case reflection::Obj: {
-      auto elem_obj = schema.objects()->Get(elem_type->index());
+      auto elem_obj = GetObjectByIndex(schema, elem_type->index());
+      if (!elem_obj) return false;
       if (elem_obj->is_struct()) {
         return v.VerifyFromPointer(elem, elem_obj->bytesize());
       } else {
@@ -130,7 +158,8 @@ static bool VerifyVector(flatbuffers::Verifier& v,
       }
     }
     case reflection::Obj: {
-      auto obj = schema.objects()->Get(vec_field.type()->index());
+      auto obj = GetObjectByIndex(schema, vec_field.type()->index());
+      if (!obj) return false;
       if (obj->is_struct()) {
         return VerifyVectorOfStructs(v, table, vec_field.offset(), *obj,
                                      vec_field.required());
@@ -233,7 +262,8 @@ static bool VerifyObject(flatbuffers::Verifier& v,
         if (!VerifyVector(v, schema, *table, *field_def)) return false;
         break;
       case reflection::Obj: {
-        auto child_obj = schema.objects()->Get(field_def->type()->index());
+        auto child_obj = GetObjectByIndex(schema, field_def->type()->index());
+        if (!child_obj) return false;
         if (child_obj->is_struct()) {
           if (!VerifyStruct(v, *table, field_def->offset(), *child_obj,
                             field_def->required())) {

--- a/tests/reflection_test.cpp
+++ b/tests/reflection_test.cpp
@@ -335,6 +335,93 @@ void ForAllFieldsReverseTest(const std::string& tests_data_path) {
   }
 }
 
+// Regression test: a reflection::Type whose `index` scalar points past the
+// end of the schema's objects vector must cause flatbuffers::Verify to
+// return false cleanly, not read out of bounds.
+void ReflectionTypeIndexBoundsTest(const std::string& tests_data_path) {
+  // Load the binary schema into a mutable byte buffer so we can mutate a
+  // single scalar in place.
+  std::string bfbs_str;
+  TEST_EQ(flatbuffers::LoadFile((tests_data_path + "monster_test.bfbs").c_str(),
+                                true, &bfbs_str),
+          true);
+  std::vector<uint8_t> bfbs_buffer(bfbs_str.begin(), bfbs_str.end());
+
+  // The original BFBS must verify.
+  {
+    flatbuffers::Verifier schema_verifier(bfbs_buffer.data(),
+                                          bfbs_buffer.size());
+    TEST_EQ(reflection::VerifySchemaBuffer(schema_verifier), true);
+  }
+
+  auto& schema = *reflection::GetSchema(bfbs_buffer.data());
+
+  // Load the Monster data buffer.
+  std::string data_str;
+  TEST_EQ(flatbuffers::LoadFile(
+              (tests_data_path + "monsterdata_test.mon").c_str(), true,
+              &data_str),
+          true);
+  std::vector<uint8_t> data_buffer(data_str.begin(), data_str.end());
+
+  // Original schema + original data must verify.
+  TEST_EQ(flatbuffers::Verify(schema, *schema.root_table(), data_buffer.data(),
+                              data_buffer.size()),
+          true);
+
+  // Locate Monster.pos, which is an Obj-typed field referencing Vec3 via
+  // type()->index().
+  auto monster_object =
+      schema.objects()->LookupByKey("MyGame.Example.Monster");
+  TEST_NOTNULL(monster_object);
+  auto pos_field = monster_object->fields()->LookupByKey("pos");
+  TEST_NOTNULL(pos_field);
+  TEST_EQ(pos_field->type()->base_type(), reflection::Obj);
+
+  const int32_t original_index = pos_field->type()->index();
+  TEST_ASSERT(original_index >= 0);
+  TEST_ASSERT(original_index <
+              static_cast<int32_t>(schema.objects()->size()));
+
+  // Find the in-place address of reflection::Type::VT_INDEX inside the
+  // mutable BFBS buffer. reflection::Type does not expose a generated mutator
+  // for index(), so use the underlying Table slot address for this test-only
+  // scalar mutation.
+  auto* type_ptr = pos_field->type();
+  auto* type_table = reinterpret_cast<flatbuffers::Table*>(
+      const_cast<reflection::Type*>(type_ptr));
+  uint8_t* idx_addr = type_table->GetAddressOf(reflection::Type::VT_INDEX);
+  TEST_NOTNULL(idx_addr);
+
+  // Mutate the index to a clearly out-of-range value. The mutation touches
+  // exactly 4 bytes and does not change any offsets.
+  const int32_t bad_index =
+      static_cast<int32_t>(schema.objects()->size() + 100);
+  flatbuffers::WriteScalar<int32_t>(idx_addr, bad_index);
+  TEST_EQ(pos_field->type()->index(), bad_index);
+
+  // The mutated BFBS is still a structurally valid FlatBuffer; only the
+  // referential semantics are broken.
+  {
+    flatbuffers::Verifier schema_verifier(bfbs_buffer.data(),
+                                          bfbs_buffer.size());
+    TEST_EQ(reflection::VerifySchemaBuffer(schema_verifier), true);
+  }
+
+  // The reflection-based data verifier must reject this cleanly rather than
+  // performing an out-of-bounds read on schema.objects().
+  TEST_EQ(flatbuffers::Verify(schema, *schema.root_table(), data_buffer.data(),
+                              data_buffer.size()),
+          false);
+
+  // Restoring the original index must make Verify pass again.
+  flatbuffers::WriteScalar<int32_t>(idx_addr, original_index);
+  TEST_EQ(pos_field->type()->index(), original_index);
+  TEST_EQ(flatbuffers::Verify(schema, *schema.root_table(), data_buffer.data(),
+                              data_buffer.size()),
+          true);
+}
+
 void MiniReflectFlatBuffersTest(uint8_t* flatbuf) {
   auto s =
       flatbuffers::FlatBufferToString(flatbuf, Monster::MiniReflectTypeTable());

--- a/tests/reflection_test.h
+++ b/tests/reflection_test.h
@@ -11,6 +11,7 @@ namespace tests {
 void ReflectionTest(const std::string& tests_data_path, uint8_t* flatbuf,
                     size_t length);
 void ForAllFieldsReverseTest(const std::string& tests_data_path);
+void ReflectionTypeIndexBoundsTest(const std::string& tests_data_path);
 void MiniReflectFixedLengthArrayTest();
 void MiniReflectFlatBuffersTest(uint8_t* flatbuf);
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1775,6 +1775,7 @@ int FlatBufferTests(const std::string& tests_data_path) {
   FixedLengthArrayJsonTest(tests_data_path, true);
   ReflectionTest(tests_data_path, flatbuf.data(), flatbuf.size());
   ForAllFieldsReverseTest(tests_data_path);
+  ReflectionTypeIndexBoundsTest(tests_data_path);
   ParseProtoTest(tests_data_path);
   EvolutionTest(tests_data_path);
   UnionDeprecationTest(tests_data_path);


### PR DESCRIPTION
# Reject out-of-range reflection Type.index values during verification

## Summary

`flatbuffers::Verify(const reflection::Schema& schema, const reflection::Object& root_table, const uint8_t* buf, size_t len, ...)` uses `reflection::Type::index()` to look up the referenced `reflection::Object` or `reflection::Enum` from `schema.objects()` / `schema.enums()`. Four verifier-reachable call sites in `src/reflection.cpp` perform this lookup without bounds-checking the index:

- `VerifyUnion`: `schema.enums()->Get(union_field.type()->index())`
- `VerifyUnion`: `schema.objects()->Get(elem_type->index())` (union element)
- `VerifyVector`: `schema.objects()->Get(vec_field.type()->index())`
- `VerifyObject`: `schema.objects()->Get(field_def->type()->index())`

`flatbuffers::Vector::Get(uoffset_t i)` does not bounds-check `i`, and `reflection::Type::index()` returns a signed `int32_t` with a default of `-1` when the field is absent. A schema buffer can be structurally well-formed and pass `reflection::VerifySchemaBuffer(...)` while still carrying semantically out-of-range `Type.index` values. When such a schema is then passed to the data verifier, the unchecked lookup reads past the end of the objects/enums vector and the subsequent dereference (e.g. `child_obj->is_struct()`) walks off mapped memory.

This PR adds two `static inline` helpers in the anonymous namespace of `src/reflection.cpp`:

```cpp
static inline const reflection::Object* GetObjectByIndex(
    const reflection::Schema& schema, int32_t index);
static inline const reflection::Enum* GetEnumByIndex(
    const reflection::Schema& schema, int32_t index);
```

Each helper returns `nullptr` if the corresponding vector is null, the index is negative, or the index is past the end of the vector. The four verifier-reachable sites are rerouted through these helpers and return `false` cleanly on `nullptr`. The defensive style mirrors the existing `GetObjectByIndex` / `GetEnumByIndex` helpers in `src/bfbs_gen.h` (lines 169–188).

There are no public API or public header changes. The helpers are file-local; no symbol is exported.

## Test

Added `ReflectionTypeIndexBoundsTest` in `tests/reflection_test.cpp` (prototype in `tests/reflection_test.h`, registered alongside `ReflectionTest` and `ForAllFieldsReverseTest` in `tests/test.cpp`).

The test:

1. Loads the existing fixture `tests/monster_test.bfbs` into a mutable byte buffer and asserts `reflection::VerifySchemaBuffer(...)` accepts it.
2. Loads the existing fixture `tests/monsterdata_test.mon` and asserts `flatbuffers::Verify(schema, *schema.root_table(), data, size)` returns `true` for the unmodified pair.
3. Locates `MyGame.Example.Monster` and its `pos` field (confirmed `reflection::Obj`).
4. Mutates only the `reflection::Type::VT_INDEX` scalar of the `pos` field in place to `static_cast<int32_t>(schema.objects()->size() + 100)` via `Table::GetAddressOf(VT_INDEX)` + `flatbuffers::WriteScalar<int32_t>` — exactly 4 bytes, no offset rewriting.
5. Asserts the mutated BFBS still passes `reflection::VerifySchemaBuffer(...)` (structurally valid).
6. Asserts `flatbuffers::Verify(...)` now returns `false` with the patch applied.
7. Restores the original index and asserts `flatbuffers::Verify(...)` returns `true` again, demonstrating the rejection is precise to the malformed input.

No new test fixtures are added; only the existing `monster_test.bfbs` and `monsterdata_test.mon` are reused.

**Negative control.** Keeping the regression test in place but reverting `src/reflection.cpp` to its pre-patch state causes `flattests` to terminate with `SIGSEGV` (process exit code 139, `ctest` reports `***Exception: SegFault`). Restoring `src/reflection.cpp` to its patched state causes the full suite, including `ReflectionTypeIndexBoundsTest`, to pass cleanly.

## Validation

```
cmake --build build_clean -j2
ctest --test-dir build_clean --output-on-failure
git diff --check
```

Observed results:

- `flattests` passed 1/1 (`100% tests passed, 0 tests failed out of 1`, total time ~0.18s).
- `git diff --check` returned clean (exit 0, no whitespace or merge-marker errors).
- Diffstat (4 files only, no build outputs): +123 / −4.

  ```
  src/reflection.cpp        | 38 +++++++++-
  tests/reflection_test.cpp | 87 ++++++++++++++++++++++
  tests/reflection_test.h   |  1 +
  tests/test.cpp            |  1 +
  4 files changed, 123 insertions(+), 4 deletions(-)
  ```

## Scope

This PR is intentionally narrow:

- **In scope.** The four verifier-reachable `Type.index()` lookups in `VerifyUnion`, `VerifyVector`, and `VerifyObject`. These are the only sites reachable through the public `flatbuffers::Verify(schema, root_table, buf, len, ...)` entry point.
- **Out of scope.** Other unchecked `Type.index()` uses in `CopyTable`, `GetAnyValueS`, `ResizeContext::ResizeTable`, and `GetUnionType`. Those paths have different threat models (they operate on inputs already trusted to match the schema and are not part of the verifier surface) and changing them would require API-level consideration. They can be addressed in a follow-up if maintainers prefer.
- **Behavior on valid schemas is unchanged.** For any `Type.index` that is non-negative and within the corresponding vector, the helpers degenerate to `vector->Get(index)` — identical to the prior code. The full pre-existing test suite continues to pass.
