### PR TITLE
fuzz: add reflection verifier fuzz target and fix null union type-vector deref

### DIFF
--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -156,6 +156,7 @@ static bool VerifyVector(flatbuffers::Verifier& v,
       auto type_vec = table.GetPointer<Vector<uint8_t>*>(vec_field.offset() -
                                                          sizeof(voffset_t));
       if (!v.VerifyVector(type_vec)) return false;
+      if (!type_vec) return false;
       if (type_vec->size() != vec->size()) return false;
       for (uoffset_t j = 0; j < vec->size(); j++) {
         //  get union type from the prev field

--- a/tests/fuzzer/CMakeLists.txt
+++ b/tests/fuzzer/CMakeLists.txt
@@ -210,6 +210,9 @@ target_link_libraries(parser_fuzzer PRIVATE flatbuffers_fuzzed)
 add_executable(verifier_fuzzer flatbuffers_verifier_fuzzer.cc)
 target_link_libraries(verifier_fuzzer PRIVATE flatbuffers_fuzzed)
 
+add_executable(reflection_verifier_fuzzer flatbuffers_reflection_verifier_fuzzer.cc)
+target_link_libraries(reflection_verifier_fuzzer PRIVATE flatbuffers_fuzzed)
+
 add_executable(flexverifier_fuzzer flexbuffers_verifier_fuzzer.cc)
 target_link_libraries(flexverifier_fuzzer PRIVATE flatbuffers_fuzzed)
 

--- a/tests/fuzzer/flatbuffers_reflection_verifier_fuzzer.cc
+++ b/tests/fuzzer/flatbuffers_reflection_verifier_fuzzer.cc
@@ -1,0 +1,47 @@
+// OSS-Fuzz target for the reflection-based binary verifier
+// (flatbuffers::Verify(const reflection::Schema&, const reflection::Object&,
+//  const uint8_t*, size_t) defined in src/reflection.cpp).
+//
+// This entry point is part of flatbuffers' untrusted-input security model: it
+// is the function callers use to make an arbitrary buffer safe to traverse when
+// the type is known only at runtime via a reflection (.bfbs) schema. It is
+// currently exercised only by unit tests (tests/reflection_test.cpp); the
+// existing verifier/monster fuzzers drive the generated-code VerifyMonsterBuffer
+// path instead, and the annotator fuzzer drives BinaryAnnotator. Neither reaches
+// this function.
+//
+// The schema is fixed and trusted; only the buffer (data) is fuzzed, matching
+// the real threat model (trusted schema, untrusted serialized data).
+
+#include <cstdint>
+#include <cstddef>
+
+#include "flatbuffers/idl.h"
+#include "flatbuffers/reflection.h"
+
+static flatbuffers::Parser *parser_ = nullptr;
+static const reflection::Schema *schema_ = nullptr;
+
+extern "C" int LLVMFuzzerInitialize(int * /*argc*/, char *** /*argv*/) {
+  // A schema containing a vector of unions, which is the case that exercises
+  // the union type-vector lookup in the reflection verifier.
+  static const char *fbs =
+      "table Foo { x:int; }\n"
+      "table Bar { y:int; }\n"
+      "union MyUnion { Foo, Bar }\n"
+      "table Root { things:[MyUnion]; }\n"
+      "root_type Root;\n";
+  parser_ = new flatbuffers::Parser();
+  parser_->Parse(fbs);
+  parser_->Serialize();
+  schema_ = reflection::GetSchema(parser_->builder_.GetBufferPointer());
+  return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (schema_ == nullptr || schema_->root_table() == nullptr) return 0;
+  // Must not crash on any input; it should return true/false safely.
+  flatbuffers::Verify(*schema_, *schema_->root_table(), data,
+                      static_cast<size_t>(size));
+  return 0;
+}


### PR DESCRIPTION
reference: https://issuetracker.google.com/issues/522017954

## What this adds

A new OSS-Fuzz target (`tests/fuzzer/flatbuffers_reflection_verifier_fuzzer.cc`)
for `flatbuffers::Verify(const reflection::Schema&, const reflection::Object&,
const uint8_t*, size_t)` in `src/reflection.cpp`.

The existing verifier/monster fuzzers exercise generated-code verification;
the annotator fuzzer exercises `BinaryAnnotator`. None of them reach
`flatbuffers::Verify`, which is the function callers use when the type is
known only at runtime via a reflection schema and the input is untrusted.

## Bug found

The fuzzer finds a null pointer dereference on the first run:

```
type_vec->size()  // src/reflection.cpp
```

in the `reflection::Union` vector case. When a buffer contains the union
value vector (field offset 6) but omits the type vector (field offset 4),
`VerifyVector(type_vec)` returns true (null vector = absent = valid), and
`type_vec` is then dereferenced without a null check.

ASan stack (44-byte reproducer):

```
Vector<uint8_t>::size()
  VerifyVector (reflection.cpp)
  VerifyObject
  flatbuffers::Verify
  LLVMFuzzerTestOneInput
```

## Fix

Add `if (!type_vec) return false;` before the dereference in
`src/reflection.cpp` (union vector case).

## CLA

I have signed the Google Individual CLA.