### PR TITLE
Removed Unused Imports

### DIFF
--- a/python/flatbuffers/builder.py
+++ b/python/flatbuffers/builder.py
@@ -18,9 +18,7 @@ from . import compat
 from . import encode
 from . import number_types as N
 from . import packer
-from .compat import memoryview_type
 from .compat import NumpyRequiredForThisFeature, import_numpy
-from .compat import range_func
 from .number_types import (SOffsetTFlags, UOffsetTFlags, VOffsetTFlags)
 
 np = import_numpy()

--- a/python/flatbuffers/encode.py
+++ b/python/flatbuffers/encode.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import number_types as N
-from . import packer
 from .compat import memoryview_type
 from .compat import NumpyRequiredForThisFeature, import_numpy
 


### PR DESCRIPTION
## Summary
The following PR aims to cleans up some of the FlatBuffers Python library by removing unused module imports from `python/flatbuffers/encode.py` and `python/flatbuffers/builder.py`. 
In particular:
* Removed the unused `packer` and `number_types` imports from `encode.py`.
* Removed the unused `compat` import from `builder.py`.