### PR TITLE
fix: harden MiniReflect union handling for NONE and unknown union types

### DIFF
--- a/include/flatbuffers/minireflect.h
+++ b/include/flatbuffers/minireflect.h
@@ -202,32 +202,52 @@ inline void IterateValue(ElementaryType type, const uint8_t* val,
           IterateObject(val, type_table, visitor);
           break;
         case ST_UNION: {
-          val += ReadScalar<uoffset_t>(val);
+          // A union value is only safe to resolve once its discriminator is
+          // known to refer to a concrete union member.  In particular, NONE
+          // entries and unknown/future union values must not be treated as
+          // tables/strings and must not index type_refs with a negative
+          // sequence_ref. Keep the original offset-slot pointer for Unknown()
+          // so visitor callbacks do not receive an already-resolved OOB
+          // pointer for unknown union types.
+          const uint8_t* union_offset = val;
           FLATBUFFERS_ASSERT(prev_val);
+          if (!prev_val) {
+            visitor->Unknown(union_offset);
+            break;
+          }
+
           auto union_type = *prev_val;  // Always a uint8_t.
           if (vector_index >= 0) {
             auto type_vec = reinterpret_cast<const Vector<uint8_t>*>(prev_val);
             union_type = type_vec->Get(static_cast<uoffset_t>(vector_index));
           }
-          auto type_code_idx =
+          const auto type_code_idx =
               LookupEnum(union_type, type_table->values, type_table->num_elems);
-          if (type_code_idx >= 0 &&
-              type_code_idx < static_cast<int32_t>(type_table->num_elems)) {
-            auto type_code = type_table->type_codes[type_code_idx];
-            switch (type_code.base_type) {
-              case ET_SEQUENCE: {
-                auto ref = type_table->type_refs[type_code.sequence_ref]();
-                IterateObject(val, ref, visitor);
-                break;
-              }
-              case ET_STRING:
-                visitor->String(reinterpret_cast<const String*>(val));
-                break;
-              default:
-                visitor->Unknown(val);
+          if (type_code_idx < 0 ||
+              type_code_idx >= static_cast<int32_t>(type_table->num_elems)) {
+            visitor->Unknown(union_offset);
+            break;
+          }
+
+          const auto type_code = type_table->type_codes[type_code_idx];
+          if (type_code.base_type == ET_SEQUENCE &&
+              type_code.sequence_ref < 0) {
+            visitor->Unknown(union_offset);
+            break;
+          }
+
+          val = union_offset + ReadScalar<uoffset_t>(union_offset);
+          switch (type_code.base_type) {
+            case ET_SEQUENCE: {
+              auto ref = type_table->type_refs[type_code.sequence_ref]();
+              IterateObject(val, ref, visitor);
+              break;
             }
-          } else {
-            visitor->Unknown(val);
+            case ET_STRING:
+              visitor->String(reinterpret_cast<const String*>(val));
+              break;
+            default:
+              visitor->Unknown(val);
           }
           break;
         }

--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -216,6 +216,9 @@ target_link_libraries(flexverifier_fuzzer PRIVATE flatbuffers_fuzzed)
 add_executable(monster_fuzzer flatbuffers_monster_fuzzer.cc)
 target_link_libraries(monster_fuzzer PRIVATE flatbuffers_fuzzed)
 
+add_executable(minireflect_fuzzer flatbuffers_minireflect_fuzzer.cc)
+target_link_libraries(minireflect_fuzzer PRIVATE flatbuffers_fuzzed)
+
 add_executable(codegen_fuzzer flatbuffers_codegen_fuzzer.cc ${FlatBuffers_Compiler_SRCS})
 target_link_libraries(codegen_fuzzer PRIVATE flatbuffers_fuzzed)
 target_compile_definitions(codegen_fuzzer PRIVATE assert=fuzzer_assert_impl)

--- a/tests/fuzzer/flatbuffers_minireflect_fuzzer.cc
+++ b/tests/fuzzer/flatbuffers_minireflect_fuzzer.cc
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "flatbuffers/flatbuffers.h"
+#include "flatbuffers/minireflect.h"
+#include "union_vector/union_vector_generated.h"
+
+namespace {
+
+uint32_t ReadU32(const uint8_t* data, size_t size, size_t offset,
+                 uint32_t fallback) {
+  if (offset + sizeof(uint32_t) > size) return fallback;
+  uint32_t value = 0;
+  std::memcpy(&value, data + offset, sizeof(value));
+  return value;
+}
+
+void WriteU32(std::vector<uint8_t>* buffer, size_t offset, uint32_t value) {
+  if (offset + sizeof(uint32_t) > buffer->size()) return;
+  std::memcpy(buffer->data() + offset, &value, sizeof(value));
+}
+
+struct UnknownValueVisitor : public flatbuffers::IterationVisitor {
+  void Unknown(const uint8_t* val) override {
+    // MiniReflect should not hand user callbacks a pointer that is unsafe to
+    // inspect after generated verification has accepted the buffer.
+    if (val) {
+      volatile uint8_t byte = *val;
+      (void)byte;
+    }
+  }
+};
+
+std::vector<uint8_t> BuildSingleNoneValue(bool size_prefixed) {
+  flatbuffers::FlatBufferBuilder builder;
+  builder.ForceDefaults(true);
+  auto value = builder.CreateString("minireflect_single_none").Union();
+  auto movie = CreateMovie(builder, Character_NONE, value, 0, 0);
+  if (size_prefixed) {
+    FinishSizePrefixedMovieBuffer(builder, movie);
+  } else {
+    FinishMovieBuffer(builder, movie);
+  }
+  return std::vector<uint8_t>(builder.GetBufferPointer(),
+                              builder.GetBufferPointer() + builder.GetSize());
+}
+
+std::vector<uint8_t> BuildVectorNoneValue(bool size_prefixed) {
+  flatbuffers::FlatBufferBuilder builder;
+  builder.ForceDefaults(true);
+  auto value = builder.CreateString("minireflect_vector_none").Union();
+  std::vector<uint8_t> types = {static_cast<uint8_t>(Character_NONE)};
+  std::vector<flatbuffers::Offset<void>> values = {value};
+  auto type_vector = builder.CreateVector(types);
+  auto value_vector = builder.CreateVector(values);
+  auto movie =
+      CreateMovie(builder, Character_NONE, 0, type_vector, value_vector);
+  if (size_prefixed) {
+    FinishSizePrefixedMovieBuffer(builder, movie);
+  } else {
+    FinishMovieBuffer(builder, movie);
+  }
+  return std::vector<uint8_t>(builder.GetBufferPointer(),
+                              builder.GetBufferPointer() + builder.GetSize());
+}
+
+std::vector<uint8_t> BuildUnknownUnionWithOffset(bool size_prefixed,
+                                                 uint32_t offset_value) {
+  flatbuffers::FlatBufferBuilder builder;
+  builder.ForceDefaults(true);
+  auto value = CreateAttacker(builder, 1337).Union();
+  std::vector<uint8_t> types = {250};  // Unknown/future union type.
+  std::vector<flatbuffers::Offset<void>> values = {value};
+  auto type_vector = builder.CreateVector(types);
+  auto value_vector = builder.CreateVector(values);
+  auto movie =
+      CreateMovie(builder, Character_NONE, 0, type_vector, value_vector);
+  if (size_prefixed) {
+    FinishSizePrefixedMovieBuffer(builder, movie);
+  } else {
+    FinishMovieBuffer(builder, movie);
+  }
+
+  std::vector<uint8_t> buffer(builder.GetBufferPointer(),
+                              builder.GetBufferPointer() + builder.GetSize());
+  const Movie* root = size_prefixed ? GetSizePrefixedMovie(buffer.data())
+                                    : GetMovie(buffer.data());
+  auto characters = root->characters();
+  if (characters) {
+    const auto offset_position = static_cast<size_t>(
+        reinterpret_cast<const uint8_t*>(characters->Data()) - buffer.data());
+    WriteU32(&buffer, offset_position, offset_value);
+  }
+  return buffer;
+}
+
+void ExerciseMiniReflect(const uint8_t* data, size_t size, bool size_prefixed) {
+  if (!data || size < sizeof(flatbuffers::uoffset_t)) return;
+
+  flatbuffers::Verifier verifier(data, size);
+  const bool ok = size_prefixed ? VerifySizePrefixedMovieBuffer(verifier)
+                                : VerifyMovieBuffer(verifier);
+  if (!ok) return;
+
+  const uint8_t* root =
+      size_prefixed ? data + sizeof(flatbuffers::uoffset_t) : data;
+  (void)flatbuffers::FlatBufferToString(root, Movie::MiniReflectTypeTable(),
+                                        true, true, "  ", true);
+
+  UnknownValueVisitor visitor;
+  flatbuffers::IterateFlatBuffer(root, Movie::MiniReflectTypeTable(), &visitor);
+}
+
+void ExerciseBuffer(const std::vector<uint8_t>& buffer, bool size_prefixed) {
+  if (buffer.empty()) return;
+  ExerciseMiniReflect(buffer.data(), buffer.size(), size_prefixed);
+}
+
+}  // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  if (!data || size == 0) return 0;
+
+  const uint8_t mode = data[0] & 0x07;
+  const bool size_prefixed = (data[0] & 0x80) != 0;
+
+  switch (mode) {
+    case 0:
+      ExerciseMiniReflect(data, size, false);
+      break;
+    case 1:
+      ExerciseMiniReflect(data, size, true);
+      break;
+    case 2:
+      ExerciseBuffer(BuildSingleNoneValue(size_prefixed), size_prefixed);
+      break;
+    case 3:
+      ExerciseBuffer(BuildVectorNoneValue(size_prefixed), size_prefixed);
+      break;
+    case 4: {
+      const uint32_t offset = ReadU32(data, size, 1, 0x7fffffffU);
+      ExerciseBuffer(BuildUnknownUnionWithOffset(size_prefixed, offset),
+                     size_prefixed);
+      break;
+    }
+    default:
+      // Keep a stable regression path for the historically problematic
+      // out-of-bounds union value offset case.
+      ExerciseBuffer(BuildUnknownUnionWithOffset(size_prefixed, 0x7fffffffU),
+                     size_prefixed);
+      break;
+  }
+
+  return 0;
+}

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -16,6 +16,7 @@
 #include <stdint.h>
 
 #include <cmath>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <string>
@@ -351,6 +352,100 @@ void UnionVectorTest(const std::string& tests_data_path) {
               "    \"Unused\"\n"
               "  ]\n"
               "}");
+
+  // MiniReflect should handle NONE and unknown union states without resolving
+  // them as concrete union members or forwarding resolved OOB pointers.
+  auto TestMiniReflectUnknownUnion = [](const uint8_t* buf, size_t size,
+                                        bool size_prefixed) {
+    flatbuffers::Verifier verifier(buf, size);
+    TEST_EQ(size_prefixed ? VerifySizePrefixedMovieBuffer(verifier)
+                          : VerifyMovieBuffer(verifier),
+            true);
+    auto text = flatbuffers::FlatBufferToString(
+        size_prefixed ? buf + sizeof(flatbuffers::uoffset_t) : buf,
+        MovieTypeTable());
+    TEST_EQ(text.find("(?)") != std::string::npos, true);
+  };
+
+  {
+    flatbuffers::FlatBufferBuilder unknown_fbb;
+    unknown_fbb.ForceDefaults(true);
+    auto unknown_val = unknown_fbb.CreateString("single none").Union();
+    FinishMovieBuffer(unknown_fbb, CreateMovie(unknown_fbb, Character_NONE,
+                                               unknown_val, 0, 0));
+    TestMiniReflectUnknownUnion(unknown_fbb.GetBufferPointer(),
+                                unknown_fbb.GetSize(), false);
+  }
+
+  {
+    flatbuffers::FlatBufferBuilder unknown_fbb;
+    unknown_fbb.ForceDefaults(true);
+    std::vector<uint8_t> unknown_types = {static_cast<uint8_t>(Character_NONE)};
+    std::vector<flatbuffers::Offset<void>> unknown_values = {
+        unknown_fbb.CreateString("vector none").Union()};
+    FinishMovieBuffer(unknown_fbb,
+                      CreateMovie(unknown_fbb, Character_NONE, 0,
+                                  unknown_fbb.CreateVector(unknown_types),
+                                  unknown_fbb.CreateVector(unknown_values)));
+    TestMiniReflectUnknownUnion(unknown_fbb.GetBufferPointer(),
+                                unknown_fbb.GetSize(), false);
+  }
+
+  {
+    flatbuffers::FlatBufferBuilder unknown_fbb;
+    unknown_fbb.ForceDefaults(true);
+    std::vector<uint8_t> unknown_types = {static_cast<uint8_t>(Character_NONE)};
+    std::vector<flatbuffers::Offset<void>> unknown_values = {
+        unknown_fbb.CreateString("vector none size-prefixed").Union()};
+    FinishSizePrefixedMovieBuffer(
+        unknown_fbb, CreateMovie(unknown_fbb, Character_NONE, 0,
+                                 unknown_fbb.CreateVector(unknown_types),
+                                 unknown_fbb.CreateVector(unknown_values)));
+    TestMiniReflectUnknownUnion(unknown_fbb.GetBufferPointer(),
+                                unknown_fbb.GetSize(), true);
+  }
+
+  struct UnknownPointerVisitor : public flatbuffers::IterationVisitor {
+    const uint8_t* base;
+    size_t size;
+    bool seen_unknown;
+    bool unknown_in_bounds;
+    UnknownPointerVisitor(const uint8_t* b, size_t s)
+        : base(b), size(s), seen_unknown(false), unknown_in_bounds(false) {}
+    void Unknown(const uint8_t* p) override {
+      seen_unknown = true;
+      unknown_in_bounds = p >= base && p < base + size;
+    }
+  };
+
+  {
+    flatbuffers::FlatBufferBuilder unknown_fbb;
+    unknown_fbb.ForceDefaults(true);
+    std::vector<uint8_t> unknown_types = {250};
+    std::vector<flatbuffers::Offset<void>> unknown_values = {
+        unknown_fbb.CreateString("unknown type").Union()};
+    FinishMovieBuffer(unknown_fbb,
+                      CreateMovie(unknown_fbb, Character_NONE, 0,
+                                  unknown_fbb.CreateVector(unknown_types),
+                                  unknown_fbb.CreateVector(unknown_values)));
+    std::vector<uint8_t> unknown_buf(
+        unknown_fbb.GetBufferPointer(),
+        unknown_fbb.GetBufferPointer() + unknown_fbb.GetSize());
+    auto unknown_movie = GetMovie(unknown_buf.data());
+    auto offset_slot =
+        reinterpret_cast<const uint8_t*>(unknown_movie->characters()->Data()) -
+        unknown_buf.data();
+    const uint32_t invalid_offset = 0x7fffffffU;
+    std::memcpy(unknown_buf.data() + offset_slot, &invalid_offset,
+                sizeof(invalid_offset));
+    flatbuffers::Verifier verifier(unknown_buf.data(), unknown_buf.size());
+    TEST_EQ(VerifyMovieBuffer(verifier), true);
+    UnknownPointerVisitor unknown_visitor(unknown_buf.data(),
+                                          unknown_buf.size());
+    IterateFlatBuffer(unknown_buf.data(), MovieTypeTable(), &unknown_visitor);
+    TEST_EQ(unknown_visitor.seen_unknown, true);
+    TEST_EQ(unknown_visitor.unknown_in_bounds, true);
+  }
 
   // Generate text using parsed schema.
   std::string jsongen;
@@ -796,7 +891,7 @@ void FixedLengthArrayTest() {
   }
 }
 #else
-void FixedLengthArrayTest() {}
+void FixedLengthArrayTest(){}
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1700
 
 #if !defined(FLATBUFFERS_SPAN_MINIMAL) && \
@@ -864,7 +959,8 @@ void FixedLengthArrayConstructorTest() {
   }
 }
 #else
