### PR TITLE
[Rust] Enable unsafe_op_in_unsafe_fn and document the runtime's unsafe operations

### DIFF
--- a/rust/flatbuffers/src/array.rs
+++ b/rust/flatbuffers/src/array.rs
@@ -89,14 +89,23 @@ impl<'a, T: Follow<'a> + 'a, const N: usize> Follow<'a> for Array<'a, T, N> {
     type Inner = Array<'a, T, N>;
     #[inline(always)]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Array::new(&buf[loc..loc + N * size_of::<T>()])
+        // SAFETY:
+        // The slice passed below is exactly `N * size_of::<T>()` bytes long,
+        // which is the length `Array::new` asserts, and the caller guarantees
+        // those bytes are a contiguous array of `T`.
+        unsafe { Array::new(&buf[loc..loc + N * size_of::<T>()]) }
     }
 }
 
 /// Place an array of EndianScalar into the provided mutable byte slice. Performs
 /// endian conversion, if necessary.
+///
 /// # Safety
-/// Caller must ensure `s.len() >= size_of::<[T; N]>()`
+///
+/// Caller must ensure `buf.len() >= loc + size_of::<[T::Scalar; N]>()`.
+///
+/// Note that the write starts at `loc`, so a bound that ignores `loc` is not
+/// sufficient to keep the write in bounds.
 pub unsafe fn emplace_scalar_array<T: EndianScalar, const N: usize>(
     buf: &mut [u8],
     loc: usize,
@@ -105,12 +114,23 @@ pub unsafe fn emplace_scalar_array<T: EndianScalar, const N: usize>(
     let mut buf_ptr = buf[loc..].as_mut_ptr();
     for item in src.iter() {
         let item_le = item.to_little_endian();
-        core::ptr::copy_nonoverlapping(
-            &item_le as *const T::Scalar as *const u8,
-            buf_ptr,
-            size_of::<T::Scalar>(),
-        );
-        buf_ptr = buf_ptr.add(size_of::<T::Scalar>());
+        // SAFETY:
+        // The caller guarantees `buf.len() >= loc + size_of::<[T::Scalar; N]>()`,
+        // so the `N` writes of `size_of::<T::Scalar>()` bytes each, starting at
+        // `loc`, all land inside `buf`. `item_le` is a distinct local, so the
+        // regions cannot overlap. `[u8]` has alignment 1, so the value is copied
+        // bytewise rather than written through a `*mut T::Scalar`.
+        //
+        // The final `add` produces a one-past-the-end pointer, which is a valid
+        // pointer to form (it is only dereferenced on earlier iterations).
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                &item_le as *const T::Scalar as *const u8,
+                buf_ptr,
+                size_of::<T::Scalar>(),
+            );
+            buf_ptr = buf_ptr.add(size_of::<T::Scalar>());
+        }
     }
 }
 

--- a/rust/flatbuffers/src/builder.rs
+++ b/rust/flatbuffers/src/builder.rs
@@ -1234,12 +1234,19 @@ mod tests {
 
     struct CountingAllocator;
 
+    // SAFETY:
+    // `CountingAllocator` only counts allocations and forwards every call to
+    // `System`, so it inherits `System`'s compliance with the `GlobalAlloc`
+    // contract.
     unsafe impl GlobalAlloc for CountingAllocator {
         unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
             ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+            // SAFETY: `layout` is forwarded unchanged from the caller.
             unsafe { System.alloc(layout) }
         }
         unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            // SAFETY: `ptr` and `layout` are forwarded unchanged from the
+            // caller, and `ptr` was allocated by `System` in `alloc` above.
             unsafe { System.dealloc(ptr, layout) }
         }
     }

