### PR TITLE
Automatically update copyright year in documentation footer

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,1 +1,18 @@
 {% extends "base.html" %}
+
+{% block scripts %}
+  {{ super() }}
+
+  <script>
+    window.addEventListener("load", function () {
+      const copyright =
+        document.querySelector(".md-copyright__highlight");
+
+      if (copyright) {
+        copyright.innerHTML =
+          `Copyright &copy; ${new Date().getFullYear()} Google`;
+      }
+    });
+  </script>
+
+{% endblock %}


### PR DESCRIPTION
 Summary

Adds a small JavaScript snippet to automatically update the copyright year displayed in the documentation footer.

 Changes

* Overrides the MkDocs Material footer in `docs/overrides/main.html`
* Replaces the hardcoded copyright year with the current year using JavaScript
* Keeps the footer up to date without requiring manual yearly updates

 Example

Before:
Copyright © 2025 Google

After:
Copyright © 2026 Google
(and automatically updates in future years)
