### PR TITLE
[Dart] Support required non-scalar fields

### DIFF
--- a/dart/test/enums.fbs
+++ b/dart/test/enums.fbs
@@ -8,3 +8,8 @@ enum OptionsEnum : uint32
 table MyTable {
     options : [OptionsEnum];
 }
+
+table RequiredTable {
+    name : string (required);
+    options : [OptionsEnum] (required);
+}

--- a/dart/test/enums_generated.dart
+++ b/dart/test/enums_generated.dart
@@ -2,8 +2,9 @@
 // ignore_for_file: unused_import, unused_field, unused_element, unused_local_variable, constant_identifier_names
 
 import 'dart:typed_data' show Uint8List;
-
 import 'package:flat_buffers/flat_buffers.dart' as fb;
+
+
 
 enum OptionsEnum {
   A(1),
@@ -15,14 +16,10 @@ enum OptionsEnum {
 
   factory OptionsEnum.fromValue(int value) {
     switch (value) {
-      case 1:
-        return OptionsEnum.A;
-      case 2:
-        return OptionsEnum.B;
-      case 3:
-        return OptionsEnum.C;
-      default:
-        throw StateError('Invalid value $value for bit flag enum');
+      case 1: return OptionsEnum.A;
+      case 2: return OptionsEnum.B;
+      case 3: return OptionsEnum.C;
+      default: throw StateError('Invalid value $value for bit flag enum');
     }
   }
 
@@ -57,9 +54,7 @@ class MyTable {
   final fb.BufferContext _bc;
   final int _bcOffset;
 
-  List<OptionsEnum>? get options => const fb.ListReader<OptionsEnum>(
-    OptionsEnum.reader,
-  ).vTableGetNullable(_bc, _bcOffset, 4);
+  List<OptionsEnum>? get options => const fb.ListReader<OptionsEnum>(OptionsEnum.reader).vTableGetNullable(_bc, _bcOffset, 4);
 
   @override
   String toString() {
@@ -67,11 +62,7 @@ class MyTable {
   }
 
   MyTableT unpack() => MyTableT(
-    options: const fb.ListReader<OptionsEnum>(
-      OptionsEnum.reader,
-      lazy: false,
-    ).vTableGetNullable(_bc, _bcOffset, 4),
-  );
+      options: options?.toList());
 
   static int pack(fb.Builder fbBuilder, MyTableT? object) {
     if (object == null) return 0;
@@ -82,12 +73,12 @@ class MyTable {
 class MyTableT implements fb.Packable {
   List<OptionsEnum>? options;
 
-  MyTableT({this.options});
+  MyTableT({
+      this.options});
 
   @override
   int pack(fb.Builder fbBuilder) {
-    final int? optionsOffset = options == null
-        ? null
+    final int? optionsOffset = options == null ? null
         : fbBuilder.writeListUint32(options!.map((f) => f.value).toList());
     fbBuilder.startTable(1);
     fbBuilder.addOffset(0, optionsOffset);
@@ -105,7 +96,7 @@ class _MyTableReader extends fb.TableReader<MyTable> {
 
   @override
   MyTable createObject(fb.BufferContext bc, int offset) =>
-      MyTable._(bc, offset);
+    MyTable._(bc, offset);
 }
 
 class MyTableBuilder {
@@ -130,16 +121,133 @@ class MyTableBuilder {
 class MyTableObjectBuilder extends fb.ObjectBuilder {
   final List<OptionsEnum>? _options;
 
-  MyTableObjectBuilder({List<OptionsEnum>? options}) : _options = options;
+  MyTableObjectBuilder({
+    List<OptionsEnum>? options,
+  })
+      : _options = options;
 
   /// Finish building, and store into the [fbBuilder].
   @override
   int finish(fb.Builder fbBuilder) {
-    final int? optionsOffset = _options == null
-        ? null
+    final int? optionsOffset = _options == null ? null
         : fbBuilder.writeListUint32(_options!.map((f) => f.value).toList());
     fbBuilder.startTable(1);
     fbBuilder.addOffset(0, optionsOffset);
+    return fbBuilder.endTable();
+  }
+
+  /// Convenience method to serialize to byte list.
+  @override
+  Uint8List toBytes([String? fileIdentifier]) {
+    final fbBuilder = fb.Builder(deduplicateTables: false);
+    fbBuilder.finish(finish(fbBuilder), fileIdentifier);
+    return fbBuilder.buffer;
+  }
+}
+class RequiredTable {
+  RequiredTable._(this._bc, this._bcOffset);
+  factory RequiredTable(List<int> bytes) {
+    final rootRef = fb.BufferContext.fromBytes(bytes);
+    return reader.read(rootRef, 0);
+  }
+
+  static const fb.Reader<RequiredTable> reader = _RequiredTableReader();
+
+  final fb.BufferContext _bc;
+  final int _bcOffset;
+
+  String get name => const fb.StringReader().vTableGetNullable(_bc, _bcOffset, 4)!;
+  List<OptionsEnum> get options => const fb.ListReader<OptionsEnum>(OptionsEnum.reader).vTableGetNullable(_bc, _bcOffset, 6)!;
+
+  @override
+  String toString() {
+    return 'RequiredTable{name: ${name}, options: ${options}}';
+  }
+
+  RequiredTableT unpack() => RequiredTableT(
+      name: name,
+      options: options.toList());
+
+  static int pack(fb.Builder fbBuilder, RequiredTableT? object) {
+    if (object == null) return 0;
+    return object.pack(fbBuilder);
+  }
+}
+
+class RequiredTableT implements fb.Packable {
+  String name;
+  List<OptionsEnum> options;
+
+  RequiredTableT({
+      required this.name,
+      required this.options});
+
+  @override
+  int pack(fb.Builder fbBuilder) {
+    final int nameOffset = fbBuilder.writeString(name);
+    final int optionsOffset = fbBuilder.writeListUint32(options.map((f) => f.value).toList());
+    fbBuilder.startTable(2);
+    fbBuilder.addOffset(0, nameOffset);
+    fbBuilder.addOffset(1, optionsOffset);
+    return fbBuilder.endTable();
+  }
+
+  @override
+  String toString() {
+    return 'RequiredTableT{name: ${name}, options: ${options}}';
+  }
+}
+
+class _RequiredTableReader extends fb.TableReader<RequiredTable> {
+  const _RequiredTableReader();
+
+  @override
+  RequiredTable createObject(fb.BufferContext bc, int offset) =>
+    RequiredTable._(bc, offset);
+}
+
+class RequiredTableBuilder {
+  RequiredTableBuilder(this.fbBuilder);
+
+  final fb.Builder fbBuilder;
+
+  void begin() {
+    fbBuilder.startTable(2);
+  }
+
+  int addNameOffset(int offset) {
+    fbBuilder.addOffset(0, offset);
+    return fbBuilder.offset;
+  }
+  int addOptionsOffset(int offset) {
+    fbBuilder.addOffset(1, offset);
+    return fbBuilder.offset;
+  }
+
+  int finish() {
+    return fbBuilder.endTable();
+  }
+}
+
+class RequiredTableObjectBuilder extends fb.ObjectBuilder {
+  final String _name;
+  final List<OptionsEnum> _options;
+
+  RequiredTableObjectBuilder({
+    required String name,
+    required List<OptionsEnum> options,
+  })
+      : _name = name,
+        _options = options;
+
+  /// Finish building, and store into the [fbBuilder].
+  @override
+  int finish(fb.Builder fbBuilder) {
+    final int nameOffset = fbBuilder.writeString(_name);
+    final int optionsOffset = fbBuilder.writeListUint32(_options.map((f) => f.value).toList());
+    fbBuilder.startTable(2);
+    fbBuilder.addOffset(0, nameOffset);
+    fbBuilder.addOffset(1, optionsOffset);
     return fbBuilder.endTable();
   }
 

--- a/dart/test/flat_buffers_test.dart
+++ b/dart/test/flat_buffers_test.dart
@@ -18,6 +18,7 @@ main() {
     defineReflectiveTests(CheckOtherLangaugesData);
     defineReflectiveTests(GeneratorTest);
     defineReflectiveTests(ListOfEnumsTest);
+    defineReflectiveTests(RequiredFieldsTest);
   });
 }
 
@@ -1007,6 +1008,24 @@ class ListOfEnumsTest {
     expect(mytable_read.options![0].value, example3.OptionsEnum.A.value);
     expect(mytable_read.options![1].value, example3.OptionsEnum.B.value);
     expect(mytable_read.options![2].value, example3.OptionsEnum.C.value);
+  }
+}
+
+@reflectiveTest
+class RequiredFieldsTest {
+  void test_requiredNonScalars() async {
+    final requiredTable = example3.RequiredTableObjectBuilder(
+      name: 'required',
+      options: [example3.OptionsEnum.B],
+    );
+    final bytes = requiredTable.toBytes();
+    final requiredTableRead = example3.RequiredTable(bytes);
+
+    final String name = requiredTableRead.name;
+    final List<example3.OptionsEnum> options = requiredTableRead.options;
+
+    expect(name, 'required');
+    expect(options.single, example3.OptionsEnum.B);
   }
 }
 

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -452,6 +452,11 @@ class DartGenerator : public BaseGenerator {
     return typeName;
   }
 
+  bool FieldIsNullable(const StructDef& struct_def, const FieldDef& field,
+                       const std::string& default_value) const {
+    return default_value.empty() && !struct_def.fixed && !field.IsRequired();
+  }
+
   std::string MaybeWrapNamespace(const std::string& type_name,
                                  Namespace* current_ns,
                                  const FieldDef& field) const {
@@ -562,16 +567,18 @@ class DartGenerator : public BaseGenerator {
 
       const std::string field_name = namer_.Field(field);
       const std::string defaultValue = getDefaultValue(field.value);
+      const bool isNullable = FieldIsNullable(struct_def, field, defaultValue);
       const std::string type_name =
           GenDartTypeName(field.value.type, struct_def.defined_namespace, field,
-                          defaultValue.empty() && !struct_def.fixed, "T");
+                          isNullable, "T");
 
       GenDocComment(field.doc_comment, "  ", code);
       code += "  " + type_name + " " + field_name + ";\n";
 
       if (!constructor_args.empty()) constructor_args += ",\n";
       constructor_args += "      ";
-      constructor_args += (struct_def.fixed ? "required " : "");
+      constructor_args +=
+          (struct_def.fixed || field.IsRequired() ? "required " : "");
       constructor_args += "this." + field_name;
       if (!struct_def.fixed && !defaultValue.empty()) {
         if (IsEnum(field.value.type)) {
@@ -614,7 +621,7 @@ class DartGenerator : public BaseGenerator {
 
       const Type& type = field.value.type;
       std::string defaultValue = getDefaultValue(field.value);
-      bool isNullable = defaultValue.empty() && !struct_def.fixed;
+      bool isNullable = FieldIsNullable(struct_def, field, defaultValue);
       std::string nullableValueAccessOperator = isNullable ? "?" : "";
       if (type.base_type == BASE_TYPE_STRUCT ||
           type.base_type == BASE_TYPE_UNION) {
@@ -675,7 +682,9 @@ class DartGenerator : public BaseGenerator {
 
       const std::string field_name = namer_.Field(field);
       const std::string defaultValue = getDefaultValue(field.value);
-      const bool isNullable = defaultValue.empty() && !struct_def.fixed;
+      const bool isNullable = FieldIsNullable(struct_def, field, defaultValue);
+      const bool useNullableAccessor =
+          defaultValue.empty() && !struct_def.fixed;
       const std::string type_name =
           GenDartTypeName(field.value.type, struct_def.defined_namespace, field,
                           isNullable, "");
@@ -716,8 +725,11 @@ class DartGenerator : public BaseGenerator {
         } else {
           code += ".vTableGet";
           std::string offset = NumToString(field.value.offset);
-          if (isNullable) {
+          if (useNullableAccessor) {
             code += "Nullable(_bc, _bcOffset, " + offset + ")";
+            if (!isNullable) {
+              code += "!";
+            }
           } else {
             code += "(_bc, _bcOffset, " + offset + ", " + defaultValue + ")";
           }
@@ -804,7 +816,7 @@ class DartGenerator : public BaseGenerator {
     }
     code += "  @override\n";
     code += "  " + struct_type +
-            " createObject(fb.BufferContext bc, int offset) => \n    " +
+            " createObject(fb.BufferContext bc, int offset) =>\n    " +
             struct_type + "._(bc, offset);\n";
     code += "}\n\n";
   }
@@ -892,6 +904,8 @@ class DartGenerator : public BaseGenerator {
       const auto offset = it->first;
       const std::string add_field = namer_.Method("add", field);
       const std::string field_var = namer_.Variable(field);
+      const std::string defaultValue = getDefaultValue(field.value);
+      const bool isNullable = FieldIsNullable(struct_def, field, defaultValue);
 
       if (IsScalar(field.value.type.base_type)) {
         code += "  int " + add_field + "(";
@@ -910,7 +924,8 @@ class DartGenerator : public BaseGenerator {
         code +=
             "    fbBuilder.addStruct(" + NumToString(offset) + ", offset);\n";
       } else {
-        code += "  int " + add_field + "Offset(int? offset) {\n";
+        code += "  int " + add_field + "Offset(" +
+                (isNullable ? "int?" : "int") + " offset) {\n";
         code +=
             "    fbBuilder.addOffset(" + NumToString(offset) + ", offset);\n";
       }
@@ -932,10 +947,12 @@ class DartGenerator : public BaseGenerator {
     for (auto it = non_deprecated_fields.begin();
          it != non_deprecated_fields.end(); ++it) {
       const FieldDef& field = *it->second;
+      const std::string defaultValue = getDefaultValue(field.value);
+      const bool isNullable = FieldIsNullable(struct_def, field, defaultValue);
 
       code += "  final " +
               GenDartTypeName(field.value.type, struct_def.defined_namespace,
-                              field, !struct_def.fixed, "ObjectBuilder") +
+                              field, isNullable, "ObjectBuilder") +
               " _" + namer_.Variable(field) + ";\n";
     }
     code += "\n";
@@ -946,11 +963,14 @@ class DartGenerator : public BaseGenerator {
       for (auto it = non_deprecated_fields.begin();
            it != non_deprecated_fields.end(); ++it) {
         const FieldDef& field = *it->second;
+        const std::string defaultValue = getDefaultValue(field.value);
+        const bool isNullable =
+            FieldIsNullable(struct_def, field, defaultValue);
 
         code += "    ";
-        code += (struct_def.fixed ? "required " : "") +
+        code += (struct_def.fixed || field.IsRequired() ? "required " : "") +
                 GenDartTypeName(field.value.type, struct_def.defined_namespace,
-                                field, !struct_def.fixed, "ObjectBuilder") +
+                                field, isNullable, "ObjectBuilder") +
                 " " + namer_.Variable(field) + ",\n";
       }
       code += "  })\n";
@@ -1002,6 +1022,10 @@ class DartGenerator : public BaseGenerator {
       std::string offset_name = namer_.Variable(field) + "Offset";
       std::string field_name =
           (prependUnderscore ? "_" : "") + namer_.Variable(field);
+      const std::string defaultValue = getDefaultValue(field.value);
+      const bool isNullable = FieldIsNullable(struct_def, field, defaultValue);
+      const std::string field_value =
+          isNullable ? field_name + "!" : field_name;
       // custom handling for fixed-sized struct in pack()
       if (pack && IsVector(field.value.type) &&
           field.value.type.VectorType().base_type == BASE_TYPE_STRUCT &&
@@ -1017,37 +1041,45 @@ class DartGenerator : public BaseGenerator {
         continue;
       }
 
-      code += "    final int? " + offset_name;
+      code += "    final " + std::string(isNullable ? "int? " : "int ") +
+              offset_name;
       if (IsVector(field.value.type)) {
-        code += " = " + field_name + " == null ? null\n";
-        code += "        : fbBuilder.writeList";
+        if (isNullable) {
+          code += " = " + field_name + " == null ? null\n";
+          code += "        : fbBuilder.writeList";
+        } else {
+          code += " = fbBuilder.writeList";
+        }
         switch (field.value.type.VectorType().base_type) {
           case BASE_TYPE_STRING:
             code +=
-                "(" + field_name + "!.map(fbBuilder.writeString).toList());\n";
+                "(" + field_value + ".map(fbBuilder.writeString).toList());\n";
             break;
           case BASE_TYPE_STRUCT:
             if (field.value.type.struct_def->fixed) {
-              code += "OfStructs(" + field_name + "!);\n";
+              code += "OfStructs(" + field_value + ");\n";
             } else {
-              code += "(" + field_name + "!.map((b) => b." +
+              code += "(" + field_value + ".map((b) => b." +
                       (pack ? "pack" : "getOrCreateOffset") +
                       "(fbBuilder)).toList());\n";
             }
             break;
           default:
-            code +=
-                GenType(field.value.type.VectorType()) + "(" + field_name + "!";
+            code += GenType(field.value.type.VectorType()) + "(" + field_value;
             if (field.value.type.enum_def) {
               code += ".map((f) => f.value).toList()";
             }
             code += ");\n";
         }
       } else if (IsString(field.value.type)) {
-        code += " = " + field_name + " == null ? null\n";
-        code += "        : fbBuilder.writeString(" + field_name + "!);\n";
+        if (isNullable) {
+          code += " = " + field_name + " == null ? null\n";
+          code += "        : fbBuilder.writeString(" + field_value + ");\n";
+        } else {
+          code += " = fbBuilder.writeString(" + field_value + ");\n";
+        }
       } else {
-        code += " = " + field_name + "?." +
+        code += " = " + field_name + (isNullable ? "?." : ".") +
                 (pack ? "pack" : "getOrCreateOffset") + "(fbBuilder);\n";
       }
     }


### PR DESCRIPTION
**Summary**
- Treat Dart table fields marked `(required)` as non-null when they do not have a default value.
- Emit non-null getters, object API constructor fields, object builder fields, and raw offset builder parameters for required non-scalar fields.
- Add a Dart fixture covering a required string and a required enum vector.

Fixes #9093

**Tests**
- `cmake -S . -B build -G Ninja -DFLATBUFFERS_BUILD_TESTS=OFF`
- `cmake --build build --target flatc`
- `./build/flatc.exe --dart --gen-object-api -o ./dart/test ./dart/test/enums.fbs`
- Regenerated `enums_generated.dart` matched a temp regeneration with `fc.exe /b`
- `git diff --check`

Not run: `dart test` because the Dart SDK is not installed in this Windows workspace I am working on atm.