### PR TITLE
fix: guard against null prev_val in JsonPrinter::PrintOffset for unions (fixes #9033)

### DIFF
--- a/src/idl_gen_text.cpp
+++ b/src/idl_gen_text.cpp
@@ -182,13 +182,15 @@ struct JsonPrinter {
                           const uint8_t* prev_val, soffset_t vector_index) {
     switch (type.base_type) {
       case BASE_TYPE_UNION: {
-        // If this assert hits, you have an corrupt buffer, a union type field
-        // was not present or was out of range.
-        FLATBUFFERS_ASSERT(prev_val);
+        // Guard against corrupt buffer where union type field is missing or out of range.
+        if (!prev_val) return "corrupt buffer: missing union type field";
         auto union_type_byte = *prev_val;  // Always a uint8_t.
         if (vector_index >= 0) {
           auto type_vec = reinterpret_cast<const Vector<uint8_t>*>(
               prev_val + ReadScalar<uoffset_t>(prev_val));
+          if (static_cast<uoffset_t>(vector_index) >= type_vec->size()) {
+            return "corrupt buffer: union type vector out of range";
+          }
           union_type_byte = type_vec->Get(static_cast<uoffset_t>(vector_index));
         }
         auto enum_val = type.enum_def->ReverseLookup(union_type_byte, true);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -398,6 +398,23 @@ void UnionVectorTest(const std::string& tests_data_path) {
                         "root_type Root;"),
           true);
   TEST_EQ(parser2.Parse("{a_type:Bool,a:{b:true}}"), true);
+  {
+    // Test corrupt buffer where union type field is missing in vtable (fixes #9033).
+    std::vector<uint8_t> corrupt_buf(
+        parser2.builder_.GetBufferPointer(),
+        parser2.builder_.GetBufferPointer() + parser2.builder_.GetSize());
+    auto root_pos =
+        flatbuffers::ReadScalar<flatbuffers::uoffset_t>(corrupt_buf.data());
+    auto vtable_soffset = flatbuffers::ReadScalar<flatbuffers::soffset_t>(
+        corrupt_buf.data() + root_pos);
+    auto vtable_pos = root_pos - vtable_soffset;
+    flatbuffers::WriteScalar<flatbuffers::voffset_t>(
+        corrupt_buf.data() + vtable_pos + 4, 0);
+    std::string corrupt_json;
+    auto corrupt_result = GenText(parser2, corrupt_buf.data(), &corrupt_json);
+    TEST_NOTNULL(corrupt_result);
+    TEST_EQ_STR(corrupt_result, "corrupt buffer: missing union type field");
+  }
 }
 #endif
 


### PR DESCRIPTION
### Summary of Changes

Fixes #9033 (CWE-476 Null Pointer Dereference in `JsonPrinter::PrintOffset()` for union types).

#### Root Cause
In `src/idl_gen_text.cpp`, `JsonPrinter::PrintOffset()` dereferences `prev_val` to obtain the union type discriminator:
```cpp
case BASE_TYPE_UNION: {
  FLATBUFFERS_ASSERT(prev_val);
  auto union_type_byte = *prev_val;
```
In release builds (`-DNDEBUG`), `FLATBUFFERS_ASSERT` is removed. When processing an untrusted or malformed FlatBuffer where the union value field is present in the table vtable but the union type discriminator is absent (vtable offset zeroed), `prev_val` is `nullptr`. Attempting `*prev_val` immediately causes a segmentation fault (`SIGSEGV`), terminating `flatc` or any library converting unverified/corrupted binary buffers to JSON.

Additionally, for vectors of unions (`vector_index >= 0`), if `vector_index >= type_vec->size()`, accessing `type_vec->Get(vector_index)` can result in an out-of-bounds read.

#### Fix
1. Replace debug-only `FLATBUFFERS_ASSERT(prev_val)` with a runtime check returning `"corrupt buffer: missing union type field"`.
2. Check vector bounds (`static_cast<uoffset_t>(vector_index) >= type_vec->size()`) returning `"corrupt buffer: union type vector out of range"`.
3. Add a unit test in `tests/test.cpp` (`UnionVectorTest`) that crafts a corrupted vtable with missing union type discriminator and verifies that `GenText()` returns an error string instead of crashing.
