### PR TITLE
[Rust] Verify nested_flatbuffer fields

### DIFF
--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -57,8 +57,8 @@ pub use crate::push::{Push, PushAlignment};
 pub use crate::table::{buffer_has_identifier, Table};
 pub use crate::vector::{follow_cast_ref, Vector, VectorIter};
 pub use crate::verifier::{
-    ErrorTraceDetail, InvalidFlatbuffer, SimpleToVerifyInSlice, TableVerifier, Verifiable,
-    Verifier, VerifierOptions,
+    ErrorTraceDetail, InvalidFlatbuffer, NestedFlatBuffer, SimpleToVerifyInSlice, TableVerifier,
+    Verifiable, Verifier, VerifierOptions,
 };
 pub use crate::vtable::field_index_to_field_offset;
 pub use bitflags;

--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -2,6 +2,7 @@ use crate::follow::Follow;
 use crate::{ForwardsUOffset, SOffsetT, SkipSizePrefix, UOffsetT, VOffsetT, Vector, SIZE_UOFFSET};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use core::marker::PhantomData;
 use core::ops::Range;
 use core::option::Option;
 
@@ -242,9 +243,17 @@ pub struct VerifierOptions {
     /// Ignore errors where a string is missing its null terminator.
     /// This is mostly a problem if the message will be sent to a client using old c-strings.
     pub ignore_missing_null_terminator: bool,
+    /// Verify the contents of fields carrying the `nested_flatbuffer` schema
+    /// attribute, rather than only checking that the byte vector holding them is
+    /// in bounds.
+    ///
+    /// This defaults to `true`, matching `check_nested_flatbuffers` in the C++
+    /// implementation. Turning it off makes the generated
+    /// `..._nested_flatbuffer()` accessors unsound for untrusted input, because
+    /// they follow those bytes without any further checking.
+    pub check_nested_flatbuffers: bool,
     // probably want an option to ignore utf8 errors since strings come from c++
     // options to error un-recognized enums and unions? possible footgun.
-    // Ignore nested flatbuffers, etc?
 }
 
 impl Default for VerifierOptions {
@@ -255,6 +264,7 @@ impl Default for VerifierOptions {
             // size_ might do something different.
             max_apparent_size: 1 << 31,
             ignore_missing_null_terminator: false,
+            check_nested_flatbuffers: true,
         }
     }
 }
@@ -386,6 +396,35 @@ impl<'opts, 'buf> Verifier<'opts, 'buf> {
             return Err(InvalidFlatbuffer::DepthLimitReached);
         }
         Ok(TableVerifier { pos: table_pos, vtable: vtable_pos, vtable_len, verifier: self })
+    }
+
+    /// Verifies the contents of a nested FlatBuffer: the bytes of a `[ubyte]`
+    /// field carrying the `nested_flatbuffer` schema attribute, whose root type
+    /// is `T`.
+    fn verify_nested_buffer<T: Verifiable>(&mut self, range: Range<usize>) -> Result<()> {
+        // `range` was produced by `verify_vector_range`, which has already
+        // bounds checked it. It is re-checked here rather than indexed because
+        // the verifier must not panic on any input, however malformed, and a
+        // future caller of this helper should not be able to turn a mistake into
+        // a panic.
+        let nested = match self.buffer.get(range.clone()) {
+            Some(nested) => nested,
+            None => return InvalidFlatbuffer::new_range_oob(range.start, range.end),
+        };
+
+        // Offsets inside the nested buffer are relative to its own start, so the
+        // verifier has to run against the nested slice rather than adjust a
+        // position. The buffer is swapped in place instead of building a second
+        // `Verifier` so that every budget -- `depth`, `num_tables`,
+        // `apparent_size`, and any added later -- keeps accumulating in `self`.
+        // A chain of nested buffers therefore cannot escape `max_tables` or
+        // `max_apparent_size` by starting each level from zero, and the accounting
+        // cannot silently drift if a new budget field is added, since there is no
+        // per-field copy to keep in sync.
+        let outer = core::mem::replace(&mut self.buffer, nested);
+        let res = <ForwardsUOffset<T>>::run_verifier(self, 0);
+        self.buffer = outer;
+        res
     }
 
     /// Runs the union variant's type's verifier assuming the variant is at the given position,
@@ -560,6 +599,32 @@ impl<T: SimpleToVerifyInSlice> Verifiable for Vector<'_, T> {
     fn run_verifier(v: &mut Verifier, pos: usize) -> Result<()> {
         verify_vector_range::<T>(v, pos)?;
         Ok(())
+    }
+}
+
+/// Verification marker for the `nested_flatbuffer` schema attribute: a `[ubyte]`
+/// field whose contents are themselves a FlatBuffer with root type `T`.
+///
+/// The generated `..._nested_flatbuffer()` accessor follows those bytes without
+/// any further bounds checking, so verifying the field only as `Vector<u8>`
+/// leaves that accessor reading unverified data. Verifying it as
+/// `NestedFlatBuffer<T>` checks the byte vector and then the buffer inside it,
+/// mirroring `VerifyNestedFlatBuffer` in the C++ implementation.
+///
+/// Unlike the other `Verifiable` types this deliberately does not implement
+/// `Follow`: the accessor reads the nested buffer through `ForwardsUOffset<T>`,
+/// so this marker exists only to carry the extra verification and can never be
+/// used to read data.
+pub struct NestedFlatBuffer<T>(PhantomData<T>);
+
+impl<T: Verifiable> Verifiable for NestedFlatBuffer<T> {
+    #[inline]
+    fn run_verifier(v: &mut Verifier, pos: usize) -> Result<()> {
+        let range = verify_vector_range::<u8>(v, pos)?;
+        if !v.opts.check_nested_flatbuffers {
+            return Ok(());
+        }
+        v.verify_nested_buffer::<T>(range)
     }
 }
 

