### PR TITLE
Fix CallbackService forward declaration scope with --grpc-callback-api

### DIFF
--- a/grpc/src/compiler/cpp_generator.cc
+++ b/grpc/src/compiler/cpp_generator.cc
@@ -983,11 +983,11 @@ static void PrintHeaderService(grpc_generator::Printer* printer,
                                       false);
   }
   printer->Outdent();
+  printer->Print("};\n");
   // Forward declaration of nested CallbackService if callback API enabled.
   if ((*vars)["generate_callback_api"] == "1") {
     printer->Print("class CallbackService;\n");
   }
-  printer->Print("};\n");
   printer->Print(
       "class Stub final : public StubInterface"
       " {\n public:\n");

--- a/tests/monster_test.grpc.fb.h
+++ b/tests/monster_test.grpc.fb.h
@@ -84,8 +84,8 @@ class MonsterStorage final {
     virtual ::grpc::ClientReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* GetMinMaxHitPointsRaw(::grpc::ClientContext* context) = 0;
     virtual ::grpc::ClientAsyncReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* AsyncGetMinMaxHitPointsRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) = 0;
     virtual ::grpc::ClientAsyncReaderWriterInterface< flatbuffers::grpc::Message<Monster>, flatbuffers::grpc::Message<Stat>>* PrepareAsyncGetMinMaxHitPointsRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) = 0;
-  class CallbackService;
   };
+  class CallbackService;
   class Stub final : public StubInterface {
    public:
     Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel);


### PR DESCRIPTION
## Summary

When `--grpc-callback-api` is used, `flatc` emitted the `CallbackService` forward declaration inside `StubInterface` instead of in the enclosing service class. The out-of-class `CallbackService` definition uses `Service::CallbackService`, so the forward declaration must be at the service scope.

## Fix

Move the `class CallbackService;` forward declaration to after the `StubInterface` closing brace, so it is declared as `MonsterStorage::CallbackService` rather than `MonsterStorage::StubInterface::CallbackService`.

## Testing

- Rebuilt `flatc` and regenerated `tests/monster_test.grpc.fb.h` golden file
- Existing compile test `grpc/tests/grpctest_callback_compile.cpp` validates `MonsterStorage::CallbackService` usage (requires gRPC to run locally)

Fixes #9130