### PR TITLE
Harden crates.io release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # For manual tests.
@@ -134,19 +135,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
           
       - name: Publish Flatbuffers
-        uses: katyo/publish-crates@v2
-        with:
-          path: ./rust/flatbuffers
-          registry-token: ${{ secrets.CARGO_TOKEN }}
+        run: cargo publish --manifest-path ./rust/flatbuffers/Cargo.toml
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
 
       - name: Publish Flexbuffers
-        uses: katyo/publish-crates@v2
-        with:
-          path: ./rust/flexbuffers
-          registry-token: ${{ secrets.CARGO_TOKEN }}
+        run: cargo publish --manifest-path ./rust/flexbuffers/Cargo.toml
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}


### PR DESCRIPTION
Summary:
- reduce the release workflow GITHUB_TOKEN permissions from read-all to contents: read
- replace the archived/third-party Rust publishing actions with rustup plus cargo publish
- keep the crates.io token in Cargo's standard CARGO_REGISTRY_TOKEN environment variable, scoped to each publish step

Security rationale:
The release workflow has access to package registry credentials. Publishing the Rust crates directly with Cargo removes third-party GitHub Actions from the crates.io credential path and reduces the default GitHub token permissions used by the workflow.

Validation:
- /tmp/actionlint-bin/actionlint .github/workflows/release.yml
- CARGO_REGISTRY_TOKEN=dummy cargo publish --dry-run --manifest-path ./rust/flatbuffers/Cargo.toml
- CARGO_REGISTRY_TOKEN=dummy cargo publish --dry-run --manifest-path ./rust/flexbuffers/Cargo.toml