--- a/src/idl_gen_rust.cpp
+++ b/src/idl_gen_rust.cpp
@@ -2063,6 +2063,22 @@ class RustGenerator : public BaseGenerator {
       if (GetFullType(field.value.type) != ftUnionValue) {
         // All types besides unions.
         code_.SetValue("TY", FollowType(field.value.type, "'_"));
+        // A field with the `nested_flatbuffer` attribute is a [ubyte] vector
+        // whose contents are themselves a flatbuffer. The generated
+        // `..._nested_flatbuffer()` accessor follows those bytes without any
+        // further bounds checking, so the bytes have to be verified as a buffer
+        // and not merely as a vector. This mirrors VerifyNestedFlatBuffer in
+        // the C++ generator.
+        //
+        // The root type is resolved by the parser, which errors out if it was
+        // never defined, so there is no lookup here that could fail and quietly
+        // leave the field verified as a plain vector.
+        if (field.nested_flatbuffer) {
+          code_.SetValue("TY",
+                         "::flatbuffers::ForwardsUOffset<"
+                         "::flatbuffers::NestedFlatBuffer<" +
+                             WrapInNameSpace(*field.nested_flatbuffer) + ">>");
+        }
         code_ +=
             "        .visit_field::<{{TY}}>(\"{{FIELD}}\", "
             "Self::{{OFFSET_NAME}}, {{IS_REQ}})?";

--- a/tests/monster_test/my_game/example/monster_generated.rs
+++ b/tests/monster_test/my_game/example/monster_generated.rs
@@ -1071,7 +1071,7 @@ impl ::flatbuffers::Verifiable for Monster<'_> {
             .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<&'_ str>>>>("testarrayofstring", Self::VT_TESTARRAYOFSTRING, false)?
             .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<Monster>>>>("testarrayoftables", Self::VT_TESTARRAYOFTABLES, false)?
             .visit_field::<::flatbuffers::ForwardsUOffset<Monster>>("enemy", Self::VT_ENEMY, false)?
-            .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, u8>>>("testnestedflatbuffer", Self::VT_TESTNESTEDFLATBUFFER, false)?
+            .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::NestedFlatBuffer<Monster>>>("testnestedflatbuffer", Self::VT_TESTNESTEDFLATBUFFER, false)?
             .visit_field::<::flatbuffers::ForwardsUOffset<Stat>>("testempty", Self::VT_TESTEMPTY, false)?
             .visit_field::<bool>("testbool", Self::VT_TESTBOOL, false)?
             .visit_field::<i32>("testhashs32_fnv1", Self::VT_TESTHASHS32_FNV1, false)?
@@ -1119,7 +1119,7 @@ impl ::flatbuffers::Verifiable for Monster<'_> {
             })?
             .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, Color>>>("vector_of_enums", Self::VT_VECTOR_OF_ENUMS, false)?
             .visit_field::<Race>("signed_enum", Self::VT_SIGNED_ENUM, false)?
-            .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, u8>>>("testrequirednestedflatbuffer", Self::VT_TESTREQUIREDNESTEDFLATBUFFER, false)?
+            .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::NestedFlatBuffer<Monster>>>("testrequirednestedflatbuffer", Self::VT_TESTREQUIREDNESTEDFLATBUFFER, false)?
             .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<Stat>>>>("scalar_key_sorted_tables", Self::VT_SCALAR_KEY_SORTED_TABLES, false)?
             .visit_field::<Test>("native_inline", Self::VT_NATIVE_INLINE, false)?
             .visit_field::<LongEnum>("long_enum_non_enum_default", Self::VT_LONG_ENUM_NON_ENUM_DEFAULT, false)?

--- a/tests/monster_test_serialize/my_game/example/monster_generated.rs
+++ b/tests/monster_test_serialize/my_game/example/monster_generated.rs
@@ -1073,7 +1073,7 @@ impl ::flatbuffers::Verifiable for Monster<'_> {
             .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<&'_ str>>>>("testarrayofstring", Self::VT_TESTARRAYOFSTRING, false)?
             .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<Monster>>>>("testarrayoftables", Self::VT_TESTARRAYOFTABLES, false)?
             .visit_field::<::flatbuffers::ForwardsUOffset<Monster>>("enemy", Self::VT_ENEMY, false)?
-            .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, u8>>>("testnestedflatbuffer", Self::VT_TESTNESTEDFLATBUFFER, false)?
+            .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::NestedFlatBuffer<Monster>>>("testnestedflatbuffer", Self::VT_TESTNESTEDFLATBUFFER, false)?
             .visit_field::<::flatbuffers::ForwardsUOffset<Stat>>("testempty", Self::VT_TESTEMPTY, false)?
             .visit_field::<bool>("testbool", Self::VT_TESTBOOL, false)?
             .visit_field::<i32>("testhashs32_fnv1", Self::VT_TESTHASHS32_FNV1, false)?
