### PR TITLE
ci: pin all GitHub Actions to full commit SHAs to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
     name: Publish NPM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
@@ -29,8 +29,8 @@ jobs:
       run:
         working-directory: ./python
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.0
         with:
           python-version: '3.10'
 
@@ -57,8 +57,8 @@ jobs:
       run:
         working-directory: ./net/flatbuffers
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.0.0
         with:
           dotnet-version: '8.0.x'
       - name: Build
@@ -80,10 +80,10 @@ jobs:
       run:
         working-directory: ./java
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.0.0
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -108,9 +108,9 @@ jobs:
       run:
         working-directory: ./kotlin
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.0.0
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -119,7 +119,7 @@ jobs:
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE # this needs to be an env var
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE # this needs to be an env par
 
       - name: Publish Kotlin Library on Maven
         run: ./gradlew publishAllPublicationsToSonatypeRepository
@@ -133,20 +133,20 @@ jobs:
     name: Publish crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: stable
           override: true
           
       - name: Publish Flatbuffers
-        uses: katyo/publish-crates@v2
+        uses: katyo/publish-crates@02cc2f1ad653fb25c7d1ff9eb590a8a50d06186b # v2.0.0
         with:
           path: ./rust/flatbuffers
           registry-token: ${{ secrets.CARGO_TOKEN }}
 
       - name: Publish Flexbuffers
-        uses: katyo/publish-crates@v2
+        uses: katyo/publish-crates@02cc2f1ad653fb25c7d1ff9eb590a8a50d06186b # v2.0.0
         with:
           path: ./rust/flexbuffers
           registry-token: ${{ secrets.CARGO_TOKEN }}


### PR DESCRIPTION
## Summary

The `release.yml` workflow uses multiple GitHub Actions pinned to **mutable version tags** (e.g. `@v6`, `@v5`, `@v1`, `@v2`). An attacker who compromises any of these upstream Action repositories can silently change what `@v5` or `@v6` points to, and that malicious code will execute the next time a release is published — with access to repository secrets (`NPM_TOKEN`, `TWINE_TOKEN`, `NUGET_API_KEY`, `CARGO_TOKEN`, `MAVEN_GPG_PRIVATE_KEY`, etc.).

## Affected file

`.github/workflows/release.yml`

## Vulnerability class

Supply-chain attack via mutable Action tag references (CWE-829).

## Affected actions (before → after)

| Action | Was | Now |
|--------|-----|-----|
| `actions/checkout` | `@v6` | `@df4cb1c069e1874edd31b4311f1884172cec0e10` |
| `actions/setup-node` | `@v6` | `@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` |
| `actions/setup-python` | `@v6` | `@ece7cb06caefa5fff74198d8649806c4678c61a1` |
| `actions/setup-dotnet` | `@v5` | `@26b0ec14cb23fa6904739307f278c14f94c95bf1` |
| `actions/setup-java` | `@v5` (×2) | `@1bcf9fb12cf4aa7d266a90ae39939e61372fe520` |
| `actions-rs/toolchain` | `@v1` | `@16499b5e05bf2e26879000db0c1d13f7e13fa3af` |
| `katyo/publish-crates` | `@v2` (×2) | `@02cc2f1ad653fb25c7d1ff9eb590a8a50d06186b` |

## Fix

All actions are now pinned to their full immutable commit SHA, with the version tag kept as an inline comment for human readability.