--- a/rust/flatbuffers/src/endian_scalar.rs
+++ b/rust/flatbuffers/src/endian_scalar.rs
@@ -135,7 +135,7 @@ impl EndianScalar for f64 {
 /// Place an EndianScalar into the provided mutable byte slice. Performs
 /// endian conversion, if necessary.
 /// # Safety
-/// Caller must ensure `s.len() >= size_of::<T>()`
+/// Caller must ensure `s.len() >= size_of::<T::Scalar>()`
 #[inline]
 pub unsafe fn emplace_scalar<T: EndianScalar>(s: &mut [u8], x: T) {
     let size = size_of::<T::Scalar>();
@@ -147,38 +147,62 @@ pub unsafe fn emplace_scalar<T: EndianScalar>(s: &mut [u8], x: T) {
     );
 
     let x_le = x.to_little_endian();
-    core::ptr::copy_nonoverlapping(
-        &x_le as *const T::Scalar as *const u8,
-        s.as_mut_ptr() as *mut u8,
-        size,
-    );
+    // SAFETY:
+    // The caller guarantees `s` is at least `size` bytes long, so writing `size`
+    // bytes into it is in bounds. `x_le` is a distinct local, so the source and
+    // destination regions cannot overlap. `[u8]` has alignment 1, so the value is
+    // copied bytewise rather than written through a `*mut T::Scalar`, which would
+    // additionally require `s` to satisfy `T::Scalar`'s alignment.
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            &x_le as *const T::Scalar as *const u8,
+            s.as_mut_ptr() as *mut u8,
+            size,
+        );
+    }
 }
 
 /// Read an EndianScalar from the provided byte slice at the specified location.
 /// Performs endian conversion, if necessary.
 /// # Safety
-/// Caller must ensure `s.len() >= loc + size_of::<T>()`.
+/// Caller must ensure `s.len() >= loc + size_of::<T::Scalar>()`.
 #[inline]
 pub unsafe fn read_scalar_at<T: EndianScalar>(s: &[u8], loc: usize) -> T {
-    read_scalar(&s[loc..])
+    // SAFETY:
+    // Slicing `s` at `loc` panics unless `loc <= s.len()`, and the caller
+    // guarantees `s.len() >= loc + size_of::<T::Scalar>()`, so the remaining
+    // slice is at least `size_of::<T::Scalar>()` bytes long as `read_scalar`
+    // requires.
+    unsafe { read_scalar(&s[loc..]) }
 }
 
 /// Read an EndianScalar from the provided byte slice. Performs endian
 /// conversion, if necessary.
 /// # Safety
-/// Caller must ensure `s.len() > size_of::<T>()`.
+/// Caller must ensure `s.len() >= size_of::<T::Scalar>()`.
 #[inline]
 pub unsafe fn read_scalar<T: EndianScalar>(s: &[u8]) -> T {
     let size = size_of::<T::Scalar>();
     debug_assert!(
         s.len() >= size,
-        "insufficient capacity for emplace_scalar, needed {} got {}",
+        "insufficient capacity for read_scalar, needed {} got {}",
         size,
         s.len()
     );
 
     let mut mem = core::mem::MaybeUninit::<T::Scalar>::uninit();
-    // Since [u8] has alignment 1, we copy it into T which may have higher alignment.
-    core::ptr::copy_nonoverlapping(s.as_ptr(), mem.as_mut_ptr() as *mut u8, size);
-    T::from_little_endian(mem.assume_init())
+    // SAFETY:
+    // The caller guarantees `s` is at least `size` bytes long, so reading `size`
+    // bytes from it is in bounds. `mem` is a distinct local allocation of exactly
+    // `size_of::<T::Scalar>() == size` bytes, so the regions cannot overlap and
+    // the write is in bounds. Since `[u8]` has alignment 1, the bytes are copied
+    // into `mem` rather than read through a `*const T::Scalar`, which would
+    // additionally require `s` to satisfy `T::Scalar`'s alignment.
+    // `T::Scalar: TriviallyTransmutable`, so every bit pattern of `size` bytes is
+    // a valid value and `assume_init` is sound.
+    let v = unsafe {
+        core::ptr::copy_nonoverlapping(s.as_ptr(), mem.as_mut_ptr() as *mut u8, size);
+        mem.assume_init()
+    };
+    T::from_little_endian(v)
 }

--- a/rust/flatbuffers/src/follow.rs
+++ b/rust/flatbuffers/src/follow.rs
@@ -51,13 +51,19 @@ impl<'a, T: Follow<'a> + 'a> FollowStart<T> {
     /// `buf[loc..]` must contain a valid value of `T`
     #[inline]
     pub unsafe fn self_follow(&'a self, buf: &'a [u8], loc: usize) -> T::Inner {
-        T::follow(buf, loc)
+        // SAFETY:
+        // Forwarded unchanged to `T::follow`, whose safety contract is identical
+        // to this function's and is guaranteed by the caller.
+        unsafe { T::follow(buf, loc) }
     }
 }
 impl<'a, T: Follow<'a>> Follow<'a> for FollowStart<T> {
     type Inner = T::Inner;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        T::follow(buf, loc)
+        // SAFETY:
+        // `FollowStart<T>` is a marker with no representation of its own; a valid
+        // `T` at `loc` is exactly what the caller guarantees.
+        unsafe { T::follow(buf, loc) }
     }
 }

