### PR TITLE
preserve float/double distinction in JSON schema output via format metadata

### DIFF
--- a/src/idl_gen_json_schema.cpp
+++ b/src/idl_gen_json_schema.cpp
@@ -87,8 +87,9 @@ static std::string GenType(BaseType type) {
       return "\"type\" : \"integer\", \"minimum\" : 0, \"maximum\" : " +
              NumToString(std::numeric_limits<uint64_t>::max());
     case BASE_TYPE_FLOAT:
+      return "\"type\" : \"number\", \"format\" : \"float\"";
     case BASE_TYPE_DOUBLE:
-      return "\"type\" : \"number\"";
+      return "\"type\" : \"number\", \"format\" : \"double\"";
     case BASE_TYPE_STRING:
       return "\"type\" : \"string\"";
     default:


### PR DESCRIPTION
Directly related to: #9071

## Summary

This PR addresses an issue where the JSON schema generator does not distinguish between `BASE_TYPE_FLOAT` and `BASE_TYPE_DOUBLE`, emitting both as: `"type": "number"`.This makes the schema less precise for downstream consumers that rely on JSON Schema for: documentation, code generation, and schema introspection

## Change

This change updates `idl_gen_json_schema.cpp` to preserve floating-point precision information using a new `"format"` key in the metadata.

## Testing
- `flattests` passes locally upon re-building `flatc` with my new changes
-verified JSON schema output using `flatc --jsonschema` shows correct distinction between float and double
