### PR TITLE
fix(flexbuffers): guard Map::Keys() against OOB heap read before buffer start

### DIFF
--- a/include/flatbuffers/flexbuffers.h
+++ b/include/flatbuffers/flexbuffers.h
@@ -341,7 +341,9 @@ class FixedTypedVector : public Object {
 
 class Map : public Vector {
  public:
-  Map(const uint8_t* data, uint8_t byte_width) : Vector(data, byte_width) {}
+  Map(const uint8_t* data, uint8_t byte_width,
+      const uint8_t* buf_start = nullptr)
+      : Vector(data, byte_width), buf_start_(buf_start) {}
 
   Reference operator[](const char* key) const;
   Reference operator[](const std::string& key) const;
@@ -350,6 +352,12 @@ class Map : public Vector {
 
   TypedVector Keys() const {
     const size_t num_prefixed_fields = 3;
+    // Guard against reading before the start of the buffer allocation when a
+    // crafted FlexBuffer places the map data pointer too close to the start.
+    if (buf_start_ != nullptr &&
+        data_ < buf_start_ + byte_width_ * num_prefixed_fields) {
+      return TypedVector::EmptyTypedVector();
+    }
     auto keys_offset = data_ - byte_width_ * num_prefixed_fields;
     return TypedVector(Indirect(keys_offset, byte_width_),
                        static_cast<uint8_t>(
@@ -365,6 +373,9 @@ class Map : public Vector {
   }
 
   bool IsTheEmptyMap() const { return data_ == EmptyMap().data_; }
+
+ private:
+  const uint8_t* buf_start_;
 };
 
 inline void IndentString(std::string& s, int indent,
@@ -404,20 +415,24 @@ void AppendToString(std::string& s, T&& v, bool keys_quoted) {
 class Reference {
  public:
   Reference()
-      : data_(nullptr), parent_width_(0), byte_width_(0), type_(FBT_NULL) {}
+      : data_(nullptr), parent_width_(0), byte_width_(0), type_(FBT_NULL),
+        buf_start_(nullptr) {}
 
   Reference(const uint8_t* data, uint8_t parent_width, uint8_t byte_width,
-            Type type)
+            Type type, const uint8_t* buf_start = nullptr)
       : data_(data),
         parent_width_(parent_width),
         byte_width_(byte_width),
-        type_(type) {}
+        type_(type),
+        buf_start_(buf_start) {}
 
-  Reference(const uint8_t* data, uint8_t parent_width, uint8_t packed_type)
+  Reference(const uint8_t* data, uint8_t parent_width, uint8_t packed_type,
+            const uint8_t* buf_start = nullptr)
       : data_(data),
         parent_width_(parent_width),
         byte_width_(static_cast<uint8_t>(1 << (packed_type & 3))),
-        type_(static_cast<Type>(packed_type >> 2)) {}
+        type_(static_cast<Type>(packed_type >> 2)),
+        buf_start_(buf_start) {}
 
   Type GetType() const { return type_; }
 
@@ -730,7 +745,7 @@ class Reference {
 
   Map AsMap() const {
     if (type_ == FBT_MAP) {
-      return Map(Indirect(), byte_width_);
+      return Map(Indirect(), byte_width_, buf_start_);
     } else {
       return Map::EmptyMap();
     }
@@ -849,6 +864,7 @@ class Reference {
   uint8_t parent_width_;
   uint8_t byte_width_;
   Type type_;
+  const uint8_t* buf_start_;
 };
 
 // Template specialization for As().
@@ -1011,7 +1027,7 @@ inline Reference GetRoot(const uint8_t* buffer, size_t size) {
   auto byte_width = *--end;
   auto packed_type = *--end;
   end -= byte_width;  // The root data item.
-  return Reference(end, byte_width, packed_type);
+  return Reference(end, byte_width, packed_type, buffer);
 }
 
 inline Reference GetRoot(const std::vector<uint8_t>& buffer) {


### PR DESCRIPTION
## Summary

`Map::Keys()` computes `data_ - byte_width_ * 3` to locate the keys vector that precedes every FlexBuffers map in memory, but performs no check that the result is within the buffer allocation. A crafted FlexBuffer that places the map's data pointer within `byte_width * 3` bytes of the buffer start causes the subtraction to produce a pointer before the allocation — an out-of-bounds heap read.

## Root cause

```cpp
// include/flatbuffers/flexbuffers.h — before this patch
TypedVector Keys() const {
  const size_t num_prefixed_fields = 3;
  auto keys_offset = data_ - byte_width_ * num_prefixed_fields;  // no bounds check
  return TypedVector(Indirect(keys_offset, byte_width_), ...);
}
```

## Fix

Thread `buf_start` from `GetRoot()` through `Reference` (as an optional field defaulting to `nullptr`) into `Map` via `AsMap()`. Add a pre-flight check in `Keys()` that returns `EmptyTypedVector()` if the backward offset would underflow:

```cpp
TypedVector Keys() const {
  const size_t num_prefixed_fields = 3;
  if (buf_start_ != nullptr &&
      data_ < buf_start_ + byte_width_ * num_prefixed_fields) {
    return TypedVector::EmptyTypedVector();
  }
  auto keys_offset = data_ - byte_width_ * num_prefixed_fields;
  ...
}
```

All existing constructors of `Map` and `Reference` are backward-compatible — `buf_start` defaults to `nullptr`, which disables the guard. Only the `GetRoot() → Reference → AsMap()` path propagates the real buffer start.