@@ -1121,7 +1121,7 @@ impl ::flatbuffers::Verifiable for Monster<'_> {
             })?
             .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, Color>>>("vector_of_enums", Self::VT_VECTOR_OF_ENUMS, false)?
             .visit_field::<Race>("signed_enum", Self::VT_SIGNED_ENUM, false)?
-            .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, u8>>>("testrequirednestedflatbuffer", Self::VT_TESTREQUIREDNESTEDFLATBUFFER, false)?
+            .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::NestedFlatBuffer<Monster>>>("testrequirednestedflatbuffer", Self::VT_TESTREQUIREDNESTEDFLATBUFFER, false)?
             .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<Stat>>>>("scalar_key_sorted_tables", Self::VT_SCALAR_KEY_SORTED_TABLES, false)?
             .visit_field::<Test>("native_inline", Self::VT_NATIVE_INLINE, false)?
             .visit_field::<LongEnum>("long_enum_non_enum_default", Self::VT_LONG_ENUM_NON_ENUM_DEFAULT, false)?

--- a/tests/rust_usage_test/tests/integration_test.rs
+++ b/tests/rust_usage_test/tests/integration_test.rs
@@ -509,6 +509,316 @@ fn verifier_in_too_deep() {
     assert!(flatbuffers::root_with_opts::<Monster>(&opts, data).is_ok());
 }
 
