### PR TITLE
fix(flatbuffers): guard GetBufferStartFromRootPointer against OOB read before buffer start

### DIFF
--- a/include/flatbuffers/flatbuffers.h
+++ b/include/flatbuffers/flatbuffers.h
@@ -41,7 +41,11 @@ namespace flatbuffers {
 /// it is the opposite transformation of GetRoot().
 /// This may be useful if you want to pass on a root and have the recipient
 /// delete the buffer afterwards.
-inline const uint8_t* GetBufferStartFromRootPointer(const void* root) {
+/// @param buf_start Optional pointer to the start of the buffer allocation.
+/// When provided, the search will not walk before this address, preventing
+/// out-of-bounds reads on malformed or truncated buffers.
+inline const uint8_t* GetBufferStartFromRootPointer(
+    const void* root, const uint8_t* buf_start = nullptr) {
   auto table = reinterpret_cast<const Table*>(root);
   auto vtable = table->GetVTable();
   // Either the vtable is before the root or after the root.
@@ -62,6 +66,8 @@ inline const uint8_t* GetBufferStartFromRootPointer(const void* root) {
                 "file_identifier is assumed to be the same size as uoffset_t");
   for (auto possible_roots = FLATBUFFERS_MAX_ALIGNMENT / sizeof(uoffset_t) + 1;
        possible_roots; possible_roots--) {
+    // Do not walk before the known start of the allocation.
+    if (buf_start != nullptr && start < buf_start + sizeof(uoffset_t)) break;
     start -= sizeof(uoffset_t);
     if (ReadScalar<uoffset_t>(start) + start ==
         reinterpret_cast<const uint8_t*>(root))


### PR DESCRIPTION
## Summary

`GetBufferStartFromRootPointer` walks backwards from the root pointer by repeatedly subtracting `sizeof(uoffset_t)` (up to 9 iterations for 32-byte-aligned buffers) to find the buffer start. It has no check that the walking pointer remains within the buffer allocation. A caller that supplies a root pointer near the beginning of the buffer — or a crafted FlatBuffer with a small or zero vtable offset — will cause the function to read memory before the heap allocation.

## Root cause

```cpp
// include/flatbuffers/flatbuffers.h — before this patch
for (auto possible_roots = FLATBUFFERS_MAX_ALIGNMENT / sizeof(uoffset_t) + 1;
     possible_roots; possible_roots--) {
  start -= sizeof(uoffset_t);   // no lower-bound guard
  if (ReadScalar<uoffset_t>(start) + start == ...)
    return start;
}
```

## Fix

Add an optional `buf_start` parameter (defaults to `nullptr` — all existing callers are unchanged). When provided, the backward search stops before walking past `buf_start`, breaking out of the loop and falling through to the existing `FLATBUFFERS_ASSERT(false)` path.

```cpp
// After patch
inline const uint8_t* GetBufferStartFromRootPointer(
    const void* root, const uint8_t* buf_start = nullptr) {
  ...
  for (...) {
    if (buf_start != nullptr && start < buf_start + sizeof(uoffset_t)) break;
    start -= sizeof(uoffset_t);
    ...
  }
}
```

The guard fires before the subtraction, so it is safe against pointer underflow. Backward compatibility is preserved — callers that omit `buf_start` behave exactly as before.