### PR TITLE
fix: add null check for file_saver in GenerateBinary to prevent null dereference

### DIFF
--- a/src/idl_gen_binary.cpp
+++ b/src/idl_gen_binary.cpp
@@ -41,6 +41,7 @@ static std::string BinaryFileName(const Parser& parser, const std::string& path,
 
 static bool GenerateBinary(const Parser& parser, const std::string& path,
                            const std::string& file_name) {
+  if (!parser.opts.file_saver) return false;
   if (parser.opts.use_flexbuffers) {
     auto data_vec = parser.flex_builder_.GetBuffer();
     auto data_ptr = reinterpret_cast<char*>(data(data_vec));


### PR DESCRIPTION
## Summary
Add a null pointer check for `parser.opts.file_saver` before dereferencing 
it in `GenerateBinary()` in `src/idl_gen_binary.cpp`.

## Problem
`GenerateBinary()` unconditionally dereferences `parser.opts.file_saver` 
without verifying it is non-null. When the parser is initialized without 
a valid file saver, this causes a null pointer dereference (SEGV).

This was discovered via OSS-Fuzz using the `codegen_fuzzer` target.

## Fix
Added an early return `if (!parser.opts.file_saver) return false;` 
at the start of `GenerateBinary()`, before any dereference occurs.

## Impact
Prevents a deterministic crash (SCARINESS: 10, null-deref) when 
processing malformed .fbs schema files.