### PR TITLE
[rust] flexbuffers: bump bitflags to 2.13.0, num_enum to 0.7.6

### DIFF
--- a/rust/flexbuffers/Cargo.toml
+++ b/rust/flexbuffers/Cargo.toml
@@ -24,5 +24,5 @@ deserialize_human_readable = []
 serde = "1.0.119"
 serde_derive = "1.0.119"
 byteorder = "1.4.2"
-num_enum = "0.5.1"
-bitflags = "1.2.1"
+num_enum = "0.7.6"
+bitflags = "2.13.0"


### PR DESCRIPTION
This removes the `syn 1.*` dependency that flexbuffers has