--- a/rust/flatbuffers/src/get_root.rs
+++ b/rust/flatbuffers/src/get_root.rs
@@ -93,7 +93,10 @@ pub unsafe fn root_unchecked<'buf, T>(data: &'buf [u8]) -> T::Inner
 where
     T: Follow<'buf> + 'buf,
 {
-    <ForwardsUOffset<T>>::follow(data, 0)
+    // SAFETY:
+    // The caller guarantees `data` is a valid flatbuffer, which is exactly the
+    // contract of `ForwardsUOffset::<T>::follow` at the root offset.
+    unsafe { <ForwardsUOffset<T>>::follow(data, 0) }
 }
 
 #[inline]
@@ -107,5 +110,8 @@ pub unsafe fn size_prefixed_root_unchecked<'buf, T>(data: &'buf [u8]) -> T::Inne
 where
     T: Follow<'buf> + 'buf,
 {
-    <SkipSizePrefix<ForwardsUOffset<T>>>::follow(data, 0)
+    // SAFETY:
+    // The caller guarantees `data` is a valid size-prefixed flatbuffer, which is
+    // exactly the contract of the composed follower at the root offset.
+    unsafe { <SkipSizePrefix<ForwardsUOffset<T>>>::follow(data, 0) }
 }

--- a/rust/flatbuffers/src/lib.rs
+++ b/rust/flatbuffers/src/lib.rs
@@ -28,6 +28,7 @@
 //! At this time, to generate Rust code, you will need the latest `master` version of `flatc`, available from here: <https://github.com/google/flatbuffers>
 //! (On OSX, you can install FlatBuffers from `HEAD` with the Homebrew package manager.)
 
+#![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(nightly, not(feature = "std")), feature(error_in_core))]
 #![cfg_attr(nightly, feature(trusted_len))]

--- a/rust/flatbuffers/src/primitives.rs
+++ b/rust/flatbuffers/src/primitives.rs
@@ -134,7 +134,11 @@ impl<T> Push for WIPOffset<T> {
     #[inline(always)]
     unsafe fn push(&self, dst: &mut [u8], written_len: usize) {
         let n = (SIZE_UOFFSET + written_len - self.value() as usize) as UOffsetT;
-        emplace_scalar::<UOffsetT>(dst, n);
+        // SAFETY:
+        // The caller guarantees `dst` is at least `Self::size()` bytes, which is
+        // `size_of::<ForwardsUOffset<T>>() == SIZE_UOFFSET`, as `emplace_scalar`
+        // requires for a `UOffsetT`.
+        unsafe { emplace_scalar::<UOffsetT>(dst, n) };
     }
 }
 
@@ -143,7 +147,11 @@ impl<T> Push for ForwardsUOffset<T> {
 
     #[inline(always)]
     unsafe fn push(&self, dst: &mut [u8], written_len: usize) {
-        self.value().push(dst, written_len);
+        // SAFETY:
+        // Forwarded to the inner scalar's `Push` impl, which writes exactly
+        // `Self::size()` bytes; the caller guarantees `dst` is that large and
+        // correctly aligned.
+        unsafe { self.value().push(dst, written_len) };
     }
 }
 
@@ -176,8 +184,14 @@ impl<'a, T: Follow<'a>> Follow<'a> for ForwardsUOffset<T> {
     #[inline(always)]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         let slice = &buf[loc..loc + SIZE_UOFFSET];
-        let off = read_scalar::<u32>(slice) as usize;
-        T::follow(buf, loc + off)
+        // SAFETY:
+        // `slice` is exactly `SIZE_UOFFSET` bytes, as `read_scalar::<u32>`
+        // requires.
+        let off = unsafe { read_scalar::<u32>(slice) } as usize;
+        // SAFETY:
+        // The caller guarantees a valid `ForwardsUOffset<T>` at `loc`, so the
+        // offset it stores points at a valid `T` within `buf`.
+        unsafe { T::follow(buf, loc + off) }
     }
 }
 
@@ -197,8 +211,14 @@ impl<'a, T: Follow<'a>> Follow<'a> for ForwardsVOffset<T> {
     #[inline(always)]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         let slice = &buf[loc..loc + SIZE_VOFFSET];
