### PR TITLE
[C++] Fix string vector lookup bug using StringCompare to support arbitrary bytes

### DIFF
--- a/include/flatbuffers/buffer.h
+++ b/include/flatbuffers/buffer.h
@@ -89,11 +89,23 @@ FLATBUFFERS_CONSTEXPR size_t AlignOf() {
 }
 
 // Lexicographically compare two strings (possibly containing nulls), and
+// return negative, 0, or positive.
+static inline int StringCompare(const char* a_data, uoffset_t a_size,
+                                const char* b_data, uoffset_t b_size) {
+  const auto cmp = memcmp(a_data, b_data, (std::min)(a_size, b_size));
+  if (cmp == 0) {
+    if (a_size < b_size) return -1;
+    if (a_size > b_size) return 1;
+    return 0;
+  }
+  return cmp;
+}
+
+// Lexicographically compare two strings (possibly containing nulls), and
 // return true if the first is less than the second.
 static inline bool StringLessThan(const char* a_data, uoffset_t a_size,
                                   const char* b_data, uoffset_t b_size) {
-  const auto cmp = memcmp(a_data, b_data, (std::min)(a_size, b_size));
-  return cmp == 0 ? a_size < b_size : cmp < 0;
+  return StringCompare(a_data, a_size, b_data, b_size) < 0;
 }
 
 // When we read serialized data from memory, in the case of most scalars,

