### PR TITLE
Fix missing null-terminator check in flexbuffers::VerifyTerminator

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -1983,8 +1983,8 @@ class Verifier FLATBUFFERS_FINAL_CLASS {
 #undef FLEX_CHECK_VERIFIED
 
   bool VerifyTerminator(const String& s) {
-    return VerifyFromPointer(reinterpret_cast<const uint8_t*>(s.c_str()),
-                             s.size() + 1);
+    const uint8_t* ptr = reinterpret_cast<const uint8_t*>(s.c_str());
+    return VerifyFromPointer(ptr, s.size() + 1) && ptr[s.size()] == '\0';
   }
 
   bool VerifyRef(Reference r) {


### PR DESCRIPTION
The previous implementation of VerifyTerminator checked that the string fits within the buffer, but failed to verify that the terminating byte is actually '\0'. This could lead to out-of-bounds reads if the caller uses .c_str() on an untrusted FlexBuffer.