-        let off = read_scalar::<VOffsetT>(slice) as usize;
-        T::follow(buf, loc + off)
+        // SAFETY:
+        // `slice` is exactly `SIZE_VOFFSET` bytes, as `read_scalar::<VOffsetT>`
+        // requires.
+        let off = unsafe { read_scalar::<VOffsetT>(slice) } as usize;
+        // SAFETY:
+        // The caller guarantees a valid `ForwardsVOffset<T>` at `loc`, so the
+        // offset it stores points at a valid `T` within `buf`.
+        unsafe { T::follow(buf, loc + off) }
     }
 }
 
@@ -207,7 +227,11 @@ impl<T> Push for ForwardsVOffset<T> {
 
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], written_len: usize) {
-        self.value().push(dst, written_len);
+        // SAFETY:
+        // Forwarded to the inner scalar's `Push` impl, which writes exactly
+        // `Self::size()` bytes; the caller guarantees `dst` is that large and
+        // correctly aligned.
+        unsafe { self.value().push(dst, written_len) };
     }
 }
 
@@ -227,8 +251,15 @@ impl<'a, T: Follow<'a>> Follow<'a> for BackwardsSOffset<T> {
     #[inline(always)]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         let slice = &buf[loc..loc + SIZE_SOFFSET];
-        let off = read_scalar::<SOffsetT>(slice);
-        T::follow(buf, (loc as SOffsetT - off) as usize)
+        // SAFETY:
+        // `slice` is exactly `SIZE_SOFFSET` bytes, as `read_scalar::<SOffsetT>`
+        // requires.
+        let off = unsafe { read_scalar::<SOffsetT>(slice) };
+        // SAFETY:
+        // The caller guarantees a valid `BackwardsSOffset<T>` at `loc`, so
+        // subtracting the stored signed offset yields the location of a valid
+        // `T` within `buf`.
+        unsafe { T::follow(buf, (loc as SOffsetT - off) as usize) }
     }
 }
 
@@ -237,7 +268,11 @@ impl<T> Push for BackwardsSOffset<T> {
 
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], written_len: usize) {
-        self.value().push(dst, written_len);
+        // SAFETY:
+        // Forwarded to the inner scalar's `Push` impl, which writes exactly
+        // `Self::size()` bytes; the caller guarantees `dst` is that large and
+        // correctly aligned.
+        unsafe { self.value().push(dst, written_len) };
     }
 }
 
@@ -248,7 +283,10 @@ impl<'a, T: Follow<'a> + 'a> Follow<'a> for SkipSizePrefix<T> {
     type Inner = T::Inner;
     #[inline(always)]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        T::follow(buf, loc + SIZE_SIZEPREFIX)
+        // SAFETY:
+        // The caller guarantees a valid `SkipSizePrefix<T>` at `loc`: a valid
+        // size prefix precedes a valid `T`, so skipping it lands on the `T`.
+        unsafe { T::follow(buf, loc + SIZE_SIZEPREFIX) }
     }
 }
 
@@ -259,7 +297,10 @@ impl<'a, T: Follow<'a> + 'a> Follow<'a> for SkipRootOffset<T> {
     type Inner = T::Inner;
     #[inline(always)]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        T::follow(buf, loc + SIZE_UOFFSET)
+        // SAFETY:
+        // The caller guarantees a valid `SkipRootOffset<T>` at `loc`: a valid
+        // root offset precedes a valid `T`, so skipping it lands on the `T`.
+        unsafe { T::follow(buf, loc + SIZE_UOFFSET) }
     }
 }
 
@@ -282,7 +323,11 @@ impl<'a, T: Follow<'a> + 'a> Follow<'a> for SkipFileIdentifier<T> {
     type Inner = T::Inner;
     #[inline(always)]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        T::follow(buf, loc + FILE_IDENTIFIER_LENGTH)
+        // SAFETY:
+        // The caller guarantees a valid `SkipFileIdentifier<T>` at `loc`: a
+        // valid file identifier precedes a valid `T`, so skipping it lands on
+        // the `T`.
+        unsafe { T::follow(buf, loc + FILE_IDENTIFIER_LENGTH) }
     }
 }
 
@@ -290,7 +335,11 @@ impl<'a> Follow<'a> for bool {
     type Inner = bool;
     #[inline(always)]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        read_scalar_at::<u8>(buf, loc) != 0
+        // SAFETY:
+        // The caller guarantees a valid `bool` at `loc`, which occupies one byte,
+        // as `read_scalar_at::<u8>` requires. Any bit pattern is read as a `u8`
+        // and then compared, so no invalid `bool` is ever materialized.
+        unsafe { read_scalar_at::<u8>(buf, loc) != 0 }
     }
 }
 