-void FixedLengthArrayConstructorTest() {}
+void FixedLengthArrayConstructorTest() {
+}
 #endif
 
 void FixedLengthArrayOperatorEqualTest() {
@@ -1304,12 +1400,8 @@ void SizeVerifierTest() {
   // to ensure that all of these APIs are tested.
   flatbuffers::SizeVerifier size_verifier(data,
                                           FLATBUFFERS_MAX_BUFFER_SIZE - 1);
-  {
-    TEST_EQ(true, VerifyMonsterBuffer(size_verifier));
-  }
-  {
-    TEST_EQ(true, size_verifier.VerifyBuffer<Monster>());
-  }
+  { TEST_EQ(true, VerifyMonsterBuffer(size_verifier)); }
+  { TEST_EQ(true, size_verifier.VerifyBuffer<Monster>()); }
   {
     const MyGame::Example::Monster* my_buffer = GetMonster(data);
     TEST_EQ(true, my_buffer->Verify(size_verifier));


### PR DESCRIPTION
## Problem

MiniReflect resolves union value offsets before fully confirming that the union discriminator represents a concrete union member.

For `NONE` and unknown/future union discriminator values, MiniReflect should avoid treating the union value as a concrete object. These cases can occur when inspecting unusual, malformed, or fuzzed FlatBuffer inputs through MiniReflect APIs such as:

```text
FlatBufferToString()
IterateFlatBuffer()
```

The affected code path is in:

```text
include/flatbuffers/minireflect.h
```

## Impact

MiniReflect is used for FlatBuffer inspection and stringification. If union traversal is not defensive for non-concrete union states, MiniReflect can attempt invalid type-reference or value-offset handling while walking the buffer.

This makes MiniReflect less robust for edge-case union states and fuzzed inputs, especially for:

```text
NONE union entries
unknown/future union discriminator values
size-prefixed buffer variants
custom IterationVisitor callbacks
```

## Fix

This PR hardens MiniReflect union traversal so that union value offsets are not resolved before the union discriminator is known to represent a concrete union member.

The change:

```text
- handles NONE union entries safely;
- handles unknown/future union types safely;
- avoids resolving union value offsets too early;
- avoids invalid MiniReflect type-reference lookup for non-concrete union entries;
- avoids forwarding resolved invalid union value pointers to IterationVisitor::Unknown().
```

## Additional coverage

This PR also adds regression coverage for:

```text
- single union NONE cases;
- vector-of-unions NONE cases;
- size-prefixed buffer variants;
- unknown/future union type handling.
```

A new MiniReflect fuzzer target is also added:

```text
tests/fuzzer/flatbuffers_minireflect_fuzzer.cc
```

The fuzzer exercises MiniReflect APIs such as `FlatBufferToString()` and `IterateFlatBuffer()` over normal and size-prefixed inputs, including `NONE` and unknown/future union states.

## Verification

Tested locally with:

```text
flattests: ALL TESTS PASSED
minireflect_fuzzer: 1000 runs completed successfully
git diff --check: no whitespace errors
```
