### PR TITLE
Lock pnpm version to 10 in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -545,7 +545,7 @@ jobs:
       # FIXME: make test script not rely on flatc
       run: cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_INSTALL=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF . && make -j
     - name: pnpm
-      run: npm install -g pnpm
+      run: npm install -g pnpm@10
     - name: deps
       run: pnpm i
     - name: compile


### PR DESCRIPTION
A temporary fix (before migration to v11) for the Build TS ci workflow