@@ -305,7 +354,11 @@ macro_rules! impl_follow_for_endian_scalar {
             type Inner = $ty;
             #[inline(always)]
             unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-                read_scalar_at::<$ty>(buf, loc)
+                // SAFETY:
+                // The caller guarantees a valid `$ty` at `loc`, so `buf` holds
+                // the `size_of::<$ty::Scalar>()` readable bytes that
+                // `read_scalar_at` requires.
+                unsafe { read_scalar_at::<$ty>(buf, loc) }
             }
         }
     };

--- a/rust/flatbuffers/src/push.rs
+++ b/rust/flatbuffers/src/push.rs
@@ -43,7 +43,11 @@ impl<'a, T: Push> Push for &'a T {
     type Output = T::Output;
 
     unsafe fn push(&self, dst: &mut [u8], written_len: usize) {
-        T::push(self, dst, written_len)
+        // SAFETY:
+        // Forwarded unchanged to `T::push`; `&T` has the same `Output`, `size`
+        // and `alignment` as `T`, so the caller's guarantees about `dst` carry
+        // over verbatim.
+        unsafe { T::push(self, dst, written_len) }
     }
 
     fn size() -> usize {
@@ -81,7 +85,11 @@ macro_rules! impl_push_for_endian_scalar {
 
             #[inline]
             unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-                emplace_scalar::<$ty>(dst, *self);
+                // SAFETY:
+                // The caller guarantees `dst` is at least `Self::size()` bytes,
+                // which for these scalar types is `size_of::<$ty::Scalar>()`, as
+                // `emplace_scalar` requires.
+                unsafe { emplace_scalar::<$ty>(dst, *self) };
             }
         }
     };

--- a/rust/flatbuffers/src/table.rs
+++ b/rust/flatbuffers/src/table.rs
@@ -66,7 +66,11 @@ impl<'a> Table<'a> {
         if o == 0 {
             return default;
         }
-        Some(<T>::follow(self.buf, self.loc + o))
+        // SAFETY:
+        // `Table::new` guarantees a valid table at `self.loc`, so the vtable
+        // lookup yields an in-bounds field offset `o` for this table, and the
+        // caller guarantees the slot's type is `T`.
+        Some(unsafe { <T>::follow(self.buf, self.loc + o) })
     }
 }
 

--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -160,24 +160,36 @@ pub unsafe fn follow_cast_ref<'a, T: Sized + 'a>(buf: &'a [u8], loc: usize) -> &
     let sz = size_of::<T>();
     let buf = &buf[loc..loc + sz];
     let ptr = buf.as_ptr() as *const T;
-    // SAFETY
-    // buf contains a value at loc of type T and T has no alignment requirements
-    &*ptr
+    // SAFETY:
+    // The slicing above guarantees `buf` covers `size_of::<T>()` in-bounds bytes
+    // at `loc`, and the caller guarantees those bytes are a valid value of `T`.
+    // `align_of::<T>() == 1` is asserted above, so `ptr` is trivially aligned.
+    // The returned reference borrows `buf`, so it cannot outlive the buffer.
+    unsafe { &*ptr }
 }
 
 impl<'a> Follow<'a> for &'a str {
     type Inner = &'a str;
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let len = read_scalar_at::<UOffsetT>(buf, loc) as usize;
+        // SAFETY:
+        // The caller guarantees a valid string at `loc`, so `buf` holds a
+        // `UOffsetT` length there.
+        let len = unsafe { read_scalar_at::<UOffsetT>(buf, loc) } as usize;
         let slice = &buf[loc + SIZE_UOFFSET..loc + SIZE_UOFFSET + len];
-        from_utf8_unchecked(slice)
+        // SAFETY:
+        // A valid flatbuffer string is UTF-8; `Verifier` checks this with
+        // `core::str::from_utf8` before any `follow` is permitted.
+        unsafe { from_utf8_unchecked(slice) }
     }
 }
 
 impl<'a> Follow<'a> for &'a [u8] {
     type Inner = &'a [u8];
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let len = read_scalar_at::<UOffsetT>(buf, loc) as usize;
+        // SAFETY:
+        // The caller guarantees a valid byte vector at `loc`, so `buf` holds a
+        // `UOffsetT` length there.
+        let len = unsafe { read_scalar_at::<UOffsetT>(buf, loc) } as usize;
         &buf[loc + SIZE_UOFFSET..loc + SIZE_UOFFSET + len]
     }
 }
