### PR TITLE
Fix vtable offset overflow when table contains >= 32,766 fields

### DIFF
--- a/goldens/py/flatbuffers/goldens/Universe.py
+++ b/goldens/py/flatbuffers/goldens/Universe.py
@@ -84,7 +84,7 @@ def UniverseCreateGalaxiesVector(builder, data):
     return builder.CreateVectorOfTables(data)
 
 def CreateGalaxiesVector(builder, data):
-    UniverseCreateGalaxiesVector(builder, data)
+    return UniverseCreateGalaxiesVector(builder, data)
 
 def UniverseEnd(builder):
     return builder.EndObject()

--- a/goldens/swift/basic_generated.swift
+++ b/goldens/swift/basic_generated.swift
@@ -8,7 +8,7 @@ import Common
 
 import FlatBuffers
 
-public struct flatbuffers_goldens_Galaxy: FlatBufferTable, FlatbuffersVectorInitializable, Verifiable {
+public struct flatbuffers_goldens_Galaxy: FlatBufferVerifiableTable, FlatbuffersVectorInitializable {
 
   static func validateVersion() { FlatBuffersVersion_25_12_19() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -17,15 +17,13 @@ public struct flatbuffers_goldens_Galaxy: FlatBufferTable, FlatbuffersVectorInit
   private init(_ t: Table) { _accessor = t }
   public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-  private enum VTOFFSET: VOffset {
-    case numStars = 4
-    var v: Int32 { Int32(self.rawValue) }
-    var p: VOffset { self.rawValue }
+  private struct VT {
+    static let numStars: VOffset = 4
   }
 
-  public var numStars: Int64 { let o = _accessor.offset(VTOFFSET.numStars.v); return o == 0 ? 0 : _accessor.readBuffer(of: Int64.self, at: o) }
+  public var numStars: Int64 { let o = _accessor.offset(VT.numStars); return o == 0 ? 0 : _accessor.readBuffer(of: Int64.self, at: o) }
   public static func startGalaxy(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 1) }
-  public static func add(numStars: Int64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: numStars, def: 0, at: VTOFFSET.numStars.p) }
+  public static func add(numStars: Int64, _ fbb: inout FlatBufferBuilder) { fbb.add(element: numStars, def: 0, at: VT.numStars) }
   public static func endGalaxy(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createGalaxy(
     _ fbb: inout FlatBufferBuilder,
@@ -38,12 +36,12 @@ public struct flatbuffers_goldens_Galaxy: FlatBufferTable, FlatbuffersVectorInit
 
   public static func verify<T>(_ verifier: inout Verifier, at position: Int, of type: T.Type) throws where T: Verifiable {
     var _v = try verifier.visitTable(at: position)
-    try _v.visit(field: VTOFFSET.numStars.p, fieldName: "numStars", required: false, type: Int64.self)
+    try _v.visit(field: VT.numStars, fieldName: "numStars", required: false, type: Int64.self)
     _v.finish()
   }
 }
 
-public struct flatbuffers_goldens_Universe: FlatBufferTable, FlatbuffersVectorInitializable, Verifiable {
+public struct flatbuffers_goldens_Universe: FlatBufferVerifiableTable, FlatbuffersVectorInitializable {
 
   static func validateVersion() { FlatBuffersVersion_25_12_19() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -52,18 +50,16 @@ public struct flatbuffers_goldens_Universe: FlatBufferTable, FlatbuffersVectorIn
   private init(_ t: Table) { _accessor = t }
   public init(_ bb: ByteBuffer, o: Int32) { _accessor = Table(bb: bb, position: o) }
 
-  private enum VTOFFSET: VOffset {
-    case age = 4
-    case galaxies = 6
-    var v: Int32 { Int32(self.rawValue) }
-    var p: VOffset { self.rawValue }
+  private struct VT {
+    static let age: VOffset = 4
+    static let galaxies: VOffset = 6
   }
 
-  public var age: Double { let o = _accessor.offset(VTOFFSET.age.v); return o == 0 ? 0.0 : _accessor.readBuffer(of: Double.self, at: o) }
-  public var galaxies: FlatbufferVector<flatbuffers_goldens_Galaxy> { return _accessor.vector(at: VTOFFSET.galaxies.v, byteSize: 4) }
+  public var age: Double { let o = _accessor.offset(VT.age); return o == 0 ? 0.0 : _accessor.readBuffer(of: Double.self, at: o) }
+  public var galaxies: FlatbufferVector<flatbuffers_goldens_Galaxy> { return _accessor.vector(at: VT.galaxies, byteSize: 4) }
   public static func startUniverse(_ fbb: inout FlatBufferBuilder) -> UOffset { fbb.startTable(with: 2) }
-  public static func add(age: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: age, def: 0.0, at: VTOFFSET.age.p) }
-  public static func addVectorOf(galaxies: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: galaxies, at: VTOFFSET.galaxies.p) }
+  public static func add(age: Double, _ fbb: inout FlatBufferBuilder) { fbb.add(element: age, def: 0.0, at: VT.age) }
+  public static func addVectorOf(galaxies: Offset, _ fbb: inout FlatBufferBuilder) { fbb.add(offset: galaxies, at: VT.galaxies) }
   public static func endUniverse(_ fbb: inout FlatBufferBuilder, start: UOffset) -> Offset { let end = Offset(offset: fbb.endTable(at: start)); return end }
   public static func createUniverse(
     _ fbb: inout FlatBufferBuilder,
@@ -78,8 +74,8 @@ public struct flatbuffers_goldens_Universe: FlatBufferTable, FlatbuffersVectorIn
 
   public static func verify<T>(_ verifier: inout Verifier, at position: Int, of type: T.Type) throws where T: Verifiable {
     var _v = try verifier.visitTable(at: position)
-    try _v.visit(field: VTOFFSET.age.p, fieldName: "age", required: false, type: Double.self)
-    try _v.visit(field: VTOFFSET.galaxies.p, fieldName: "galaxies", required: false, type: ForwardOffset<Vector<ForwardOffset<flatbuffers_goldens_Galaxy>, flatbuffers_goldens_Galaxy>>.self)
+    try _v.visit(field: VT.age, fieldName: "age", required: false, type: Double.self)
+    try _v.visit(field: VT.galaxies, fieldName: "galaxies", required: false, type: ForwardOffset<Vector<ForwardOffset<flatbuffers_goldens_Galaxy>, flatbuffers_goldens_Galaxy>>.self)
     _v.finish()
   }
 }

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -894,6 +894,12 @@ CheckedError Parser::ParseType(Type& type) {
 
 CheckedError Parser::AddField(StructDef& struct_def, const std::string& name,
                               const Type& type, FieldDef** dest) {
+  if (!struct_def.fixed) {
+    if (struct_def.fields.vec.size() >=
+        (flatbuffers::numeric_limits<voffset_t>::max() - 2 * sizeof(voffset_t)) / sizeof(voffset_t)) {
+      return Error("more than " + NumToString((flatbuffers::numeric_limits<voffset_t>::max() - 2 * sizeof(voffset_t)) / sizeof(voffset_t)) + " fields in table " + struct_def.name);
+    }
+  }
   auto& field = *new FieldDef();
   field.value.offset =
       FieldIndexToOffset(static_cast<voffset_t>(struct_def.fields.vec.size()));
@@ -2921,8 +2927,10 @@ CheckedError Parser::ParseDecl(const char* filename) {
       // been specified.
       std::sort(fields.begin(), fields.end(), compareFieldDefs);
       // Verify we have a contiguous set, and reassign vtable offsets.
-      FLATBUFFERS_ASSERT(fields.size() <=
-                         flatbuffers::numeric_limits<voffset_t>::max());
+      if (fields.size() >
+          (flatbuffers::numeric_limits<voffset_t>::max() - 2 * sizeof(voffset_t)) / sizeof(voffset_t)) {
+        return Error("more than " + NumToString((flatbuffers::numeric_limits<voffset_t>::max() - 2 * sizeof(voffset_t)) / sizeof(voffset_t)) + " fields in table " + struct_def->name);
+      }
       for (voffset_t i = 0; i < static_cast<voffset_t>(fields.size()); i++) {
         auto& field = *fields[i];
         const auto& id_str = field.attributes.Lookup("id")->constant;


### PR DESCRIPTION
### Description
This PR fixes a critical validation gap in `flatc` (`idl_parser.cpp`) where computed vtable offsets could silently overflow and wrap around when a table defines 32,766 or more fields.

### Details
- The vtable offset calculation formula is `fixed_fields (4) + id * sizeof(voffset_t) (2)`.
- Since the offset is cast to `voffset_t` (`uint16_t`), once `field_id` reaches `32,766`, the calculated offset reaches `65,536`, which wraps to `0` and collides with the vtable `vsize` metadata slot. Field index `32,768` wraps to `4`, colliding directly with `VT_FIELD0` (offset 4).
- This allows a malformed buffer to bypass verification because the C++ `Verifier` validates layout using one field type, while the application reads using another (causing type confusion and OOB reads).

### Fixes
- **Auto-Incrementing Path (`Parser::AddField`)**: Added active validation returning a compiler error if the table fields count reaches `32,766` (which translates to a maximum offset of `65,534`, the last value that safely fits in `voffset_t`).
- **Explicit IDs Path (`Parser::ParseDecl`)**: Replaced a release-stripped `FLATBUFFERS_ASSERT` with an active `Error()` return check.
