### PR TITLE
Use rules_js v3 with Bazel 8

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,4 +1,5 @@
 ts/node_modules
+ts/tests/ts/node_modules
 
 # Test workspaces
 tests/bazel_repository_test_dir

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -61,6 +61,7 @@ bazel_dep(
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(
     name = "flatbuffers_npm",
+    npm_package_target_name = "flatbuffers",
     npmrc = "//:.npmrc",
     pnpm_lock = "//ts:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,11 +15,11 @@ bazel_dep(
 )
 bazel_dep(
     name = "aspect_rules_js",
-    version = "2.3.8",
+    version = "3.0.3",
 )
 bazel_dep(
     name = "aspect_rules_ts",
-    version = "3.6.0",
+    version = "3.9.1",
 )
 bazel_dep(
     name = "grpc",
@@ -61,9 +61,7 @@ bazel_dep(
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(
     name = "flatbuffers_npm",
-    npmrc = "//:.npmrc",
     pnpm_lock = "//ts:pnpm-lock.yaml",
-    verify_node_modules_ignored = "//:.bazelignore",
 )
 use_repo(npm, "flatbuffers_npm")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -61,7 +61,9 @@ bazel_dep(
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(
     name = "flatbuffers_npm",
+    npmrc = "//:.npmrc",
     pnpm_lock = "//ts:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
 )
 use_repo(npm, "flatbuffers_npm")
 

--- a/tests/ts/BUILD.bazel
+++ b/tests/ts/BUILD.bazel
@@ -10,7 +10,6 @@ package(default_visibility = ["//visibility:private"])
 npm_link_package(
     name = "node_modules/flatbuffers",
     src = "//ts:flatbuffers",
-    root_package = "tests/ts",
 )
 
 flatbuffer_ts_library(

--- a/tests/ts/bazel_repository_test_dir/MODULE.bazel
+++ b/tests/ts/bazel_repository_test_dir/MODULE.bazel
@@ -12,11 +12,11 @@ bazel_dep(
 )
 bazel_dep(
     name = "aspect_rules_js",
-    version = "2.1.3",
+    version = "3.0.3",
 )
 bazel_dep(
     name = "aspect_rules_ts",
-    version = "3.4.0",
+    version = "3.9.1",
 )
 bazel_dep(
     name = "rules_nodejs",
@@ -26,9 +26,7 @@ bazel_dep(
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(
     name = "npm",
-    npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
-    verify_node_modules_ignored = "//:.bazelignore",
 )
 use_repo(npm, "npm")
 

--- a/tests/ts/bazel_repository_test_dir/MODULE.bazel
+++ b/tests/ts/bazel_repository_test_dir/MODULE.bazel
@@ -26,7 +26,9 @@ bazel_dep(
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(
     name = "npm",
+    npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
 )
 use_repo(npm, "npm")
 

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -53,7 +53,6 @@ ts_project(
             "skipLibCheck": True,
         },
     },
-    validate = False,
     visibility = ["//visibility:public"],
     deps = [
         ":node_modules/@types/node",

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -67,13 +67,6 @@ npm_package(
     visibility = ["//visibility:public"],
 )
 
-# rules_js v3 defaults npm_package_target_name to "pkg" for workspace packages.
-alias(
-    name = "pkg",
-    actual = ":flatbuffers",
-    visibility = ["//visibility:public"],
-)
-
 sh_binary(
     name = "compile_flat_file",
     srcs = ["compile_flat_file.sh"],

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -42,6 +42,7 @@ ts_project(
             "module": "commonjs",
             "declaration": True,
             "moduleResolution": "node",
+            "ignoreDeprecations": "6.0",
             "lib": [
                 "ES2015",
                 "ES2020.BigInt",
@@ -49,8 +50,10 @@ ts_project(
             ],
             "types": ["node"],
             "strict": True,
+            "skipLibCheck": True,
         },
     },
+    validate = False,
     visibility = ["//visibility:public"],
     deps = [
         ":node_modules/@types/node",
@@ -62,6 +65,13 @@ npm_package(
     srcs = [":flatbuffers_ts"],
     include_external_repositories = ["*"],
     package = "flatbuffers",
+    visibility = ["//visibility:public"],
+)
+
+# rules_js v3 defaults npm_package_target_name to "pkg" for workspace packages.
+alias(
+    name = "pkg",
+    actual = ":flatbuffers",
     visibility = ["//visibility:public"],
 )
 

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -42,6 +42,7 @@ ts_project(
             "module": "commonjs",
             "declaration": True,
             "moduleResolution": "node",
+            # Suppress TS5107 deprecation error for moduleResolution=node in TypeScript 5.8+.
             "ignoreDeprecations": "6.0",
             "lib": [
                 "ES2015",
@@ -50,6 +51,7 @@ ts_project(
             ],
             "types": ["node"],
             "strict": True,
+            # Skip checking mixed 3rd-party .d.ts files to prevent TS2403 declaration clashes between @types/node and lib.dom.d.ts.
             "skipLibCheck": True,
         },
     },

--- a/ts/compile_flat_file.sh
+++ b/ts/compile_flat_file.sh
@@ -17,6 +17,9 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 set -eu
 runfiles_export_envvars
 FLATC=$(rlocation com_github_google_flatbuffers/flatc)
-TS_FILE=$(${FLATC}  $@  | grep  "Entry point.*generated" | grep -o "bazel-out.*ts")
+FBS_FILE="${!#}"
+SCHEMA_BASE=$(basename "${FBS_FILE}" .fbs)
+${FLATC} "$@"
+TS_FILE=$(${FLATC} --file-names-only "$@" 2>/dev/null | grep "/${SCHEMA_BASE}\(_[a-zA-Z0-9_-]*\)\?\.ts$" | head -n 1)
 export PATH="$(rlocation nodejs_linux_amd64/bin/nodejs/bin):${PATH}"
-${ESBUILD_BIN} ${TS_FILE} --format=cjs --bundle --outfile="${OUTPUT_FILE}"  --external:flatbuffers --log-level=warning
+${ESBUILD_BIN} "${TS_FILE}" --format=cjs --bundle --outfile="${OUTPUT_FILE}"  --external:flatbuffers --log-level=warning

--- a/ts/compile_flat_file.sh
+++ b/ts/compile_flat_file.sh
@@ -2,8 +2,8 @@
 # This is a script used by the typescript flatbuffer bazel rules to compile
 # a flatbuffer schema (.fbs file) to typescript and then use esbuild to
 # generate a single output.
-# Note: This relies on parsing the stdout of flatc to figure out how to
-# run esbuild.
+# Note: This uses flatc --file-names-only to determine the generated main entry
+# point file to pass to esbuild.
 # --- begin runfiles.bash initialization v2 ---
 # Copy-pasted from the Bazel Bash runfiles library v2.
 set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
@@ -17,9 +17,12 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 set -eu
 runfiles_export_envvars
 FLATC=$(rlocation com_github_google_flatbuffers/flatc)
+# The schema file (.fbs) is the last argument passed to flatc ($@).
 FBS_FILE="${!#}"
 SCHEMA_BASE=$(basename "${FBS_FILE}" .fbs)
 ${FLATC} "$@"
+# flatc no longer prints generated entry point paths to console output when
+# compiling. Use --file-names-only to discover the generated .ts entry point.
 TS_FILE=$(${FLATC} --file-names-only "$@" 2>/dev/null | grep "/${SCHEMA_BASE}\(_[a-zA-Z0-9_-]*\)\?\.ts$" | head -n 1)
 export PATH="$(rlocation nodejs_linux_amd64/bin/nodejs/bin):${PATH}"
 ${ESBUILD_BIN} "${TS_FILE}" --format=cjs --bundle --outfile="${OUTPUT_FILE}"  --external:flatbuffers --log-level=warning


### PR DESCRIPTION
This is the smallest amount of changes needed to use rules_js v3 with Bazel 8 (locally I have a .bazelversion set to 8.4.0 in my fork).