### PR TITLE
fix: bounds checks in reflection API for malformed schemas

### DIFF
--- a/src/bfbs_gen.h
+++ b/src/bfbs_gen.h
@@ -72,6 +72,11 @@ static std::vector<uint32_t> FieldIdToIndex(const reflection::Object* object) {
   // Create the mapping of field ID to the index into the vector.
   for (uint32_t i = 0; i < object->fields()->size(); ++i) {
     auto field = object->fields()->Get(i);
+    // Bounds check: field->id() is a uint16_t from the schema and could
+    // exceed fields()->size() in a malformed schema.
+    if (field->id() >= object->fields()->size()) {
+      return {};  // Malformed schema, return empty.
+    }
     field_index_by_id[field->id()] = i;
   }
 

--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -250,6 +250,10 @@ static bool VerifyObject(flatbuffers::Verifier& v,
       }
       case reflection::Union: {
         //  get union type from the prev field
+        // Bounds check: offset must be >= sizeof(voffset_t) to avoid underflow
+        if (field_def->offset() < sizeof(voffset_t)) {
+          return false;
+        }
         voffset_t utype_offset = field_def->offset() - sizeof(voffset_t);
         auto utype = table->GetField<uint8_t>(utype_offset, 0);
         auto uval = reinterpret_cast<const uint8_t*>(
@@ -384,6 +388,11 @@ void ForAllFields(const reflection::Object* object, bool reverse,
   // Create the mapping of field ID to the index into the vector.
   for (uint32_t i = 0; i < object->fields()->size(); ++i) {
     auto field = object->fields()->Get(i);
+    // Bounds check: field->id() is a uint16_t from the schema and could
+    // exceed fields()->size() in a malformed schema.
+    if (field->id() >= object->fields()->size()) {
+      return;  // Malformed schema, abort.
+    }
     field_to_id_map[field->id()] = i;
   }
 


### PR DESCRIPTION
Adds bounds checks to prevent OOB memory access when processing malformed `.bfbs` files.

**Bug 1 — OOB write in `ForAllFields()` / `FieldIdToIndex()`:**
`field->id()` is `uint16_t` (0-65535) used as array index into vector sized to `fields()->size()`. No bounds check.

**Bug 2 — OOB read in `VerifyObject()`:**
`field->offset() - sizeof(voffset_t)` underflows when `offset < 2`, causing read at offset 0xFFFF.

**Fix:**
- `ForAllFields()`: skip if `field->id() >= fields()->size()`
- `VerifyObject()`: return false if `offset < sizeof(voffset_t)`
- `FieldIdToIndex()`: same fix as `ForAllFields()`

All tests pass.