+/// Builds a Monster whose `testnestedflatbuffer` field holds `payload`.
+#[cfg(test)]
+fn monster_with_nested_payload(payload: &[u8]) -> Vec<u8> {
+    use my_game::example::*;
+    let b = &mut flatbuffers::FlatBufferBuilder::new();
+    let name = Some(b.create_string("outer"));
+    let nested = Some(b.create_vector::<u8>(payload));
+    let m = Monster::create(b, &MonsterArgs {
+        name,  // required field.
+        testnestedflatbuffer: nested,
+        ..Default::default()
+    });
+    b.finish(m, None);
+    b.finished_data().to_vec()
+}
+
+/// A well-formed nested Monster, so the nested check has something valid to accept.
+#[cfg(test)]
+fn valid_nested_monster(name: &str) -> Vec<u8> {
+    use my_game::example::*;
+    let b = &mut flatbuffers::FlatBufferBuilder::new();
+    let n = Some(b.create_string(name));
+    let m = Monster::create(b, &MonsterArgs { name: n, hp: 1234, ..Default::default() });
+    b.finish(m, None);
+    b.finished_data().to_vec()
+}
+
+#[test]
+fn verifier_accepts_valid_nested_flatbuffer() {
+    use my_game::example::*;
+    let data = monster_with_nested_payload(&valid_nested_monster("nested"));
+    let m = flatbuffers::root::<Monster>(&data).unwrap();
+    let nested = m.testnestedflatbuffer_nested_flatbuffer().unwrap();
+    assert_eq!(nested.name(), "nested");
+    assert_eq!(nested.hp(), 1234);
+}
+
+#[test]
+fn verifier_rejects_nested_flatbuffer_with_invalid_utf8() {
+    use my_game::example::*;
+    // The nested buffer is structurally fine but its string is not UTF-8.
+    // Without verifying the nested buffer, the safe
+    // `testnestedflatbuffer_nested_flatbuffer()` accessor would hand out a
+    // `&str` that is not valid UTF-8.
+    let mut nested = valid_nested_monster("AAAA");
+    let pos = nested.windows(4).position(|w| w == b"AAAA").unwrap();
+    for i in 0..4 { nested[pos + i] = 0xFF; }
+    let data = monster_with_nested_payload(&nested);
+    assert!(flatbuffers::root::<Monster>(&data).is_err());
+}
+
+#[test]
+fn verifier_rejects_nested_flatbuffer_with_out_of_bounds_offsets() {
+    use my_game::example::*;
+    // uoffset 4 -> table at 4; soffset -7 -> vtable at 11, which leaves only one
+    // byte for a two-byte VOffsetT read.
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&4u32.to_le_bytes());
+    payload.extend_from_slice(&(-7i32).to_le_bytes());
+    payload.extend_from_slice(&[0xAA; 4]);
+    let data = monster_with_nested_payload(&payload);
+    assert!(flatbuffers::root::<Monster>(&data).is_err());
+}
+
+#[test]
+fn verifier_rejects_truncated_nested_flatbuffer() {
+    use my_game::example::*;
+    // Too short to even hold a root uoffset.
+    let data = monster_with_nested_payload(&[0u8; 2]);
+    assert!(flatbuffers::root::<Monster>(&data).is_err());
+}
+
+#[test]
+fn nested_flatbuffer_verification_can_be_disabled() {
+    use my_game::example::*;
+    let mut nested = valid_nested_monster("AAAA");
+    let pos = nested.windows(4).position(|w| w == b"AAAA").unwrap();
+    for i in 0..4 { nested[pos + i] = 0xFF; }
+    let data = monster_with_nested_payload(&nested);
+
+    let mut opts = flatbuffers::VerifierOptions::default();
+    assert!(opts.check_nested_flatbuffers);
+    assert!(flatbuffers::root_with_opts::<Monster>(&opts, &data).is_err());
+
+    // Opting out restores the previous behaviour, matching the C++ option of
+    // the same name. Accessors are then unsound for untrusted input.
+    opts.check_nested_flatbuffers = false;
+    assert!(flatbuffers::root_with_opts::<Monster>(&opts, &data).is_ok());
+}
+
+#[test]
+#[cfg(not(miri))] // slow.
+fn nested_flatbuffer_large_payload_still_verifies() {
+    use my_game::example::*;
+    // Verifying the nested buffer accounts for its contents against the outer
+    // budgets, so a legitimate, sizeable nested buffer must still verify under
+    // the default options.
+    let mut b = flatbuffers::FlatBufferBuilder::new();
+    let n = b.create_string("big");
+    let payload_bytes: Vec<u8> = (0..200_000u32).map(|i| i as u8).collect();
+    let inv = b.create_vector::<u8>(&payload_bytes);
+    let m = Monster::create(
+        &mut b,
+        &MonsterArgs { name: Some(n), inventory: Some(inv), ..Default::default() },
+    );
+    b.finish(m, None);
+    let nested = b.finished_data().to_vec();
+    assert!(nested.len() > 200_000);
+
+    let data = monster_with_nested_payload(&nested);
+    let m = flatbuffers::root::<Monster>(&data).expect("large nested buffer must still verify");
+    let nm = m.testnestedflatbuffer_nested_flatbuffer().unwrap();
+    assert_eq!(nm.name(), "big");
+    assert_eq!(nm.inventory().unwrap().len(), 200_000);
+}
+
+#[test]
+#[cfg(not(miri))] // slow: builds 200 nested buffers.
+fn nested_flatbuffer_chain_is_bounded() {
+    use my_game::example::*;
+    // Each level of nesting is verified with a verifier of its own. If the depth
+    // budget were not carried across that boundary, a chain of nested buffers
+    // would be unbounded and could exhaust the stack instead of being rejected.
+    let mut payload = valid_nested_monster("leaf");
+    for _ in 0..200 {
+        payload = monster_with_nested_payload(&payload);
+    }
+    assert_eq!(
+        flatbuffers::root::<Monster>(&payload).unwrap_err(),
+        flatbuffers::InvalidFlatbuffer::DepthLimitReached
+    );
+}
+
+#[test]
+fn nested_flatbuffer_compat_empty_and_absent() {
+    use my_game::example::*;
+    // Absent field: unaffected, still verifies.
+    let b = &mut flatbuffers::FlatBufferBuilder::new();
+    let name = Some(b.create_string("outer"));
+    let m = Monster::create(b, &MonsterArgs { name, ..Default::default() });
+    b.finish(m, None);
+    assert!(flatbuffers::root::<Monster>(b.finished_data()).is_ok());
+
+    // Present but empty: cannot hold a root, so it is now rejected. This
+    // matches C++, which requires a nested buffer to be at least
+    // FLATBUFFERS_MIN_BUFFER_SIZE. Previously it verified and then panicked in
+    // the accessor.
+    let data = monster_with_nested_payload(&[]);
+    assert!(flatbuffers::root::<Monster>(&data).is_err());
+}
+
+#[test]
+fn nested_flatbuffer_depth_counts_toward_max_depth() {
+    use my_game::example::*;
+    // The nested buffer is verified with its own Verifier, so its budgets must
+    // be carried over from the outer one; otherwise a chain of nested buffers
+    // could reset max_depth at every level.
+    let data = monster_with_nested_payload(&valid_nested_monster("nested"));
+    let mut opts = flatbuffers::VerifierOptions::default();
+    opts.max_depth = 1;
+    assert_eq!(
+        flatbuffers::root_with_opts::<Monster>(&opts, &data).unwrap_err(),
+        flatbuffers::InvalidFlatbuffer::DepthLimitReached
+    );
+    opts.max_depth = 64;
+    assert!(flatbuffers::root_with_opts::<Monster>(&opts, &data).is_ok());
+}
+
+/// A nested Monster carrying `n` bytes of inventory, so that verifying it costs
+/// a measurable amount of the apparent-size budget.
+#[cfg(test)]
+fn nested_monster_with_inventory(n: usize) -> Vec<u8> {
+    use my_game::example::*;
+    let b = &mut flatbuffers::FlatBufferBuilder::new();
+    let name = Some(b.create_string("inner"));
+    let inventory = Some(b.create_vector::<u8>(&vec![7u8; n]));
+    let m = Monster::create(b, &MonsterArgs { name, inventory, ..Default::default() });
+    b.finish(m, None);
+    b.finished_data().to_vec()
+}
+
+/// The smallest `max_apparent_size` that still accepts `data`.
+#[cfg(test)]
+fn min_apparent_size_budget(data: &[u8], check_nested: bool) -> usize {
+    use my_game::example::*;
+    let (mut lo, mut hi) = (0usize, 4 * 1024 * 1024usize);
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        let mut opts = flatbuffers::VerifierOptions::default();
+        opts.check_nested_flatbuffers = check_nested;
+        opts.max_apparent_size = mid;
+        if flatbuffers::root_with_opts::<Monster>(&opts, data).is_ok() {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    lo
+}
+
+/// Work done inside a nested buffer must be charged to the *outer* verifier's
+/// apparent-size budget. If the nested buffer got a fresh budget, an attacker
+/// could use nesting to multiply the amount of verification work a single
+/// message can buy, which would make this fix a denial-of-service vector.
+///
+/// The thresholds are measured rather than hard-coded so this cannot go stale
+/// if the generated layout changes.
+#[test]
+fn nested_flatbuffer_work_counts_toward_apparent_size() {
+    use my_game::example::*;
+    let data = monster_with_nested_payload(&nested_monster_with_inventory(4096));
+
+    let without = min_apparent_size_budget(&data, false);
+    let with = min_apparent_size_budget(&data, true);
+    assert!(
+        with > without,
+        "verifying the nested buffer must consume apparent-size budget \
+         (without={}, with={}); if these are equal the nested contents are \
+         being verified for free and nesting is an amplifier",
+        without,
+        with
+    );
+
+    // At exactly the budget that suffices when the nested contents are skipped,
+    // verifying them must run out rather than proceed unbilled.
+    let mut opts = flatbuffers::VerifierOptions::default();
+    opts.max_apparent_size = without;
+    assert_eq!(
+        flatbuffers::root_with_opts::<Monster>(&opts, &data).unwrap_err(),
+        flatbuffers::InvalidFlatbuffer::ApparentSizeTooLarge
+    );
+    // Control: the same budget is enough when the nested check is off, so the
+    // rejection above is caused by the nested work and not by a budget that was
+    // too small to begin with.
+    opts.check_nested_flatbuffers = false;
+    assert!(flatbuffers::root_with_opts::<Monster>(&opts, &data).is_ok());
+}
+
+/// Tables inside a nested buffer must count toward `max_tables` for the same
+/// reason: otherwise each nesting level would grant a fresh table budget.
+#[test]
+fn nested_flatbuffer_tables_count_toward_max_tables() {
+    use my_game::example::*;
+    let data = monster_with_nested_payload(&valid_nested_monster("nested"));
+
+    // The outer Monster is one table; the nested one makes two.
+    let mut opts = flatbuffers::VerifierOptions::default();
+    opts.max_tables = 1;
+    assert_eq!(
+        flatbuffers::root_with_opts::<Monster>(&opts, &data).unwrap_err(),
+        flatbuffers::InvalidFlatbuffer::TooManyTables
+    );
+    // Control: one table is enough once the nested contents are not verified,
+    // so the limit above is reached by the nested table and not by the outer one.
+    opts.check_nested_flatbuffers = false;
+    assert!(flatbuffers::root_with_opts::<Monster>(&opts, &data).is_ok());
+
+    opts.check_nested_flatbuffers = true;
+    opts.max_tables = 2;
+    assert!(flatbuffers::root_with_opts::<Monster>(&opts, &data).is_ok());
+}
+
+#[test]
+fn nested_flatbuffer_is_verified_recursively() {
+    use my_game::example::*;
+    // A nested buffer can itself hold a nested buffer, so verification has to
+    // recurse all the way down rather than stopping at the first level. Build
+    // outer -> nested Monster -> its own nested buffer holding malformed bytes,
+    // and confirm the outer verifier rejects it.
+    let malformed = [0xFFu8, 0xFF, 0xFF, 0xFF, 0x01, 0, 0, 0, 0xAA, 0xBB];
+    let mut b = flatbuffers::FlatBufferBuilder::new();
+    let name = Some(b.create_string("inner"));
+    let inner = Some(b.create_vector::<u8>(&malformed));
+    let m = Monster::create(&mut b, &MonsterArgs {
+        name,
+        testnestedflatbuffer: inner,
+        ..Default::default()
+    });
+    b.finish(m, None);
+    let level_one = b.finished_data().to_vec();
+
+    let data = monster_with_nested_payload(&level_one);
+    assert!(
+        flatbuffers::root::<Monster>(&data).is_err(),
+        "the malformed innermost buffer must be caught by recursive verification"
+    );
+}
+
+#[test]
+fn nested_flatbuffer_verified_on_size_prefixed_root() {
+    use my_game::example::*;
+    // The nested check lives in the `Verifiable` impl, so it must apply on every
+    // safe entry point, not just `root`. Confirm `size_prefixed_root` rejects a
+    // malformed nested buffer too.
+    let malformed = [0xFFu8, 0xFF, 0xFF, 0xFF, 0x01, 0, 0, 0, 0xAA, 0xBB];
+    let mut b = flatbuffers::FlatBufferBuilder::new();
+    let name = Some(b.create_string("outer"));
+    let nested = Some(b.create_vector::<u8>(&malformed));
+    let m = Monster::create(&mut b, &MonsterArgs {
+        name,
+        testnestedflatbuffer: nested,
+        ..Default::default()
+    });
+    b.finish_size_prefixed(m, None);
+    assert!(
+        flatbuffers::size_prefixed_root::<Monster>(b.finished_data()).is_err(),
+        "size_prefixed_root must verify nested buffers like root does"
+    );
+}
+
 #[cfg(test)]
 mod generated_constants {
     extern crate flatbuffers;

--- a/tests/rust_usage_test/tests/nested_flatbuffer_invariant.rs
+++ b/tests/rust_usage_test/tests/nested_flatbuffer_invariant.rs
@@ -1,0 +1,214 @@
+//! Differential check for the invariant the Rust docs promise:
+//!
+//!   "All of the safe Rust APIs ensure the verifier is run over these
+//!    flatbuffers before accessing them."
+//!
+//! Concretely: if `root::<Monster>()` accepts a buffer, then reading the nested
+//! flatbuffer out of it through the generated accessor must not panic and must
+//! not produce a `&str` that is not valid UTF-8.
+//!
+//! The nested payload is entirely attacker-controlled, so this mutates it and
+//! checks the invariant over every mutant the verifier accepts. Mutation is
+//! driven by a fixed-seed LCG so failures are reproducible and CI is stable.
+#![allow(dead_code, unused_imports)]
+
+#[allow(dead_code, unused_imports, clippy::approx_constant)]
+#[path = "../../monster_test/mod.rs"]
+mod monster_test_generated;
+pub use monster_test_generated::my_game;
+use my_game::example::{Monster, MonsterArgs};
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+fn valid_nested(name: &str) -> Vec<u8> {
+    let mut b = flatbuffers::FlatBufferBuilder::new();
+    let n = b.create_string(name);
+    let inv = b.create_vector::<u8>(&[1, 2, 3, 4]);
+    let m = Monster::create(
+        &mut b,
+        &MonsterArgs { name: Some(n), hp: 1234, inventory: Some(inv), ..Default::default() },
+    );
+    b.finish(m, None);
+    b.finished_data().to_vec()
+}
+
+fn outer_with(payload: &[u8]) -> Vec<u8> {
+    let mut b = flatbuffers::FlatBufferBuilder::new();
+    let name = b.create_string("outer");
+    let nested = b.create_vector::<u8>(payload);
+    let m = Monster::create(
+        &mut b,
+        &MonsterArgs { name: Some(name), testnestedflatbuffer: Some(nested), ..Default::default() },
+    );
+    b.finish(m, None);
+    b.finished_data().to_vec()
+}
+
+/// Exercises the nested buffer the way an application would. Returns Err if the
+/// product misbehaved: a panic, or a `&str` that is not valid UTF-8.
+fn traverse(data: &[u8], opts: &flatbuffers::VerifierOptions) -> Result<bool, String> {
+    let monster = match flatbuffers::root_with_opts::<Monster>(opts, data) {
+        Ok(m) => m,
+        Err(_) => return Ok(false), // rejected: nothing to check
+    };
+    let res = catch_unwind(AssertUnwindSafe(|| {
+        let nested = match monster.testnestedflatbuffer_nested_flatbuffer() {
+            Some(n) => n,
+            None => return Ok(()),
+        };
+        // Ordinary field reads, the same as any application would do.
+        let name: &str = nested.name();
+        if core::str::from_utf8(name.as_bytes()).is_err() {
+            return Err(format!("accessor produced non-UTF-8 &str: {:02X?}", name.as_bytes()));
+        }
+        let _ = nested.hp();
+        let _ = nested.mana();
+        if let Some(inv) = nested.inventory() {
+            for i in 0..inv.len() {
+                let _ = inv.get(i);
+            }
+        }
+        if let Some(v) = nested.testarrayofstring() {
+            for i in 0..v.len() {
+                let s = v.get(i);
+                if core::str::from_utf8(s.as_bytes()).is_err() {
+                    return Err("vector element produced non-UTF-8 &str".to_string());
+                }
+            }
+        }
+        Ok(())
+    }));
+    match res {
+        Err(_) => Err("panicked while reading a verified buffer".to_string()),
+        Ok(Err(e)) => Err(e),
+        Ok(Ok(())) => Ok(true),
+    }
+}
+
+/// Result of one mutation sweep.
+struct Sweep {
+    /// Buffers the verifier accepted and which traversed cleanly.
+    accepted: usize,
+    /// Buffers the verifier accepted but which then misbehaved. This is the
+    /// number that must be zero.
+    misbehaved: usize,
+    /// First few distinct failures, for the assertion message. Kept separate
+    /// from `misbehaved` so the count is never truncated by the sample limit.
+    examples: Vec<String>,
+}
+
+/// Deterministic mutation sweep over the attacker-controlled nested payload.
+fn sweep(opts: &flatbuffers::VerifierOptions) -> Sweep {
+    let base = valid_nested("AAAA");
+    let mut state: u64 = 0x5EED_1234_ABCD_0001;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as usize
+    };
+    let mut out = Sweep { accepted: 0, misbehaved: 0, examples: Vec::new() };
+    for _ in 0..4000 {
+        let mut payload = base.clone();
+        // Corrupt one to three bytes anywhere in the nested buffer.
+        let n = 1 + next() % 3;
+        for _ in 0..n {
+            let idx = next() % payload.len();
+            payload[idx] = (next() % 256) as u8;
+        }
+        let data = outer_with(&payload);
+        match traverse(&data, opts) {
+            Ok(true) => out.accepted += 1,
+            Ok(false) => {}
+            Err(e) => {
+                out.misbehaved += 1;
+                if out.examples.len() < 5 && !out.examples.contains(&e) {
+                    out.examples.push(e);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// With nested verification on (the default), every buffer the verifier accepts
+/// must survive a full traversal.
+#[test]
+#[cfg(not(miri))] // slow.
+fn accepted_buffers_are_safe_to_traverse() {
+    let opts = flatbuffers::VerifierOptions::default();
+    assert!(opts.check_nested_flatbuffers, "nested checking must default to on");
+    let s = sweep(&opts);
+    assert!(s.accepted > 0, "no buffer was accepted; the sweep would prove nothing");
+    assert_eq!(
+        s.misbehaved, 0,
+        "verifier accepted {} buffers, {} of which misbehaved when read: {:?}",
+        s.accepted, s.misbehaved, s.examples
+    );
+}
+
+/// The verifier must never panic, whatever it is handed. The sweep above only
+/// corrupts the nested payload, leaving the outer buffer well-formed, so it
+/// never exercises a hostile *vector header* -- and the length field of that
+/// header is what determines the range handed to the nested verifier.
+///
+/// This corrupts the whole outer buffer instead, so the length, the offsets and
+/// the vtable are all attacker-controlled. Any panic here is a denial-of-service
+/// bug, so the assertion is simply that verification always returns.
+#[test]
+#[cfg(not(miri))] // slow.
+fn verifier_never_panics_on_a_corrupt_outer_buffer() {
+    let base = outer_with(&valid_nested("AAAA"));
+    let mut state: u64 = 0xA11C_E501_2345_6789;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as usize
+    };
+
+    let opts = flatbuffers::VerifierOptions::default();
+    let mut accepted = 0usize;
+    let mut rejected = 0usize;
+    for _ in 0..20000 {
+        let mut data = base.clone();
+        let n = 1 + next() % 4;
+        for _ in 0..n {
+            let idx = next() % data.len();
+            data[idx] = (next() % 256) as u8;
+        }
+        let res = catch_unwind(AssertUnwindSafe(|| {
+            flatbuffers::root_with_opts::<Monster>(&opts, &data).is_ok()
+        }));
+        match res {
+            Ok(true) => accepted += 1,
+            Ok(false) => rejected += 1,
+            Err(_) => panic!(
+                "verifier panicked on a corrupt buffer; this is a DoS. Input: {:02X?}",
+                data
+            ),
+        }
+    }
+    // Non-vacuity: the sweep has to actually reach both outcomes, otherwise it
+    // is not exercising the verifier's decision paths at all.
+    assert!(
+        accepted > 0 && rejected > 0,
+        "sweep reached only one outcome (accepted={}, rejected={}), so it is not \
+         exercising the verifier's decision paths",
+        accepted,
+        rejected
+    );
+}
+
+/// Control: the same sweep with nested verification disabled reproduces the
+/// old behaviour, which does misbehave. This keeps the test above honest -- if
+/// it ever passes for the wrong reason, this one will stop failing to fail.
+#[test]
+#[cfg(not(miri))] // slow.
+fn control_disabling_nested_check_reintroduces_the_problem() {
+    let mut opts = flatbuffers::VerifierOptions::default();
+    opts.check_nested_flatbuffers = false;
+    let s = sweep(&opts);
+    assert!(
+        s.misbehaved > 0,
+        "expected the unverified path to misbehave on at least one mutant. If it \
+         no longer does, the sweep has stopped reaching the behaviour it is meant \
+         to guard and the test above proves nothing."
+    );
+}


### PR DESCRIPTION
## The problem

A field with the `nested_flatbuffer` attribute is verified only as `Vector<u8>`.
The generated `..._nested_flatbuffer()` accessor then follows those bytes as a
FlatBuffer root with no further checking — so on a buffer `flatbuffers::root()`
has already returned `Ok` for, every offset inside the nested buffer is still
attacker-controlled.

The result is that safe generated accessors read outside the buffer's
allocation.

## Reproduction

Against the published `flatbuffers = "25.12.19"` crate, from a binary that is
`#![forbid(unsafe_code)]`:

```
root_as_monster()     : Ok (VERIFIER ACCEPTED)
nested slice offset   : 148 .. 160
bytes after it in buf : 0
calling nm.hp() (safe accessor) ...
```

Under Miri, with `-Zmiri-disable-stacked-borrows` so this is a spatial error and
not an aliasing technicality:

```
error: Undefined Behavior: memory access failed: attempting to access 2 bytes,
but got alloc3344+0x9f which is only 1 byte from the end of the allocation
   --> flatbuffers-25.12.19/src/endian_scalar.rs:182:5
    |
182 |     core::ptr::copy_nonoverlapping(s.as_ptr(), mem.as_mut_ptr() as *mut u8, size);

  0: flatbuffers::read_scalar::<u16>
  1: flatbuffers::read_scalar_at::<u16>
  2: flatbuffers::vtable::VTable::<'_>::num_bytes
  3: flatbuffers::vtable::VTable::<'_>::get
  4: flatbuffers::Table::<'_>::get::<i16>
  5: my_game::example::Monster::<'_>::hp     <-- safe accessor
  6: main
```

`read_scalar` bounds-checks with a `debug_assert!` only, so release builds read
past the end. In debug the same input trips that assert with `insufficient
capacity for emplace_scalar, needed 2 got 1` — showing directly that 2 bytes are
read from a 1-byte slice.

A present-but-empty nested vector has the same root cause: accepted by the
verifier, then panics in the accessor with `range end index 4 out of range for
slice of length 0`.

## Why this is a soundness bug rather than hardening

`docs/source/languages/rust.md` promises exactly what this breaks:

> The safe Rust functions to interpret a slice as a table (`root`, ...) verify
> the data first. ... **intended to be safe for use on flatbuffers from
> untrusted sources.**

> The generated accessor functions access fields over offsets ... **without any
> further bounds checking. All of the safe Rust APIs ensure the verifier is run
> over these flatbuffers before accessing them.**

> Reading a FlatBuffer **does not touch any memory outside the original
> buffer.**

And the generated accessor carries this safety comment today (unchanged by this
PR):

```rust
// Safety:
// Created from a valid Table for this object
// Which contains a valid flatbuffer in this slot
unsafe { <::flatbuffers::ForwardsUOffset<Monster<'a>>>::follow(data.bytes(), 0) }
```

Nothing established "contains a valid flatbuffer in this slot". This PR makes
that comment true.

## C++ already does this

`Verifier::VerifyNestedFlatBuffer` runs a nested verifier, gated on
`check_nested_flatbuffers`, which **defaults to `true`**. A buffer Rust accepts
today is already rejected by every C++ peer, so this brings Rust in line rather
than inventing a policy.

## The change

**Runtime** (`rust/flatbuffers/src/verifier.rs`)

- `VerifierOptions::check_nested_flatbuffers`, default `true` — same name and
  default as C++. It replaces the existing `// Ignore nested flatbuffers, etc?`
  TODO.
- `NestedFlatBuffer<T>`: a verification marker implementing `Verifiable` that
  checks the `[ubyte]` vector, then the buffer inside it. It deliberately does
  not implement `Follow`, so it can only ever be used for verification.
- `Verifier::verify_nested_buffer`, which runs a verifier over the nested slice.

**Generator** (`src/idl_gen_rust.cpp`)

Emit `ForwardsUOffset<NestedFlatBuffer<Root>>` instead of
`ForwardsUOffset<Vector<u8>>` for the *verifier* slot of such a field. Accessor
return types are untouched — 4 lines change across the two generated files.

Generated code was regenerated with the patched `flatc` so the effect of the
generator change is visible in the diff, and `scripts/clang-format-git.sh`
leaves the C++ change unmodified.

### Two details worth reviewing

**Budgets cross the nesting boundary.** Offsets inside a nested buffer are
relative to its own start, so the verifier runs against the nested slice:
`self.buffer` is swapped for it and restored afterwards. Swapping rather than
building a second `Verifier` keeps `depth`, `num_tables` and `apparent_size` —
and anything added later — accumulating in one place, with no per-field copy to
keep in sync.

That matters, because porting the C++ design literally (fresh verifier, fresh
budgets per level) would introduce a *new* DoS: every level resets `max_depth`.
Measured on a 200-level chain of nested Monsters — budgets reset:
`thread 'main' has overflowed its stack`; budgets carried:
`Nested table depth limit reached.` on the same input.

The same carry stops nesting becoming a work amplifier: `range_in_buffer`
charges `apparent_size` and `visit_table` charges `num_tables`, so nested bytes
are billed rather than verified for free.
`nested_flatbuffer_work_counts_toward_apparent_size`,
`nested_flatbuffer_depth_counts_toward_max_depth` and
`nested_flatbuffer_tables_count_toward_max_tables` assert this by measuring the
budgets rather than hard-coding thresholds.

**No lookup that can fail quietly.** The generator uses
`field.nested_flatbuffer`, the root type the parser already resolved, rather
than re-resolving the attribute string. A name lookup that missed would fall
back to `Vector<u8>` and silently emit an unverified field — the exact failure
mode this PR exists to remove.

## Compatibility

- **Generated code**: 4 lines, verified byte-identical to patched-flatc output.
- **Accessor signatures**: unchanged. Only the `Verifiable` slot differs.
- **No `unsafe` added**: the patch adds zero lines containing `unsafe`.
- **No allocations added**: both alloc checks pass unchanged.
- **Empty nested vector is now rejected.** Matches C++
  (`>= FLATBUFFERS_MIN_BUFFER_SIZE`), and it previously panicked in the accessor,
  so nothing working depended on it.
- **The one case that can turn working Rust-only code red**: an application that
  puts the attribute on a field but stores bytes that are *not* a flatbuffer of
  that type, and only ever reads them through the plain `[ubyte]` accessor. I
  think rejecting that is correct — the attribute is a declaration about the
  contents, and C++ has enforced it by default for years — but it is a real
  change, and it is a one-line opt-out.
- **`VerifierOptions` is not `#[non_exhaustive]`**, so adding a public field is
  technically breaking for struct-literal construction. Everything in-tree uses
  `..Default::default()`. Flagging rather than adding `#[non_exhaustive]`
  unilaterally — happy to if you'd prefer.

## Tests

`integration_test.rs` — valid nested buffer still accepted; invalid UTF-8,
out-of-bounds offsets and truncation rejected; opt-out works; empty/absent
pinned; a >200 KB nested payload still verifies; depth, `max_tables` and
`max_apparent_size` all shown to count nested work.

`nested_flatbuffer_invariant.rs` — a deterministic 4,000-mutation sweep over the
attacker-controlled payload asserting every buffer the verifier accepts survives
a full traversal without panicking or yielding a non-UTF-8 `&str` (231 accepted,
0 misbehaved). A second sweep corrupts the *outer* buffer 20,000 times and
asserts verification always returns rather than panicking.

The budget tests each carry a control asserting the same budget suffices when
the nested check is off, and the invariant sweep carries
`control_disabling_nested_check_reintroduces_the_problem`, which asserts the old
path still *does* misbehave. If these ever stop reaching the behaviour they
guard, the suite goes red instead of passing vacuously.

The four sweep/large-payload tests are `#[cfg(not(miri))] // slow.`, matching
existing use in this crate, since `RustTest.sh` runs `cargo miri test` over the
whole suite. The targeted nested tests still run under Miri and pass clean.

## Credit

#8291 reported this root cause in April 2024, framed as a panic, and was
auto-closed as stale. Credit to @Nekrolm.

---

*Noticed while working here, not addressed: `Verifier::reset()` assigns
`num_tables` twice and never clears `apparent_size`. It has no in-tree callers
and only makes a reused verifier stricter, so it is not a soundness issue —
happy to send separately.*
