### PR TITLE
fix(python): preserve existing __init__.py files during code generation (fixes #9229)

### DIFF
--- a/src/idl_gen_python.cpp
+++ b/src/idl_gen_python.cpp
@@ -2957,7 +2957,9 @@ class PythonGenerator : public BaseGenerator {
          i != std::string::npos; i = directories.find(kPathSeparator, i + 1)) {
       const std::string init_py =
           directories.substr(0, i) + kPathSeparator + "__init__.py";
-      parser_.opts.file_saver->SaveFile(init_py.c_str(), "", false);
+      if (!FileExists(init_py.c_str())) {
+        parser_.opts.file_saver->SaveFile(init_py.c_str(), "", false);
+      }
     }
 
     const std::string filename = directories + defname;

--- a/tests/PythonTest.sh
+++ b/tests/PythonTest.sh
@@ -30,6 +30,16 @@ ${test_dir}/../flatc -p -o ${gen_code_path} -I include_test nested_union_test.fb
 ${test_dir}/../flatc -p -o ${gen_code_path} -I include_test service_test.fbs --grpc --grpc-python-typed-handlers --python-typing --no-python-gen-numpy --gen-onefile
 ${test_dir}/../flatc -p -o ${gen_code_path} union_name_test.fbs --gen-object-api
 
+# Verify that flatc --python preserves existing __init__.py files (#9229)
+mkdir -p ${gen_code_path}/preserve_test
+echo "# HANDWRITTEN CONTENT" > ${gen_code_path}/preserve_test/__init__.py
+${test_dir}/../flatc -p -o ${gen_code_path}/preserve_test -I include_test monster_test.fbs
+if ! grep -q "# HANDWRITTEN CONTENT" ${gen_code_path}/preserve_test/__init__.py; then
+  echo "FAIL: flatc overwrote existing __init__.py"
+  exit 1
+fi
+rm -rf ${gen_code_path}/preserve_test
+
 # Syntax: run_tests <interpreter> <benchmark vtable dedupes>
 #                   <benchmark read count> <benchmark build count>
 interpreters_tested=()


### PR DESCRIPTION
Fixes #9229.

### Problem
`flatc --python` creates an empty `__init__.py` in every folder of the generated namespace path.
Currently, it unconditionally calls `parser_.opts.file_saver->SaveFile(init_py.c_str(), "", false)` on every directory, silently overwriting and destroying any pre-existing, hand-written `__init__.py` files with an empty file without warning.

### Solution
Check `if (!FileExists(init_py.c_str()))` before writing, ensuring that only missing `__init__.py` files are created while any existing files (e.g. containing user imports, exports, or application code) are preserved intact.

### Testing
Added a regression test to `tests/PythonTest.sh` that writes a pre-existing `__init__.py` file with custom content, executes `flatc -p`, and asserts that the custom content was not overwritten.
