### PR TITLE
Fix C# verification for union vectors

### DIFF
--- a/net/FlatBuffers/FlatBufferVerify.cs
+++ b/net/FlatBuffers/FlatBufferVerify.cs
@@ -750,7 +750,7 @@ namespace Google.FlatBuffers
       for (uint i = 0; i < typeIdVectorLength; i++)
       {
         // Get type id
-        byte typeId = verifier_buffer.Get(Convert.ToInt32(typeIdStart + i * SIZE_U_OFFSET));
+        byte typeId = verifier_buffer.Get(Convert.ToInt32(typeIdStart + i * SIZE_BYTE));
         // get offset to vector item
         uint off = valueStart + i * SIZE_U_OFFSET;
         // Check the vector item has a proper offset

--- a/src/idl_gen_csharp.cpp
+++ b/src/idl_gen_csharp.cpp
@@ -785,7 +785,18 @@ class CSharpGenerator : public BaseGenerator {
             break;
           }
           case BASE_TYPE_UNION: {
-            // Vectors of unions are not yet supported for go
+            auto union_name = NamespacedName(*field.value.type.enum_def);
+            code_.SetValue("ENUM_NAME", union_name);
+            // Caution: This construction assumes, that UNION type id element has
+            // been created just before union data and its offset precedes union.
+            // Such assumption is common in flatbuffer implementation
+            code_.SetValue("TYPE_ID_OFFSET",
+                           NumToString(field.value.offset - sizeof(voffset_t)));
+            code_ +=
+                "{{PRE}}      && verifier.VerifyVectorOfUnion(tablePos, "
+                "{{TYPE_ID_OFFSET}}, "
+                "{{OFFSET}} /*{{NAME}}*/, {{ENUM_NAME}}Verify.Verify, "
+                "{{REQUIRED_FLAG}})";
             break;
           }
           default:

--- a/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
+++ b/tests/FlatBuffers.Test/FlatBuffersExampleTests.cs
@@ -508,6 +508,22 @@ namespace Google.FlatBuffers.Test
         }
 
         [FlatBuffersTestMethod]
+        public void TestUnionVectorVerifierRejectsTypeStrideMismatch()
+        {
+            var validBuffer = BuildMovieBufferWithUnionVector();
+            Assert.IsTrue(Movie.VerifyMovie(validBuffer));
+
+            var invalidBuffer = BuildMovieBufferWithInvalidUnionVectorType();
+            var movie = Movie.GetRootAsMovie(invalidBuffer);
+            Assert.AreEqual(Character.Other, movie.CharactersType(1));
+
+            var verifier = new Verifier(invalidBuffer);
+            var tablePos = (uint)(invalidBuffer.GetInt(invalidBuffer.Position) + invalidBuffer.Position);
+            Assert.IsFalse(verifier.VerifyVectorOfUnion(tablePos, 8, 10, CharacterVerify.Verify, false));
+            Assert.IsFalse(Movie.VerifyMovie(invalidBuffer));
+        }
+
+        [FlatBuffersTestMethod]
         public void TestUnionUtility()
         {
             var movie = new MovieT
@@ -525,6 +541,55 @@ namespace Google.FlatBuffers.Test
             Movie.FinishMovieBuffer(fbb, Movie.Pack(fbb, movie));
 
             TestObjectAPI(Movie.GetRootAsMovie(fbb.DataBuffer));
+        }
+
+        private static ByteBuffer BuildMovieBufferWithUnionVector()
+        {
+            var fbb = new FlatBufferBuilder(100);
+            var rapunzel = Rapunzel.CreateRapunzel(fbb, 40).Value;
+
+            var characterTypes = new[]
+            {
+                Character.MuLan,
+                Character.Belle,
+            };
+            var characterTypesOffset = Movie.CreateCharactersTypeVector(fbb, characterTypes);
+
+            var characters = new[]
+            {
+                Attacker.CreateAttacker(fbb, 10).Value,
+                BookReader.CreateBookReader(fbb, 20).Value,
+            };
+            var charactersOffset = Movie.CreateCharactersVector(fbb, characters);
+
+            var movieOffset = Movie.CreateMovie(
+                fbb,
+                Character.Rapunzel,
+                rapunzel,
+                characterTypesOffset,
+                charactersOffset);
+            Movie.FinishMovieBuffer(fbb, movieOffset);
+
+            return new ByteBuffer(fbb.DataBuffer.ToSizedArray());
+        }
+
+        private static ByteBuffer BuildMovieBufferWithInvalidUnionVectorType()
+        {
+            var invalidBuffer = BuildMovieBufferWithUnionVector();
+            var tablePos = invalidBuffer.GetInt(invalidBuffer.Position) + invalidBuffer.Position;
+            var table = new Table(tablePos, invalidBuffer);
+
+            var typeVectorOffset = table.__offset(8);
+            var typeVectorStart = table.__vector(typeVectorOffset);
+            var valueVectorOffset = table.__offset(10);
+            var valueVectorStart = table.__vector(valueVectorOffset);
+            var secondValueOffset = valueVectorStart + sizeof(int);
+
+            invalidBuffer.Put(typeVectorStart + 1, (byte)Character.Other);
+            invalidBuffer.Put(typeVectorStart + 4, (byte)Character.Belle);
+            invalidBuffer.PutUint(secondValueOffset, (uint)(typeVectorStart - secondValueOffset));
+
+            return invalidBuffer;
         }
 
         private void AreEqual(Monster a, MonsterT b)

