### PR TITLE
build(java): add stable JPMS module name

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -102,6 +102,11 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>5.1.2</version>
         <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Automatic-Module-Name>com.google.flatbuffers</Automatic-Module-Name>
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
## Problem

`flatbuffers-java` currently lands on the module path as a filename-derived automatic module, so downstream `module-info.java` files see the unstable name `flatbuffers.java` and modular builds can warn about publishing with filename-based automodules.

## Root cause

The Java artifact does not declare any JPMS module name metadata, while the Maven build still targets Java 8 (`--release 8` on newer JDKs). Adding a top-level `module-info.java` would raise that source-level assumption.

## Solution

Add `Automatic-Module-Name: com.google.flatbuffers` through the existing bundle plugin manifest instructions. This gives JPMS users a stable module name while preserving the Java 8 runtime/build target.

Addresses #9111.

## Tests run

- `mvn -f java/pom.xml -Dmaven.test.skip=true clean package`
- inspected `META-INF/MANIFEST.MF` from `java/target/flatbuffers-java-25.12.19.jar`
- `jar --describe-module --file java/target/flatbuffers-java-25.12.19.jar`
- `git diff --check`