### PR TITLE
Fix heap-buffer-overflow in minireflect.h during union vector parsing

### DIFF
--- a/include/flatbuffers/minireflect.h
+++ b/include/flatbuffers/minireflect.h
@@ -207,7 +207,15 @@ inline void IterateValue(ElementaryType type, const uint8_t* val,
           auto union_type = *prev_val;  // Always a uint8_t.
           if (vector_index >= 0) {
             auto type_vec = reinterpret_cast<const Vector<uint8_t>*>(prev_val);
-            union_type = type_vec->Get(static_cast<uoffset_t>(vector_index));
+            // FIX: Bounds check to prevent OOB read when union data vector
+            // size is desynchronized from union type vector size.
+            if (type_vec && static_cast<size_t>(vector_index) < type_vec->size()) {
+              union_type = type_vec->Get(static_cast<uoffset_t>(vector_index));
+            } else {
+              // Out of bounds: mark as unknown to prevent crash
+              visitor->Unknown(val);
+              break;
+            }
           }
           auto type_code_idx =
               LookupEnum(union_type, type_table->values, type_table->num_elems);

--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -250,6 +250,20 @@ add_custom_command(
   ${CMAKE_CURRENT_BINARY_DIR}/seed_64bit/test_64bit.bin
 )
 
+# Mini-reflection fuzzer for union vector OOB testing
+add_executable(minireflect_fuzzer flatbuffers_minireflect_fuzzer.cc)
+target_link_libraries(minireflect_fuzzer PRIVATE flatbuffers_fuzzed)
+
+# Copy seed corpus for minireflect fuzzer
+add_custom_command(
+  TARGET minireflect_fuzzer PRE_BUILD
+  COMMAND ${CMAKE_COMMAND} -E make_directory
+    ${CMAKE_CURRENT_BINARY_DIR}/seed_minireflect
+  COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_SOURCE_DIR}/../fuzzer/seed_minireflect/movie_seed.bin
+    ${CMAKE_CURRENT_BINARY_DIR}/seed_minireflect/movie_seed.bin
+)
+
 # Build debugger for weird cases found with fuzzer.
 if(BUILD_DEBUGGER)
   add_library(flatbuffers_nonfuzz STATIC ${FlatBuffers_Library_SRCS})

--- a/tests/fuzzer/flatbuffers_minireflect_fuzzer.cc
+++ b/tests/fuzzer/flatbuffers_minireflect_fuzzer.cc
@@ -1,0 +1,33 @@
+// Copyright 2024 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// libFuzzer harness for FlatBuffers mini-reflection path.
+// Exercises FlatBufferToString() with union vectors to detect
+// OOB reads from desynchronized vector sizes.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
+
+#include "flatbuffers/minireflect.h"
+#include "tests/union_vector/union_vector_generated.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // Movie schema — characters union vector (primary crash path)
+  {
+    std::string s = flatbuffers::FlatBufferToString(data, MovieTypeTable());
+    (void)s;
+  }
+  return 0;
+}

--- a/tests/fuzzer/seed_minireflect/.gitkeep
+++ b/tests/fuzzer/seed_minireflect/.gitkeep
@@ -1,0 +1,2 @@
+# Seed corpus directory for minireflect_fuzzer
+# movie_seed.bin will be added in a follow-up commit


### PR DESCRIPTION
 Summary
Fixes a heap-buffer-overflow in `IterateValue()` when processing union vectors
where the data vector size is desynchronized from the type tag vector size.

 Bug Description
In `minireflect.h`, the `ST_UNION` branch reads the union type tag using:

union_type = type_vec->Get(static_cast<uoffset_t>(vector_index));
The vector_index comes from a loop bounded by vec->size() of the data
vector, but type_vec points to the type tag vector — a separate vector
that may have a smaller size. When the buffer is malformed (e.g., data vector
size inflated), this causes an out-of-bounds read.
Fix
Added bounds check before type_vec->Get():
cpp
if (type_vec && static_cast<size_t>(vector_index) < type_vec->size()) {
    union_type = type_vec->Get(static_cast<uoffset_t>(vector_index));
} else {
    visitor->Unknown(val);
    break;
}
Testing
Added minireflect_fuzzer libFuzzer harness
Added seed_minireflect/ directory for corpus
The fuzzer exercises FlatBufferToString() with the Movie schema which
contains union vectors
Related
This addresses a security issue where FlatBufferToString() can crash on
malformed buffers due to missing bounds checking in the mini-reflection
union vector path.