--- a/tests/union_vector/Movie.cs
+++ b/tests/union_vector/Movie.cs
@@ -221,6 +221,7 @@ static public class MovieVerify
       && verifier.VerifyField(tablePos, 4 /*MainCharacterType*/, 1 /*Character*/, 1, false)
       && verifier.VerifyUnion(tablePos, 4, 6 /*MainCharacter*/, CharacterVerify.Verify, false)
       && verifier.VerifyVectorOfData(tablePos, 8 /*CharactersType*/, 1 /*Character*/, false)
+      && verifier.VerifyVectorOfUnion(tablePos, 8, 10 /*Characters*/, CharacterVerify.Verify, false)
       && verifier.VerifyTableEnd(tablePos);
   }
 }


### PR DESCRIPTION
## Summary
- fix `Verifier.VerifyVectorOfUnion()` so C# union type vectors are indexed byte-by-byte
- generate `VerifyVectorOfUnion()` calls for C# vector-of-union fields
- add a regression test for malformed union vectors and regenerate the checked-in C# union-vector fixture

## Testing
- `python3 scripts/generate_code.py --flatc build/flatc`
- `./tests/FlatBuffers.Test/.dotnet_tmp/dotnet build -c Release -f net8.0 tests/FlatBuffers.Test/FlatBuffers.Test.csproj`
- `(cd tests/FlatBuffers.Test/bin/Release/net8.0 && ../../../.dotnet_tmp/dotnet FlatBuffers.Test.dll)`
- `./tests/FlatBuffers.Test/.dotnet_tmp/dotnet build -c Release -f net8.0 -p:UnsafeByteBuffer=true tests/FlatBuffers.Test/FlatBuffers.Test.csproj && (cd tests/FlatBuffers.Test/bin/Release/net8.0 && ../../../.dotnet_tmp/dotnet FlatBuffers.Test.dll)`
- `./tests/FlatBuffers.Test/.dotnet_tmp/dotnet build -c Release -f net8.0 -p:UnsafeByteBuffer=true -p:EnableSpanT=true tests/FlatBuffers.Test/FlatBuffers.Test.csproj && (cd tests/FlatBuffers.Test/bin/Release/net8.0 && ../../../.dotnet_tmp/dotnet FlatBuffers.Test.dll)`