--- a/include/flatbuffers/buffer.h
+++ b/include/flatbuffers/buffer.h
@@ -90,21 +90,23 @@ FLATBUFFERS_CONSTEXPR size_t AlignOf() {
 
 // Lexicographically compare two strings (possibly containing nulls), and
 // return negative, 0, or positive.
-static inline int StringCompare(const char* a_data, uoffset_t a_size,
-                                const char* b_data, uoffset_t b_size) {
-  const auto cmp = memcmp(a_data, b_data, (std::min)(a_size, b_size));
-  if (cmp == 0) {
-    if (a_size < b_size) return -1;
-    if (a_size > b_size) return 1;
-    return 0;
+static inline int StringCompare(const char* a_data, size_t a_size,
+                                const char* b_data, size_t b_size) {
+  const auto min_size = (std::min)(a_size, b_size);
+  // Guard against memcmp with nullptr, which is UB even if min_size is 0.
+  if (min_size > 0) {
+    const auto cmp = memcmp(a_data, b_data, min_size);
+    if (cmp != 0) return cmp;
   }
-  return cmp;
+  if (a_size < b_size) return -1;
+  if (a_size > b_size) return 1;
+  return 0;
 }
 
 // Lexicographically compare two strings (possibly containing nulls), and
 // return true if the first is less than the second.
-static inline bool StringLessThan(const char* a_data, uoffset_t a_size,
-                                  const char* b_data, uoffset_t b_size) {
+static inline bool StringLessThan(const char* a_data, size_t a_size,
+                                  const char* b_data, size_t b_size) {
   return StringCompare(a_data, a_size, b_data, b_size) < 0;
 }
 

--- a/include/flatbuffers/reflection_generated.h
+++ b/include/flatbuffers/reflection_generated.h
@@ -273,13 +273,11 @@ struct KeyValue FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *key() < *o->key();
   }
   int KeyCompareWithValue(const char *_key) const {
-    return strcmp(key()->c_str(), _key);
+    return ::flatbuffers::StringCompare(key()->c_str(), key()->size(), _key, strlen(_key));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _key) const {
-    if (key()->c_str() < _key) return -1;
-    if (_key < key()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(key()->c_str(), key()->size(), _key.data(), _key.size());
   }
   const ::flatbuffers::String *value() const {
     return GetPointer<const ::flatbuffers::String *>(VT_VALUE);
@@ -471,13 +469,11 @@ struct Enum FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *name() < *o->name();
   }
   int KeyCompareWithValue(const char *_name) const {
-    return strcmp(name()->c_str(), _name);
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
-    if (name()->c_str() < _name) return -1;
-    if (_name < name()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
   }
   const ::flatbuffers::Vector<::flatbuffers::Offset<reflection::EnumVal>> *values() const {
     return GetPointer<const ::flatbuffers::Vector<::flatbuffers::Offset<reflection::EnumVal>> *>(VT_VALUES);
@@ -630,13 +626,11 @@ struct Field FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *name() < *o->name();
   }
   int KeyCompareWithValue(const char *_name) const {
-    return strcmp(name()->c_str(), _name);
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
-    if (name()->c_str() < _name) return -1;
-    if (_name < name()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
   }
   const reflection::Type *type() const {
     return GetPointer<const reflection::Type *>(VT_TYPE);
@@ -855,13 +849,11 @@ struct Object FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *name() < *o->name();
   }
   int KeyCompareWithValue(const char *_name) const {
-    return strcmp(name()->c_str(), _name);
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
-    if (name()->c_str() < _name) return -1;
-    if (_name < name()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
   }
   const ::flatbuffers::Vector<::flatbuffers::Offset<reflection::Field>> *fields() const {
     return GetPointer<const ::flatbuffers::Vector<::flatbuffers::Offset<reflection::Field>> *>(VT_FIELDS);
@@ -1014,13 +1006,11 @@ struct RPCCall FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *name() < *o->name();
   }
   int KeyCompareWithValue(const char *_name) const {
-    return strcmp(name()->c_str(), _name);
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
-    if (name()->c_str() < _name) return -1;
-    if (_name < name()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
   }
   const reflection::Object *request() const {
     return GetPointer<const reflection::Object *>(VT_REQUEST);
@@ -1137,13 +1127,11 @@ struct Service FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *name() < *o->name();
   }
   int KeyCompareWithValue(const char *_name) const {
-    return strcmp(name()->c_str(), _name);
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
-    if (name()->c_str() < _name) return -1;
-    if (_name < name()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
   }
   const ::flatbuffers::Vector<::flatbuffers::Offset<reflection::RPCCall>> *calls() const {
     return GetPointer<const ::flatbuffers::Vector<::flatbuffers::Offset<reflection::RPCCall>> *>(VT_CALLS);
@@ -1263,13 +1251,11 @@ struct SchemaFile FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *filename() < *o->filename();
   }
   int KeyCompareWithValue(const char *_filename) const {
-    return strcmp(filename()->c_str(), _filename);
+    return ::flatbuffers::StringCompare(filename()->c_str(), filename()->size(), _filename, strlen(_filename));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _filename) const {
-    if (filename()->c_str() < _filename) return -1;
-    if (_filename < filename()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(filename()->c_str(), filename()->size(), _filename.data(), _filename.size());
   }
   /// Names of included files, relative to project root.
   const ::flatbuffers::Vector<::flatbuffers::Offset<::flatbuffers::String>> *included_filenames() const {

--- a/include/flatbuffers/reflection_generated.h
+++ b/include/flatbuffers/reflection_generated.h
@@ -275,6 +275,9 @@ struct KeyValue FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int KeyCompareWithValue(const char *_key) const {
     return ::flatbuffers::StringCompare(key()->c_str(), key()->size(), _key, strlen(_key));
   }
+  int KeyCompareWithValue(char *_key) const {
+    return KeyCompareWithValue(static_cast<const char *>(_key));
+  }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _key) const {
     return ::flatbuffers::StringCompare(key()->c_str(), key()->size(), _key.data(), _key.size());
@@ -471,6 +474,9 @@ struct Enum FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int KeyCompareWithValue(const char *_name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
+  int KeyCompareWithValue(char *_name) const {
+    return KeyCompareWithValue(static_cast<const char *>(_name));
+  }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
@@ -627,6 +633,9 @@ struct Field FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   int KeyCompareWithValue(const char *_name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
+  }
+  int KeyCompareWithValue(char *_name) const {
+    return KeyCompareWithValue(static_cast<const char *>(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
@@ -851,6 +860,9 @@ struct Object FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int KeyCompareWithValue(const char *_name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
+  int KeyCompareWithValue(char *_name) const {
+    return KeyCompareWithValue(static_cast<const char *>(_name));
+  }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
@@ -1008,6 +1020,9 @@ struct RPCCall FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int KeyCompareWithValue(const char *_name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
+  int KeyCompareWithValue(char *_name) const {
+    return KeyCompareWithValue(static_cast<const char *>(_name));
+  }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
@@ -1128,6 +1143,9 @@ struct Service FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   int KeyCompareWithValue(const char *_name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
+  }
+  int KeyCompareWithValue(char *_name) const {
+    return KeyCompareWithValue(static_cast<const char *>(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
@@ -1252,6 +1270,9 @@ struct SchemaFile FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   int KeyCompareWithValue(const char *_filename) const {
     return ::flatbuffers::StringCompare(filename()->c_str(), filename()->size(), _filename, strlen(_filename));
+  }
+  int KeyCompareWithValue(char *_filename) const {
+    return KeyCompareWithValue(static_cast<const char *>(_filename));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _filename) const {

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2608,6 +2608,9 @@ class CppGenerator : public BaseGenerator {
       code_ += "  int KeyCompareWithValue(const char *_{{FIELD_NAME}}) const {";
       code_ += "    return ::flatbuffers::StringCompare({{FIELD_NAME}}()->c_str(), {{FIELD_NAME}}()->size(), _{{FIELD_NAME}}, strlen(_{{FIELD_NAME}}));";
       code_ += "  }";
+      code_ += "  int KeyCompareWithValue(char *_{{FIELD_NAME}}) const {";
+      code_ += "    return KeyCompareWithValue(static_cast<const char *>(_{{FIELD_NAME}}));";
+      code_ += "  }";
       // Compares key against any string-like object (e.g. std::string_view or
       // std::string) that has .data() and .size() methods.
       code_ += "  template<typename StringType>";

--- a/src/idl_gen_cpp.cpp
+++ b/src/idl_gen_cpp.cpp
@@ -2606,18 +2606,16 @@ class CppGenerator : public BaseGenerator {
     if (is_string) {
       // Compares key against a null-terminated char array.
       code_ += "  int KeyCompareWithValue(const char *_{{FIELD_NAME}}) const {";
-      code_ += "    return strcmp({{FIELD_NAME}}()->c_str(), _{{FIELD_NAME}});";
+      code_ += "    return ::flatbuffers::StringCompare({{FIELD_NAME}}()->c_str(), {{FIELD_NAME}}()->size(), _{{FIELD_NAME}}, strlen(_{{FIELD_NAME}}));";
       code_ += "  }";
       // Compares key against any string-like object (e.g. std::string_view or
-      // std::string) that implements operator< comparison with const char*.
+      // std::string) that has .data() and .size() methods.
       code_ += "  template<typename StringType>";
       code_ +=
           "  int KeyCompareWithValue(const StringType& _{{FIELD_NAME}}) const "
           "{";
       code_ +=
-          "    if ({{FIELD_NAME}}()->c_str() < _{{FIELD_NAME}}) return -1;";
-      code_ += "    if (_{{FIELD_NAME}} < {{FIELD_NAME}}()->c_str()) return 1;";
-      code_ += "    return 0;";
+          "    return ::flatbuffers::StringCompare({{FIELD_NAME}}()->c_str(), {{FIELD_NAME}}()->size(), _{{FIELD_NAME}}.data(), _{{FIELD_NAME}}.size());";
     } else if (is_array) {
       const auto& elem_type = field.value.type.VectorType();
       std::string input_type = "::flatbuffers::Array<" +

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -1445,13 +1445,11 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *name() < *o->name();
   }
   int KeyCompareWithValue(const char *_name) const {
-    return strcmp(name()->c_str(), _name);
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
-    if (name()->c_str() < _name) return -1;
-    if (_name < name()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
   }
   const ::flatbuffers::Vector<uint8_t> *inventory() const {
     return GetPointer<const ::flatbuffers::Vector<uint8_t> *>(VT_INVENTORY);

--- a/tests/cpp17/generated_cpp17/monster_test_generated.h
+++ b/tests/cpp17/generated_cpp17/monster_test_generated.h
@@ -1447,6 +1447,9 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int KeyCompareWithValue(const char *_name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
+  int KeyCompareWithValue(char *_name) const {
+    return KeyCompareWithValue(static_cast<const char *>(_name));
+  }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -340,6 +340,99 @@ void AccessFlatBufferTest(const uint8_t* flatbuf, size_t length, bool pooled) {
   std::string_view invalid_truncated_key = valid_key;
   invalid_truncated_key.remove_suffix(3);  // "Bar"
   TEST_NULL(vecoftables->LookupByKey(invalid_truncated_key));
+
+  // Tests for LookupByKey with a key containing a null byte
+  {
+    flatbuffers::FlatBufferBuilder fbb;
+    std::string key1("A\0B", 3);
+    std::string key2("A\0C", 3);
+    std::string key3("A\0A", 3);
+    std::string key4("A\x7F", 2);
+    std::string key5("A\xC2\xA2", 3); // Cent sign (2 bytes)
+    std::string key6("A\xE2\x82\xAC", 4); // Euro sign (3 bytes)
+    std::string key7("A\xF0\x90\x8D\x88", 5); // Old Italic letter (4 bytes)
+
+    auto m1_name = fbb.CreateString(flatbuffers::string_view(key1.data(), key1.size()));
+    auto m2_name = fbb.CreateString(flatbuffers::string_view(key2.data(), key2.size()));
+    auto m3_name = fbb.CreateString(flatbuffers::string_view(key3.data(), key3.size()));
+    auto m4_name = fbb.CreateString(flatbuffers::string_view(key4.data(), key4.size()));
+    auto m5_name = fbb.CreateString(flatbuffers::string_view(key5.data(), key5.size()));
+    auto m6_name = fbb.CreateString(flatbuffers::string_view(key6.data(), key6.size()));
+    auto m7_name = fbb.CreateString(flatbuffers::string_view(key7.data(), key7.size()));
+
+    MonsterBuilder mb1(fbb);
+    mb1.add_name(m1_name);
+    mb1.add_hp(11);
+    auto m1 = mb1.Finish();
+
+    MonsterBuilder mb2(fbb);
+    mb2.add_name(m2_name);
+    mb2.add_hp(22);
+    auto m2 = mb2.Finish();
+
+    MonsterBuilder mb3(fbb);
+    mb3.add_name(m3_name);
+    mb3.add_hp(33);
+    auto m3 = mb3.Finish();
+
+    MonsterBuilder mb4(fbb);
+    mb4.add_name(m4_name);
+    mb4.add_hp(44);
+    auto m4 = mb4.Finish();
+
+    MonsterBuilder mb5(fbb);
+    mb5.add_name(m5_name);
+    mb5.add_hp(55);
+    auto m5 = mb5.Finish();
+
+    MonsterBuilder mb6(fbb);
+    mb6.add_name(m6_name);
+    mb6.add_hp(66);
+    auto m6 = mb6.Finish();
+
+    MonsterBuilder mb7(fbb);
+    mb7.add_name(m7_name);
+    mb7.add_hp(77);
+    auto m7 = mb7.Finish();
+
+    std::vector<flatbuffers::Offset<Monster>> mlocs_null;
+    mlocs_null.push_back(m1);
+    mlocs_null.push_back(m2);
+    mlocs_null.push_back(m3);
+    mlocs_null.push_back(m4);
+    mlocs_null.push_back(m5);
+    mlocs_null.push_back(m6);
+    mlocs_null.push_back(m7);
+
+    auto vec_null_offset = fbb.CreateVectorOfSortedTables(&mlocs_null);
+
+    auto parent_name = fbb.CreateString("ParentMonster");
+    MonsterBuilder mb(fbb);
+    mb.add_name(parent_name);
+    mb.add_testarrayoftables(vec_null_offset);
+    auto monster_offset = mb.Finish();
+    fbb.Finish(monster_offset);
+
+    auto monster = flatbuffers::GetRoot<Monster>(fbb.GetBufferPointer());
+    auto vec_null = monster->testarrayoftables();
+    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key1.data(), key1.size())));
+    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key1.data(), key1.size()))->hp(), 11);
+    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key2.data(), key2.size())));
+    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key2.data(), key2.size()))->hp(), 22);
+    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key3.data(), key3.size())));
+    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key3.data(), key3.size()))->hp(), 33);
+    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key4.data(), key4.size())));
+    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key4.data(), key4.size()))->hp(), 44);
+    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key5.data(), key5.size())));
+    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key5.data(), key5.size()))->hp(), 55);
+    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key6.data(), key6.size())));
+    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key6.data(), key6.size()))->hp(), 66);
+    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key7.data(), key7.size())));
+    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key7.data(), key7.size()))->hp(), 77);
+
+    // Also test that searching for "A" returns null, since it's a different length
+    TEST_NULL(vec_null->LookupByKey(flatbuffers::string_view("A", 1)));
+  }
 #endif  // FLATBUFFERS_HAS_STRING_VIEW
 
   // Test accessing a vector of sorted structs

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -324,6 +324,10 @@ void AccessFlatBufferTest(const uint8_t* flatbuf, size_t length, bool pooled) {
   TEST_EQ(vecoftables->LookupByKey("Wilma"),
           vecoftables->LookupByKey(std::string("Wilma")));
 
+  char char_key[] = "Barney";
+  TEST_EQ(vecoftables->LookupByKey("Barney"),
+          vecoftables->LookupByKey(char_key));
+
 #ifdef FLATBUFFERS_HAS_STRING_VIEW
   // Tests for LookupByKey with a key that is a truncated
   // version of a longer, invalid key.
@@ -351,14 +355,16 @@ void AccessFlatBufferTest(const uint8_t* flatbuf, size_t length, bool pooled) {
     std::string key5("A\xC2\xA2", 3); // Cent sign (2 bytes)
     std::string key6("A\xE2\x82\xAC", 4); // Euro sign (3 bytes)
     std::string key7("A\xF0\x90\x8D\x88", 5); // Old Italic letter (4 bytes)
+    std::string key8("", 0); // Empty string
 
-    auto m1_name = fbb.CreateString(flatbuffers::string_view(key1.data(), key1.size()));
-    auto m2_name = fbb.CreateString(flatbuffers::string_view(key2.data(), key2.size()));
-    auto m3_name = fbb.CreateString(flatbuffers::string_view(key3.data(), key3.size()));
-    auto m4_name = fbb.CreateString(flatbuffers::string_view(key4.data(), key4.size()));
-    auto m5_name = fbb.CreateString(flatbuffers::string_view(key5.data(), key5.size()));
-    auto m6_name = fbb.CreateString(flatbuffers::string_view(key6.data(), key6.size()));
-    auto m7_name = fbb.CreateString(flatbuffers::string_view(key7.data(), key7.size()));
+    auto m1_name = fbb.CreateString(key1);
+    auto m2_name = fbb.CreateString(key2);
+    auto m3_name = fbb.CreateString(key3);
+    auto m4_name = fbb.CreateString(key4);
+    auto m5_name = fbb.CreateString(key5);
+    auto m6_name = fbb.CreateString(key6);
+    auto m7_name = fbb.CreateString(key7);
+    auto m8_name = fbb.CreateString(key8);
 
     MonsterBuilder mb1(fbb);
     mb1.add_name(m1_name);
@@ -395,6 +401,11 @@ void AccessFlatBufferTest(const uint8_t* flatbuf, size_t length, bool pooled) {
     mb7.add_hp(77);
     auto m7 = mb7.Finish();
 
+    MonsterBuilder mb8(fbb);
+    mb8.add_name(m8_name);
+    mb8.add_hp(88);
+    auto m8 = mb8.Finish();
+
     std::vector<flatbuffers::Offset<Monster>> mlocs_null;
     mlocs_null.push_back(m1);
     mlocs_null.push_back(m2);
@@ -403,6 +414,7 @@ void AccessFlatBufferTest(const uint8_t* flatbuf, size_t length, bool pooled) {
     mlocs_null.push_back(m5);
     mlocs_null.push_back(m6);
     mlocs_null.push_back(m7);
+    mlocs_null.push_back(m8);
 
     auto vec_null_offset = fbb.CreateVectorOfSortedTables(&mlocs_null);
 
@@ -415,20 +427,22 @@ void AccessFlatBufferTest(const uint8_t* flatbuf, size_t length, bool pooled) {
 
     auto monster = flatbuffers::GetRoot<Monster>(fbb.GetBufferPointer());
     auto vec_null = monster->testarrayoftables();
-    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key1.data(), key1.size())));
-    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key1.data(), key1.size()))->hp(), 11);
-    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key2.data(), key2.size())));
-    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key2.data(), key2.size()))->hp(), 22);
-    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key3.data(), key3.size())));
-    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key3.data(), key3.size()))->hp(), 33);
-    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key4.data(), key4.size())));
-    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key4.data(), key4.size()))->hp(), 44);
-    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key5.data(), key5.size())));
-    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key5.data(), key5.size()))->hp(), 55);
-    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key6.data(), key6.size())));
-    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key6.data(), key6.size()))->hp(), 66);
-    TEST_NOTNULL(vec_null->LookupByKey(flatbuffers::string_view(key7.data(), key7.size())));
-    TEST_EQ(vec_null->LookupByKey(flatbuffers::string_view(key7.data(), key7.size()))->hp(), 77);
+    TEST_NOTNULL(vec_null->LookupByKey(key1));
+    TEST_EQ(vec_null->LookupByKey(key1)->hp(), 11);
+    TEST_NOTNULL(vec_null->LookupByKey(key2));
+    TEST_EQ(vec_null->LookupByKey(key2)->hp(), 22);
+    TEST_NOTNULL(vec_null->LookupByKey(key3));
+    TEST_EQ(vec_null->LookupByKey(key3)->hp(), 33);
+    TEST_NOTNULL(vec_null->LookupByKey(key4));
+    TEST_EQ(vec_null->LookupByKey(key4)->hp(), 44);
+    TEST_NOTNULL(vec_null->LookupByKey(key5));
+    TEST_EQ(vec_null->LookupByKey(key5)->hp(), 55);
+    TEST_NOTNULL(vec_null->LookupByKey(key6));
+    TEST_EQ(vec_null->LookupByKey(key6)->hp(), 66);
+    TEST_NOTNULL(vec_null->LookupByKey(key7));
+    TEST_EQ(vec_null->LookupByKey(key7)->hp(), 77);
+    TEST_NOTNULL(vec_null->LookupByKey(key8));
+    TEST_EQ(vec_null->LookupByKey(key8)->hp(), 88);
 
     // Also test that searching for "A" returns null, since it's a different length
     TEST_NULL(vec_null->LookupByKey(flatbuffers::string_view("A", 1)));

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -1461,13 +1461,11 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *name() < *o->name();
   }
   int KeyCompareWithValue(const char *_name) const {
-    return strcmp(name()->c_str(), _name);
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
-    if (name()->c_str() < _name) return -1;
-    if (_name < name()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
   }
   const ::flatbuffers::Vector<uint8_t> *inventory() const {
     return GetPointer<const ::flatbuffers::Vector<uint8_t> *>(VT_INVENTORY);

--- a/tests/monster_test_generated.h
+++ b/tests/monster_test_generated.h
@@ -1463,6 +1463,9 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int KeyCompareWithValue(const char *_name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
+  int KeyCompareWithValue(char *_name) const {
+    return KeyCompareWithValue(static_cast<const char *>(_name));
+  }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());

--- a/tests/monster_test_suffix/ext_only/monster_test_generated.hpp
+++ b/tests/monster_test_suffix/ext_only/monster_test_generated.hpp
@@ -1454,6 +1454,9 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int KeyCompareWithValue(const char *_name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
+  int KeyCompareWithValue(char *_name) const {
+    return KeyCompareWithValue(static_cast<const char *>(_name));
+  }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());

--- a/tests/monster_test_suffix/ext_only/monster_test_generated.hpp
+++ b/tests/monster_test_suffix/ext_only/monster_test_generated.hpp
@@ -1452,13 +1452,11 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *name() < *o->name();
   }
   int KeyCompareWithValue(const char *_name) const {
-    return strcmp(name()->c_str(), _name);
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
-    if (name()->c_str() < _name) return -1;
-    if (_name < name()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
   }
   const ::flatbuffers::Vector<uint8_t> *inventory() const {
     return GetPointer<const ::flatbuffers::Vector<uint8_t> *>(VT_INVENTORY);

--- a/tests/monster_test_suffix/filesuffix_only/monster_test_suffix.h
+++ b/tests/monster_test_suffix/filesuffix_only/monster_test_suffix.h
@@ -1454,6 +1454,9 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int KeyCompareWithValue(const char *_name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
+  int KeyCompareWithValue(char *_name) const {
+    return KeyCompareWithValue(static_cast<const char *>(_name));
+  }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());

--- a/tests/monster_test_suffix/filesuffix_only/monster_test_suffix.h
+++ b/tests/monster_test_suffix/filesuffix_only/monster_test_suffix.h
@@ -1452,13 +1452,11 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *name() < *o->name();
   }
   int KeyCompareWithValue(const char *_name) const {
-    return strcmp(name()->c_str(), _name);
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
-    if (name()->c_str() < _name) return -1;
-    if (_name < name()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
   }
   const ::flatbuffers::Vector<uint8_t> *inventory() const {
     return GetPointer<const ::flatbuffers::Vector<uint8_t> *>(VT_INVENTORY);

--- a/tests/monster_test_suffix/monster_test_suffix.hpp
+++ b/tests/monster_test_suffix/monster_test_suffix.hpp
@@ -1454,6 +1454,9 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int KeyCompareWithValue(const char *_name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
+  int KeyCompareWithValue(char *_name) const {
+    return KeyCompareWithValue(static_cast<const char *>(_name));
+  }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
     return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());

--- a/tests/monster_test_suffix/monster_test_suffix.hpp
+++ b/tests/monster_test_suffix/monster_test_suffix.hpp
@@ -1452,13 +1452,11 @@ struct Monster FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return *name() < *o->name();
   }
   int KeyCompareWithValue(const char *_name) const {
-    return strcmp(name()->c_str(), _name);
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name, strlen(_name));
   }
   template<typename StringType>
   int KeyCompareWithValue(const StringType& _name) const {
-    if (name()->c_str() < _name) return -1;
-    if (_name < name()->c_str()) return 1;
-    return 0;
+    return ::flatbuffers::StringCompare(name()->c_str(), name()->size(), _name.data(), _name.size());
   }
   const ::flatbuffers::Vector<uint8_t> *inventory() const {
     return GetPointer<const ::flatbuffers::Vector<uint8_t> *>(VT_INVENTORY);


### PR DESCRIPTION
Partial fix for #9180 

Instead of using `strcmp` we should use `memcmp` to do a byte-by-byte comparison of a string during map lookup. The encoding logic already does this, so the current implementation of `LookupByKey` will not be able to find string keys with a null-terminating byte (e.g. `"foo\0bar"`, `"foo\0baz"`). This change aligns the lookup comparator with the encoding comparator.