### PR TITLE
Fix missing schema conformance checks

### DIFF
--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -4538,6 +4538,14 @@ std::string Parser::ConformTo(const Parser& base) {
         struct_def.defined_namespace->GetFullyQualifiedName(struct_def.name);
     auto struct_def_base = base.LookupStruct(qualified_name);
     if (!struct_def_base) continue;
+    if (struct_def.fixed != struct_def_base->fixed) {
+      return "object types differ: " + qualified_name;
+    }
+    if (struct_def.fixed &&
+        (struct_def.minalign != struct_def_base->minalign ||
+         struct_def.bytesize != struct_def_base->bytesize)) {
+      return "struct layout differs: " + qualified_name;
+    }
     std::set<FieldDef*> renamed_fields;
     for (auto fit = struct_def.fields.vec.begin();
          fit != struct_def.fields.vec.end(); ++fit) {
@@ -4550,6 +4558,9 @@ std::string Parser::ConformTo(const Parser& base) {
         }
         if (field.value.constant != field_base->value.constant) {
           return "defaults differ for field: " + qualified_field_name;
+        }
+        if (field.presence != field_base->presence) {
+          return "presence differs for field: " + qualified_field_name;
         }
         if (!EqualByName(field.value.type, field_base->value.type)) {
           return "types differ for field: " + qualified_field_name;
@@ -4607,6 +4618,14 @@ std::string Parser::ConformTo(const Parser& base) {
           return "values differ for enum: " + enum_val.name;
       }
     }
+    for (auto evit = enum_def_base->Vals().begin();
+         evit != enum_def_base->Vals().end(); ++evit) {
+      auto& enum_val_base = **evit;
+      if (!enum_def.Lookup(enum_val_base.name)) {
+        return std::string(enum_def.is_union ? "union" : "enum") +
+               " value deleted: " + qualified_name + "." + enum_val_base.name;
+      }
+    }
     // Check underlying type changes
     if (enum_def_base->underlying_type.base_type !=
         enum_def.underlying_type.base_type) {
@@ -4614,6 +4633,19 @@ std::string Parser::ConformTo(const Parser& base) {
              std::string(enum_def.is_union ? "union: " : "enum: ") +
              qualified_name;
     }
+  }
+  if (root_struct_def_ != nullptr || base.root_struct_def_ != nullptr) {
+    const auto root_name = [](const StructDef* struct_def) {
+      return struct_def ? struct_def->defined_namespace->GetFullyQualifiedName(
+                              struct_def->name)
+                        : std::string();
+    };
+    if (root_name(root_struct_def_) != root_name(base.root_struct_def_)) {
+      return "root types differ";
+    }
+  }
+  if (file_identifier_ != base.file_identifier_) {
+    return "file identifiers differ";
   }
   return "";
 }

--- a/tests/evolution_test.cpp
+++ b/tests/evolution_test.cpp
@@ -104,6 +104,8 @@ void ConformTest() {
   test_conform(ref, "table T { B:float; }",
                "field renamed to different type: T.B (renamed from T.A)");
   test_conform(ref, "enum E:byte { B, A }", "values differ for enum: A");
+  test_conform("enum E:byte { A, B }", "enum E:byte { A }",
+               "enum value deleted: E.B");
   test_conform(ref, "table T { }", "field deleted: T.A");
   test_conform(ref, "table T { B:int; }", "");  // renaming a field is allowed
 
@@ -114,6 +116,24 @@ void ConformTest() {
   // Check enum underlying type changes.
   test_conform("enum E:int32 {A}", "enum E: byte {A}",
                "underlying type differ for enum: E");
+
+  // Check enum-like deletion and table-field presence changes.
+  test_conform("table A {} table B {} union U { A, B }",
+               "table A {} table B {} union U { A }",
+               "union value deleted: U.B");
+  test_conform("table T { a:string; }", "table T { a:string (required); }",
+               "presence differs for field: T.a");
+
+  // Check fixed struct layout changes that do not alter field offsets.
+  test_conform("struct S { a:int; }", "struct S (force_align: 8) { a:int; }",
+               "struct layout differs: S");
+
+  // Check schema-level buffer identification changes.
+  test_conform("table A {} table B {} root_type A;",
+               "table A {} table B {} root_type B;", "root types differ");
+  test_conform("table T {} file_identifier \"ABCD\";",
+               "table T {} file_identifier \"WXYZ\";",
+               "file identifiers differ");
 
   // Check union underlying type changes.
   const char ref3[] = "table A {} table B {} union C {A, B}";


### PR DESCRIPTION
Reject deleted enum and union values, required field changes, fixed struct layout changes, and root type or file identifier changes when using `flatc --conform`.