@@ -186,7 +198,10 @@ impl<'a> Follow<'a> for &'a [u8] {
 impl<'a, T: Follow<'a> + 'a> Follow<'a> for Vector<'a, T> {
     type Inner = Vector<'a, T>;
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Vector::new(buf, loc)
+        // SAFETY:
+        // A valid vector at `loc` is exactly what the caller guarantees, which is
+        // the contract of `Vector::new`.
+        unsafe { Vector::new(buf, loc) }
     }
 }
 

--- a/rust/flatbuffers/src/vtable.rs
+++ b/rust/flatbuffers/src/vtable.rs
@@ -110,6 +110,9 @@ pub fn field_offset_to_field_index(field_o: VOffsetT) -> VOffsetT {
 impl<'a> Follow<'a> for VTable<'a> {
     type Inner = VTable<'a>;
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        VTable::init(buf, loc)
+        // SAFETY:
+        // A valid vtable at `loc` is exactly what the caller guarantees, which is
+        // the contract of `VTable::init`.
+        unsafe { VTable::init(buf, loc) }
     }
 }


### PR DESCRIPTION
## The gap

On edition 2018 the body of an `unsafe fn` is itself an implicit `unsafe` block, so
unsafe operations inside one never have to be acknowledged. The runtime has 38 such
bodies. Enabling the lint makes the compiler count what is sitting in them:

```
error: could not compile `flatbuffers` (lib) due to 54 previous errors
```

54 unsafe operations, none carrying a safety comment — the compiler cannot tell
"carefully reasoned about" from "happens to sit inside an `unsafe fn`".

#8638 closed exactly this for *generated* code ahead of edition 2024, but it only
touched `*_generated.rs` and `idl_gen_rust.cpp` — never the runtime crate that
generated code calls into. This closes it there.

## The change

- `#![deny(unsafe_op_in_unsafe_fn)]` on the runtime crate, so new unsafe code
  cannot silently regress.
- The 54 operations wrapped in explicit `unsafe` blocks, each with a `// SAFETY:`
  comment naming the invariant and who establishes it.
- Four safety contracts corrected — they were wrong, not merely missing.
- A copy-pasted `debug_assert!` in `read_scalar` that reported itself as
  `emplace_scalar`.

## The four wrong contracts

| Function | Documented | Actually required |
|---|---|---|
| `read_scalar` | `s.len() > size_of::<T>()` | `s.len() >= size_of::<T::Scalar>()` |
| `read_scalar_at` | `s.len() >= loc + size_of::<T>()` | `loc + size_of::<T::Scalar>()` |
| `emplace_scalar` | `s.len() >= size_of::<T>()` | `size_of::<T::Scalar>()` |
| `emplace_scalar_array` | `s.len() >= size_of::<[T; N]>()` | `buf.len() >= loc + size_of::<[T::Scalar; N]>()` |

`read_scalar` also said `>` where the requirement is `>=`. `emplace_scalar_array`
named a parameter that does not exist and ignored `loc` entirely, so a caller
honouring the documented bound could still write out of bounds.

`EndianScalar` is public and only its associated type is sealed, so an out-of-crate
implementation may pair a small `Self` with a wider `Scalar`. A caller honouring the
documented bound then reads out of bounds: with `Self` one byte and `Scalar` four,
Miri reports a 4-byte read from a 1-byte allocation.

No in-tree type is affected — every in-crate implementor has
`size_of::<T>() == size_of::<T::Scalar>()`. These are latent contract defects, but
they are what external `unsafe` callers are told to rely on.

## No functional change

Verified rather than assumed: `monster_example` built with `--emit asm` before and
after gives **9,153 instruction lines each, zero differing**. The `.s` files are not
byte-identical only because three `.asciz` panic-location records shift when lines
are added.

Test suite 316 passed / 0 failed. Builds clean for default, `--no-default-features`
and `--features serialize`. `unsafe_op_in_unsafe_fn` stabilised in 1.52; the crate
declares `rust-version = "1.51"`, but that is already unreachable on master
(`bitflags 2.8` requires 1.56), so the effective MSRV does not move.

## Your call

- **`deny` vs `warn`** — `deny` is what stops backsliding, but it is a one-word change.
- **`// SAFETY:` vs `// Safety:`** — I used the former because
  `clippy::undocumented_unsafe_blocks` recognises it. The crate currently has 28 of
  the latter and 1 of the former; happy to match the majority instead.
