### PR TITLE
Fix Dart bit flag enum combinations

### DIFF
--- a/dart/test/flat_buffers_test.dart
+++ b/dart/test/flat_buffers_test.dart
@@ -895,13 +895,32 @@ class ObjectAPITest {
 
     final monster2 = example.Monster(data); // Monster (reader)
     expect(
-        // map Monster => MonsterT, Vec3 => Vec3T, ...
-        monster2.toString().replaceAllMapped(
-            RegExp('([a-zA-z0-9]+){'), (match) => match.group(1)! + 'T{'),
-        monster.toString());
+      // map Monster => MonsterT, Vec3 => Vec3T, ...
+      monster2.toString().replaceAllMapped(
+        RegExp('([a-zA-z0-9]+){'),
+        (match) => match.group(1)! + 'T{',
+      ),
+      monster.toString(),
+    );
 
     final monster3 = monster2.unpack(); // MonsterT
     expect(monster3.toString(), monster.toString());
+  }
+
+  void test_bitFlagsEnumCombination() {
+    final color = example.Color.fromValue(
+      example.Color.Red.value | example.Color.Green.value,
+    );
+    final monster = example.MonsterT(color: color);
+
+    final fbBuilder = Builder();
+    fbBuilder.finish(monster.pack(fbBuilder));
+
+    final monster2 = example.Monster(fbBuilder.buffer);
+    expect(monster2.color, color);
+    expect(monster2.color.value, color.value);
+    expect(monster2.color.toString(), 'Color(3)');
+    expect(monster2.unpack().color, color);
   }
 
   void test_Lists() {

--- a/dart/test/monster_test_my_game.example_generated.dart
+++ b/dart/test/monster_test_my_game.example_generated.dart
@@ -12,14 +12,14 @@ import './monster_test_my_game.example2_generated.dart' as my_game_example2;
 import './monster_test_my_game_generated.dart' as my_game;
 
 ///  Composite components of Monster color.
-enum Color {
-  Red(1),
-  Green(2),
-  Blue(8),
-  _default(0);
+class Color {
+  static const Color Red = Color._(1);
+  static const Color Green = Color._(2);
+  static const Color Blue = Color._(8);
+  static const Color _default = Color._(0);
 
   final int value;
-  const Color(this.value);
+  const Color._(this.value);
 
   factory Color.fromValue(int value) {
     switch (value) {
@@ -32,12 +32,37 @@ enum Color {
       case 0:
         return Color._default;
       default:
-        throw StateError('Invalid value $value for bit flag enum');
+        return Color._(value);
     }
   }
 
   static Color? _createOrNull(int? value) =>
       value == null ? null : Color.fromValue(value);
+
+  static const List<Color> values = <Color>[Red, Green, Blue, _default];
+
+  @override
+  String toString() {
+    switch (value) {
+      case 1:
+        return 'Color.Red';
+      case 2:
+        return 'Color.Green';
+      case 8:
+        return 'Color.Blue';
+      case 0:
+        return 'Color._default';
+      default:
+        return 'Color($value)';
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is Color && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 
   static const fb.Reader<Color> reader = _ColorReader();
 }
@@ -96,14 +121,14 @@ class _RaceReader extends fb.Reader<Race> {
       Race.fromValue(const fb.Int8Reader().read(bc, offset));
 }
 
-enum LongEnum {
-  LongOne(2),
-  LongTwo(4),
-  LongBig(1099511627776),
-  _default(0);
+class LongEnum {
+  static const LongEnum LongOne = LongEnum._(2);
+  static const LongEnum LongTwo = LongEnum._(4);
+  static const LongEnum LongBig = LongEnum._(1099511627776);
+  static const LongEnum _default = LongEnum._(0);
 
   final int value;
-  const LongEnum(this.value);
+  const LongEnum._(this.value);
 
   factory LongEnum.fromValue(int value) {
     switch (value) {
@@ -116,12 +141,42 @@ enum LongEnum {
       case 0:
         return LongEnum._default;
       default:
-        throw StateError('Invalid value $value for bit flag enum');
+        return LongEnum._(value);
     }
   }
 
   static LongEnum? _createOrNull(int? value) =>
       value == null ? null : LongEnum.fromValue(value);
+
+  static const List<LongEnum> values = <LongEnum>[
+    LongOne,
+    LongTwo,
+    LongBig,
+    _default,
+  ];
+
+  @override
+  String toString() {
+    switch (value) {
+      case 2:
+        return 'LongEnum.LongOne';
+      case 4:
+        return 'LongEnum.LongTwo';
+      case 1099511627776:
+        return 'LongEnum.LongBig';
+      case 0:
+        return 'LongEnum._default';
+      default:
+        return 'LongEnum($value)';
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is LongEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 
   static const fb.Reader<LongEnum> reader = _LongEnumReader();
 }

--- a/src/idl_gen_dart.cpp
+++ b/src/idl_gen_dart.cpp
@@ -231,20 +231,35 @@ class DartGenerator : public BaseGenerator {
     // a default value of zero, even if it's not a valid enum value...
     const bool auto_default = is_bit_flags && !enum_def.FindByValue("0");
 
-    code += "enum " + enum_type + " {\n";
-    for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
-      auto& ev = **it;
-      const auto enum_var = namer_.Variant(ev);
-      if (it != enum_def.Vals().begin()) code += ",\n";
-      code += "  " + enum_var + "(" + enum_def.ToString(ev) + ")";
+    if (is_bit_flags) {
+      code += "class " + enum_type + " {\n";
+      for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end();
+           ++it) {
+        auto& ev = **it;
+        const auto enum_var = namer_.Variant(ev);
+        code += "  static const " + enum_type + " " + enum_var + " = " +
+                enum_type + "._(" + enum_def.ToString(ev) + ");\n";
+      }
+      if (auto_default) {
+        code += "  static const " + enum_type + " _default = " + enum_type +
+                "._(0);\n";
+      }
+      code += "\n";
+    } else {
+      code += "enum " + enum_type + " {\n";
+      for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end();
+           ++it) {
+        auto& ev = **it;
+        const auto enum_var = namer_.Variant(ev);
+        if (it != enum_def.Vals().begin()) code += ",\n";
+        code += "  " + enum_var + "(" + enum_def.ToString(ev) + ")";
+      }
+      code += ";\n\n";
     }
-    if (auto_default) {
-      code += ",\n  _default(0)";
-    }
-    code += ";\n\n";
 
     code += "  final int value;\n";
-    code += "  const " + enum_type + "(this.value);\n\n";
+    code += "  const " + enum_type + (is_bit_flags ? "._" : "") +
+            "(this.value);\n\n";
     code += "  factory " + enum_type + ".fromValue(int value) {\n";
     code += "    switch (value) {\n";
     for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end(); ++it) {
@@ -256,8 +271,12 @@ class DartGenerator : public BaseGenerator {
     if (auto_default) {
       code += "      case 0: return " + enum_type + "._default;\n";
     }
-    code += "      default: throw StateError(";
-    code += "'Invalid value $value for bit flag enum');\n";
+    if (is_bit_flags) {
+      code += "      default: return " + enum_type + "._(value);\n";
+    } else {
+      code += "      default: throw StateError(";
+      code += "'Invalid value $value for bit flag enum');\n";
+    }
     code += "    }\n";
     code += "  }\n\n";
 
@@ -265,9 +284,43 @@ class DartGenerator : public BaseGenerator {
     code +=
         "      value == null ? null : " + enum_type + ".fromValue(value);\n\n";
 
-    // This is meaningless for bit_flags, however, note that unlike "regular"
-    // dart enums this enum can still have holes.
-    if (!is_bit_flags) {
+    if (is_bit_flags) {
+      code += "  static const List<" + enum_type + "> values = <" + enum_type +
+              ">[\n";
+      for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end();
+           ++it) {
+        auto& ev = **it;
+        code += "    " + namer_.Variant(ev) + ",\n";
+      }
+      if (auto_default) {
+        code += "    _default,\n";
+      }
+      code += "  ];\n\n";
+
+      code += "  @override\n";
+      code += "  String toString() {\n";
+      code += "    switch (value) {\n";
+      for (auto it = enum_def.Vals().begin(); it != enum_def.Vals().end();
+           ++it) {
+        auto& ev = **it;
+        const auto enum_var = namer_.Variant(ev);
+        code += "      case " + enum_def.ToString(ev) + ":";
+        code += " return '" + enum_type + "." + enum_var + "';\n";
+      }
+      if (auto_default) {
+        code += "      case 0: return '" + enum_type + "._default';\n";
+      }
+      code += "      default: return '" + enum_type + "($value)';\n";
+      code += "    }\n";
+      code += "  }\n\n";
+
+      code += "  @override\n";
+      code += "  bool operator ==(Object other) =>\n";
+      code += "      identical(this, other) || other is " + enum_type +
+              " && other.value == value;\n\n";
+      code += "  @override\n";
+      code += "  int get hashCode => value.hashCode;\n\n";
+    } else {
       code += "  static const int minValue = " +
               enum_def.ToString(*enum_def.MinValue()) + ";\n";
       code += "  static const int maxValue = " +


### PR DESCRIPTION
## Problem
Dart generated code rejects valid `bit_flags` enum masks when multiple bits are set, such as `Color.Red.value | Color.Green.value`.

## Root cause
Dart `enum` instances can only represent declared enum constants. For `bit_flags`, FlatBuffers permits arbitrary combinations of the declared bits on the wire, so the generated `fromValue` method threw for valid combined masks.

## Solution
Generate Dart `bit_flags` enums as lightweight value classes instead of Dart `enum`s. Named values remain available as constants, `.value` is preserved, and `fromValue` now returns an instance carrying unknown combined masks. Regular enums continue to use Dart `enum` generation.

The Dart regression packs a table with a combined bit flag mask and verifies it survives both reader and object API unpacking.

Fixes #9087

## Tests
- `cmake -S . -B build -G Ninja -DFLATBUFFERS_BUILD_TESTS=OFF`
- `cmake --build build --target flatc`
- `build\flatc.exe --dart --gen-object-api -I tests\include_test -o dart\test tests\monster_test.fbs`
- `build\flatc.exe --dart --gen-object-api -I tests\include_test\sub -o dart\test tests\include_test\include_test1.fbs`
- `build\flatc.exe --dart --gen-object-api -I tests\include_test -o dart\test tests\include_test\sub\include_test2.fbs`
- `build\flatc.exe --dart --gen-object-api -o dart\test dart\test\enums.fbs`
- `build\flatc.exe --dart --gen-object-api -o dart\test dart\test\bool_structs.fbs`
- `dart pub get`
- `dart test test\flat_buffers_test.dart -n bitFlagsEnumCombination`
- `dart test`
- `git diff --check`