### PR TITLE
[Rust] Fix Verifier::reset() not resetting apparent_size

### DIFF
--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -278,7 +278,7 @@ impl<'opts, 'buf> Verifier<'opts, 'buf> {
     pub fn reset(&mut self) {
         self.depth = 0;
         self.num_tables = 0;
-        self.num_tables = 0;
+        self.apparent_size = 0;
     }
     /// Checks `pos` is aligned to T's alignment. This does not mean `buffer[pos]` is aligned w.r.t
     /// memory since `buffer: &[u8]` has alignment 1.
@@ -627,3 +627,30 @@ impl_verifiable_for!(f32);
 impl_verifiable_for!(u64);
 impl_verifiable_for!(i64);
 impl_verifiable_for!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `reset()` must clear every field it is documented to reset. Previously
+    /// `apparent_size` was left untouched (the `num_tables` assignment was
+    /// duplicated), so a reused `Verifier` accumulated size across resets and
+    /// eventually rejected every buffer with `ApparentSizeTooLarge`.
+    #[test]
+    fn reset_clears_apparent_size() {
+        let opts = VerifierOptions {
+            max_apparent_size: 100,
+            ..Default::default()
+        };
+        let buffer = [0u8; 64];
+        let mut verifier = Verifier::new(&opts, &buffer);
+
+        verifier
+            .range_in_buffer(0, 60)
+            .expect("60 bytes is within the 100 byte limit");
+        verifier.reset();
+        verifier
+            .range_in_buffer(0, 60)
+            .expect("after reset the same range must fit again");
+    }
+}


### PR DESCRIPTION
Fixes #9189.

`Verifier::reset()` assigned `self.num_tables = 0` twice and never cleared `apparent_size`:

```rust
/// Resets verifier internal state.
pub fn reset(&mut self) {
    self.depth = 0;
    self.num_tables = 0;
    self.num_tables = 0;
}
```

`apparent_size` is initialized in `new()` and incremented in `range_in_buffer()`, but was never reset. A `Verifier` reused via `reset()` therefore accumulated it across uses, and once the running total passed `max_apparent_size` (default `1 << 31`) it rejected every subsequent buffer with `ApparentSizeTooLarge` regardless of validity.

This is over-rejection rather than a verification bypass, so it could not cause malicious buffers to be accepted.

### Changes

- `reset()` now clears `apparent_size` (the second `num_tables` assignment appears to have been a copy/paste).
- Adds a regression test in an in-file `#[cfg(test)] mod tests`, matching the convention already used in `builder.rs`. The test fails without the one-line fix and passes with it.

### Note on an unrelated pre-existing test failure

`cargo test --lib` currently reports `builder::tests::with_internal_capacity_preallocates_vecs` as failing. That failure also reproduces on a clean checkout of `master` (81edeb1) without this change, so it is not introduced here. The rest of the suite passes, and the `no_std` build (`--no-default-features`) is unaffected.
