### PR TITLE
reflection: reject out-of-bounds shrink in ResizeContext

### DIFF
--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -468,6 +468,17 @@ class ResizeContext {
     auto mask = static_cast<int>(sizeof(largest_scalar_t) - 1);
     delta_ = (delta_ + mask) & ~mask;
     if (!delta_) return;  // We can't shrink by less than largest_scalar_t.
+    // Bounds-check the resize range BEFORE rewriting any offsets, so that a
+    // refusal leaves the buffer untouched (never partially mutated). When
+    // shrinking (delta_ < 0) the first erased index is `start + delta_`; if it
+    // underflows below 0, std::vector::erase would memmove to a destination
+    // before the allocation -> out-of-bounds write (CWE-787). This is reachable
+    // from SetString() when a string is longer than its own byte offset + 4.
+    // Reject such a request instead of corrupting the heap.
+    if (static_cast<size_t>(start) > buf_.size() ||
+        (delta_ < 0 && static_cast<int64_t>(start) + delta_ < 0)) {
+      return;
+    }
     // Now change all the offsets by delta_.
     auto root = GetAnyRoot(buf_.data());
     Straddle<uoffset_t, 1>(buf_.data(), root, buf_.data());

--- a/tests/reflection_test.cpp
+++ b/tests/reflection_test.cpp
@@ -1,5 +1,6 @@
 #include "reflection_test.h"
 
+#include "flatbuffers/idl.h"
 #include "flatbuffers/minireflect.h"
 #include "flatbuffers/reflection.h"
 #include "flatbuffers/reflection_generated.h"
@@ -407,6 +408,86 @@ void MiniReflectFixedLengthArrayTest() {
       "}",
       s.c_str());
 #endif
+}
+
+// Regression test for a heap out-of-bounds write in ResizeContext (reached via
+// SetString) when shrinking. SetString computes the erase range as
+// start = str_start + 4 and removes the full old length; when a string is longer
+// than its own byte offset + 4 + the replacement length, the first erase
+// iterator (buf.begin() + start + delta) underflows below begin(), and
+// std::vector::erase memmoves to a destination before the allocation. A buffer
+// that passes Verify() is sufficient to trigger it. After the fix the dangerous
+// shrink is rejected and the buffer is left intact. The bounds check lives in
+// the shared ResizeContext, so this also confirms a legitimate vector shrink
+// still works.
+void ResizeContextShrinkBoundsTest() {
+  // (1) SetString: a single large string near the front of the buffer makes
+  //     old_len > str_start + 4 + new_len, the precondition for the underflow.
+  {
+    flatbuffers::Parser schema_parser;
+    TEST_EQ(schema_parser.Parse("table Root { name:string; } root_type Root;"),
+            true);
+    schema_parser.Serialize();
+    const auto &schema =
+        *reflection::GetSchema(schema_parser.builder_.GetBufferPointer());
+
+    flatbuffers::Parser data_parser;
+    TEST_EQ(data_parser.Parse("table Root { name:string; } root_type Root;"),
+            true);
+    const std::string big_string(1000, 'A');
+    TEST_EQ(data_parser.Parse(("{ name: \"" + big_string + "\" }").c_str()),
+            true);
+    std::vector<uint8_t> buf(data_parser.builder_.GetBufferPointer(),
+                             data_parser.builder_.GetBufferPointer() +
+                                 data_parser.builder_.GetSize());
+
+    // The crafted buffer is well-formed and passes verification.
+    TEST_EQ(flatbuffers::Verify(schema, *schema.root_table(), buf.data(),
+                                buf.size()),
+            true);
+
+    auto &name_field = *schema.root_table()->fields()->LookupByKey("name");
+    auto rroot = flatbuffers::piv(flatbuffers::GetAnyRoot(buf.data()), buf);
+    // Pre-fix: out-of-bounds write (caught by AddressSanitizer).
+    // Post-fix: the dangerous shrink is rejected; the buffer stays valid.
+    flatbuffers::SetString(schema, "x",
+                           flatbuffers::GetFieldS(**rroot, name_field), &buf);
+    TEST_EQ(flatbuffers::Verify(schema, *schema.root_table(), buf.data(),
+                                buf.size()),
+            true);
+  }
+
+  // (2) A legitimate vector shrink must still succeed after the bounds check
+  //     (the check lives in the shared ResizeContext used by ResizeAnyVector).
+  {
+    flatbuffers::Parser schema_parser;
+    TEST_EQ(schema_parser.Parse("table Root { data:[ubyte]; } root_type Root;"),
+            true);
+    schema_parser.Serialize();
+    const auto &schema =
+        *reflection::GetSchema(schema_parser.builder_.GetBufferPointer());
+
+    flatbuffers::Parser data_parser;
+    TEST_EQ(data_parser.Parse("table Root { data:[ubyte]; } root_type Root;"),
+            true);
+    std::string json = "{ data: [";
+    for (int i = 0; i < 1000; i++) json += (i ? ",7" : "7");
+    json += "] }";
+    TEST_EQ(data_parser.Parse(json.c_str()), true);
+    std::vector<uint8_t> buf(data_parser.builder_.GetBufferPointer(),
+                             data_parser.builder_.GetBufferPointer() +
+                                 data_parser.builder_.GetSize());
+
+    auto &data_field = *schema.root_table()->fields()->LookupByKey("data");
+    auto rroot = flatbuffers::piv(flatbuffers::GetAnyRoot(buf.data()), buf);
+    auto rvec = flatbuffers::piv(
+        flatbuffers::GetFieldV<uint8_t>(**rroot, data_field), buf);
+    flatbuffers::ResizeVector<uint8_t>(schema, 10, 0, *rvec, &buf);
+    TEST_EQ(rvec->size(), 10);
+    TEST_EQ(flatbuffers::Verify(schema, *schema.root_table(), buf.data(),
+                                buf.size()),
+            true);
+  }
 }
 
 }  // namespace tests

