### PR TITLE
Add out of bounds checks in memcpy_downward

### DIFF
--- a/include/flatbuffers/allocator.h
+++ b/include/flatbuffers/allocator.h
@@ -57,9 +57,13 @@ class Allocator {
   void memcpy_downward(uint8_t* old_p, size_t old_size, uint8_t* new_p,
                        size_t new_size, size_t in_use_back,
                        size_t in_use_front) {
-    memcpy(new_p + new_size - in_use_back, old_p + old_size - in_use_back,
-           in_use_back);
-    memcpy(new_p, old_p, in_use_front);
+     FLATBUFFERS_ASSERT(in_use_back <= old_size);
+     FLATBUFFERS_ASSERT(in_use_back <= new_size);
+     memcpy(new_p + new_size - in_use_back, old_p + old_size - in_use_back,
+         in_use_back);
+     FLATBUFFERS_ASSERT(in_use_front <= old_size);
+     FLATBUFFERS_ASSERT(in_use_front <= new_size);
+     memcpy(new_p, old_p, in_use_front);
   }
 };
 

--- a/include/flatbuffers/allocator.h
+++ b/include/flatbuffers/allocator.h
@@ -57,13 +57,13 @@ class Allocator {
   void memcpy_downward(uint8_t* old_p, size_t old_size, uint8_t* new_p,
                        size_t new_size, size_t in_use_back,
                        size_t in_use_front) {
-     FLATBUFFERS_ASSERT(in_use_back <= old_size);
-     FLATBUFFERS_ASSERT(in_use_back <= new_size);
-     memcpy(new_p + new_size - in_use_back, old_p + old_size - in_use_back,
-         in_use_back);
-     FLATBUFFERS_ASSERT(in_use_front <= old_size);
-     FLATBUFFERS_ASSERT(in_use_front <= new_size);
-     memcpy(new_p, old_p, in_use_front);
+    FLATBUFFERS_ASSERT(in_use_back <= old_size);
+    FLATBUFFERS_ASSERT(in_use_back <= new_size);
+    memcpy(new_p + new_size - in_use_back, old_p + old_size - in_use_back,
+           in_use_back);
+    FLATBUFFERS_ASSERT(in_use_front <= old_size);
+    FLATBUFFERS_ASSERT(in_use_front <= new_size);
+    memcpy(new_p, old_p, in_use_front);
   }
 };
 


### PR DESCRIPTION
out of bounds checks in memcpy_downward are added to protect against misuse 
which can lead to memory corruption

Closes: https://github.com/google/flatbuffers/issues/9162