--- a/tests/reflection_test.h
+++ b/tests/reflection_test.h
@@ -11,6 +11,7 @@ namespace tests {
 void ReflectionTest(const std::string& tests_data_path, uint8_t* flatbuf,
                     size_t length);
 void ForAllFieldsReverseTest(const std::string& tests_data_path);
+void ResizeContextShrinkBoundsTest();
 void MiniReflectFixedLengthArrayTest();
 void MiniReflectFlatBuffersTest(uint8_t* flatbuf);
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1775,6 +1775,7 @@ int FlatBufferTests(const std::string& tests_data_path) {
   FixedLengthArrayJsonTest(tests_data_path, true);
   ReflectionTest(tests_data_path, flatbuf.data(), flatbuf.size());
   ForAllFieldsReverseTest(tests_data_path);
+  ResizeContextShrinkBoundsTest();
   ParseProtoTest(tests_data_path);
   EvolutionTest(tests_data_path);
   UnionDeprecationTest(tests_data_path);


### PR DESCRIPTION
## What

`ResizeContext` (in `src/reflection.cpp`) shrinks a buffer with

```cpp
buf_.erase(buf_.begin() + start + delta_, buf_.begin() + start);
```

When `start + delta_` is negative, the first iterator points before `begin()`
and `std::vector::erase` memmoves the trailing elements to a destination before
the allocation — a heap out-of-bounds write.

## How it's reached

The public reflection helper `SetString()` sets `start = str_start + 4` and
`delta = new_len - old_len`. A string longer than its own byte offset + 4 + the
replacement length underflows on shrink. The buffer does **not** need to be
malformed — a normal buffer that passes `flatbuffers::Verify()` (e.g. one
dominated by a large string near the front) triggers it when an application
edits it in place with `SetString(schema, "x", big_string, &buf)`.

## Fix

Bounds-check the resize range before rewriting any offsets, so an out-of-range
request is rejected without partially mutating the buffer. The check must
precede `Straddle()`/`ResizeTable()`, which would otherwise already have
rewritten every offset by `delta_` and left the buffer inconsistent.

Legitimate grow/shrink edits are unaffected — the `ResizeAnyVector` path
computes `start` at the end of the vector, so its `start + delta` is always
`>= 0`.

## Tests

Adds `ResizeContextShrinkBoundsTest` (in `tests/reflection_test.cpp`, registered
in `tests/reflection_test.h`, called from `tests/test.cpp`). Built with
`-DFLATBUFFERS_CODE_SANITIZE=ON`, the test aborts with an AddressSanitizer heap
out-of-bounds on the current code and passes with this change; it also asserts
that a normal vector shrink still works. `flattests` is green with the fix
(`ALL TESTS PASSED`).
